### PR TITLE
fix(release): verify signed macOS entitlements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,12 +169,14 @@ jobs:
           codesign --verify --strict --verbose=2 "$runtime_path/web-server"
           codesign --verify --strict --verbose=2 "$runtime_path/streamer"
           test -f "$app_path/Contents/embedded.provisionprofile"
-          codesign -d --entitlements "$RUNNER_TEMP/openbot-entitlements.plist" "$app_path"
-          plutil -extract com.apple.developer.associated-domains.0 raw \
+          codesign -d --entitlements :- "$app_path" > "$RUNNER_TEMP/openbot-entitlements.plist"
+          test -s "$RUNNER_TEMP/openbot-entitlements.plist"
+          plutil -lint "$RUNNER_TEMP/openbot-entitlements.plist"
+          /usr/libexec/PlistBuddy -c 'Print :com.apple.developer.associated-domains:0' \
             "$RUNNER_TEMP/openbot-entitlements.plist" | grep -Fx 'applinks:openbot.run'
-          plutil -extract com.apple.developer.team-identifier raw \
+          /usr/libexec/PlistBuddy -c 'Print :com.apple.developer.team-identifier' \
             "$RUNNER_TEMP/openbot-entitlements.plist" | grep -Fx 'ZTRDTUL87R'
-          plutil -extract com.apple.security.device.audio-input raw \
+          /usr/libexec/PlistBuddy -c 'Print :com.apple.security.device.audio-input' \
             "$RUNNER_TEMP/openbot-entitlements.plist" | grep -Fx 'true'
           plutil -extract NSUserActivityTypes.0 raw "$app_path/Contents/Info.plist" \
             | grep -Fx 'NSUserActivityTypeBrowsingWeb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OpenBot will be documented here. The project follows
 
 ## [Unreleased]
 
-## [0.1.13] - 2026-08-22
+## [0.1.14] - 2026-08-22
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openbot",
   "productName": "OpenBot",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A local-first multi-agent desktop workspace for Codex and Claude.",
   "author": {
     "name": "Norbert Bodziony",


### PR DESCRIPTION
## Summary\n- export signed macOS entitlements from codesign to a real plist\n- require a non-empty valid plist before checking values\n- read entitlement keys with PlistBuddy because the keys contain dots\n- prepare corrected release v0.1.14 without rewriting failed tags\n\n## Verification\n- exact extraction and validation pipeline passed against a locally signed executable\n- associated domains, team identifier, and audio-input entitlement checks passed\n- protected CI and macOS package verification required before merge