### PR TITLE
fix(runtime): add loopback identity to Sunshine TLS

### DIFF
--- a/native-runtime.lock.json
+++ b/native-runtime.lock.json
@@ -28,18 +28,18 @@
       "sourceMode": "openbot-fork",
       "repository": "https://github.com/NorbertBodziony/Sunshine.git",
       "version": "v2026.516.143833",
-      "commit": "a667b6804af5077c441de384fb463f1aa41ab268",
+      "commit": "f54b1b91d4ecfec83e81dde24de8b90369fc8ff5",
       "upstream": {
         "repository": "https://github.com/LizardByte/Sunshine.git",
         "commit": "14ffa6fdaa53f7b51512be2b3d24f3939695403c"
       },
-      "sourceArchive": "https://github.com/NorbertBodziony/Sunshine/archive/a667b6804af5077c441de384fb463f1aa41ab268.tar.gz",
-      "sourceSha256": "90587917a971cb066844bb4f470e8a452f53845377e231b82fdc286b064c5886",
+      "sourceArchive": "https://github.com/NorbertBodziony/Sunshine/archive/f54b1b91d4ecfec83e81dde24de8b90369fc8ff5.tar.gz",
+      "sourceSha256": "377763178a29f42223d08179ec0df5960324cdf3429749f1010877d9d5d0b248",
       "license": "GPL-3.0",
       "licenseSha256": "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986",
       "patch": {
         "path": "vendor/remote-desktop/patches/sunshine-v2026.516.143833-openbot.patch",
-        "sha256": "d3c57e6a86b1cfe4345be1484ac2a1d3d8de77fee2e4f62bae8d85aab5e81b52"
+        "sha256": "54aa2942ef0060d8fde6f64943a0371cb131fa81b7e96009916782dc2c735abc"
       },
       "overrides": [],
       "submodules": {

--- a/src/main/sunshine-moonlight-runtime.ts
+++ b/src/main/sunshine-moonlight-runtime.ts
@@ -566,6 +566,7 @@ async function requestStream(url: string, headers: Record<string, string>, body:
 
 async function waitForHttps(port: number, certificatePath: string): Promise<void> {
   const deadline = Date.now() + 20_000;
+  let lastError: unknown;
   while (Date.now() < deadline) {
     try {
       const tls = await sunshineTlsOptions(certificatePath);
@@ -577,11 +578,13 @@ async function waitForHttps(port: number, certificatePath: string): Promise<void
         request.once("error", reject);
       });
       return;
-    } catch {
+    } catch (error) {
+      lastError = error;
       await shortDelay();
     }
   }
-  throw new Error("Sunshine did not become ready.");
+  const detail = lastError instanceof Error ? ` ${lastError.message}` : "";
+  throw new Error(`Sunshine did not become ready.${detail}`, { cause: lastError });
 }
 
 async function sunshineTlsOptions(certificatePath: string): Promise<{
@@ -592,8 +595,8 @@ async function sunshineTlsOptions(certificatePath: string): Promise<{
   const ca = await readFile(certificatePath);
   const expected = new X509Certificate(ca).raw;
   return {
-    // Sunshine creates a self-signed leaf certificate without a CA basic constraint.
-    // Treat only this pinned leaf as the local trust anchor on strict TLS implementations.
+    // Sunshine creates a self-signed certificate for its loopback API.
+    // Treat only this pinned certificate as the local trust anchor.
     allowPartialTrustChain: true,
     ca,
     checkServerIdentity: (_hostname, certificate) => {

--- a/vendor/remote-desktop/patches/sunshine-v2026.516.143833-openbot.patch
+++ b/vendor/remote-desktop/patches/sunshine-v2026.516.143833-openbot.patch
@@ -235,7 +235,7 @@ index 195a666c..f0b09b8a 100644
  TEST_F(ConfigHttpTest, AuthenticateRejectsInvalidPassword) {
    SimpleWeb::CaseInsensitiveMultimap headers;
 diff --git a/src/crypto.cpp b/src/crypto.cpp
-index c5e236e9..ac0a1555 100644
+index c5e236e9..d6f8cd74 100644
 --- a/src/crypto.cpp
 +++ b/src/crypto.cpp
 @@ -5,12 +5,14 @@
@@ -253,7 +253,7 @@ index c5e236e9..ac0a1555 100644
  
    cert_chain_t::cert_chain_t():
        _certs {},
-@@ -465,6 +467,15 @@ namespace crypto {
+@@ -465,6 +467,19 @@ namespace crypto {
      X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (const std::uint8_t *) cn.data(), (int) cn.size(), -1, 0);
  
      X509_set_issuer_name(x509.get(), name);
@@ -265,6 +265,10 @@ index c5e236e9..ac0a1555 100644
 +      X509V3_EXT_conf_nid(nullptr, &extension_context, NID_basic_constraints, (char *) "critical,CA:TRUE")
 +    };
 +    X509_add_ext(x509.get(), basic_constraints.get(), -1);
++    x509_extension_t subject_alt_name {
++      X509V3_EXT_conf_nid(nullptr, &extension_context, NID_subject_alt_name, (char *) "IP:127.0.0.1,DNS:localhost")
++    };
++    X509_add_ext(x509.get(), subject_alt_name.get(), -1);
 +
      X509_sign(x509.get(), pkey.get(), EVP_sha256());
  


### PR DESCRIPTION
## Summary
- pin Sunshine fork commit with a loopback SAN in its generated certificate
- keep strict CA trust and exact certificate pinning
- preserve the last HTTPS startup error for diagnostics

## Verification
- full source build of Sunshine and Moonlight Web
- runtime verification
- smoke test with Bun 1.3.11 and four paired streamer slots
- `bun run check`
- runtime lock and installer tests