### PR TITLE
release: prepare v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,34 @@ All notable changes to OpenBot will be documented here. The project follows
 
 ## [Unreleased]
 
+## [0.1.12] - 2026-08-22
+
+### Added
+
+- Add full-window P2P Remote Control for active server members, with shared mouse and keyboard control,
+  four concurrent sessions, monitor selection, hide and resume, retry, and explicit disconnect.
+- Bundle pinned Sunshine and Moonlight Web runtimes built from source, with immutable artifacts,
+  corresponding GPL source, checksums, SBOMs, and build provenance.
+- Add speech-to-text message input with local Whisper model preparation.
+- Add universal server invitation links and updated account, server, queue, attachment, and conversation
+  controls.
+
 ### Changed
 
 - Changed the project license from Apache-2.0 to PolyForm Noncommercial 1.0.0.
+- Publish the OpenBot application for macOS only in this release while Windows application packaging is
+  paused.
+- Start Remote Control only from the server header and keep a hidden session active until the user
+  disconnects or changes servers.
+
+### Removed
+
+- Remove QuickDesk, VNC, noVNC, remote passwords, and view-only remote access paths.
+
+### Security
+
+- Authorize Remote Control through active team membership and one-time in-memory viewer grants.
+- Verify the local Sunshine TLS chain and pin the exact generated certificate.
 
 ## [0.1.11] - 2026-08-16
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openbot",
   "productName": "OpenBot",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "A local-first multi-agent desktop workspace for Codex and Claude.",
   "author": {
     "name": "Norbert Bodziony",


### PR DESCRIPTION
## Summary\n- prepare OpenBot v0.1.12 for macOS\n- document full-window P2P Remote Control and pinned Sunshine/Moonlight runtime\n- keep Windows application packaging out of this release\n\n## Verification\n- local Remote Control E2E passed with true P2P video, mouse, keyboard, hide/resume, display switch, and disconnect\n- published runtime artifact passed source build, checksum, SBOM, provenance, TLS, and four-slot smoke checks\n- protected CI and CodeQL required before merge