### PR TITLE
Fix composer bot mentions and worktree setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -3,7 +3,14 @@ version = 1
 name = "openbot"
 
 [setup]
-script = "bun install --frozen-lockfile"
+script = """
+test -f .env.keys || {
+  echo "Missing .env.keys. Add it to the local checkout so Codex can copy it through .worktreeinclude."
+  exit 1
+}
+bun install --frozen-lockfile
+bun run api:migrate:local
+"""
 
 [[actions]]
 name = "Run"
@@ -14,3 +21,8 @@ command = "bun run dev"
 name = "Storybook"
 icon = "tool"
 command = "bun run storybook"
+
+[[actions]]
+name = "Test"
+icon = "test"
+command = "bun run test"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 
 ## Test value policy
 
+- Keep verification minimal and proportional to the change. Run the narrowest relevant automated test and, when needed, one manual UI check; do not repeat equivalent checks across Vitest, Storybook, and the integrated app unless they cover genuinely different runtime behavior.
 - Write tests only when they protect user behavior, accessibility, data integrity, security or permission boundaries, IPC contracts, persistence, error recovery, asynchronous ordering, or a reproduced regression.
 - Do not add tests that only check static text, CSS classes, visual-only data attributes, DOM structure, component variants, sizes, layout, animation timing, hover appearance, or Storybook states. Verify visual details in Storybook or with `bun run dev`.
 - Tests can use accessible roles and names to find controls. Assert the action and its result, not the exact wording. Assert exact text only when the text is a product contract, an error or security message, serialized output, or a localization key.

--- a/src/renderer/src/components/ComposerEditor.test.tsx
+++ b/src/renderer/src/components/ComposerEditor.test.tsx
@@ -56,6 +56,33 @@ function placeCaretAtEnd(editor: HTMLElement): void {
   selection?.addRange(range);
 }
 
