### PR TITLE
fix(runtime): generate trusted Sunshine certificate

### DIFF
--- a/native-runtime.lock.json
+++ b/native-runtime.lock.json
@@ -28,18 +28,18 @@
       "sourceMode": "openbot-fork",
       "repository": "https://github.com/NorbertBodziony/Sunshine.git",
       "version": "v2026.516.143833",
-      "commit": "cbef4bbb73f3ce327815c4da159a1e7b22d54997",
+      "commit": "a667b6804af5077c441de384fb463f1aa41ab268",
       "upstream": {
         "repository": "https://github.com/LizardByte/Sunshine.git",
         "commit": "14ffa6fdaa53f7b51512be2b3d24f3939695403c"
       },
-      "sourceArchive": "https://github.com/NorbertBodziony/Sunshine/archive/cbef4bbb73f3ce327815c4da159a1e7b22d54997.tar.gz",
-      "sourceSha256": "2a59b33479c7e4eda8cb1cf62cd8ccd950dd1b9df170e069c50851ddf102ebc8",
+      "sourceArchive": "https://github.com/NorbertBodziony/Sunshine/archive/a667b6804af5077c441de384fb463f1aa41ab268.tar.gz",
+      "sourceSha256": "90587917a971cb066844bb4f470e8a452f53845377e231b82fdc286b064c5886",
       "license": "GPL-3.0",
       "licenseSha256": "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986",
       "patch": {
         "path": "vendor/remote-desktop/patches/sunshine-v2026.516.143833-openbot.patch",
-        "sha256": "69c69779ec8dd46abaf1b6a46be0d04d0c9f557287da54faa2ca2379365d1717"
+        "sha256": "d3c57e6a86b1cfe4345be1484ac2a1d3d8de77fee2e4f62bae8d85aab5e81b52"
       },
       "overrides": [],
       "submodules": {

--- a/vendor/remote-desktop/patches/sunshine-v2026.516.143833-openbot.patch
+++ b/vendor/remote-desktop/patches/sunshine-v2026.516.143833-openbot.patch
@@ -234,3 +234,38 @@ index 195a666c..f0b09b8a 100644
  // Test: confighttp::authenticate() rejects invalid password
  TEST_F(ConfigHttpTest, AuthenticateRejectsInvalidPassword) {
    SimpleWeb::CaseInsensitiveMultimap headers;
+diff --git a/src/crypto.cpp b/src/crypto.cpp
+index c5e236e9..ac0a1555 100644
+--- a/src/crypto.cpp
++++ b/src/crypto.cpp
+@@ -5,12 +5,14 @@
+ // lib includes
+ #include <openssl/pem.h>
+ #include <openssl/rsa.h>
++#include <openssl/x509v3.h>
+ 
+ // local includes
+ #include "crypto.h"
+ 
+ namespace crypto {
+   using asn1_string_t = util::safe_ptr<ASN1_STRING, ASN1_STRING_free>;
++  using x509_extension_t = util::safe_ptr<X509_EXTENSION, X509_EXTENSION_free>;
+ 
+   cert_chain_t::cert_chain_t():
+       _certs {},
+@@ -465,6 +467,15 @@ namespace crypto {
+     X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (const std::uint8_t *) cn.data(), (int) cn.size(), -1, 0);
+ 
+     X509_set_issuer_name(x509.get(), name);
++
++    X509V3_CTX extension_context {};
++    X509V3_set_ctx_nodb(&extension_context);
++    X509V3_set_ctx(&extension_context, x509.get(), x509.get(), nullptr, nullptr, 0);
++    x509_extension_t basic_constraints {
++      X509V3_EXT_conf_nid(nullptr, &extension_context, NID_basic_constraints, (char *) "critical,CA:TRUE")
++    };
++    X509_add_ext(x509.get(), basic_constraints.get(), -1);
++
+     X509_sign(x509.get(), pkey.get(), EVP_sha256());
+ 
+     return {pem(x509), pem(pkey)};


### PR DESCRIPTION
Pins the Sunshine fork update that marks the generated self-signed TLS certificate as a valid trust anchor. OpenBot continues to verify the chain and pin the exact presented certificate. This fixes the strict macOS CI runtime smoke test.