### PR TITLE
fix(runtime): scope native Perl to OpenSSL

### DIFF
--- a/.github/workflows/remote-desktop-runtime.yml
+++ b/.github/workflows/remote-desktop-runtime.yml
@@ -224,8 +224,10 @@ jobs:
         env:
           CMAKE_GENERATOR: Ninja
         run: |
-          export PATH="$(cygpath "$OPENBOT_BUN_DIR"):$(cygpath "$OPENBOT_CARGO_DIR"):$(cygpath "$OPENBOT_NODE_DIR"):$(cygpath "$OPENBOT_PERL_DIR"):$PATH"
-          perl -e 'die "Windows Perl is required\n" unless $^O eq "MSWin32";'
+          native_perl="$(cygpath "$OPENBOT_PERL_DIR")/perl.exe"
+          "$native_perl" -e 'die "Windows Perl is required\n" unless $^O eq "MSWin32";'
+          export OPENSSL_SRC_PERL="$(cygpath -w "$native_perl")"
+          export PATH="$PATH:$(cygpath "$OPENBOT_BUN_DIR"):$(cygpath "$OPENBOT_CARGO_DIR"):$(cygpath "$OPENBOT_NODE_DIR")"
           bun run build:remote-desktop-runtime
 
       - name: Verify runtime

--- a/native-runtime.lock.json
+++ b/native-runtime.lock.json
@@ -23,7 +23,7 @@
     }
   },
   "remoteDesktop": {
-    "recipeVersion": 6,
+    "recipeVersion": 7,
     "sunshine": {
       "sourceMode": "openbot-fork",
       "repository": "https://github.com/NorbertBodziony/Sunshine.git",


### PR DESCRIPTION
## Summary
- keep the UCRT64 toolchain first for Sunshine CMake
- pass Strawberry Perl only through `OPENSSL_SRC_PERL`
- verify the selected Perl reports `MSWin32`
- bump the runtime recipe version

## Verification
- workflow YAML parse
- runtime lock and installer tests
- confirmed `openssl-src 300.5.3` reads `OPENSSL_SRC_PERL`