### PR TITLE
Refactor settings experience

### DIFF
--- a/packages/contracts/src/input-limits.ts
+++ b/packages/contracts/src/input-limits.ts
@@ -3,7 +3,7 @@ export const INPUT_LIMITS = {
   email: 254,
   accountName: 120,
   serverNameMin: 6,
-  serverName: 64,
+  serverName: 32,
   inviteUrl: 4_096,
   hostname: 253,
   browserUrl: 8_192,

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1198,6 +1198,37 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() => expect(window.openbot.openExternal).toHaveBeenCalledWith("message"));
   });
 
+  it("opens global settings from the account menu and restores focus after every close path", async () => {
+    render(() => <App />);
+    const accountButton = await screen.findByRole("button", { name: "Open account menu" });
+
+    await fireEvent.click(accountButton);
+    await fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    let dialog = await screen.findByRole("dialog", { name: "General" });
+    const launchSwitch = within(dialog).getByRole("switch", { name: "Launch OpenBot at login" });
+    await fireEvent.click(launchSwitch);
+    expect(launchSwitch).not.toBeChecked();
+
+    await fireEvent.click(within(dialog).getByRole("button", { name: "Close settings" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "General" })).not.toBeInTheDocument());
+    await waitFor(() => expect(accountButton).toHaveFocus());
+
+    await fireEvent.click(accountButton);
+    await fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    dialog = await screen.findByRole("dialog", { name: "General" });
+    expect(within(dialog).getByRole("switch", { name: "Launch OpenBot at login" })).not.toBeChecked();
+    await fireEvent.keyDown(dialog, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "General" })).not.toBeInTheDocument());
+    await waitFor(() => expect(accountButton).toHaveFocus());
+
+    await fireEvent.click(accountButton);
+    await fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    await screen.findByRole("dialog", { name: "General" });
+    await fireEvent.pointerDown(screen.getByTestId("settings-modal-backdrop"), { button: 0 });
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "General" })).not.toBeInTheDocument());
+    await waitFor(() => expect(accountButton).toHaveFocus());
+  });
+
   it("removes a custom account avatar from the account menu", async () => {
     vi.mocked(window.openbot.auth.getState).mockResolvedValueOnce({
       status: "signed_in",
@@ -4608,10 +4639,10 @@ describe("OpenBot connected desktop shell", () => {
       clientY: 80,
     });
     await fireEvent.pointerUp(screen.getByRole("menuitem", { name: "Server settings" }), { button: 0 });
-    await fireEvent.input(screen.getByRole("textbox", { name: "Server name" }), {
+    await fireEvent.input(await screen.findByRole("textbox", { name: "Server name" }), {
       target: { value: "Design studio" },
     });
-    await fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(window.openbot.host.configure).toHaveBeenCalledWith({ serverName: "Design studio" }));
     expect(window.openbot.host.start).not.toHaveBeenCalled();

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -60,6 +60,7 @@ import {
   toBotProfile,
   withoutBot,
 } from "./app-message-projection";
+import { DEFAULT_GENERAL_SETTINGS, type GeneralSettingsValue } from "./app-settings";
 import { playCompletionSoundForAgentEvent } from "./completion-sound";
 import { createFirstBotDraft, type FirstBotDraft } from "./components/FirstBotSetup";
 import { readPanelWidth } from "./components/PanelResizer";
@@ -267,6 +268,8 @@ export function createAppController(props: AppProps = {}) {
   const [authSuccessVisible, setAuthSuccessVisible] = createSignal(false);
   const [permissionsOpen, setPermissionsOpen] = createSignal(false);
   const [skillsMarketplaceOpen, setSkillsMarketplaceOpen] = createSignal(false);
+  const [appSettingsOpen, setAppSettingsOpen] = createSignal(false);
+  const [generalSettings, setGeneralSettings] = createSignal<GeneralSettingsValue>(DEFAULT_GENERAL_SETTINGS);
   const [servers, setServers] = createSignal<ServerSummary[]>([]);
   const [joinServerOpen, setJoinServerOpen] = createSignal(false);
   const [pendingInviteUrl, setPendingInviteUrl] = createSignal("");
@@ -315,6 +318,7 @@ export function createAppController(props: AppProps = {}) {
   let directConversationRequest = 0;
   let serverSettingsRequest = 0;
   let serverSettingsRestoreTarget: HTMLElement | null = null;
+  let appSettingsRestoreTarget: HTMLElement | null = null;
   let appFrameElement: HTMLDivElement | undefined;
   let remoteDesktopRestoreTarget: HTMLElement | null = null;
   let remoteDesktopConnectPromise: Promise<RemoteDesktopSession | undefined> | null = null;
@@ -1796,6 +1800,11 @@ export function createAppController(props: AppProps = {}) {
     }
   }
 
+  function openAppSettings(trigger: HTMLElement): void {
+    appSettingsRestoreTarget = trigger;
+    setAppSettingsOpen(true);
+  }
+
   async function selectServer(serverId: string): Promise<void> {
     if (botSetupOpen() && creatingAgent()) return;
     const previousServerId = servers().find((server) => server.active)?.id;
@@ -2391,6 +2400,12 @@ export function createAppController(props: AppProps = {}) {
     runUpdateAction,
     updateAccountAvatar,
     setPermissionsOpen,
+    appSettingsOpen,
+    setAppSettingsOpen,
+    generalSettings,
+    setGeneralSettings,
+    openAppSettings,
+    appSettingsRestoreTarget: () => appSettingsRestoreTarget,
     skillsMarketplaceOpen,
     setSkillsMarketplaceOpen,
     LEFT_PANEL_DEFAULT,

--- a/src/renderer/src/AppView.tsx
+++ b/src/renderer/src/AppView.tsx
@@ -32,6 +32,9 @@ const RemoteDesktopWorkspace = lazy(() =>
 const ServerSettingsModal = lazy(() =>
   import("./components/ServerSettingsModal").then((module) => ({ default: module.ServerSettingsModal })),
 );
+const SettingsModal = lazy(() =>
+  import("./components/SettingsModal").then((module) => ({ default: module.SettingsModal })),
+);
 const SkillsMarketplaceModal = lazy(() =>
   import("./components/SkillsMarketplaceModal").then((module) => ({ default: module.SkillsMarketplaceModal })),
 );
@@ -163,6 +166,8 @@ function WorkspaceShell(props: {
     updateAccountAvatar,
     logoutCentralAccount,
     setPermissionsOpen,
+    appSettingsOpen,
+    openAppSettings,
     setSkillsMarketplaceOpen,
     LEFT_PANEL_DEFAULT,
     LEFT_PANEL_MIN,
@@ -335,6 +340,7 @@ function WorkspaceShell(props: {
             onLogout={logoutCentralAccount}
             onOpenExternal={(destination) => window.openbot.openExternal(destination)}
             onOpenPermissions={() => setPermissionsOpen(true)}
+            onOpenSettings={openAppSettings}
             onOpenSkills={() => setSkillsMarketplaceOpen(true)}
           />
         </Loading>
@@ -434,7 +440,7 @@ function WorkspaceShell(props: {
           prompt={activeBot() ? pendingPrompts()[activeBot()?.id ?? ""] : undefined}
           approval={activeBot() ? pendingApprovals()[activeBot()?.id ?? ""] : undefined}
           activeTurnId={activeBot() ? activeTurns()[activeBot()?.id ?? ""] : null}
-          globalOverlayOpen={globalSearchOpen() || joinServerOpen() || serverSettingsOpen()}
+          globalOverlayOpen={globalSearchOpen() || joinServerOpen() || serverSettingsOpen() || appSettingsOpen()}
           settingsRequest={settingsRequest()}
           messageFocusRequest={messageFocusRequest()}
           onSelectAgent={selectBot}
@@ -477,6 +483,11 @@ function WorkspaceOverlays(props: {
   const {
     props: appProps,
     permissionsOpen,
+    appSettingsOpen,
+    setAppSettingsOpen,
+    generalSettings,
+    setGeneralSettings,
+    appSettingsRestoreTarget,
     skillsMarketplaceOpen,
     setSkillsMarketplaceOpen,
     setupState,
@@ -508,6 +519,8 @@ function WorkspaceOverlays(props: {
     updateServerMember,
     removeServerMember,
     revokeServerInvite,
+    updateStatus,
+    runUpdateAction,
     globalSearchOpen,
     botList,
     activeBot,
@@ -594,6 +607,18 @@ function WorkspaceOverlays(props: {
           </Loading>
         )}
       </Show>
+      <Loading>
+        <SettingsModal
+          open={appSettingsOpen()}
+          onOpenChange={setAppSettingsOpen}
+          value={generalSettings()}
+          onValueChange={setGeneralSettings}
+          appInfo={appInfo()}
+          updateStatus={updateStatus()}
+          onUpdateAction={runUpdateAction}
+          restoreFocusTarget={appSettingsRestoreTarget()}
+        />
+      </Loading>
       <Show when={globalSearchOpen()}>
         <Loading>
           <GlobalSearch

--- a/src/renderer/src/app-settings.ts
+++ b/src/renderer/src/app-settings.ts
@@ -1,0 +1,21 @@
+export type ExternalLinkTarget = "Default browser" | "OpenBot";
+
+export interface GeneralSettingsValue {
+  launchAtLogin: boolean;
+  keepRunningInBackground: boolean;
+  restoreLastWorkspace: boolean;
+  externalLinkTarget: ExternalLinkTarget;
+  desktopNotifications: boolean;
+  taskCompletionSound: boolean;
+  autoDownloadUpdates: boolean;
+}
+
+export const DEFAULT_GENERAL_SETTINGS: GeneralSettingsValue = {
+  launchAtLogin: true,
+  keepRunningInBackground: false,
+  restoreLastWorkspace: true,
+  externalLinkTarget: "Default browser",
+  desktopNotifications: true,
+  taskCompletionSound: false,
+  autoDownloadUpdates: true,
+};

--- a/src/renderer/src/components/AccountDock.tsx
+++ b/src/renderer/src/components/AccountDock.tsx
@@ -9,7 +9,8 @@ import type {
 } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, Show } from "solid-js";
 import { normalizeAvatarFile } from "../avatar-image";
-import { Badge, Button, buttonVariants, Input, Popover, Puzzle } from "./ui";
+import { presentUpdateStatus } from "../update-status";
+import { Badge, Button, buttonVariants, Input, Popover, Puzzle, Settings } from "./ui";
 
 interface AccountDockProps {
   account: CentralAuthUser;
@@ -25,6 +26,7 @@ interface AccountDockProps {
   onLogout: () => Promise<void>;
   onOpenExternal: (destination: ExternalDestination) => Promise<void>;
   onOpenPermissions: () => void;
+  onOpenSettings: (trigger: HTMLElement) => void;
   onOpenSkills: () => void;
 }
 
@@ -112,6 +114,7 @@ export function AccountDock(props: AccountDockProps) {
   const [avatarFailed, setAvatarFailed] = createSignal(false);
   const [loggingOut, setLoggingOut] = createSignal(false);
   let avatarInput: HTMLInputElement | undefined;
+  let triggerElement: HTMLButtonElement | undefined;
 
   const accountName = createMemo(() => props.account.name?.trim() || props.account.email);
   const accountInitials = createMemo(() => {
@@ -133,33 +136,7 @@ export function AccountDock(props: AccountDockProps) {
     const usage = weeklyUsage();
     return usage ? Math.max(0, Math.round(100 - usage.usedPercent)) : null;
   });
-  const updateAvailable = createMemo(() =>
-    ["available", "downloading", "ready", "installing"].includes(props.updateStatus.phase),
-  );
-  const updateBusy = createMemo(() => ["checking", "downloading", "installing"].includes(props.updateStatus.phase));
-  const updateLabel = createMemo(() => {
-    switch (props.updateStatus.phase) {
-      case "checking":
-        return "Checking for updates…";
-      case "available":
-        return "Download update";
-      case "downloading":
-        return "Downloading update…";
-      case "ready":
-        return "Restart to update";
-      case "installing":
-        return "Restarting…";
-      default:
-        return "Check for updates";
-    }
-  });
-  const updateDetail = createMemo(() => {
-    const status = props.updateStatus;
-    if (status.phase === "downloading" && status.progress !== null) return `${Math.round(status.progress)}%`;
-    if (status.availableVersion) return `v${status.availableVersion}`;
-    if (status.phase === "up-to-date") return "Up to date";
-    return status.currentVersion ? `v${status.currentVersion}` : "";
-  });
+  const updatePresentation = createMemo(() => presentUpdateStatus(props.updateStatus));
   const popoverError = createMemo(
     () => error() ?? (props.updateStatus.phase === "error" ? props.updateStatus.message : null),
   );
@@ -274,6 +251,7 @@ export function AccountDock(props: AccountDockProps) {
         gutter={8}
       >
         <Popover.Trigger
+          ref={(element) => (triggerElement = element)}
           as="button"
           type="button"
           class={buttonVariants({ variant: "ghost", class: "account-dock-trigger" })}
@@ -294,7 +272,7 @@ export function AccountDock(props: AccountDockProps) {
               )}
             </Show>
           </span>
-          <Show when={updateAvailable()}>
+          <Show when={updatePresentation().available}>
             <Badge class="sidebar-update-pill" tone="accent" shape="pill">
               Update
             </Badge>
@@ -354,11 +332,11 @@ export function AccountDock(props: AccountDockProps) {
                 type="button"
                 class="account-menu-row account-update-row"
                 onClick={runUpdateAction}
-                disabled={updateBusy()}
+                disabled={updatePresentation().busy}
               >
-                <UpdateIcon active={updateBusy()} />
-                <span>{updateLabel()}</span>
-                <small>{updateDetail()}</small>
+                <UpdateIcon active={updatePresentation().busy} />
+                <span>{updatePresentation().actionLabel}</span>
+                <small>{updatePresentation().detail}</small>
               </Button>
             </Show>
             <Button
@@ -374,6 +352,18 @@ export function AccountDock(props: AccountDockProps) {
             </Button>
 
             <div class="account-menu-separator" />
+            <Button
+              variant="ghost"
+              type="button"
+              class="account-menu-row"
+              onClick={() => {
+                setOpen(false);
+                if (triggerElement) props.onOpenSettings(triggerElement);
+              }}
+            >
+              <Settings class="account-menu-icon" />
+              <span>Settings</span>
+            </Button>
             <Button
               variant="ghost"
               type="button"

--- a/src/renderer/src/components/ServerSettingsModal.test.tsx
+++ b/src/renderer/src/components/ServerSettingsModal.test.tsx
@@ -116,13 +116,14 @@ describe("ServerSettingsModal", () => {
 
     const name = screen.getByRole("textbox", { name: "Server name" });
     expect(name).toHaveValue("");
+    expect(name).toHaveAttribute("placeholder", "e.g. Design studio");
     expect(screen.getByRole("switch", { name: "Publish this server" })).toBeDisabled();
 
     await fireEvent.input(name, { target: { value: "Draft Team" } });
     await fireEvent.click(screen.getByRole("button", { name: "Reset" }));
     expect(name).toHaveValue("");
     await fireEvent.input(name, { target: { value: "Studio Team" } });
-    await fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(onSaveIdentity).toHaveBeenCalledWith({ serverName: "Studio Team" }));
     expect(onSetPublished).not.toHaveBeenCalled();
@@ -136,7 +137,7 @@ describe("ServerSettingsModal", () => {
 
     const name = screen.getByRole("textbox", { name: "Server name" });
     await fireEvent.input(name, { target: { value: "Studio Team" } });
-    await fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("The identity could not save.");
     expect(name).toHaveValue("Studio Team");
@@ -174,11 +175,30 @@ describe("ServerSettingsModal", () => {
     expect(name).toHaveAttribute("aria-invalid", "true");
     expect(name).toHaveAttribute("aria-describedby", error.id);
 
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(name).toHaveFocus();
+
     await fireEvent.input(name, { target: { value: "Studio Team" } });
     expect(screen.queryByText("Enter at least 6 characters.")).not.toBeInTheDocument();
     expect(name).not.toHaveAttribute("aria-invalid");
     await fireEvent.keyDown(name, { key: "Enter" });
     await waitFor(() => expect(onSaveIdentity).toHaveBeenCalledWith({ serverName: "Studio Team" }));
+  });
+
+  it("returns an erased first setup name to its pristine state", async () => {
+    render(() => <ServerSettingsModal {...props()} />);
+
+    const name = screen.getByRole("textbox", { name: "Server name" });
+    await fireEvent.input(name, { target: { value: "Tiny" } });
+    await fireEvent.blur(name);
+    expect(screen.getByText("Enter at least 6 characters.")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Unsaved changes" })).toBeInTheDocument();
+
+    await fireEvent.input(name, { target: { value: "" } });
+
+    expect(screen.queryByText("Enter at least 6 characters.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Unsaved changes" })).not.toBeInTheDocument();
+    expect(name).not.toHaveAttribute("aria-invalid");
   });
 
   it("keeps remote member settings read-only", async () => {
@@ -286,5 +306,36 @@ describe("ServerSettingsModal", () => {
     await fireEvent.pointerUp(memberActions, { button: 0 });
     await fireEvent.pointerUp(await screen.findByRole("menuitem", { name: "Pause access" }), { button: 0 });
     await waitFor(() => expect(onUpdateMember).toHaveBeenCalledWith({ memberId: "alice-1", disabled: true }));
+  });
+
+  it("associates invite validation with the email field and creates invite links", async () => {
+    const onCreateInvite = vi.fn(async (input: { role: "admin" | "member"; email?: string }) => ({
+      id: "invite-new",
+      role: input.role,
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      usedAt: null,
+      inviteUrl: "https://studio.example.com/invite/new",
+      email: input.email ?? null,
+    }));
+    render(() => (
+      <ServerSettingsModal {...props({ server: remoteServer, hostStatus: null, members, onCreateInvite })} />
+    ));
+
+    await fireEvent.click(screen.getByRole("tab", { name: "Members" }));
+    const email = screen.getByRole("textbox", { name: "Email address" });
+    await fireEvent.input(email, { target: { value: "invalid" } });
+    await fireEvent.blur(email);
+
+    const error = screen.getByRole("alert");
+    expect(error).toHaveTextContent("Enter a valid email address.");
+    expect(email).toHaveAttribute("aria-invalid", "true");
+    expect(email).toHaveAttribute("aria-describedby", error.id);
+
+    await fireEvent.click(screen.getByRole("tab", { name: "Invite link" }));
+    expect(screen.queryByText("Enter a valid email address.")).not.toBeInTheDocument();
+    await fireEvent.click(screen.getByRole("button", { name: "Create link" }));
+
+    await waitFor(() => expect(onCreateInvite).toHaveBeenCalledWith({ role: "member" }));
+    expect(await screen.findByRole("button", { name: "Copy link" })).toBeInTheDocument();
   });
 });

--- a/src/renderer/src/components/ServerSettingsModal.tsx
+++ b/src/renderer/src/components/ServerSettingsModal.tsx
@@ -13,7 +13,7 @@ import { normalizeEmailAddress } from "@openbot/contracts/validation";
 import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
 import { normalizeAvatarFile } from "../avatar-image";
 import { SettingsDialogShell } from "./SettingsDialogShell";
-import { TeamPersonAvatar, teamMemberName } from "./TeamPersonAvatar";
+import { teamMemberName } from "./TeamPersonAvatar";
 import {
   Alert,
   AlertActions,
@@ -31,7 +31,7 @@ import {
   DropdownMenu,
   Ellipsis,
   Field,
-  Heading,
+  Image,
   Input,
   Item,
   ItemActions,
@@ -51,14 +51,18 @@ import {
   SelectTrigger,
   SelectValue,
   Settings,
+  SettingsSection,
   ShieldCheck,
+  SlidingTabs,
   SwitchField,
   Tabs,
   Text,
   Trash2,
   UserRound,
   UsersRound,
+  X,
 } from "./ui";
+import { truncateMiddle } from "./ui/utils";
 
 export interface ServerSettingsModalProps {
   open: boolean;
@@ -100,6 +104,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   const [draftLogo, setDraftLogo] = createSignal<AvatarImageInput | null | undefined>(undefined);
   const [identityEditing, setIdentityEditing] = createSignal(false);
   const [nameTouched, setNameTouched] = createSignal(false);
+  const [nameShaking, setNameShaking] = createSignal(false);
   const [logoError, setLogoError] = createSignal<string | null>(null);
   const [actionError, setActionError] = createSignal<string | null>(null);
   const [busy, setBusy] = createSignal<string | null>(null);
@@ -113,6 +118,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   const [now, setNow] = createSignal(Date.now());
   let modalElement: HTMLElement | undefined;
   let logoInput: HTMLInputElement | undefined;
+  let nameInput: HTMLInputElement | undefined;
   let removeMemberTrigger: HTMLElement | undefined;
   let syncedServerId = "";
   let expiryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -134,7 +140,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
       return `Use no more than ${INPUT_LIMITS.serverName} characters.`;
     return null;
   };
-  const visibleNameError = () => (identityEditing() && nameTouched() ? nameError() : null);
+  const visibleNameError = () => (nameTouched() ? nameError() : null);
   const identityDirty = () =>
     canEditIdentity() &&
     (trimmedName() !== savedName() || draftLogo() !== undefined || draftLogoUrl() !== savedLogoUrl());
@@ -148,7 +154,6 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
       [teamMemberName(member), member.email, member.username].some((value) => value?.toLowerCase().includes(query)),
     );
   });
-  const onlineCount = createMemo(() => props.members.filter((member) => member.online && !member.disabled).length);
   const removeMember = createMemo(() => props.members.find((member) => member.id === removeMemberId()) ?? null);
   const canInvite = createMemo(
     () =>
@@ -173,6 +178,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
         setSection("general");
         setIdentityEditing(false);
         setNameTouched(false);
+        setNameShaking(false);
         setMemberSearch("");
         setActionError(null);
         setInviteResult(null);
@@ -184,6 +190,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
         setDraftLogoUrl(logoUrl);
         setDraftLogo(undefined);
         setNameTouched(false);
+        setNameShaking(false);
       }
     },
   );
@@ -244,13 +251,42 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
     setDraftLogo(undefined);
     setIdentityEditing(false);
     setNameTouched(false);
+    setNameShaking(false);
     setLogoError(null);
     setActionError(null);
   }
 
+  function updateDraftName(value: string): void {
+    const namePristine = value.trim() === savedName();
+    const logoPristine = draftLogo() === undefined && draftLogoUrl() === savedLogoUrl();
+    setDraftName(value);
+    setIdentityEditing(!(namePristine && logoPristine));
+    if (namePristine) {
+      setNameTouched(false);
+      setNameShaking(false);
+    } else if (!nameError()) {
+      setNameShaking(false);
+    }
+    setActionError(null);
+  }
+
+  function restartNameShake(): void {
+    setNameShaking(false);
+    queueMicrotask(() => {
+      if (!nameInput || !nameError()) return;
+      void nameInput.offsetWidth;
+      setNameShaking(true);
+    });
+  }
+
   async function saveIdentity(): Promise<void> {
     setNameTouched(true);
-    if (!identityDirty() || nameError()) return;
+    if (nameError()) {
+      restartNameShake();
+      queueMicrotask(() => nameInput?.focus({ preventScroll: true }));
+      return;
+    }
+    if (!identityDirty()) return;
     const logo = draftLogo();
     const saved = await run("identity", () =>
       props.onSaveIdentity({
@@ -264,6 +300,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
     setDraftLogo(undefined);
     setIdentityEditing(false);
     setNameTouched(false);
+    setNameShaking(false);
   }
 
   function showCopyError(): void {
@@ -355,13 +392,10 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
         }
         footer={
           <Show when={section() === "general" && identityDirty()}>
-            <section class="server-settings-save-bar" aria-label="Unsaved identity changes">
-              <div class="server-settings-save-copy">
-                <span class="server-settings-save-dot" aria-hidden="true" />
-                <Text variant="caption" tone="secondary">
-                  Unsaved identity changes
-                </Text>
-              </div>
+            <section class="server-settings-save-bar" aria-label="Unsaved changes">
+              <Text variant="caption" tone="muted">
+                Changes not saved
+              </Text>
               <div class="server-settings-save-actions">
                 <Button type="button" size="sm" variant="ghost" disabled={Boolean(busy())} onClick={resetIdentity}>
                   Reset
@@ -375,7 +409,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                   disabled={Boolean(busy())}
                   onClick={() => void saveIdentity()}
                 >
-                  Save changes
+                  Save
                 </Button>
               </div>
             </section>
@@ -471,13 +505,10 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   function GeneralPanel() {
     return (
       <>
-        <section class="server-settings-general-section" aria-labelledby="server-identity-heading">
-          <Heading id="server-identity-heading" class="server-settings-section-heading" as="h3" size="sm">
-            Identity
-          </Heading>
+        <SettingsSection title="Identity">
           <Input
             ref={(element) => (logoInput = element)}
-            class="sr-only"
+            hidden
             type="file"
             aria-label="Server logo"
             accept="image/png,image/jpeg,image/webp"
@@ -488,49 +519,6 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
             }}
           />
           <ItemGroup class="server-settings-general-card">
-            <Item class="server-settings-logo-row">
-              <ItemContent>
-                <ItemTitle>Server logo</ItemTitle>
-                <ItemDescription class={logoError() ? "server-settings-item-error" : undefined}>
-                  {logoError() ??
-                    (canEditIdentity()
-                      ? "Shown to everyone who connects."
-                      : "Only the server owner can change this logo.")}
-                </ItemDescription>
-              </ItemContent>
-              <ItemActions class="server-settings-logo-control">
-                <ServerLogo name={draftName() || props.server.name} url={draftLogoUrl()} />
-                <Show when={canEditIdentity()}>
-                  <div class="server-settings-logo-actions">
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="secondary"
-                      aria-label="Change server logo"
-                      onClick={() => logoInput?.click()}
-                    >
-                      Change
-                    </Button>
-                    <Show when={draftLogoUrl()}>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="ghost"
-                        aria-label="Remove server logo"
-                        onClick={() => {
-                          setIdentityEditing(true);
-                          setDraftLogoUrl(null);
-                          setDraftLogo(null);
-                          setLogoError(null);
-                        }}
-                      >
-                        Remove
-                      </Button>
-                    </Show>
-                  </div>
-                </Show>
-              </ItemActions>
-            </Item>
             <Show
               when={canEditIdentity()}
               fallback={
@@ -547,38 +535,107 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 </Item>
               }
             >
-              <Field
-                class="server-settings-name-field"
-                label="Server name"
-                description="Shown in invitations and shared spaces."
-                error={visibleNameError() ?? undefined}
-                htmlFor="server-settings-name"
-              >
-                <Input
-                  id="server-settings-name"
-                  size="md"
-                  maxlength={INPUT_LIMITS.serverName}
-                  value={draftName()}
-                  onValueChange={(value) => {
-                    setIdentityEditing(true);
-                    setDraftName(value);
-                    setActionError(null);
-                  }}
-                  onBlur={() => setNameTouched(true)}
-                  onKeyDown={(event) => {
-                    if (event.key !== "Enter" || event.isComposing) return;
-                    event.preventDefault();
-                    void saveIdentity();
-                  }}
-                />
-              </Field>
+              <Item class="server-settings-name-row">
+                <ItemContent>
+                  <ItemTitle id="server-settings-name-label">Server name</ItemTitle>
+                  <ItemDescription id="server-settings-name-description">
+                    Shown in invitations and shared spaces.
+                  </ItemDescription>
+                </ItemContent>
+                <ItemActions class="server-settings-name-control" data-invalid={visibleNameError() ? "" : undefined}>
+                  <Input
+                    ref={(element) => (nameInput = element)}
+                    class={nameShaking() ? "server-settings-name-input is-shaking" : "server-settings-name-input"}
+                    id="server-settings-name"
+                    size="md"
+                    maxlength={INPUT_LIMITS.serverName}
+                    placeholder="e.g. Design studio"
+                    value={draftName()}
+                    aria-labelledby="server-settings-name-label"
+                    aria-describedby={
+                      visibleNameError() ? "server-settings-name-error" : "server-settings-name-description"
+                    }
+                    aria-invalid={visibleNameError() ? "true" : undefined}
+                    onValueChange={updateDraftName}
+                    onBlur={() => {
+                      if (trimmedName() === savedName()) return;
+                      setNameTouched(true);
+                      if (nameError()) restartNameShake();
+                    }}
+                    onAnimationEnd={() => setNameShaking(false)}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" || event.isComposing) return;
+                      event.preventDefault();
+                      void saveIdentity();
+                    }}
+                  />
+                  <span
+                    id="server-settings-name-error"
+                    class="ui-field-error server-settings-name-error"
+                    role="alert"
+                    aria-hidden={visibleNameError() ? undefined : "true"}
+                  >
+                    {visibleNameError() ?? ""}
+                  </span>
+                </ItemActions>
+              </Item>
             </Show>
+            <Item class="server-settings-logo-row">
+              <ItemContent>
+                <ItemTitle>Server logo</ItemTitle>
+                <ItemDescription class={logoError() ? "server-settings-item-error" : undefined}>
+                  {logoError() ??
+                    (canEditIdentity()
+                      ? "Shown to everyone who connects."
+                      : "Only the server owner can change this logo.")}
+                </ItemDescription>
+              </ItemContent>
+              <ItemActions class="server-settings-logo-control">
+                <Show
+                  when={canEditIdentity()}
+                  fallback={<ServerLogo name={draftName() || props.server.name} url={draftLogoUrl()} />}
+                >
+                  <div class="server-settings-logo-picker">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon-lg"
+                      class="server-settings-logo-trigger"
+                      aria-label={draftLogoUrl() ? "Edit server logo" : "Add server logo"}
+                      onClick={() => logoInput?.click()}
+                    >
+                      <Show
+                        when={draftLogoUrl()}
+                        fallback={<Image class="server-settings-logo-placeholder" aria-hidden="true" />}
+                      >
+                        {(logoUrl) => <ServerLogo name={draftName() || props.server.name} url={logoUrl()} />}
+                      </Show>
+                    </Button>
+                    <Show when={draftLogoUrl()}>
+                      <Button
+                        type="button"
+                        variant="destructive-ghost"
+                        size="icon-xs"
+                        class="server-settings-logo-remove"
+                        aria-label="Remove server logo"
+                        title="Remove server logo"
+                        onClick={() => {
+                          setIdentityEditing(true);
+                          setDraftLogoUrl(null);
+                          setDraftLogo(null);
+                          setLogoError(null);
+                        }}
+                      >
+                        <X aria-hidden="true" />
+                      </Button>
+                    </Show>
+                  </div>
+                </Show>
+              </ItemActions>
+            </Item>
           </ItemGroup>
-        </section>
-        <section class="server-settings-general-section" aria-labelledby="server-access-heading">
-          <Heading id="server-access-heading" class="server-settings-section-heading" as="h3" size="sm">
-            Access
-          </Heading>
+        </SettingsSection>
+        <SettingsSection title="Access">
           <ItemGroup class="server-settings-general-card">
             <SwitchField
               class="server-settings-publish-setting"
@@ -594,19 +651,29 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 <ItemTitle>Server address</ItemTitle>
                 <ItemDescription>Use this address to connect to the server.</ItemDescription>
               </ItemContent>
-              <ItemActions class="server-settings-address-control">
-                <code>{address() ?? "Not available while private"}</code>
-                <CopyButton
-                  value={address()}
-                  label="Copy"
-                  aria-label="Copy server address"
-                  onCopyError={showCopyError}
-                  class="server-settings-copy-button"
-                />
-              </ItemActions>
+              <Show
+                when={address()}
+                fallback={
+                  <Badge tone="neutral" size="md" shape="pill">
+                    Private
+                  </Badge>
+                }
+              >
+                {(serverAddress) => (
+                  <CopyButton
+                    value={serverAddress()}
+                    label={truncateMiddle(serverAddress(), 31)}
+                    copiedLabel="Copied"
+                    aria-label="Copy server address"
+                    title={serverAddress()}
+                    onCopyError={showCopyError}
+                    class="server-settings-address-control"
+                  />
+                )}
+              </Show>
             </Item>
           </ItemGroup>
-        </section>
+        </SettingsSection>
       </>
     );
   }
@@ -615,7 +682,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
     return (
       <>
         <Show when={!configured() || !published()}>
-          <Alert tone="warning" role="status">
+          <Alert class="server-settings-members-alert" tone="warning" role="status">
             <AlertIcon>
               <ShieldCheck />
             </AlertIcon>
@@ -630,36 +697,42 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
           </Alert>
         </Show>
         <Show when={canManage()}>{inviteComposer()}</Show>
-        <section class="settings-modal-group" aria-labelledby="server-members-heading">
-          <div class="server-settings-section-title server-settings-members-heading">
-            <div>
-              <Heading id="server-members-heading" as="h3" size="sm" tone="secondary">
-                Server members
-              </Heading>
-              <Text variant="caption" tone="muted">
-                {props.members.length} members · {onlineCount()} online
-              </Text>
-            </div>
+        <SettingsSection
+          class="server-settings-members-section"
+          title="Server members"
+          description={<>{props.members.length} members</>}
+          actions={
             <label class="server-settings-search">
               <Search aria-hidden="true" />
               <span class="sr-only">Search members</span>
               <Input
+                size="sm"
                 type="search"
                 placeholder="Search members"
                 value={memberSearch()}
                 onValueChange={setMemberSearch}
               />
             </label>
-          </div>
-          <ItemGroup class="server-settings-people-card server-settings-members-list" data-testid="server-members-list">
+          }
+        >
+          <ItemGroup
+            class="server-settings-general-card server-settings-members-list"
+            data-testid="server-members-list"
+          >
             <Show
               when={filteredMembers().length > 0}
-              fallback={<p class="server-settings-empty">No members match this search.</p>}
+              fallback={
+                <Item class="server-settings-empty-row">
+                  <ItemContent>
+                    <ItemDescription>No members match this search.</ItemDescription>
+                  </ItemContent>
+                </Item>
+              }
             >
               <For each={filteredMembers()}>{(member) => memberRow(member)}</For>
             </Show>
           </ItemGroup>
-        </section>
+        </SettingsSection>
         <Show when={canManage()}>{pendingInvites()}</Show>
       </>
     );
@@ -667,46 +740,49 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
 
   function inviteComposer() {
     return (
-      <section class="settings-modal-group" aria-labelledby="invite-people-heading">
-        <Heading id="invite-people-heading" as="h3" size="sm" tone="secondary">
-          Invite people
-        </Heading>
-        <Card class="server-settings-people-card server-settings-invite-card">
-          <Tabs.Root {...inviteTabsProps}>
-            <Tabs.List class="server-settings-invite-tabs" aria-label="Invitation method">
-              <Tabs.Trigger value="email">Email</Tabs.Trigger>
-              <Tabs.Trigger value="link">Invite link</Tabs.Trigger>
-            </Tabs.List>
+      <SlidingTabs.Root {...inviteTabsProps}>
+        <SettingsSection
+          class="server-settings-invite-section"
+          title="Invite people"
+          description="Invitations can be used once and expire after 24 hours."
+          actions={
+            <SlidingTabs.List aria-label="Invitation method">
+              <SlidingTabs.Trigger value="email">Email</SlidingTabs.Trigger>
+              <SlidingTabs.Trigger value="link">Invite link</SlidingTabs.Trigger>
+            </SlidingTabs.List>
+          }
+        >
+          <Card class="server-settings-invite-card">
             <div class="server-settings-invite-composer">
-              <Tabs.Content value="email" class="server-settings-invite-mode-panel">
-                <label class="server-settings-invite-email-control">
-                  <span class="sr-only">Email address</span>
-                  <Input
-                    size="lg"
-                    type="email"
-                    autocomplete="email"
-                    maxlength={INPUT_LIMITS.email}
-                    disabled={!published()}
-                    aria-invalid={inviteEmailError() ? "true" : undefined}
-                    placeholder="person@company.com"
-                    value={inviteEmail()}
-                    onValueChange={(value) => {
-                      setInviteEmail(value);
-                      setInviteEmailError(null);
-                    }}
-                    onBlur={() =>
-                      inviteEmail() &&
-                      !normalizeEmailAddress(inviteEmail()) &&
-                      setInviteEmailError("Enter a valid email address.")
-                    }
-                  />
-                </label>
-              </Tabs.Content>
-              <Tabs.Content value="link" class="server-settings-invite-mode-panel">
-                <Text variant="body-sm" tone="secondary">
-                  Create a private one-time link.
-                </Text>
-              </Tabs.Content>
+              <SlidingTabs.ContentSlot>
+                <SlidingTabs.Content value="email" class="server-settings-invite-mode-panel">
+                  <Field class="server-settings-invite-email-field" label="Email address" error={inviteEmailError()}>
+                    <Input
+                      size="md"
+                      type="email"
+                      autocomplete="email"
+                      maxlength={INPUT_LIMITS.email}
+                      disabled={!published()}
+                      placeholder="person@company.com"
+                      value={inviteEmail()}
+                      onValueChange={(value) => {
+                        setInviteEmail(value);
+                        setInviteEmailError(null);
+                      }}
+                      onBlur={() =>
+                        inviteEmail() &&
+                        !normalizeEmailAddress(inviteEmail()) &&
+                        setInviteEmailError("Enter a valid email address.")
+                      }
+                    />
+                  </Field>
+                </SlidingTabs.Content>
+                <SlidingTabs.Content value="link" class="server-settings-invite-mode-panel">
+                  <Text variant="body-sm" tone="secondary">
+                    Create a private one-time link.
+                  </Text>
+                </SlidingTabs.Content>
+              </SlidingTabs.ContentSlot>
               <Select<string>
                 options={ROLE_OPTIONS}
                 value={roleLabel(inviteRole())}
@@ -715,14 +791,14 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 onChange={(value) => value && setInviteRole(value === "Admin" ? "admin" : "member")}
                 itemComponent={(item) => <SelectItem item={item.item}>{item.item.rawValue}</SelectItem>}
               >
-                <SelectTrigger class="server-settings-role-select" aria-label="Invitation role">
+                <SelectTrigger class="server-settings-role-select" size="sm" aria-label="Invitation role">
                   <SelectValue<string>>{(state) => state.selectedOption()}</SelectValue>
                 </SelectTrigger>
                 <SelectContent />
               </Select>
               <Button
                 type="button"
-                size="default"
+                size="sm"
                 variant="default"
                 loading={busy() === "invite"}
                 disabled={!canInvite()}
@@ -731,16 +807,6 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 {inviteMode() === "email" ? "Send invite" : "Create link"}
               </Button>
             </div>
-            <Show when={inviteEmailError()}>
-              {(message) => (
-                <Text variant="caption" tone="danger" role="alert">
-                  {message()}
-                </Text>
-              )}
-            </Show>
-            <Text class="server-settings-invite-help" variant="caption" tone="muted">
-              Invitations can be used once and expire after 24 hours.
-            </Text>
             <Show when={inviteResult()}>
               {(result) => (
                 <Alert class="server-settings-invite-result" tone="success" role="status">
@@ -759,31 +825,18 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 </Alert>
               )}
             </Show>
-          </Tabs.Root>
-        </Card>
-      </section>
+          </Card>
+        </SettingsSection>
+      </SlidingTabs.Root>
     );
   }
 
   function memberRow(member: TeamPresenceMember) {
     return (
       <Item class="server-settings-member-row" data-disabled={member.disabled ? "" : undefined}>
-        <ItemMedia>
-          <TeamPersonAvatar member={member} />
-        </ItemMedia>
         <ItemContent>
           <ItemTitle>{teamMemberName(member)}</ItemTitle>
-          <ItemDescription class="server-settings-member-meta">
-            <span>{member.email ?? member.username}</span>
-            <span aria-hidden="true">·</span>
-            <span
-              class="server-settings-member-status"
-              data-state={member.disabled ? "paused" : member.online ? "online" : "offline"}
-            >
-              <span aria-hidden="true" />
-              {member.disabled ? "Paused" : member.online ? "Online" : "Offline"}
-            </span>
-          </ItemDescription>
+          <ItemDescription class="server-settings-member-meta">{member.email ?? member.username}</ItemDescription>
         </ItemContent>
         <ItemActions class="server-settings-member-actions">
           <Show when={member.role !== "owner"} fallback={<Badge tone="accent">Owner</Badge>}>
@@ -814,23 +867,28 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
 
   function pendingInvites() {
     return (
-      <section class="settings-modal-group" aria-labelledby="pending-invitations-heading">
-        <div class="server-settings-section-title">
-          <Heading id="pending-invitations-heading" as="h3" size="sm" tone="secondary">
-            Pending invitations
-          </Heading>
+      <SettingsSection
+        title="Pending invitations"
+        actions={
           <Text variant="caption" tone="muted">
             {activeInvites().length} pending
           </Text>
-        </div>
-        <ItemGroup class="server-settings-people-card server-settings-invites-list">
+        }
+      >
+        <ItemGroup class="server-settings-general-card server-settings-invites-list">
           <Show
             when={activeInvites().length > 0}
-            fallback={<p class="server-settings-empty">No pending invitations.</p>}
+            fallback={
+              <Item class="server-settings-empty-row">
+                <ItemContent>
+                  <ItemDescription>No pending invitations.</ItemDescription>
+                </ItemContent>
+              </Item>
+            }
           >
             <For each={activeInvites()}>
               {(invite) => (
-                <Item class="server-settings-invite-row" size="compact">
+                <Item class="server-settings-invite-row">
                   <ItemContent>
                     <ItemTitle>{invite.email ?? "Private invitation link"}</ItemTitle>
                     <ItemDescription>
@@ -841,7 +899,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                     <Button
                       type="button"
                       size="sm"
-                      variant="ghost"
+                      variant="destructive-ghost"
                       disabled={!actionsAvailable() || Boolean(busy())}
                       onClick={() => void run(`invite:${invite.id}`, () => props.onRevokeInvite(invite.id))}
                     >
@@ -853,16 +911,13 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
             </For>
           </Show>
         </ItemGroup>
-      </section>
+      </SettingsSection>
     );
   }
 
   function DesktopPanel() {
     return (
-      <section class="server-settings-general-section" aria-labelledby="remote-desktop-heading">
-        <Heading id="remote-desktop-heading" class="server-settings-section-heading" as="h3" size="sm">
-          Remote desktop access
-        </Heading>
+      <SettingsSection title="Remote desktop access">
         <ItemGroup class="server-settings-general-card server-settings-desktop-card">
           <Show when={local()} fallback={remoteDesktopConnection()}>
             <Item size="spacious">
@@ -888,7 +943,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
             </Item>
           </Show>
         </ItemGroup>
-      </section>
+      </SettingsSection>
     );
   }
 

--- a/src/renderer/src/components/SettingsDialogShell.tsx
+++ b/src/renderer/src/components/SettingsDialogShell.tsx
@@ -128,6 +128,9 @@ export function SettingsDialogShell(props: SettingsDialogShellProps) {
           class="settings-modal-backdrop"
           data-motion={closing() ? "closing" : "open"}
           data-testid="settings-modal-backdrop"
+          onPointerDown={(event) => {
+            if (event.target === event.currentTarget) requestOpenChange(false);
+          }}
         >
           <Dialog.Content
             as="section"

--- a/src/renderer/src/components/SettingsModal.test.tsx
+++ b/src/renderer/src/components/SettingsModal.test.tsx
@@ -1,0 +1,115 @@
+import type { UpdateStatus } from "@openbot/contracts/ipc";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_GENERAL_SETTINGS } from "../app-settings";
+import { SettingsModal } from "./SettingsModal";
+
+const idleUpdateStatus: UpdateStatus = {
+  phase: "idle",
+  currentVersion: "0.2.1",
+  availableVersion: null,
+  progress: null,
+  checkedAt: null,
+  message: null,
+};
+
+describe("SettingsModal", () => {
+  it("keeps General preferences controlled across close and reopen", async () => {
+    const [open, setOpen] = createSignal(true);
+    const [value, setValue] = createSignal({ ...DEFAULT_GENERAL_SETTINGS });
+    let openTrigger: HTMLButtonElement | undefined;
+
+    render(() => (
+      <>
+        <button ref={(element) => (openTrigger = element)} type="button" onClick={() => setOpen(true)}>
+          Open settings
+        </button>
+        <SettingsModal
+          open={open()}
+          onOpenChange={setOpen}
+          value={value()}
+          onValueChange={setValue}
+          appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+          updateStatus={idleUpdateStatus}
+          onUpdateAction={vi.fn(async () => undefined)}
+          restoreFocusTarget={openTrigger}
+        />
+      </>
+    ));
+
+    const launchSwitch = screen.getByRole("switch", { name: "Launch OpenBot at login" });
+    await fireEvent.click(launchSwitch);
+    expect(value().launchAtLogin).toBe(false);
+
+    const select = screen.getByRole("button", { name: /^Open external links in/ });
+    await fireEvent.pointerDown(select, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "OpenBot" }));
+    expect(value().externalLinkTarget).toBe("OpenBot");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Close settings" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "General" })).not.toBeInTheDocument());
+    await fireEvent.click(screen.getByRole("button", { name: "Open settings" }));
+
+    expect(await screen.findByRole("switch", { name: "Launch OpenBot at login" })).not.toBeChecked();
+    expect(screen.getByRole("button", { name: /^Open external links in/ })).toHaveTextContent("OpenBot");
+  });
+
+  it("runs the updater and reflects its live status", async () => {
+    const [status, setStatus] = createSignal<UpdateStatus>(idleUpdateStatus);
+    const onUpdateAction = vi.fn(async () => {
+      setStatus({ ...idleUpdateStatus, phase: "up-to-date", checkedAt: "2026-08-26T12:00:00.000Z" });
+    });
+
+    render(() => (
+      <SettingsModal
+        open
+        onOpenChange={() => undefined}
+        value={DEFAULT_GENERAL_SETTINGS}
+        onValueChange={() => undefined}
+        appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+        updateStatus={status()}
+        onUpdateAction={onUpdateAction}
+      />
+    ));
+
+    await fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+    await waitFor(() => expect(onUpdateAction).toHaveBeenCalledOnce());
+    expect(await screen.findByText("OpenBot is up to date.")).toBeInTheDocument();
+  });
+
+  it("disables busy update actions and shows action failures", async () => {
+    const onUpdateAction = vi.fn(async () => {
+      throw new Error("Update service is offline.");
+    });
+    const view = render(() => (
+      <SettingsModal
+        open
+        onOpenChange={() => undefined}
+        value={DEFAULT_GENERAL_SETTINGS}
+        onValueChange={() => undefined}
+        appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+        updateStatus={idleUpdateStatus}
+        onUpdateAction={onUpdateAction}
+      />
+    ));
+
+    await fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+    expect(await screen.findByText("Update service is offline.")).toBeInTheDocument();
+
+    view.unmount();
+    render(() => (
+      <SettingsModal
+        open
+        onOpenChange={() => undefined}
+        value={DEFAULT_GENERAL_SETTINGS}
+        onValueChange={() => undefined}
+        appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+        updateStatus={{ ...idleUpdateStatus, phase: "checking" }}
+        onUpdateAction={onUpdateAction}
+      />
+    ));
+
+    expect(screen.getByRole("button", { name: "Checking for updates…" })).toBeDisabled();
+  });
+});

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,20 +1,32 @@
-import { createSignal, Show } from "solid-js";
+import type { AppInfo, UpdateStatus } from "@openbot/contracts/ipc";
+import { createMemo, createSignal } from "solid-js";
+import type { GeneralSettingsValue } from "../app-settings";
+import { presentUpdateStatus } from "../update-status";
 import { SettingsDialogShell } from "./SettingsDialogShell";
 import {
   Badge,
   Bell,
   Button,
   Card,
-  Check,
-  ChevronDown,
   Field,
-  Heading,
   Input,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemTitle,
   Palette,
-  SelectPrimitive,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Settings,
+  SettingsSection,
   SlidersHorizontal,
   SwitchField,
+  Tabs,
   Text,
   UserRound,
 } from "./ui";
@@ -22,6 +34,12 @@ import {
 export interface SettingsModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  value: GeneralSettingsValue;
+  onValueChange: (value: GeneralSettingsValue) => void;
+  appInfo: AppInfo | null;
+  updateStatus: UpdateStatus;
+  onUpdateAction: () => Promise<void>;
+  restoreFocusTarget?: HTMLElement | null;
 }
 
 type SettingsTab = "general" | "profile";
@@ -43,48 +61,70 @@ const navItems: ReadonlyArray<SettingsNavItem> = [
   { value: "advanced", label: "Advanced", icon: SlidersHorizontal, enabled: false },
 ];
 
-const linkTargetOptions = ["Default browser", "OpenBot"];
+const linkTargetOptions: GeneralSettingsValue["externalLinkTarget"][] = ["Default browser", "OpenBot"];
 
 export function SettingsModal(props: SettingsModalProps) {
   const [activeTab, setActiveTab] = createSignal<SettingsTab>("general");
-  const [linkTarget, setLinkTarget] = createSignal("Default browser");
   const [profileName, setProfileName] = createSignal("OpenBot user");
-  const [updateChecked, setUpdateChecked] = createSignal(false);
+  const [updateError, setUpdateError] = createSignal<string | null>(null);
   let modalElement: HTMLElement | undefined;
-
-  function selectTab(tab: SettingsTab): void {
-    setActiveTab(tab);
-  }
 
   const title = () => (activeTab() === "general" ? "General" : "Profile");
   const description = () =>
     activeTab() === "general" ? "Control how OpenBot behaves on this computer." : "Manage how you appear in OpenBot.";
+  const updatePresentation = createMemo(() => presentUpdateStatus(props.updateStatus));
+  const installedVersion = () => props.updateStatus.currentVersion || props.appInfo?.version || "Unknown";
+  const updateMessage = () =>
+    updateError() ??
+    (props.updateStatus.phase === "error" ? props.updateStatus.message : null) ??
+    (props.updateStatus.phase === "up-to-date" ? "OpenBot is up to date." : "Installed version");
+  const tabsProps = {
+    get value() {
+      return activeTab();
+    },
+    onChange(value: string) {
+      if (value === "general" || value === "profile") setActiveTab(value);
+    },
+    orientation: "vertical" as const,
+    activationMode: "automatic" as const,
+  };
+
+  function updateSetting<Key extends keyof GeneralSettingsValue>(key: Key, value: GeneralSettingsValue[Key]): void {
+    props.onValueChange({ ...props.value, [key]: value });
+  }
+
+  async function runUpdateAction(): Promise<void> {
+    if (updatePresentation().busy || !updatePresentation().supported) return;
+    setUpdateError(null);
+    try {
+      await props.onUpdateAction();
+    } catch (error) {
+      setUpdateError(error instanceof Error ? error.message : "Could not update OpenBot.");
+    }
+  }
 
   return (
-    <SettingsDialogShell
-      open={props.open}
-      onOpenChange={props.onOpenChange}
-      title={title()}
-      description={description()}
-      contentKey={activeTab()}
-      onContentElement={(element) => (modalElement = element)}
-      sidebar={
-        <>
-          <Text class="settings-modal-label" variant="label" tone="secondary">
-            Settings
-          </Text>
-          <nav class="settings-modal-nav" aria-label="Settings sections">
+    <Tabs.Root {...tabsProps}>
+      <SettingsDialogShell
+        class="app-settings-modal-shell"
+        open={props.open}
+        onOpenChange={props.onOpenChange}
+        title={title()}
+        description={description()}
+        contentKey={activeTab()}
+        restoreFocusTarget={props.restoreFocusTarget}
+        onContentElement={(element) => (modalElement = element)}
+        sidebar={
+          <Tabs.List class="settings-modal-nav" aria-label="Settings sections">
             {navItems.map((item) => {
               const NavIcon = item.icon;
               return (
-                <Button
-                  type="button"
+                <Tabs.Trigger
                   class="settings-modal-nav-item"
-                  variant="ghost"
-                  aria-current={activeTab() === item.value ? "page" : undefined}
+                  value={item.value}
                   disabled={!item.enabled}
                   title={item.enabled ? undefined : "Coming soon"}
-                  onClick={() => item.enabled && selectTab(item.value)}
+                  aria-current={activeTab() === item.value ? "page" : undefined}
                 >
                   <NavIcon aria-hidden="true" />
                   <span>{item.label}</span>
@@ -93,174 +133,159 @@ export function SettingsModal(props: SettingsModalProps) {
                       Soon
                     </span>
                   )}
-                </Button>
+                </Tabs.Trigger>
               );
             })}
-          </nav>
-        </>
-      }
-    >
-      <Show
-        when={activeTab() === "general"}
-        fallback={
-          <div class="settings-modal-tab-panel" data-tab="profile">
-            <section class="settings-modal-group" aria-labelledby="settings-profile-account">
-              <Heading id="settings-profile-account" as="h3" size="sm" tone="secondary">
-                Account
-              </Heading>
-              <Card class="settings-modal-card settings-modal-profile-card">
-                <div class="settings-modal-profile-summary">
-                  <div class="settings-modal-avatar" aria-hidden="true">
-                    OB
-                  </div>
-                  <div class="settings-modal-profile-copy">
-                    <span class="settings-modal-row-title">{profileName()}</span>
-                    <Text tone="muted" variant="caption">
-                      person@example.com
-                    </Text>
-                  </div>
-                  <Button variant="outline" type="button" size="sm">
-                    Change avatar
-                  </Button>
-                </div>
-              </Card>
-            </section>
-
-            <section class="settings-modal-group" aria-labelledby="settings-profile-details">
-              <Heading id="settings-profile-details" as="h3" size="sm" tone="secondary">
-                Profile details
-              </Heading>
-              <Card class="settings-modal-card settings-modal-profile-fields">
-                <Field
-                  label="Display name"
-                  description="This name is visible in shared workspaces."
-                  htmlFor="settings-profile-name"
-                >
-                  <Input id="settings-profile-name" value={profileName()} onValueChange={setProfileName} />
-                </Field>
-                <SwitchField
-                  defaultChecked
-                  label="Show activity status"
-                  description="Let workspace members see when you are active."
-                />
-              </Card>
-            </section>
-          </div>
+          </Tabs.List>
         }
       >
-        <div class="settings-modal-tab-panel" data-tab="general">
-          <section class="settings-modal-group" aria-labelledby="settings-app-behavior">
-            <Heading id="settings-app-behavior" as="h3" size="sm" tone="secondary">
-              App behavior
-            </Heading>
-            <Card class="settings-modal-card">
+        <Tabs.Content value="general" class="settings-modal-tab-panel" data-tab="general">
+          <SettingsSection title="App behavior">
+            <ItemGroup class="settings-modal-card" surface="subtle">
               <SwitchField
-                defaultChecked
+                checked={props.value.launchAtLogin}
+                onChange={(checked) => updateSetting("launchAtLogin", checked)}
                 label="Launch OpenBot at login"
                 description="Open the app when you sign in to this computer."
               />
               <SwitchField
+                checked={props.value.keepRunningInBackground}
+                onChange={(checked) => updateSetting("keepRunningInBackground", checked)}
                 label="Keep OpenBot running in the background"
                 description="Keep active tasks running after you close the window."
               />
-            </Card>
-          </section>
+            </ItemGroup>
+          </SettingsSection>
 
-          <section class="settings-modal-group" aria-labelledby="settings-workspace">
-            <Heading id="settings-workspace" as="h3" size="sm" tone="secondary">
-              Workspace
-            </Heading>
-            <Card class="settings-modal-card">
+          <SettingsSection title="Workspace">
+            <ItemGroup class="settings-modal-card" surface="subtle">
               <SwitchField
-                defaultChecked
+                checked={props.value.restoreLastWorkspace}
+                onChange={(checked) => updateSetting("restoreLastWorkspace", checked)}
                 label="Restore the last workspace on launch"
                 description="Open the workspace and tasks from your previous session."
               />
-              <div class="settings-modal-row">
-                <div class="settings-modal-row-copy">
-                  <span class="settings-modal-row-title">Open external links in</span>
-                  <Text tone="muted" variant="caption">
-                    Choose where links from conversations open.
-                  </Text>
-                </div>
-                <SelectPrimitive.Root<string>
-                  options={linkTargetOptions}
-                  value={linkTarget()}
-                  onChange={(value) => value && setLinkTarget(value)}
-                  placement="bottom-end"
-                  gutter={4}
-                  sameWidth
-                  itemComponent={(selectProps) => (
-                    <SelectPrimitive.Item class="settings-modal-select-item" item={selectProps.item}>
-                      <SelectPrimitive.ItemLabel>{selectProps.item.rawValue}</SelectPrimitive.ItemLabel>
-                      <SelectPrimitive.ItemIndicator class="settings-modal-select-indicator">
-                        <Check aria-hidden="true" />
-                      </SelectPrimitive.ItemIndicator>
-                    </SelectPrimitive.Item>
-                  )}
-                >
-                  <SelectPrimitive.Trigger class="settings-modal-select-trigger" aria-label="Open external links in">
-                    <SelectPrimitive.Value<string>>{(state) => state.selectedOption()}</SelectPrimitive.Value>
-                    <ChevronDown aria-hidden="true" />
-                  </SelectPrimitive.Trigger>
-                  <SelectPrimitive.HiddenSelect />
-                  <SelectPrimitive.Portal mount={modalElement}>
-                    <SelectPrimitive.Content class="settings-modal-select-content">
-                      <SelectPrimitive.Listbox class="settings-modal-select-listbox" />
-                    </SelectPrimitive.Content>
-                  </SelectPrimitive.Portal>
-                </SelectPrimitive.Root>
-              </div>
-            </Card>
-          </section>
+              <Item class="settings-modal-row">
+                <ItemContent>
+                  <ItemTitle>Open external links in</ItemTitle>
+                  <ItemDescription>Choose where links from conversations open.</ItemDescription>
+                </ItemContent>
+                <ItemActions>
+                  <Select<GeneralSettingsValue["externalLinkTarget"]>
+                    class="settings-modal-select"
+                    options={linkTargetOptions}
+                    value={props.value.externalLinkTarget}
+                    onChange={(value) => value && updateSetting("externalLinkTarget", value)}
+                    placement="bottom-end"
+                    itemComponent={(selectProps) => (
+                      <SelectItem item={selectProps.item}>{selectProps.item.rawValue}</SelectItem>
+                    )}
+                  >
+                    <SelectTrigger size="sm" aria-label="Open external links in">
+                      <SelectValue<GeneralSettingsValue["externalLinkTarget"]>>
+                        {(state) => state.selectedOption()}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent mount={modalElement} />
+                  </Select>
+                </ItemActions>
+              </Item>
+            </ItemGroup>
+          </SettingsSection>
 
-          <section class="settings-modal-group" aria-labelledby="settings-notifications">
-            <Heading id="settings-notifications" as="h3" size="sm" tone="secondary">
-              Notifications
-            </Heading>
-            <Card class="settings-modal-card">
+          <SettingsSection title="Notifications">
+            <ItemGroup class="settings-modal-card" surface="subtle">
               <SwitchField
-                defaultChecked
+                checked={props.value.desktopNotifications}
+                onChange={(checked) => updateSetting("desktopNotifications", checked)}
                 label="Desktop notifications"
                 description="Show a notification when an agent needs attention."
               />
               <SwitchField
+                checked={props.value.taskCompletionSound}
+                onChange={(checked) => updateSetting("taskCompletionSound", checked)}
                 label="Play a sound when a task finishes"
                 description="Use a short sound for completed tasks."
               />
-            </Card>
-          </section>
+            </ItemGroup>
+          </SettingsSection>
 
-          <section class="settings-modal-group" aria-labelledby="settings-updates">
-            <Heading id="settings-updates" as="h3" size="sm" tone="secondary">
-              Updates
-            </Heading>
-            <Card class="settings-modal-card">
+          <SettingsSection title="Updates">
+            <ItemGroup class="settings-modal-card" surface="subtle">
               <SwitchField
-                defaultChecked
+                checked={props.value.autoDownloadUpdates}
+                onChange={(checked) => updateSetting("autoDownloadUpdates", checked)}
                 label="Automatically download updates"
                 description="Download new versions when they become available."
               />
-              <div class="settings-modal-row">
-                <div class="settings-modal-row-copy">
-                  <span class="settings-modal-row-title">OpenBot version</span>
-                  <div class="settings-modal-version">
-                    <Text tone="muted" variant="caption">
-                      Installed version
-                    </Text>
-                    <Badge tone={updateChecked() ? "success" : "accent"}>
-                      {updateChecked() ? "Up to date" : "0.1.11"}
-                    </Badge>
-                  </div>
+              <Item class="settings-modal-row settings-modal-update-row">
+                <ItemContent>
+                  <ItemTitle>OpenBot version</ItemTitle>
+                  <ItemDescription
+                    class={updateError() || props.updateStatus.phase === "error" ? "settings-modal-error" : undefined}
+                  >
+                    {updateMessage()}
+                  </ItemDescription>
+                </ItemContent>
+                <ItemActions class="settings-modal-update-actions">
+                  <Badge tone={props.updateStatus.phase === "up-to-date" ? "success" : "accent"}>
+                    v{installedVersion()}
+                  </Badge>
+                  <Button
+                    variant="outline"
+                    type="button"
+                    size="sm"
+                    loading={updatePresentation().busy}
+                    loadingLabel={updatePresentation().actionLabel}
+                    disabled={!updatePresentation().supported}
+                    onClick={() => void runUpdateAction()}
+                  >
+                    {updatePresentation().supported ? updatePresentation().actionLabel : "Updates unavailable"}
+                  </Button>
+                </ItemActions>
+              </Item>
+            </ItemGroup>
+          </SettingsSection>
+        </Tabs.Content>
+
+        <Tabs.Content value="profile" class="settings-modal-tab-panel" data-tab="profile">
+          <SettingsSection title="Account">
+            <Card class="settings-modal-card settings-modal-profile-card">
+              <div class="settings-modal-profile-summary">
+                <div class="settings-modal-avatar" aria-hidden="true">
+                  OB
                 </div>
-                <Button variant="outline" type="button" size="sm" onClick={() => setUpdateChecked(true)}>
-                  {updateChecked() ? "Checked" : "Check for updates"}
+                <div class="settings-modal-profile-copy">
+                  <span class="settings-modal-row-title">{profileName()}</span>
+                  <Text tone="muted" variant="caption">
+                    person@example.com
+                  </Text>
+                </div>
+                <Button variant="outline" type="button" size="sm">
+                  Change avatar
                 </Button>
               </div>
             </Card>
-          </section>
-        </div>
-      </Show>
-    </SettingsDialogShell>
+          </SettingsSection>
+
+          <SettingsSection title="Profile details">
+            <Card class="settings-modal-card settings-modal-profile-fields">
+              <Field
+                label="Display name"
+                description="This name is visible in shared workspaces."
+                htmlFor="settings-profile-name"
+              >
+                <Input id="settings-profile-name" value={profileName()} onValueChange={setProfileName} />
+              </Field>
+              <SwitchField
+                defaultChecked
+                label="Show activity status"
+                description="Let workspace members see when you are active."
+              />
+            </Card>
+          </SettingsSection>
+        </Tabs.Content>
+      </SettingsDialogShell>
+    </Tabs.Root>
   );
 }

--- a/src/renderer/src/components/ui/button.tsx
+++ b/src/renderer/src/components/ui/button.tsx
@@ -115,13 +115,14 @@ export interface CopyButtonProps extends Omit<ButtonProps, "children" | "onClick
   value: string | null | undefined;
   label?: string;
   copiedLabel?: string;
+  iconOnly?: boolean;
   onCopyError?: (error: unknown) => void;
 }
 
 export function CopyButton(props: CopyButtonProps): JSX.Element {
   const [copied, setCopied] = createSignal(false);
   let resetTimer: number | undefined;
-  const others = omit(props, "value", "label", "copiedLabel", "onCopyError", "disabled");
+  const others = omit(props, "value", "label", "copiedLabel", "iconOnly", "onCopyError", "disabled", "class", "size");
 
   function clearResetTimer(): void {
     if (resetTimer === undefined) return;
@@ -160,7 +161,8 @@ export function CopyButton(props: CopyButtonProps): JSX.Element {
     <Button
       type="button"
       variant="ghost"
-      size="sm"
+      size={props.size ?? (props.iconOnly ? "icon-sm" : "sm")}
+      class={cx(props.iconOnly && "ui-icon-button", props.class)}
       disabled={Boolean(props.disabled || !props.value)}
       data-copied={copied() ? "" : undefined}
       {...others}
@@ -169,7 +171,9 @@ export function CopyButton(props: CopyButtonProps): JSX.Element {
       <Show when={copied()} fallback={<Copy aria-hidden="true" />}>
         <Check aria-hidden="true" />
       </Show>
-      <span aria-live="polite">{copied() ? (props.copiedLabel ?? "Copied") : (props.label ?? "Copy")}</span>
+      <span class={props.iconOnly ? "sr-only" : undefined} aria-live="polite">
+        {copied() ? (props.copiedLabel ?? "Copied") : (props.label ?? "Copy")}
+      </span>
     </Button>
   );
 }

--- a/src/renderer/src/components/ui/index.ts
+++ b/src/renderer/src/components/ui/index.ts
@@ -7,6 +7,8 @@ export * from "./form";
 export * from "./icons";
 export * from "./item";
 export * from "./select";
+export * from "./settings";
+export * from "./sliding-tabs";
 export * from "./surface";
 export * from "./switch";
 export * from "./toast";

--- a/src/renderer/src/components/ui/select.tsx
+++ b/src/renderer/src/components/ui/select.tsx
@@ -64,13 +64,15 @@ export function SelectValue<Option>(props: SelectValueProps<Option>): JSX.Elemen
 }
 
 export type SelectContentProps = PolymorphicProps<"div", SelectPrimitive.SelectContentProps<"div">> &
-  Pick<ComponentProps<"div">, "class">;
+  Pick<ComponentProps<"div">, "class"> & {
+    mount?: Element;
+  };
 
 export function SelectContent(props: SelectContentProps): JSX.Element {
-  const others = omit(props, "class");
+  const others = omit(props, "class", "mount");
   let contentElement: HTMLElement | undefined;
   return (
-    <SelectPrimitive.Portal>
+    <SelectPrimitive.Portal mount={props.mount}>
       <SelectPrimitive.Content
         ref={(element) => {
           contentElement = element;

--- a/src/renderer/src/components/ui/settings.tsx
+++ b/src/renderer/src/components/ui/settings.tsx
@@ -1,0 +1,36 @@
+import type { JSX } from "@solidjs/web";
+import { createUniqueId, omit, Show } from "solid-js";
+import { Heading, Text } from "./typography";
+import { cx } from "./utils";
+
+export interface SettingsSectionProps extends Omit<JSX.HTMLAttributes<HTMLElement>, "title"> {
+  title: JSX.Element;
+  description?: JSX.Element;
+  actions?: JSX.Element;
+}
+
+export function SettingsSection(props: SettingsSectionProps): JSX.Element {
+  const headingId = `settings-section-${createUniqueId()}`;
+  const others = omit(props, "class", "title", "description", "actions", "children");
+
+  return (
+    <section class={cx("ui-settings-section", props.class)} aria-labelledby={headingId} {...others}>
+      <div class="ui-settings-section-header">
+        <div class="ui-settings-section-copy">
+          <Heading id={headingId} class="ui-settings-section-heading" as="h3" size="sm" tone="secondary">
+            {props.title}
+          </Heading>
+          <Show when={props.description}>
+            <Text class="ui-settings-section-description" variant="caption" tone="muted">
+              {props.description}
+            </Text>
+          </Show>
+        </div>
+        <Show when={props.actions}>
+          <div class="ui-settings-section-actions">{props.actions}</div>
+        </Show>
+      </div>
+      {props.children}
+    </section>
+  );
+}

--- a/src/renderer/src/components/ui/sliding-tabs.tsx
+++ b/src/renderer/src/components/ui/sliding-tabs.tsx
@@ -1,0 +1,81 @@
+import { useTabsContext } from "@kobalte/core/tabs";
+import type { ComponentProps, JSX } from "@solidjs/web";
+import { omit, onCleanup } from "solid-js";
+import { Tabs } from "./complex";
+import { cx } from "./utils";
+
+export type SlidingTabsRootProps = ComponentProps<typeof Tabs.Root>;
+export type SlidingTabsListProps = ComponentProps<typeof Tabs.List>;
+export type SlidingTabsTriggerProps = ComponentProps<typeof Tabs.Trigger>;
+export type SlidingTabsContentProps = ComponentProps<typeof Tabs.Content>;
+export type SlidingTabsContentSlotProps = JSX.HTMLAttributes<HTMLDivElement>;
+
+function SlidingTabsRoot(props: SlidingTabsRootProps) {
+  const others = omit(props, "activationMode", "orientation");
+  return <Tabs.Root {...others} activationMode={props.activationMode ?? "automatic"} orientation="horizontal" />;
+}
+
+function SlidingTabsList(props: SlidingTabsListProps) {
+  const others = omit(props, "class", "children");
+  let indicator: HTMLDivElement | undefined;
+  let readyFrame: number | undefined;
+  let disposed = false;
+
+  queueMicrotask(() => {
+    if (disposed) return;
+    readyFrame = window.requestAnimationFrame(() => {
+      if (!indicator) return;
+      void indicator.offsetWidth;
+      indicator.removeAttribute("data-initializing");
+    });
+  });
+
+  onCleanup(() => {
+    disposed = true;
+    if (readyFrame !== undefined) window.cancelAnimationFrame(readyFrame);
+  });
+
+  return (
+    <Tabs.List {...others} class={cx("ui-sliding-tabs", props.class)}>
+      <Tabs.Indicator ref={indicator} class="ui-sliding-tabs-pill" data-initializing="" />
+      {props.children}
+    </Tabs.List>
+  );
+}
+
+function SlidingTabsTrigger(props: SlidingTabsTriggerProps) {
+  return <Tabs.Trigger {...props} class={cx("ui-sliding-tabs-trigger", props.class)} />;
+}
+
+function SlidingTabsContentSlot(props: SlidingTabsContentSlotProps) {
+  const others = omit(props, "class", "children");
+  return (
+    <div {...others} class={cx("ui-sliding-tabs-content-slot", props.class)}>
+      {props.children}
+    </div>
+  );
+}
+
+function SlidingTabsContent(props: SlidingTabsContentProps) {
+  const context = useTabsContext();
+  const others = omit(props, "class", "forceMount", "aria-hidden", "inert");
+  const isSelected = () => context.listState().selectedKey() === props.value;
+
+  return (
+    <Tabs.Content
+      {...others}
+      forceMount
+      class={cx("ui-sliding-tabs-content", props.class)}
+      aria-hidden={isSelected() ? undefined : "true"}
+      inert={isSelected() ? undefined : true}
+    />
+  );
+}
+
+export const SlidingTabs = {
+  Root: SlidingTabsRoot,
+  List: SlidingTabsList,
+  Trigger: SlidingTabsTrigger,
+  ContentSlot: SlidingTabsContentSlot,
+  Content: SlidingTabsContent,
+};

--- a/src/renderer/src/components/ui/utils.ts
+++ b/src/renderer/src/components/ui/utils.ts
@@ -16,3 +16,11 @@ export function cx(...values: ClassValue[]): string {
     })
     .join(" ");
 }
+
+export function truncateMiddle(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  const visibleLength = maxLength - 1;
+  const startLength = Math.ceil((visibleLength * 2) / 3);
+  const endLength = visibleLength - startLength;
+  return `${value.slice(0, startLength)}…${value.slice(-endLength)}`;
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3,6 +3,7 @@
 @import "tailwindcss";
 @import "@openbot/brand/logo.css";
 @import "./styles/primitives.css";
+@import "./styles/sliding-tabs.css";
 @import "./styles/action-menu.css";
 @import "./styles/base.css";
 @import "./styles/auth.css";
@@ -27,6 +28,8 @@
   --openbot-bg-control: #1b1b1b;
   --openbot-bg-control-hover: #313131;
   --openbot-bg-control-active: #3a3a3a;
+  --openbot-tabs-bar-bg: #202020;
+  --openbot-tabs-pill-bg: #454545;
   --openbot-bg-switch: #5f5f5f;
   --openbot-bg-overlay: rgba(7, 7, 7, 0.92);
   --openbot-dialog-overlay: rgba(0, 0, 0, 0.1);
@@ -191,6 +194,7 @@
   --openbot-space-4: 16px;
   --openbot-space-6: 24px;
   --openbot-space-8: 32px;
+  --openbot-scrollbar-size: 8px;
   --openbot-radius-xs: 4px;
   --openbot-radius-sm: 6px;
   --openbot-radius-md: 8px;

--- a/src/renderer/src/styles/auth.css
+++ b/src/renderer/src/styles/auth.css
@@ -1279,7 +1279,7 @@ textarea:focus-visible {
 }
 
 ::-webkit-scrollbar {
-  width: 8px;
+  width: var(--openbot-scrollbar-size);
 }
 
 ::-webkit-scrollbar-track {

--- a/src/renderer/src/styles/primitives.css
+++ b/src/renderer/src/styles/primitives.css
@@ -909,6 +909,41 @@
   gap: var(--openbot-space-2);
 }
 
+.ui-settings-section {
+  display: grid;
+  gap: var(--openbot-space-2);
+}
+
+.ui-settings-section-header {
+  min-width: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--openbot-space-3);
+  padding-inline: var(--openbot-space-1);
+}
+
+.ui-settings-section-copy {
+  min-width: 0;
+  display: grid;
+  gap: var(--openbot-space-1);
+}
+
+.ui-settings-section-heading {
+  font-weight: var(--openbot-weight-regular);
+}
+
+.ui-settings-section-description {
+  display: block;
+}
+
+.ui-settings-section-actions {
+  min-width: 0;
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+}
+
 .ui-alert {
   min-width: 0;
   display: grid;

--- a/src/renderer/src/styles/server-settings-modal.css
+++ b/src/renderer/src/styles/server-settings-modal.css
@@ -1,9 +1,11 @@
-.server-settings-modal-shell.settings-modal {
-  grid-template-columns: 188px minmax(0, 1fr);
-}
-
 .server-settings-modal-shell .settings-modal-main {
   background: var(--openbot-bg-canvas);
+}
+
+@media (min-width: 721px) {
+  .server-settings-modal-shell .settings-modal-header {
+    padding: var(--openbot-space-4) var(--openbot-space-4) var(--openbot-space-6) var(--openbot-space-8);
+  }
 }
 
 .server-settings-modal-shell .settings-modal-scroll-frame::before {
@@ -24,52 +26,28 @@
   );
 }
 
-.server-settings-modal-shell .settings-modal-nav-item {
-  cursor: pointer;
-}
-
-.server-settings-modal-shell .settings-modal-nav-item[data-selected] {
-  background: var(--openbot-bg-control-hover);
-  color: var(--openbot-text-primary);
-  font-weight: var(--openbot-weight-medium);
-}
-
-.server-settings-modal-shell .settings-modal-nav-item:focus-visible {
-  outline: 0;
-  box-shadow: var(--openbot-focus-ring);
-}
-
 .server-settings-panel {
   width: 100%;
   gap: var(--openbot-space-6);
   animation: none;
 }
 
-.server-settings-general-section,
 .server-settings-modal-shell .settings-modal-group {
   display: grid;
   gap: var(--openbot-space-3);
 }
 
-.server-settings-section-heading {
-  padding-inline: var(--openbot-space-1);
-  color: var(--openbot-text-muted);
-  font-size: var(--openbot-text-sm);
-  font-weight: var(--openbot-weight-regular);
-  line-height: var(--openbot-leading-sm);
-}
-
 .server-settings-general-card.ui-item-group {
+  width: 100%;
+  overflow: hidden;
   border: 0;
   border-radius: var(--openbot-radius-lg);
   background: var(--openbot-bg-surface);
   box-shadow: none;
 }
 
-.server-settings-people-card.ui-item-group,
-.server-settings-people-card.ui-card {
-  border-color: var(--openbot-border-strong);
-  background: var(--openbot-bg-surface);
+.server-settings-general-card > .ui-item {
+  min-height: 64px;
 }
 
 .server-settings-logo {
@@ -101,57 +79,125 @@
   gap: var(--openbot-space-2);
 }
 
-.server-settings-logo-actions,
 .server-settings-save-actions {
   display: flex;
   align-items: center;
   gap: var(--openbot-space-1);
 }
 
+.server-settings-logo-picker {
+  position: relative;
+  display: flex;
+}
+
+.server-settings-logo-trigger {
+  position: relative;
+  width: calc(var(--openbot-control-xl) + var(--openbot-space-2));
+  height: calc(var(--openbot-control-xl) + var(--openbot-space-2));
+  overflow: hidden;
+  border-radius: var(--openbot-radius-md);
+  color: var(--openbot-text-muted);
+}
+
+.server-settings-logo-trigger .server-settings-logo {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.server-settings-logo-placeholder {
+  width: var(--openbot-icon-md);
+  height: var(--openbot-icon-md);
+}
+
+.server-settings-logo-remove {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  border: 1px solid var(--openbot-border-strong);
+  border-radius: var(--openbot-radius-pill);
+  background: color-mix(in srgb, var(--openbot-bg-surface-raised) 72%, transparent);
+  backdrop-filter: blur(8px) saturate(1.1);
+  -webkit-backdrop-filter: blur(8px) saturate(1.1);
+  opacity: 0;
+  scale: 0.9;
+  transition:
+    opacity var(--openbot-duration-hover) ease,
+    scale var(--openbot-duration-hover) ease,
+    background-color var(--openbot-duration-hover) ease;
+}
+
+.server-settings-logo-picker:hover .server-settings-logo-remove,
+.server-settings-logo-picker:focus-within .server-settings-logo-remove {
+  opacity: 1;
+  scale: 1;
+}
+
+@media (hover: none) {
+  .server-settings-logo-remove {
+    opacity: 1;
+    scale: 1;
+  }
+}
+
 .server-settings-item-error {
   color: var(--openbot-danger);
 }
 
-.server-settings-name-field,
+.server-settings-name-row.ui-item,
+.server-settings-logo-row.ui-item,
+.server-settings-readonly-name.ui-item {
+  min-height: 72px;
+}
+
 .server-settings-publish-setting.ui-switch-field {
   min-height: 64px;
+}
+
+.server-settings-publish-setting.ui-switch-field {
   padding: var(--openbot-space-3) var(--openbot-space-4);
 }
 
-.server-settings-name-field {
-  min-width: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(200px, 280px);
-  grid-template-rows: auto auto;
-  column-gap: var(--openbot-space-6);
-  row-gap: var(--openbot-space-0-5);
-  align-items: center;
+.server-settings-name-control {
+  --server-settings-name-error-reveal-duration: 280ms;
+  --server-settings-name-shake-distance: 6px;
+  --server-settings-name-shake-overshoot: 4px;
+  --server-settings-name-shake-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  position: relative;
+  width: 220px;
+  height: var(--openbot-control-md);
 }
 
-.server-settings-name-field .ui-label {
-  grid-column: 1;
-  grid-row: 1;
-  align-self: end;
-  color: var(--openbot-text-primary);
-  font-size: var(--openbot-text-md);
-}
-
-.server-settings-name-field .ui-field-description,
-.server-settings-name-field .ui-field-error {
-  grid-column: 1;
-  grid-row: 2;
-  align-self: start;
-}
-
-.server-settings-name-field .ui-input {
+.server-settings-name-input.ui-input {
   width: 100%;
-  grid-column: 2;
-  grid-row: 1 / span 2;
-  align-self: center;
+  transition: border-color 150ms ease-out;
+  will-change: transform;
 }
 
-.server-settings-name-field[data-invalid] .ui-field-description {
+.server-settings-name-input.is-shaking {
+  animation: server-settings-name-shake 280ms linear;
+}
+
+.server-settings-name-error {
+  position: absolute;
+  top: calc(100% + var(--openbot-space-0-5));
+  right: 0;
+  left: 0;
+  opacity: 0;
   visibility: hidden;
+  transition:
+    opacity var(--server-settings-name-error-reveal-duration) ease-out,
+    visibility 0s linear var(--server-settings-name-error-reveal-duration);
+}
+
+.server-settings-name-control[data-invalid] .server-settings-name-error {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity var(--server-settings-name-error-reveal-duration) ease-out,
+    visibility 0s linear;
 }
 
 .server-settings-publish-setting.ui-switch-field {
@@ -170,38 +216,39 @@
   user-select: text;
 }
 
-.server-settings-address-control {
+.server-settings-address-control.ui-button {
   width: 320px;
+  height: var(--openbot-control-md);
   min-width: 0;
-  min-height: var(--openbot-control-md);
+  flex-direction: row-reverse;
   justify-content: space-between;
-  overflow: hidden;
+  overflow: visible;
   border: 0;
   border-radius: var(--openbot-radius-md);
   background: var(--openbot-bg-control);
-  padding-left: var(--openbot-space-3);
+  padding-inline: var(--openbot-space-3) var(--openbot-space-2);
+  color: var(--openbot-text-secondary);
   box-shadow: inset 0 0 0 1px var(--openbot-border);
 }
 
-.server-settings-address-control code {
+.server-settings-address-control > span {
   min-width: 0;
+  flex: 1 1 auto;
   overflow: hidden;
-  color: var(--openbot-text-secondary);
   font-family: var(--openbot-font-mono);
-  font-size: var(--openbot-text-sm);
-  line-height: var(--openbot-leading-sm);
+  font-weight: var(--openbot-weight-regular);
+  text-align: left;
   text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.server-settings-address-control .server-settings-copy-button {
-  align-self: stretch;
-  border-left: 1px solid var(--openbot-border);
-  border-radius: 0;
-  padding-inline: var(--openbot-space-2);
+.server-settings-address-control > svg {
+  width: var(--openbot-icon-sm);
+  height: var(--openbot-icon-sm);
+  flex: 0 0 auto;
+  stroke-width: 1.75;
 }
 
-.server-settings-copy-button[data-copied] {
+.server-settings-address-control[data-copied] {
   color: var(--openbot-success);
 }
 
@@ -214,21 +261,6 @@
   border-top: 1px solid var(--openbot-border);
   background: var(--openbot-bg-surface);
   padding: var(--openbot-space-3) var(--openbot-space-6);
-}
-
-.server-settings-save-copy {
-  display: flex;
-  align-items: center;
-  gap: var(--openbot-space-2);
-}
-
-.server-settings-save-dot {
-  width: 6px;
-  height: 6px;
-  flex: 0 0 auto;
-  border-radius: var(--openbot-radius-pill);
-  background: var(--openbot-warning);
-  box-shadow: 0 0 0 4px var(--openbot-warning-soft);
 }
 
 .server-settings-error-toast {
@@ -244,22 +276,9 @@
   bottom: calc(60px + var(--openbot-space-3));
 }
 
-.server-settings-section-title {
-  min-height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--openbot-space-3);
-}
-
-.server-settings-members-heading {
-  align-items: flex-end;
-}
-
-.server-settings-members-heading > div {
-  min-width: 0;
-  display: grid;
-  gap: var(--openbot-space-1);
+.server-settings-members-alert {
+  border: 0;
+  background: var(--openbot-bg-control);
 }
 
 .server-settings-search {
@@ -285,80 +304,54 @@
 }
 
 .server-settings-invite-card.ui-card {
-  padding: var(--openbot-space-4);
-}
-
-.server-settings-invite-tabs {
-  width: fit-content;
-  display: flex;
-  border: 1px solid var(--openbot-border);
-  border-radius: var(--openbot-radius-md);
-  background: var(--openbot-bg-control);
-  padding: var(--openbot-space-0-5);
-}
-
-.server-settings-invite-tabs button {
-  min-height: var(--openbot-control-md);
   border: 0;
-  border-radius: var(--openbot-radius-sm);
-  outline: 0;
-  background: transparent;
-  padding-inline: var(--openbot-space-3);
-  color: var(--openbot-text-muted);
-  font: inherit;
-  font-size: var(--openbot-text-sm);
-  cursor: pointer;
-  transition:
-    background-color var(--openbot-duration-hover) ease,
-    color var(--openbot-duration-hover) ease;
-}
-
-.server-settings-invite-tabs button[data-selected] {
-  background: var(--openbot-accent-soft);
-  color: var(--openbot-accent-text);
-}
-
-.server-settings-invite-tabs button:focus-visible {
-  box-shadow: var(--openbot-focus-ring);
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .server-settings-invite-tabs button:not([data-selected]):hover {
-    background: var(--openbot-hover);
-    color: var(--openbot-text-secondary);
-  }
+  background: var(--openbot-bg-surface);
+  padding: var(--openbot-space-4);
+  box-shadow: none;
 }
 
 .server-settings-invite-composer {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 126px auto;
-  align-items: center;
+  grid-template-columns: minmax(0, 1fr) 112px auto;
+  align-items: start;
   gap: var(--openbot-space-2);
-  margin-top: var(--openbot-space-3);
 }
 
 .server-settings-invite-mode-panel,
-.server-settings-invite-email-control,
-.server-settings-invite-email-control .ui-input {
+.server-settings-invite-email-field,
+.server-settings-invite-email-field .ui-input {
   min-width: 0;
   width: 100%;
 }
 
+.server-settings-invite-email-field {
+  position: relative;
+}
+
+.server-settings-invite-email-field > .ui-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 .server-settings-invite-mode-panel .ui-text {
+  min-height: var(--openbot-control-md);
+  display: flex;
+  align-items: center;
   padding-inline: var(--openbot-space-1);
 }
 
 .server-settings-role-select {
-  width: 126px;
-}
-
-.server-settings-invite-help {
-  display: block;
-  margin-top: var(--openbot-space-2);
-  color: var(--openbot-text-secondary);
+  width: 100%;
 }
 
 .server-settings-invite-result {
+  border: 0;
+  background: var(--openbot-bg-surface-raised);
   margin-top: var(--openbot-space-3);
 }
 
@@ -366,44 +359,12 @@
   background: var(--openbot-bg-control);
 }
 
-.server-settings-member-row .person-avatar {
-  flex: 0 0 auto;
-}
-
 .server-settings-member-meta {
-  display: flex;
-  align-items: center;
-  gap: var(--openbot-space-1-5);
-}
-
-.server-settings-member-meta > span:first-child {
+  display: block;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.server-settings-member-status {
-  display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: var(--openbot-space-1-5);
   white-space: nowrap;
-}
-
-.server-settings-member-status > span {
-  width: 6px;
-  height: 6px;
-  flex: 0 0 auto;
-  border-radius: var(--openbot-radius-pill);
-  background: var(--openbot-text-dim);
-}
-
-.server-settings-member-status[data-state="online"] > span {
-  background: var(--openbot-success);
-}
-
-.server-settings-member-status[data-state="paused"] > span {
-  background: var(--openbot-warning);
 }
 
 .server-settings-member-actions {
@@ -429,11 +390,7 @@
   height: var(--openbot-icon-sm);
 }
 
-.server-settings-empty {
-  margin: 0;
-  padding: var(--openbot-space-8) var(--openbot-space-4);
-  color: var(--openbot-text-muted);
-  font-size: var(--openbot-text-sm);
+.server-settings-empty-row .ui-item-content {
   text-align: center;
 }
 
@@ -552,32 +509,42 @@
   }
 }
 
+@keyframes server-settings-name-shake {
+  0% {
+    transform: translateX(0);
+    animation-timing-function: var(--server-settings-name-shake-ease);
+  }
+
+  28.57% {
+    transform: translateX(var(--server-settings-name-shake-distance));
+    animation-timing-function: var(--server-settings-name-shake-ease);
+  }
+
+  57.14% {
+    transform: translateX(calc(var(--server-settings-name-shake-distance) * -1));
+    animation-timing-function: var(--server-settings-name-shake-ease);
+  }
+
+  78.57% {
+    transform: translateX(var(--server-settings-name-shake-overshoot));
+    animation-timing-function: var(--server-settings-name-shake-ease);
+  }
+
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .server-settings-name-input.is-shaking {
+    animation: none;
+    transform: none;
+  }
+}
+
 @media (max-width: 720px) {
-  .server-settings-modal-shell.settings-modal {
-    width: calc(100vw - 24px);
-    height: calc(100dvh - 24px);
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .server-settings-modal-shell .settings-modal-sidebar {
-    gap: var(--openbot-space-3);
-    border-right: 0;
-    border-bottom: 1px solid var(--openbot-border);
-    background: var(--openbot-bg-sidebar);
-    padding: var(--openbot-space-3);
-  }
-
-  .server-settings-modal-shell .settings-modal-nav {
-    display: flex;
-    overflow-x: auto;
-  }
-
-  .server-settings-modal-shell .settings-modal-nav-item {
-    width: auto;
-    flex: 0 0 auto;
-  }
-
   .server-settings-logo-row,
+  .server-settings-name-row,
   .server-settings-address-setting,
   .server-settings-readonly-name {
     align-items: flex-start;
@@ -598,31 +565,19 @@
     text-align: left;
   }
 
-  .server-settings-name-field {
+  .server-settings-name-control {
+    width: min(320px, 100%);
+    max-width: 320px;
+    height: auto;
+    display: grid;
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto auto auto auto;
-    row-gap: var(--openbot-space-1);
+    grid-template-rows: var(--openbot-control-md) var(--openbot-leading-xs);
+    align-items: stretch;
+    row-gap: var(--openbot-space-0-5);
   }
 
-  .server-settings-name-field .ui-label,
-  .server-settings-name-field .ui-field-description,
-  .server-settings-name-field .ui-input,
-  .server-settings-name-field .ui-field-error {
-    grid-column: 1;
-  }
-
-  .server-settings-name-field .ui-label {
-    grid-row: 1;
-  }
-
-  .server-settings-name-field .ui-field-description,
-  .server-settings-name-field .ui-field-error {
-    grid-row: 2;
-  }
-
-  .server-settings-name-field .ui-input {
-    grid-row: 3;
-    margin-top: var(--openbot-space-2);
+  .server-settings-name-error {
+    position: static;
   }
 
   .server-settings-address-control {
@@ -646,10 +601,6 @@
     grid-column: 1 / -1;
   }
 
-  .server-settings-member-meta {
-    max-width: 100%;
-  }
-
   .server-settings-desktop-card .ui-item {
     align-items: flex-start;
     flex-wrap: wrap;
@@ -665,11 +616,13 @@
 }
 
 @media (max-width: 520px) {
-  .server-settings-members-heading {
+  :is(.server-settings-invite-section, .server-settings-members-section) .ui-settings-section-header {
     align-items: stretch;
     flex-direction: column;
   }
 
+  .server-settings-invite-section .ui-settings-section-actions,
+  .server-settings-members-section .ui-settings-section-actions,
   .server-settings-search {
     width: 100%;
   }
@@ -682,7 +635,6 @@
     width: 100%;
     min-width: 0;
     justify-content: flex-end;
-    padding-left: 52px;
   }
 
   .server-settings-invite-composer {
@@ -707,10 +659,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .server-settings-invite-tabs button {
-    transition: none;
-  }
-
   .server-settings-confirm-backdrop,
   .server-settings-confirm-dialog {
     animation: none;

--- a/src/renderer/src/styles/server-settings-modal.css
+++ b/src/renderer/src/styles/server-settings-modal.css
@@ -172,7 +172,7 @@
 
 .server-settings-name-input.ui-input {
   width: 100%;
-  transition: border-color 150ms ease-out;
+  transition: border-color var(--openbot-duration-normal) ease-out;
   will-change: transform;
 }
 

--- a/src/renderer/src/styles/settings-modal.css
+++ b/src/renderer/src/styles/settings-modal.css
@@ -215,8 +215,8 @@
   align-content: start;
   gap: var(--openbot-space-6);
   overflow-y: auto;
-  padding: 0 var(--openbot-space-6) var(--openbot-space-6);
-  scrollbar-gutter: stable;
+  padding: 0 calc(var(--openbot-space-6) - var(--openbot-scrollbar-size)) var(--openbot-space-6);
+  scrollbar-gutter: stable both-edges;
 }
 
 .settings-modal-tab-panel {
@@ -325,110 +325,6 @@
   line-height: var(--openbot-leading-lg);
 }
 
-.settings-modal-version {
-  display: flex;
-  align-items: center;
-  gap: var(--openbot-space-2);
-}
-
-.settings-modal-select-trigger {
-  width: 168px;
-  height: var(--openbot-control-sm);
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--openbot-space-2);
-  border: 1px solid var(--openbot-border-strong);
-  border-radius: var(--openbot-radius-md);
-  outline: 0;
-  background: var(--openbot-bg-surface-raised);
-  padding: 0 var(--openbot-space-2);
-  color: var(--openbot-text-secondary);
-  font: inherit;
-  font-size: var(--openbot-text-lg);
-  line-height: var(--openbot-leading-lg);
-  transition:
-    background-color var(--openbot-duration-hover) ease,
-    border-color var(--openbot-duration-hover) ease,
-    box-shadow var(--openbot-duration-hover) ease;
-}
-
-.settings-modal-select-trigger svg {
-  width: var(--openbot-icon-sm);
-  height: var(--openbot-icon-sm);
-  flex: 0 0 auto;
-  color: var(--openbot-text-muted);
-  transition: transform var(--openbot-duration-normal) var(--openbot-ease-out);
-}
-
-.settings-modal-select-trigger[data-expanded] {
-  border-color: var(--openbot-border-focus);
-  background: var(--openbot-bg-control-hover);
-}
-
-.settings-modal-select-trigger[data-expanded] svg {
-  transform: rotate(180deg);
-}
-
-.settings-modal-select-trigger:focus-visible {
-  border-color: var(--openbot-border-focus);
-  box-shadow: var(--openbot-focus-ring);
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .settings-modal-select-trigger:hover {
-    background: var(--openbot-bg-control-hover);
-  }
-}
-
-.settings-modal-select-content {
-  z-index: var(--openbot-layer-popover);
-  min-width: 168px;
-  border: 1px solid var(--openbot-border-strong);
-  border-radius: var(--openbot-radius-md);
-  background: var(--openbot-bg-surface-raised);
-  padding: var(--openbot-space-1);
-  box-shadow: var(--openbot-shadow-raised);
-  color: var(--openbot-text-primary);
-  transform-origin: var(--kb-select-content-transform-origin);
-  animation: settings-modal-select-in var(--openbot-duration-normal) var(--openbot-ease-out) both;
-}
-
-.settings-modal-select-listbox {
-  display: grid;
-  gap: var(--openbot-space-0-5);
-  outline: 0;
-}
-
-.settings-modal-select-item {
-  min-height: var(--openbot-control-sm);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--openbot-space-3);
-  border-radius: var(--openbot-radius-sm);
-  outline: 0;
-  padding: 0 var(--openbot-space-2);
-  color: var(--openbot-text-secondary);
-  font-size: var(--openbot-text-sm);
-  cursor: default;
-}
-
-.settings-modal-select-item[data-highlighted] {
-  background: var(--openbot-bg-control-hover);
-  color: var(--openbot-text-primary);
-}
-
-.settings-modal-select-item[data-selected] {
-  color: var(--openbot-text-primary);
-}
-
-.settings-modal-select-indicator {
-  display: inline-flex;
-  color: var(--openbot-accent-hover);
-}
-
 .settings-modal :where(.ui-button-variant-default) {
   background: var(--openbot-settings-accent);
   color: var(--openbot-text-primary);
@@ -462,9 +358,120 @@
   }
 }
 
-.settings-modal-select-indicator svg {
-  width: var(--openbot-icon-sm);
-  height: var(--openbot-icon-sm);
+:is(.app-settings-modal-shell, .server-settings-modal-shell).settings-modal {
+  --settings-divider-inset: var(--openbot-space-4);
+  width: min(920px, calc(100vw - 48px));
+  height: min(640px, calc(100dvh - 48px));
+  grid-template-columns: 196px minmax(0, 1fr);
+  border-radius: var(--openbot-radius-dialog);
+  box-shadow:
+    var(--openbot-shadow-raised),
+    0 0 0 1px var(--openbot-dialog-ring);
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-sidebar {
+  gap: 0;
+  padding: var(--openbot-space-4) var(--openbot-space-3);
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-nav {
+  gap: var(--openbot-space-1);
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-nav-item {
+  min-height: var(--openbot-control-md);
+  padding-inline: var(--openbot-space-3);
+  font-size: var(--openbot-text-lg);
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-nav-item[data-selected] {
+  background: var(--openbot-bg-control-hover);
+  color: var(--openbot-text-primary);
+  font-weight: var(--openbot-weight-medium);
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-header {
+  align-items: center;
+  padding: var(--openbot-space-8);
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-title {
+  font-size: var(--openbot-text-2xl);
+  line-height: var(--openbot-leading-2xl);
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-description {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-content {
+  gap: var(--openbot-space-6);
+  padding: 0 calc(var(--openbot-space-8) - var(--openbot-scrollbar-size)) var(--openbot-space-8);
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-tab-panel {
+  gap: var(--openbot-space-6);
+  animation: none;
+  will-change: auto;
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .ui-settings-section {
+  gap: var(--openbot-space-2);
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .ui-settings-section-header {
+  padding-inline: 0;
+}
+
+:is(.app-settings-modal-shell, .server-settings-modal-shell) .ui-settings-section-heading {
+  font-size: var(--openbot-text-md);
+  line-height: var(--openbot-leading-md);
+}
+
+.app-settings-modal-shell .settings-modal-card.ui-item-group {
+  width: 100%;
+  overflow: hidden;
+  border: 0;
+  border-radius: var(--openbot-radius-lg);
+  background: var(--openbot-bg-control);
+}
+
+.app-settings-modal-shell .settings-modal-card > .ui-switch-field {
+  min-height: 64px;
+  padding: var(--openbot-space-3) var(--openbot-space-4);
+}
+
+.app-settings-modal-shell .settings-modal-card > .ui-item {
+  min-height: 64px;
+}
+
+.app-settings-modal-shell .settings-modal-card > :not(:first-child)::before,
+.app-settings-modal-shell .ui-item-group > :not(:first-child)::before {
+  right: var(--openbot-space-4);
+  left: var(--openbot-space-4);
+}
+
+.app-settings-modal-shell .settings-modal-select {
+  width: 168px;
+}
+
+.app-settings-modal-shell .settings-modal-select .ui-select-trigger {
+  background: var(--openbot-bg-surface-raised);
+  color: var(--openbot-text-secondary);
+}
+
+.app-settings-modal-shell .settings-modal-update-actions {
+  flex-wrap: wrap;
+}
+
+.app-settings-modal-shell .settings-modal-error {
+  color: var(--openbot-danger);
 }
 
 .settings-modal-profile-card.ui-card {
@@ -504,18 +511,6 @@
 
 .settings-modal-profile-fields .ui-input {
   max-width: 320px;
-}
-
-@keyframes settings-modal-select-in {
-  from {
-    opacity: 0;
-    transform: translateY(-4px) scale(0.97);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
 }
 
 @keyframes settings-modal-tab-in {
@@ -574,7 +569,7 @@
   }
 }
 
-@media (max-width: 700px) {
+@media (max-width: 720px) {
   .settings-modal-backdrop {
     padding: var(--openbot-space-3);
   }
@@ -613,7 +608,50 @@
 
   .settings-modal-content {
     gap: var(--openbot-space-4);
-    padding: 0 var(--openbot-space-4) var(--openbot-space-4);
+    padding: 0 calc(var(--openbot-space-4) - var(--openbot-scrollbar-size)) var(--openbot-space-4);
+  }
+
+  :is(.app-settings-modal-shell, .server-settings-modal-shell).settings-modal {
+    width: calc(100vw - 24px);
+    height: calc(100dvh - 24px);
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  :is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-sidebar {
+    gap: var(--openbot-space-2);
+    border-right: 0;
+    border-bottom: 1px solid var(--openbot-border);
+    padding: var(--openbot-space-3);
+  }
+
+  :is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-header {
+    padding: var(--openbot-space-4);
+  }
+
+  :is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-content,
+  :is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-tab-panel {
+    gap: var(--openbot-space-6);
+  }
+
+  :is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-content {
+    padding: 0 calc(var(--openbot-space-4) - var(--openbot-scrollbar-size)) var(--openbot-space-4);
+  }
+}
+
+@media (max-width: 520px) {
+  .app-settings-modal-shell .settings-modal-row.ui-item {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .app-settings-modal-shell .settings-modal-row .ui-item-actions,
+  .app-settings-modal-shell .settings-modal-select {
+    width: 100%;
+  }
+
+  .app-settings-modal-shell .settings-modal-update-actions {
+    justify-content: space-between;
   }
 }
 
@@ -626,13 +664,8 @@
   }
 
   .settings-modal-scroll-frame::before,
-  .settings-modal-scroll-frame::after,
-  .settings-modal-select-trigger svg {
+  .settings-modal-scroll-frame::after {
     transition: none;
-  }
-
-  .settings-modal-select-content {
-    animation: none;
   }
 
   .settings-modal-tab-panel {

--- a/src/renderer/src/styles/sliding-tabs.css
+++ b/src/renderer/src/styles/sliding-tabs.css
@@ -1,0 +1,108 @@
+.ui-sliding-tabs {
+  --sliding-tabs-duration: 250ms;
+  --sliding-tabs-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  position: relative;
+  width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border-radius: var(--openbot-radius-md);
+  background: var(--openbot-tabs-bar-bg);
+  padding: 3px;
+}
+
+.ui-sliding-tabs-trigger {
+  position: relative;
+  z-index: 1;
+  height: 30px;
+  appearance: none;
+  border: 0;
+  border-radius: var(--openbot-radius-sm);
+  outline: 0;
+  background: transparent;
+  padding: 4px var(--openbot-space-3);
+  color: var(--openbot-text-muted);
+  font: inherit;
+  font-size: var(--openbot-text-sm);
+  cursor: pointer;
+  transition: color var(--sliding-tabs-duration) var(--sliding-tabs-ease);
+}
+
+.ui-sliding-tabs-trigger[aria-selected="true"],
+.ui-sliding-tabs-trigger:not([aria-selected="true"]):hover {
+  color: var(--openbot-text-primary);
+}
+
+.ui-sliding-tabs-trigger:focus-visible {
+  box-shadow: var(--openbot-focus-ring);
+}
+
+.ui-sliding-tabs-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.ui-sliding-tabs-pill {
+  position: absolute;
+  top: 3px;
+  left: 0;
+  z-index: 0;
+  width: 0;
+  height: 30px;
+  border-radius: var(--openbot-radius-sm);
+  background: var(--openbot-tabs-pill-bg);
+  pointer-events: none;
+  transition:
+    transform var(--sliding-tabs-duration) var(--sliding-tabs-ease),
+    width var(--sliding-tabs-duration) var(--sliding-tabs-ease);
+  will-change: transform, width;
+}
+
+.ui-sliding-tabs-pill:is([data-initializing], [data-resizing]) {
+  transition: none;
+}
+
+.ui-sliding-tabs-content-slot {
+  --sliding-tabs-content-duration: 150ms;
+  --sliding-tabs-content-distance: 4px;
+  --sliding-tabs-content-blur: 2px;
+  min-width: 0;
+  display: grid;
+}
+
+.ui-sliding-tabs-content {
+  min-width: 0;
+  grid-area: 1 / 1;
+  opacity: 0;
+  visibility: hidden;
+  filter: blur(var(--sliding-tabs-content-blur));
+  transform: translateY(var(--sliding-tabs-content-distance));
+  pointer-events: none;
+  transition:
+    transform var(--sliding-tabs-content-duration) ease-in-out,
+    filter var(--sliding-tabs-content-duration) ease-in-out,
+    opacity var(--sliding-tabs-content-duration) ease-in-out,
+    visibility 0s linear var(--sliding-tabs-content-duration);
+  will-change: transform, filter, opacity;
+}
+
+.ui-sliding-tabs-content[data-selected] {
+  opacity: 1;
+  visibility: visible;
+  filter: blur(0);
+  transform: translateY(0);
+  pointer-events: auto;
+  transition:
+    transform var(--sliding-tabs-content-duration) ease-in-out,
+    filter var(--sliding-tabs-content-duration) ease-in-out,
+    opacity var(--sliding-tabs-content-duration) ease-in-out,
+    visibility 0s linear;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ui-sliding-tabs-pill,
+  .ui-sliding-tabs-trigger,
+  .ui-sliding-tabs-content {
+    transition: none;
+  }
+}

--- a/src/renderer/src/update-status.ts
+++ b/src/renderer/src/update-status.ts
@@ -1,0 +1,47 @@
+import type { UpdateStatus } from "@openbot/contracts/ipc";
+
+export interface UpdateStatusPresentation {
+  actionLabel: string;
+  available: boolean;
+  busy: boolean;
+  detail: string;
+  supported: boolean;
+}
+
+export function presentUpdateStatus(status: UpdateStatus): UpdateStatusPresentation {
+  const available = ["available", "downloading", "ready", "installing"].includes(status.phase);
+  const busy = ["checking", "downloading", "installing"].includes(status.phase);
+  let actionLabel = "Check for updates";
+
+  switch (status.phase) {
+    case "checking":
+      actionLabel = "Checking for updates…";
+      break;
+    case "available":
+      actionLabel = "Download update";
+      break;
+    case "downloading":
+      actionLabel = "Downloading update…";
+      break;
+    case "ready":
+      actionLabel = "Restart to update";
+      break;
+    case "installing":
+      actionLabel = "Restarting…";
+      break;
+  }
+
+  let detail = "";
+  if (status.phase === "downloading" && status.progress !== null) detail = `${Math.round(status.progress)}%`;
+  else if (status.availableVersion) detail = `v${status.availableVersion}`;
+  else if (status.phase === "up-to-date") detail = "Up to date";
+  else if (status.currentVersion) detail = `v${status.currentVersion}`;
+
+  return {
+    actionLabel,
+    available,
+    busy,
+    detail,
+    supported: status.phase !== "unsupported",
+  };
+}

--- a/src/renderer/stories/Button.stories.tsx
+++ b/src/renderer/stories/Button.stories.tsx
@@ -93,6 +93,7 @@ export const Gallery: Story = {
             Invalid
           </Button>
           <CopyButton value="https://openbot.example/invite" label="Copy link" variant="outline" />
+          <CopyButton value="https://openbot.example/invite" label="Copy link" iconOnly title="Copy link" />
         </div>
       </section>
     </main>

--- a/src/renderer/stories/Interactions.stories.tsx
+++ b/src/renderer/stories/Interactions.stories.tsx
@@ -18,6 +18,7 @@ import {
   Popover,
   RadioGroup,
   SelectPrimitive,
+  SlidingTabs,
   Tabs,
   Tooltip,
   Trash2,
@@ -307,6 +308,39 @@ export const TabsAndRadioGroup: Story = {
     general.focus();
     await userEvent.keyboard("{ArrowDown}");
     await expect(canvas.getByRole("radio", { name: "Research" })).toBeChecked();
+  },
+};
+
+export const SlidingSelectionTabs: Story = {
+  render: () => (
+    <main class="foundation-story foundation-interaction-stage">
+      <Heading as="h1" size="lg">
+        Sliding tabs
+      </Heading>
+      <SlidingTabs.Root defaultValue="plan">
+        <SlidingTabs.List aria-label="Response mode">
+          <SlidingTabs.Trigger value="plan">Plan</SlidingTabs.Trigger>
+          <SlidingTabs.Trigger value="debug">Debug</SlidingTabs.Trigger>
+          <SlidingTabs.Trigger value="ask">Ask</SlidingTabs.Trigger>
+        </SlidingTabs.List>
+        <SlidingTabs.ContentSlot>
+          <SlidingTabs.Content value="plan">Plan mode</SlidingTabs.Content>
+          <SlidingTabs.Content value="debug">Debug mode</SlidingTabs.Content>
+          <SlidingTabs.Content value="ask">Ask mode</SlidingTabs.Content>
+        </SlidingTabs.ContentSlot>
+      </SlidingTabs.Root>
+    </main>
+  ),
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const plan = canvas.getByRole("tab", { name: "Plan" });
+    const debug = canvas.getByRole("tab", { name: "Debug" });
+    await expect(plan).toHaveAttribute("aria-selected", "true");
+    await userEvent.click(debug);
+    await expect(debug).toHaveAttribute("aria-selected", "true");
+    debug.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    await expect(canvas.getByRole("tab", { name: "Ask" })).toHaveAttribute("aria-selected", "true");
   },
 };
 

--- a/src/renderer/stories/ServerSettingsModal.stories.tsx
+++ b/src/renderer/stories/ServerSettingsModal.stories.tsx
@@ -62,6 +62,10 @@ const meta = {
           name: "Server settings — 640 × 720",
           styles: { width: "640px", height: "720px" },
         },
+        serverNarrow: {
+          name: "Server settings — 480 × 720",
+          styles: { width: "480px", height: "720px" },
+        },
       },
     },
   },
@@ -95,12 +99,47 @@ export const LocalFirstSetup: Story = {
     const dialog = await within(document.body).findByRole("dialog", { name: "General" });
     const name = within(dialog).getByRole("textbox", { name: "Server name" });
     await expect(name).toHaveValue("");
-    await fireEvent.input(name, { target: { value: "First server" } });
-    await expect(name).toHaveValue("First server");
+    await expect(name).toHaveAttribute("placeholder", "e.g. Design studio");
   },
 };
 
+export const FirstSetupInvalidName: Story = {
+  args: LocalFirstSetup.args,
+  play: async () => {
+    const dialog = await within(document.body).findByRole("dialog", { name: "General" });
+    const name = within(dialog).getByRole("textbox", { name: "Server name" });
+    await fireEvent.input(name, { target: { value: "Tiny" } });
+    await fireEvent.blur(name);
+    await expect(within(dialog).getByText("Enter at least 6 characters.")).toBeVisible();
+  },
+};
+
+export const FirstSetupValidFooter: Story = {
+  args: LocalFirstSetup.args,
+  play: async () => {
+    const dialog = await within(document.body).findByRole("dialog", { name: "General" });
+    await fireEvent.input(within(dialog).getByRole("textbox", { name: "Server name" }), {
+      target: { value: "First server" },
+    });
+    await expect(within(dialog).getByRole("button", { name: "Set up server" })).toBeVisible();
+  },
+};
+
+export const FirstSetupInvalidNameSmallViewport: Story = {
+  args: LocalFirstSetup.args,
+  parameters: {
+    viewport: { defaultViewport: "serverMobile" },
+  },
+  play: FirstSetupInvalidName.play,
+};
+
 export const LocalOnline: Story = {
+  args: {
+    hostStatus: {
+      ...STORY_HOST_STATUS,
+      apiUrl: "https://eu-west-1.gateway.example.com/openbot/servers/team_7f3c19a2",
+    },
+  },
   play: async ({ userEvent }) => {
     const dialog = await within(document.body).findByRole("dialog", { name: "General" });
     const name = within(dialog).getByRole("textbox", { name: "Server name" });
@@ -127,7 +166,7 @@ export const DirtyFooter: Story = {
     const dialog = await within(document.body).findByRole("dialog", { name: "General" });
     const name = within(dialog).getByRole("textbox", { name: "Server name" });
     await fireEvent.input(name, { target: { value: "OpenBot production" } });
-    await waitFor(() => expect(within(dialog).getByRole("region", { name: "Unsaved identity changes" })).toBeVisible());
+    await waitFor(() => expect(within(dialog).getByRole("region", { name: "Unsaved changes" })).toBeVisible());
   },
 };
 
@@ -142,6 +181,46 @@ export const RemoteAdministrator: Story = {
     server: { ...remoteServer, role: "admin" },
     hostStatus: null,
   },
+};
+
+export const Members: Story = {
+  play: async ({ userEvent }) => {
+    const body = within(document.body);
+    await body.findByRole("dialog", { name: "General" });
+    await userEvent.click(body.getByRole("tab", { name: "Members" }));
+    await expect(body.getByTestId("server-members-list")).toBeVisible();
+  },
+};
+
+export const MembersEmptyResults: Story = {
+  play: async ({ userEvent }) => {
+    const body = within(document.body);
+    await body.findByRole("dialog", { name: "General" });
+    await userEvent.click(body.getByRole("tab", { name: "Members" }));
+    await userEvent.type(body.getByRole("searchbox", { name: "Search members" }), "nobody");
+    await expect(body.getByText("No members match this search.")).toBeVisible();
+  },
+};
+
+export const MembersUnpublished: Story = {
+  args: {
+    server: { ...remoteServer, state: "offline", role: "admin" },
+    hostStatus: null,
+  },
+  play: async ({ userEvent }) => {
+    const body = within(document.body);
+    await body.findByRole("dialog", { name: "General" });
+    await userEvent.click(body.getByRole("tab", { name: "Members" }));
+    await expect(body.getByRole("status")).toBeVisible();
+    await expect(body.getByRole("button", { name: "Send invite" })).toBeDisabled();
+  },
+};
+
+export const MembersSmallViewport: Story = {
+  parameters: {
+    viewport: { defaultViewport: "serverNarrow" },
+  },
+  play: Members.play,
 };
 
 export const DenseMemberList: Story = {

--- a/src/renderer/stories/SettingsModal.stories.tsx
+++ b/src/renderer/stories/SettingsModal.stories.tsx
@@ -1,22 +1,46 @@
+import type { UpdateStatus } from "@openbot/contracts/ipc";
 import { createSignal } from "solid-js";
-import { expect, waitFor, within } from "storybook/test";
+import { expect, fn, waitFor, within } from "storybook/test";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { DEFAULT_GENERAL_SETTINGS } from "../src/app-settings";
 import { SettingsModal } from "../src/components/SettingsModal";
 import { Button, Heading, Text } from "../src/components/ui";
 
+const storyAppInfo = { name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" } as const;
+const storyUpdateStatus: UpdateStatus = {
+  phase: "idle",
+  currentVersion: "0.2.1",
+  availableVersion: null,
+  progress: null,
+  checkedAt: null,
+  message: null,
+};
+
 function SettingsModalStory(props: { initialOpen: boolean }) {
   const [open, setOpen] = createSignal(props.initialOpen);
+  const [value, setValue] = createSignal({ ...DEFAULT_GENERAL_SETTINGS });
+  const [updateStatus, setUpdateStatus] = createSignal<UpdateStatus>(storyUpdateStatus);
 
   return (
     <main class="foundation-story foundation-interaction-stage">
       <Heading as="h1" size="lg">
         Workspace settings
       </Heading>
-      <Text tone="secondary">Preview the standalone settings surface before it is connected to the app.</Text>
+      <Text tone="secondary">Preview the global settings surface with session-scoped preferences.</Text>
       <Button variant="outline" type="button" onClick={() => setOpen(true)}>
         Open settings
       </Button>
-      <SettingsModal open={open()} onOpenChange={setOpen} />
+      <SettingsModal
+        open={open()}
+        onOpenChange={setOpen}
+        value={value()}
+        onValueChange={setValue}
+        appInfo={storyAppInfo}
+        updateStatus={updateStatus()}
+        onUpdateAction={async () => {
+          setUpdateStatus({ ...storyUpdateStatus, phase: "up-to-date", checkedAt: new Date().toISOString() });
+        }}
+      />
     </main>
   );
 }
@@ -24,8 +48,31 @@ function SettingsModalStory(props: { initialOpen: boolean }) {
 const meta = {
   title: "Settings/SettingsModal",
   component: SettingsModal,
-  args: { open: false, onOpenChange: () => undefined },
-  parameters: { layout: "fullscreen", a11y: { test: "error" } },
+  args: {
+    open: false,
+    onOpenChange: fn(),
+    value: DEFAULT_GENERAL_SETTINGS,
+    onValueChange: fn(),
+    appInfo: storyAppInfo,
+    updateStatus: storyUpdateStatus,
+    onUpdateAction: fn(async () => undefined),
+  },
+  parameters: {
+    layout: "fullscreen",
+    a11y: { test: "error" },
+    viewport: {
+      options: {
+        settingsDesktop: {
+          name: "Settings — 1200 × 820",
+          styles: { width: "1200px", height: "820px" },
+        },
+        settingsNarrow: {
+          name: "Settings — 640 × 720",
+          styles: { width: "640px", height: "720px" },
+        },
+      },
+    },
+  },
 } satisfies Meta<typeof SettingsModal>;
 
 export default meta;
@@ -33,6 +80,11 @@ type Story = StoryObj<typeof meta>;
 
 export const Open: Story = {
   render: () => <SettingsModalStory initialOpen />,
+};
+
+export const Narrow: Story = {
+  render: () => <SettingsModalStory initialOpen />,
+  parameters: { viewport: { defaultViewport: "settingsNarrow" } },
 };
 
 export const Interactive: Story = {
@@ -45,21 +97,22 @@ export const Interactive: Story = {
     let dialog = await body.findByRole("dialog", { name: "General" });
     await waitFor(() => expect(dialog).toBeVisible());
     await expect(body.getByTestId("settings-modal-scroll-frame")).toHaveAttribute("data-scroll-down");
-    await expect(body.getByRole("button", { name: "Appearance" })).toBeDisabled();
-    await expect(body.getByRole("button", { name: "Notifications" })).toBeDisabled();
-    await expect(body.getByRole("button", { name: "Advanced" })).toBeDisabled();
+    await expect(body.getByRole("tab", { name: "Appearance" })).toBeDisabled();
+    await expect(body.getByRole("tab", { name: "Notifications" })).toBeDisabled();
+    await expect(body.getByRole("tab", { name: "Advanced" })).toBeDisabled();
 
-    const profileTab = body.getByRole("button", { name: "Profile" });
-    await userEvent.click(profileTab);
-    await expect(profileTab).toHaveAttribute("aria-current", "page");
+    const generalTab = body.getByRole("tab", { name: "General" });
+    generalTab.focus();
+    await userEvent.keyboard("{ArrowDown}");
+    const profileTab = body.getByRole("tab", { name: "Profile" });
+    await expect(profileTab).toHaveAttribute("aria-selected", "true");
     await expect(body.getByRole("heading", { name: "Profile", level: 2 })).toBeVisible();
     await expect(body.getByRole("textbox", { name: "Display name" })).toHaveValue("OpenBot user");
 
-    const generalTab = body.getByRole("button", { name: "General" });
     await userEvent.click(generalTab);
-    await expect(generalTab).toHaveAttribute("aria-current", "page");
+    await expect(generalTab).toHaveAttribute("aria-selected", "true");
 
-    const linkTarget = body.getByRole("button", { name: /Open external links in/ });
+    const linkTarget = body.getByRole("button", { name: /^Open external links in/ });
     await userEvent.click(linkTarget);
     await waitFor(() => expect(body.getByRole("listbox")).toBeVisible());
     await userEvent.click(body.getByRole("option", { name: "OpenBot" }));
@@ -70,6 +123,9 @@ export const Interactive: Story = {
     await userEvent.click(launchSwitch);
     await expect(launchSwitch).not.toBeChecked();
 
+    await userEvent.click(body.getByRole("button", { name: "Check for updates" }));
+    await expect(body.getByText("OpenBot is up to date.")).toBeVisible();
+
     await userEvent.click(body.getByRole("button", { name: "Close settings" }));
     await expect(dialog).toHaveAttribute("data-motion", "closing");
     await waitFor(() => expect(body.queryByRole("dialog", { name: "General" })).not.toBeInTheDocument());
@@ -77,7 +133,7 @@ export const Interactive: Story = {
 
     await userEvent.click(trigger);
     dialog = await body.findByRole("dialog", { name: "General" });
-    await waitFor(() => expect(dialog).toBeVisible());
+    await expect(body.getByRole("switch", { name: "Launch OpenBot at login" })).not.toBeChecked();
     await userEvent.keyboard("{Escape}");
     await expect(dialog).toHaveAttribute("data-motion", "closing");
     await waitFor(() => expect(body.queryByRole("dialog", { name: "General" })).not.toBeInTheDocument());

--- a/src/renderer/stories/Surface.stories.tsx
+++ b/src/renderer/stories/Surface.stories.tsx
@@ -19,6 +19,7 @@ import {
   ItemTitle,
   Kbd,
   Separator,
+  SettingsSection,
   ShieldCheck,
   Skeleton,
   Spinner,
@@ -92,6 +93,31 @@ export const Gallery: Story = {
           </Item>
         </ItemGroup>
       </section>
+
+      <SettingsSection
+        class="foundation-story-section"
+        title="Workspace preferences"
+        description="Settings shared by this workspace."
+        actions={
+          <Button size="sm" variant="ghost">
+            Manage
+          </Button>
+        }
+      >
+        <ItemGroup surface="subtle">
+          <Item>
+            <ItemContent>
+              <ItemTitle>Restore recent workspace</ItemTitle>
+              <ItemDescription>Return to the workspace from your previous session.</ItemDescription>
+            </ItemContent>
+            <ItemActions>
+              <Button size="sm" variant="outline">
+                Configure
+              </Button>
+            </ItemActions>
+          </Item>
+        </ItemGroup>
+      </SettingsSection>
 
       <section class="foundation-story-section" aria-labelledby="alert-primitives">
         <Heading id="alert-primitives" as="h2" size="sm">


### PR DESCRIPTION
## Summary

- redesign the global Settings modal and connect it to the account menu with session-scoped General preferences and shared updater status
- align Server Settings General and Members with reusable SettingsSection and SlidingTabs primitives
- improve server identity validation, logo selection, address copying, responsive layout, focus restoration, and accessibility
- expand Storybook coverage and behavior tests for the updated settings flows

## Verification

- pre-commit Biome check across all changed files
- typecheck:brand
- typecheck:contracts
- typecheck:node
- typecheck:renderer
- typecheck:storybook
- typecheck:api
- ServerSettingsModal and SettingsModal tests: 13 passed
- App integration tests: 108 passed