### PR TITLE
fix(runtime): expose cargo to Windows build

### DIFF
--- a/.github/workflows/remote-desktop-runtime.yml
+++ b/.github/workflows/remote-desktop-runtime.yml
@@ -178,6 +178,7 @@ jobs:
         shell: pwsh
         run: |
           "OPENBOT_BUN_DIR=$(Split-Path (Get-Command bun).Source -Parent)" >> $env:GITHUB_ENV
+          "OPENBOT_CARGO_DIR=$(Split-Path (Get-Command cargo).Source -Parent)" >> $env:GITHUB_ENV
           "OPENBOT_NODE_DIR=$(Split-Path (Get-Command node).Source -Parent)" >> $env:GITHUB_ENV
 
       - name: Install macOS build dependencies
@@ -222,7 +223,7 @@ jobs:
         env:
           CMAKE_GENERATOR: Ninja
         run: |
-          export PATH="$PATH:$(cygpath "$OPENBOT_BUN_DIR"):$(cygpath "$OPENBOT_NODE_DIR")"
+          export PATH="$PATH:$(cygpath "$OPENBOT_BUN_DIR"):$(cygpath "$OPENBOT_CARGO_DIR"):$(cygpath "$OPENBOT_NODE_DIR")"
           bun run build:remote-desktop-runtime
 
       - name: Verify runtime

--- a/native-runtime.lock.json
+++ b/native-runtime.lock.json
@@ -23,7 +23,7 @@
     }
   },
   "remoteDesktop": {
-    "recipeVersion": 4,
+    "recipeVersion": 5,
     "sunshine": {
       "sourceMode": "openbot-fork",
       "repository": "https://github.com/NorbertBodziony/Sunshine.git",


### PR DESCRIPTION
Exports the preinstalled Windows Rust tool directory into the MSYS build path so the Moonlight npm build can invoke cargo. Bumps the native runtime recipe version because the build environment changed.