### PR TITLE
build(runtime): pin published remote desktop artifacts

### DIFF
--- a/native-runtime.lock.json
+++ b/native-runtime.lock.json
@@ -86,7 +86,23 @@
       "overrides": [],
       "submodules": {}
     },
-    "releaseArtifacts": {},
+    "artifactRelease": {
+      "repository": "NorbertBodziony/openbot",
+      "tag": "remote-desktop-runtime-ee34f22191f226e3cdf9903e95a85f26ae759dd07ac23dca9f3fab65ec0e6e23",
+      "inputDigest": "ee34f22191f226e3cdf9903e95a85f26ae759dd07ac23dca9f3fab65ec0e6e23",
+      "manifestAsset": "remote-desktop-runtime-manifest.json",
+      "manifestSha256": "5134c54a31715afb740ab0c7697a28dabea311c9f70ca86e0f9d01023d3a7296"
+    },
+    "releaseArtifacts": {
+      "darwin-arm64": {
+        "asset": "remote-desktop-runtime-darwin-arm64.tar.gz",
+        "sha256": "36e2eaa2ffab02180b2c1e402de378a0889d89bd50f30f181cd1a1cae8794e55"
+      },
+      "win32-x64": {
+        "asset": "remote-desktop-runtime-win32-x64.tar.gz",
+        "sha256": "24b2b2fc52a2f4270a9a7ba1d9e3cf60d63f87d43f6965ac5419ded5b79a8940"
+      }
+    },
     "targets": {
       "darwin-arm64": ["Sunshine.app/Contents/MacOS/Sunshine", "web-server", "streamer"],
       "win32-x64": ["sunshine.exe", "web-server.exe", "streamer.exe"]


### PR DESCRIPTION
## Summary
- pin immutable runtime prerelease `remote-desktop-runtime-ee34f221...`
- record manifest and macOS/Windows archive SHA-256 values

## Verification
- published macOS and Windows archives built and checksum verification passed
- published macOS artifact downloaded and installed locally
- full smoke passed with Bun 1.3.11 and four Moonlight slots
- runtime lock and installer tests passed

Windows application release remains out of scope. Its package check reached the final Authenticode check and failed because the runner could not load the PowerShell security module.