+function placeCaret(container: Node, offset: number): void {
+  const range = document.createRange();
+  range.setStart(container, offset);
+  range.collapse(true);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+function testBot(id: string, name: string, description = ""): BotProfile {
+  return {
+    id,
+    name,
+    title: "Agent",
+    description,
+    notifications: true,
+    model: "gpt-5.6-luna",
+    reasoningEffort: "medium",
+    threadId: null,
+    avatarSeed: id,
+    avatarHue: null,
+    avatarUrl: null,
+    time: "",
+    preview: "",
+  };
+}
+
 describe("ComposerEditor", () => {
   it("focuses the editor and places the caret at the end for a focus request", async () => {
     const [focusRequest, setFocusRequest] = createSignal(0);
@@ -320,6 +347,102 @@ describe("ComposerEditor", () => {
 
     expect(await screen.findByRole("option", { name: "Studio Agent" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "Research Agent" })).toBeNull();
+  });
+
+  it("navigates the mention picker with arrows and inserts the active agent with Enter", async () => {
+    const research = testBot("research", "Research");
+    const sales = testBot("sales", "Sales");
+    const { editor, onSubmit, onValueChange } = renderComposer([], "", [research, sales]);
+    editor.textContent = "@";
+    placeCaretAtEnd(editor);
+    await fireEvent.input(editor);
+
+    const researchOption = await screen.findByRole("option", { name: "Research Agent" });
+    const salesOption = screen.getByRole("option", { name: "Sales Agent" });
+    expect(researchOption).toHaveClass("mention-picker-option-active");
+
+    await fireEvent.keyDown(editor, { key: "ArrowDown" });
+    expect(salesOption).toHaveClass("mention-picker-option-active");
+    await fireEvent.keyDown(editor, { key: "ArrowUp" });
+    expect(researchOption).toHaveClass("mention-picker-option-active");
+    await fireEvent.keyDown(editor, { key: "ArrowUp" });
+    expect(salesOption).toHaveClass("mention-picker-option-active");
+    await fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onValueChange).toHaveBeenLastCalledWith("@[Sales](sales) ");
+    expect(editor.querySelector('[data-mention-id="sales"]')).not.toBeNull();
+    expect(screen.queryByRole("listbox", { name: "Insert mention" })).toBeNull();
+    expect(editor).toHaveFocus();
+  });
+
+  it("removes a leading mention atomically with Backspace", async () => {
+    const research = testBot("research", "Research");
+    const { editor, onValueChange } = renderComposer([], "@[Research](research)after", [research]);
+    const trailingText = editor.lastChild;
+    if (!trailingText) throw new Error("Composer did not render trailing text");
+    editor.focus();
+    placeCaret(trailingText, 0);
+
+    await fireEvent.keyDown(editor, { key: "Backspace" });
+
+    expect(editor.querySelector('[data-mention-id="research"]')).toBeNull();
+    expect(editor).toHaveTextContent("after");
+    expect(onValueChange).toHaveBeenLastCalledWith("after");
+  });
+
+  it("removes a trailing mention atomically with Delete", async () => {
+    const research = testBot("research", "Research");
+    const { editor, onValueChange } = renderComposer([], "before@[Research](research)", [research]);
+    const leadingText = editor.firstChild;
+    if (!leadingText) throw new Error("Composer did not render leading text");
+    editor.focus();
+    placeCaret(leadingText, leadingText.textContent?.length ?? 0);
+
+    await fireEvent.keyDown(editor, { key: "Delete" });
+
+    expect(editor.querySelector('[data-mention-id="research"]')).toBeNull();
+    expect(editor).toHaveTextContent("before");
+    expect(onValueChange).toHaveBeenLastCalledWith("before");
+  });
+
+  it("removes the automatic mention space without creating a phantom line", async () => {
+    const research = testBot("research", "Research");
+    const { editor, onValueChange } = renderComposer([], "", [research]);
+    editor.textContent = "before @";
+    placeCaretAtEnd(editor);
+    await fireEvent.input(editor);
+    await fireEvent.keyDown(editor, { key: "Enter" });
+    placeCaretAtEnd(editor);
+
+    await fireEvent.keyDown(editor, { key: "Backspace" });
+
+    expect(editor.querySelector('[data-mention-id="research"]')).not.toBeNull();
+    expect(editor.querySelector("br, [data-composer-trailing-line]")).toBeNull();
+    expect(onValueChange).toHaveBeenLastCalledWith("before @[Research](research)");
+
+    await fireEvent.keyDown(editor, { key: "Backspace" });
+
+    expect(editor.querySelector('[data-mention-id="research"]')).toBeNull();
+    expect(editor.querySelector("br, [data-composer-trailing-line]")).toBeNull();
+    expect(onValueChange).toHaveBeenLastCalledWith("before ");
+  });
+
+  it("keeps the caret editable after removing a mention from the middle", async () => {
+    const research = testBot("research", "Research");
+    const { editor, onValueChange } = renderComposer([], "before@[Research](research)after", [research]);
+    const token = editor.querySelector<HTMLElement>('[data-mention-id="research"]');
+    if (!token) throw new Error("Composer did not render the mention");
+    editor.focus();
+    placeCaret(editor, Array.from(editor.childNodes).indexOf(token) + 1);
+
+    await fireEvent.keyDown(editor, { key: "Backspace" });
+    await fireEvent.keyDown(editor, { key: "x" });
+
+    await waitFor(() => expect(onValueChange).toHaveBeenLastCalledWith("beforexafter"));
+    expect(editor.querySelector('[data-mention-id="research"]')).toBeNull();
+    expect(editor).toHaveTextContent("beforexafter");
+    expect(editor.contains(window.getSelection()?.getRangeAt(0).commonAncestorContainer ?? null)).toBe(true);
   });
 
   it("inserts an attached file from the mention picker and opens the chip", async () => {

--- a/src/renderer/src/components/ComposerEditor.tsx
+++ b/src/renderer/src/components/ComposerEditor.tsx
@@ -94,6 +94,7 @@ export function ComposerEditor(props: ComposerEditorProps) {
     const option = matchingOptions()[activeOption()];
     return option ? new Set([pickerOptionKey(option)]) : new Set<string>();
   });
+  const pickerOptionElements = new Map<string, HTMLElement>();
   let editor: HTMLDivElement | undefined;
   let lastBotId: string | undefined;
   let lastAttachmentKey = "";
@@ -249,15 +250,16 @@ export function ComposerEditor(props: ComposerEditorProps) {
     editor.focus();
   }
 
-  function ensureEditorSelection() {
+  function ensureEditorSelection(normalize = false) {
     if (!editor) return;
     const selection = window.getSelection();
     const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
     if (!range || !editor.contains(range.commonAncestorContainer)) {
-      editor.normalize();
+      if (normalize) editor.normalize();
       placeCaretAtEnd(editor);
       return;
     }
+    if (!normalize) return;
     const startPrefix = range.cloneRange();
     startPrefix.selectNodeContents(editor);
     startPrefix.setEnd(range.startContainer, range.startOffset);
@@ -273,8 +275,95 @@ export function ComposerEditor(props: ComposerEditorProps) {
     selection?.addRange(normalizedRange);
   }
 
+  function moveActiveOption(delta: number, optionCount: number) {
+    setActiveOption((current) => {
+      const next = (current + delta + optionCount) % optionCount;
+      const option = matchingOptions()[next];
+      if (option) {
+        queueMicrotask(() => pickerOptionElements.get(pickerOptionKey(option))?.scrollIntoView?.({ block: "nearest" }));
+      }
+      return next;
+    });
+  }
+
+  function handleMentionPickerKeyDown(event: KeyboardEvent): boolean {
+    if (!mention()) return false;
+    const options = matchingOptions();
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setMention(null);
+      return true;
+    }
+    if (options.length === 0) return false;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveActiveOption(1, options.length);
+      return true;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveActiveOption(-1, options.length);
+      return true;
+    }
+    if ((event.key === "Enter" && !event.shiftKey) || event.key === "Tab") {
+      event.preventDefault();
+      const option = options[activeOption()];
+      if (option) insertOption(option);
+      return true;
+    }
+    return false;
+  }
+
+  function removeAdjacentMention(key: "Backspace" | "Delete"): boolean {
+    if (!editor) return false;
+    const selection = window.getSelection();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    if (!range?.collapsed || !editor.contains(range.commonAncestorContainer)) return false;
+    const token = mentionTokenAtCaretBoundary(editor, range, key);
+    if (!token) return false;
+
+    const tokenParent = token.parentNode;
+    if (!tokenParent) return false;
+    const caretOffset = Array.from(tokenParent.childNodes).indexOf(token);
+    token.remove();
+    setMention(null);
+    emitValue();
+    editor.focus();
+    placeCaretAtChildOffset(tokenParent, Math.min(caretOffset, tokenParent.childNodes.length));
+    return true;
+  }
+
+  function removeAutomaticMentionSpace(): boolean {
+    if (!editor) return false;
+    const selection = window.getSelection();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    if (!range?.collapsed || !editor.contains(range.commonAncestorContainer)) return false;
+    const boundary = automaticMentionSpaceAtCaretBoundary(editor, range);
+    if (!boundary) return false;
+
+    boundary.text.deleteData(boundary.offset - 1, 1);
+    if (!boundary.text.data) boundary.text.remove();
+    const tokenParent = boundary.token.parentNode;
+    if (!tokenParent) return false;
+    const caretOffset = Array.from(tokenParent.childNodes).indexOf(boundary.token) + 1;
+    setMention(null);
+    emitValue();
+    editor.focus();
+    placeCaretAtChildOffset(tokenParent, caretOffset);
+    return true;
+  }
+
   function handleKeyDown(event: KeyboardEvent) {
     if (event.key === "Enter" && (isComposing || event.isComposing)) return;
+    if (handleMentionPickerKeyDown(event)) return;
+    if (event.key === "Backspace" && removeAutomaticMentionSpace()) {
+      event.preventDefault();
+      return;
+    }
+    if ((event.key === "Backspace" || event.key === "Delete") && removeAdjacentMention(event.key)) {
+      event.preventDefault();
+      return;
+    }
     ensureEditorSelection();
 
     if (event.key === "Backspace" && removeTrailingLineBreak()) {
@@ -304,30 +393,6 @@ export function ComposerEditor(props: ComposerEditorProps) {
       return;
     }
 
-    const options = matchingOptions();
-    if (mention() && options.length > 0) {
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setActiveOption((current) => (current + 1) % options.length);
-        return;
-      }
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setActiveOption((current) => (current - 1 + options.length) % options.length);
-        return;
-      }
-      if ((event.key === "Enter" && !event.shiftKey) || event.key === "Tab") {
-        event.preventDefault();
-        const bot = options[activeOption()];
-        if (bot) insertOption(bot);
-        return;
-      }
-    }
-    if (event.key === "Escape" && mention()) {
-      event.preventDefault();
-      setMention(null);
-      return;
-    }
     if (event.key === "Enter" && event.shiftKey) {
       event.preventDefault();
       if (!editor) return;
@@ -397,7 +462,7 @@ export function ComposerEditor(props: ComposerEditorProps) {
         aria-disabled={props.disabled ? "true" : "false"}
         aria-multiline="true"
         spellcheck="true"
-        onFocus={ensureEditorSelection}
+        onFocus={() => ensureEditorSelection(true)}
         onInput={(event) => {
           acknowledgeNativePrintableInput(event);
           emitValue();
@@ -454,9 +519,16 @@ export function ComposerEditor(props: ComposerEditorProps) {
                     <div class="mention-picker-section">Files</div>
                   </Show>
                   <Listbox.Item
+                    ref={(element) => pickerOptionElements.set(pickerOptionKey(option), element)}
                     item={item}
                     aria-label={pickerOptionText(option)}
-                    class={["mention-picker-option", { "mention-picker-file-option": option.type === "attachment" }]}
+                    class={[
+                      "mention-picker-option",
+                      {
+                        "mention-picker-file-option": option.type === "attachment",
+                        "mention-picker-option-active": activeOption() === optionIndex(),
+                      },
+                    ]}
                     onPointerDown={(event) => event.preventDefault()}
                     onMouseEnter={() => setActiveOption(optionIndex())}
                   >
@@ -719,6 +791,97 @@ function placeCaretAtEnd(editor: HTMLDivElement): void {
   const selection = window.getSelection();
   selection?.removeAllRanges();
   selection?.addRange(range);
+}
+
+function placeCaretAtChildOffset(container: Node, offset: number): void {
+  const range = document.createRange();
+  range.setStart(container, offset);
+  range.collapse(true);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+function mentionTokenAtCaretBoundary(
+  editor: HTMLDivElement,
+  range: Range,
+  key: "Backspace" | "Delete",
+): HTMLElement | null {
+  const tokenAtCaret = closestMentionToken(range.startContainer, editor);
+  if (tokenAtCaret) return tokenAtCaret;
+
+  let candidate: Node | null = null;
+  const container = range.startContainer;
+  if (container === editor) {
+    candidate = editor.childNodes[key === "Backspace" ? range.startOffset - 1 : range.startOffset] ?? null;
+  } else if (container.nodeType === Node.TEXT_NODE) {
+    const length = container.textContent?.length ?? 0;
+    const atBoundary = key === "Backspace" ? range.startOffset === 0 : range.startOffset === length;
+    if (!atBoundary) return null;
+    const directChild = directChildOf(editor, container);
+    candidate = key === "Backspace" ? (directChild?.previousSibling ?? null) : (directChild?.nextSibling ?? null);
+  } else if (container instanceof HTMLElement) {
+    candidate =
+      container.childNodes[key === "Backspace" ? range.startOffset - 1 : range.startOffset] ??
+      (key === "Backspace" ? container.previousSibling : container.nextSibling);
+  }
+
+  while (candidate?.nodeType === Node.TEXT_NODE && !candidate.textContent) {
+    candidate = key === "Backspace" ? candidate.previousSibling : candidate.nextSibling;
+  }
+  return candidate ? closestMentionToken(candidate, editor) : null;
+}
+
+function closestMentionToken(node: Node, editor: HTMLDivElement): HTMLElement | null {
+  const element = node instanceof HTMLElement ? node : node.parentElement;
+  const token = element?.closest<HTMLElement>("[data-mention-id]") ?? null;
+  return token && editor.contains(token) ? token : null;
+}
+
+function directChildOf(editor: HTMLDivElement, node: Node): Node | null {
+  let current: Node | null = node;
+  while (current?.parentNode && current.parentNode !== editor) current = current.parentNode;
+  return current?.parentNode === editor ? current : null;
+}
+
+function automaticMentionSpaceAtCaretBoundary(
+  editor: HTMLDivElement,
+  range: Range,
+): { text: Text; offset: number; token: HTMLElement } | null {
+  const container = range.startContainer;
+  let text: Text | null = null;
+  let offset = 0;
+  if (isTextNode(container)) {
+    text = container;
+    offset = range.startOffset;
+    if (!offset && !text.data) {
+      const candidate = previousNonemptySibling(text.previousSibling);
+      if (!candidate || !isTextNode(candidate)) return null;
+      text = candidate;
+      offset = candidate.data.length;
+    }
+  } else if (container === editor) {
+    const candidate = previousNonemptySibling(editor.childNodes[range.startOffset - 1] ?? null);
+    if (!candidate || !isTextNode(candidate)) return null;
+    text = candidate;
+    offset = candidate.data.length;
+  }
+
+  if (!text || offset !== 1 || text.data[0] !== " ") return null;
+  let previous = text.previousSibling;
+  while (previous && isTextNode(previous) && !previous.data) previous = previous.previousSibling;
+  const token = previous ? closestMentionToken(previous, editor) : null;
+  return token ? { text, offset, token } : null;
+}
+
+function isTextNode(node: Node): node is Text {
+  return node.nodeType === Node.TEXT_NODE;
+}
+
+function previousNonemptySibling(node: Node | null): Node | null {
+  let candidate = node;
+  while (candidate?.nodeType === Node.TEXT_NODE && !candidate.textContent) candidate = candidate.previousSibling;
+  return candidate;
 }
 
 function rangeFromTextOffsets(root: HTMLElement, start: number, end: number): Range | null {

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -6202,17 +6202,17 @@
 
 .composer-mention-token {
   display: inline-flex;
-  height: 22px;
+  height: 20px;
   align-items: center;
   gap: 4px;
   margin: 0 1px;
   border-radius: var(--openbot-radius-sm);
   background: var(--openbot-border);
-  padding: 1px 6px 1px 3px;
+  padding: 0 6px 0 3px;
   color: var(--openbot-text-primary);
   font-size: var(--openbot-text-sm);
   line-height: 18px;
-  vertical-align: middle;
+  vertical-align: top;
   white-space: nowrap;
 }
 

--- a/src/renderer/stories/ComposerEditor.stories.tsx
+++ b/src/renderer/stories/ComposerEditor.stories.tsx
@@ -75,41 +75,29 @@ export const MentionPicker: Story = {
     const [value, setValue] = createSignal(storyArgs.value);
     return <ComposerEditor {...storyArgs} value={value()} onValueChange={setValue} onSubmit={storyArgs.onSubmit} />;
   },
-  play: async ({ canvas, userEvent }) => {
+  play: async ({ args: storyArgs, canvas, userEvent }) => {
     const editor = canvas.getByRole("textbox", { name: "Message Chief" });
     await userEvent.click(editor);
-    editor.textContent = "@Res";
+    editor.textContent = "@";
     const textNode = editor.firstChild;
     if (!textNode) throw new Error("Composer editor did not create a text node");
     const selectionRange = document.createRange();
     selectionRange.setStart(textNode, textNode.textContent?.length ?? 0);
     selectionRange.collapse(true);
-    const selection = {
-      anchorNode: textNode,
-      anchorOffset: textNode.textContent?.length ?? 0,
-      rangeCount: 1,
-      getRangeAt: () => selectionRange,
-      removeAllRanges: () => undefined,
-      addRange: () => undefined,
-      // biome-ignore lint/nursery/noUnsafeTypeAssertion: Storybook needs a minimal Selection double for contenteditable caret placement.
-    } as unknown as Selection;
-    const originalGetSelection = window.getSelection;
-    Object.defineProperty(window, "getSelection", {
-      configurable: true,
-      value: () => selection,
-    });
-    try {
-      editor.dispatchEvent(new Event("input", { bubbles: true }));
-      const picker = await within(document.body).findByRole("listbox", { name: "Insert mention" });
-      await expect(picker).toBeInTheDocument();
-      await userEvent.click(within(document.body).getByRole("option", { name: /Research/i }));
-      await expect(editor.querySelector('[data-mention-id="research"]')).not.toBeNull();
-    } finally {
-      Object.defineProperty(window, "getSelection", {
-        configurable: true,
-        value: originalGetSelection,
-      });
-    }
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(selectionRange);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    const picker = await within(document.body).findByRole("listbox", { name: "Insert mention" });
+    await expect(picker).toBeInTheDocument();
+    const research = within(document.body).getByRole("option", { name: "Research Agent" });
+    const sales = within(document.body).getByRole("option", { name: "Sales Outbound Agent" });
+    await expect(research).toHaveClass("mention-picker-option-active");
+    await userEvent.keyboard("{ArrowDown}");
+    await expect(sales).toHaveClass("mention-picker-option-active");
+    await userEvent.keyboard("{Enter}");
+    await expect(editor.querySelector('[data-mention-id="sales"]')).not.toBeNull();
+    await expect(storyArgs.onSubmit).not.toHaveBeenCalled();
   },
 };
 


### PR DESCRIPTION
## What changed

- Make the bot mention picker keyboard-first: Arrow keys move the active option, Enter and Tab insert it without submitting, and Escape closes the picker.
- Keep bot chips atomic during Backspace and Delete, preserve the caret, and prevent Chromium from creating a phantom line after deleting the automatic trailing space.
- Keep the composer line height stable when a bot chip appears.
- Extend the Codex worktree setup with an environment-key check, local D1 migrations, and a Test action.
- Document minimal, proportional verification in AGENTS.md.

## Verification

- [ ] bun run check
- [x] Relevant manual smoke test completed in the integrated Electron dev app
- [x] No credentials, private data, generated output, or real user files are included

Additional targeted verification:
- ComposerEditor tests: 28 passed
- Full repository typecheck passed through the commit hook
- Staged Biome checks and git diff checks passed

## Risk and security impact

Low. Composer keyboard and contenteditable behavior changed. Worktree setup now applies migrations only to the local D1 development database. No credentials are committed; .env.keys remains ignored.