### PR TITLE
fix(release): install cloudflared before packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,11 @@ jobs:
       - name: Run repository check
         run: bun run check
 
-      - name: Install and verify remote desktop runtime
-        run: bun run install:remote-desktop-runtime && bun run verify:remote-desktop-runtime
+      - name: Install and verify native runtimes
+        run: |
+          bun run install:cloudflared
+          bun run install:remote-desktop-runtime
+          bun run verify:remote-desktop-runtime
 
       - name: Install Developer ID provisioning profile
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OpenBot will be documented here. The project follows
 
 ## [Unreleased]
 
-## [0.1.12] - 2026-08-22
+## [0.1.13] - 2026-08-22
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openbot",
   "productName": "OpenBot",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A local-first multi-agent desktop workspace for Codex and Claude.",
   "author": {
     "name": "Norbert Bodziony",


### PR DESCRIPTION
## Summary\n- install the pinned cloudflared runtime before the signed macOS package build\n- prepare corrected release v0.1.13 without rewriting the failed v0.1.12 tag\n\n## Cause\nThe release workflow installed Sunshine/Moonlight but skipped the cloudflared installer. Electron Builder therefore omitted its extraResources.\n\n## Verification\n- pinned cloudflared installer succeeded\n- cloudflared executable and source manifest exist\n- native runtime lock and resolver tests passed\n- protected CI and macOS package verification required before merge