### PR TITLE
Add bot reactions and improve server invite workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,14 @@
 - Use `lucide-solid` for renderer UI icons. Reuse a suitable Lucide icon before you add an inline SVG or a local icon component. Add a custom icon only when Lucide has no suitable icon, and document the exception next to the custom icon.
 - Treat the `:root` properties in `src/renderer/src/styles.css` as the renderer color palette. Use the closest semantic `--openbot-*` token, including opacity variants, instead of ad-hoc color literals. Add a token there only for a new semantic role. Keep existing compatibility aliases when used, and isolate fixed integration, generated asset, SVG, or platform colors at their boundaries.
 
+## Database migrations
+
+- OpenBot does not create an automatic full copy of `openbot.db` before upgrading. Treat every migration as an irreversible production data operation: preserve all user data, support every shipped source schema, and never depend on a backup being available.
+- Keep each schema change and its `schema_migrations` marker in the same transaction. Roll back on any error, restore foreign-key enforcement in `finally`, and run the integrity checks before allowing startup to continue.
+- Never edit or delete a migration that may have shipped, including the frozen version 8 baseline. Append the next contiguous version and update the separate latest schema used for new databases.
+- Migration changes require data-preservation fixtures for every affected released schema plus failure, rollback, retry, downgrade, missing-version, foreign-key, and integrity coverage at the stable database boundary.
+- Do not add automatic full-database migration backups. Their time and disk cost is unbounded because conversation history lives in SQLite; make the migration itself safe instead.
+
 ## Test value policy
 
 - Keep verification minimal and proportional to the change. Run the narrowest relevant automated test and, when needed, one manual UI check; do not repeat equivalent checks across Vitest, Storybook, and the integrated app unless they cover genuinely different runtime behavior.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,6 +61,10 @@ renderer ──► @openbot/contracts ◄── preload ◄── main ──►
    only repository lint and format tools.
 7. Do not add compatibility paths without a removal condition and a test for that condition.
 
+SQLite migration history starts at the frozen version 8 compatibility baseline. Keep the baseline
+schema unchanged, append every later migration in numeric order, and update the separate latest
+schema used for new databases. Never remove or rewrite a migration that may have shipped.
+
 ## Required verification
 
 Run `bun run check` for normal changes. Changes to packaging, native modules, or Electron security

--- a/packages/contracts/src/invite-links.test.ts
+++ b/packages/contracts/src/invite-links.test.ts
@@ -16,6 +16,11 @@ const payload = {
 };
 const missingTokenUrl = new URL(createInviteUrl(payload));
 missingTokenUrl.searchParams.delete("invite");
+const localDevelopmentPayload = {
+  ...payload,
+  apiUrl: "http://localhost:43123/",
+};
+const localDevelopmentOptions = { allowLocalDevelopmentApiUrl: true };
 
 describe("OpenBot invite links", () => {
   it("creates and parses the canonical HTTPS invitation", () => {
@@ -38,6 +43,24 @@ describe("OpenBot invite links", () => {
     expect(isValidRemoteApiUrl("https://example.com/")).toBe(false);
     expect(isValidRemoteApiUrl(`${payload.apiUrl}path`)).toBe(false);
   });
+
+  it("supports localhost invitations only when local development is explicitly enabled", () => {
+    expect(() => createInviteUrl(localDevelopmentPayload)).toThrow("invalid");
+    expect(isValidRemoteApiUrl(localDevelopmentPayload.apiUrl)).toBe(false);
+
+    const url = createInviteUrl(localDevelopmentPayload, localDevelopmentOptions);
+    expect(parseInviteUrl(url, localDevelopmentOptions)).toEqual(localDevelopmentPayload);
+    expect(isCanonicalInviteUrl(url, localDevelopmentOptions)).toBe(true);
+    expect(() => parseInviteUrl(url)).toThrow("invalid");
+    expect(isValidRemoteApiUrl(localDevelopmentPayload.apiUrl, localDevelopmentOptions)).toBe(true);
+  });
+
+  it.each(["http://localhost/", "https://localhost:43123/", "http://127.0.0.1:43123/", "http://localhost:43123/path"])(
+    "rejects an unsafe local development API URL: %s",
+    (apiUrl) => {
+      expect(isValidRemoteApiUrl(apiUrl, localDevelopmentOptions)).toBe(false);
+    },
+  );
 
   it.each([
     "https://evil.example/join",

--- a/packages/contracts/src/invite-links.ts
+++ b/packages/contracts/src/invite-links.ts
@@ -15,27 +15,31 @@ export interface InviteLinkPayload {
   token: string;
 }
 
-export function createInviteUrl(payload: InviteLinkPayload): string {
-  validatePayload(payload);
+export interface InviteLinkOptions {
+  allowLocalDevelopmentApiUrl?: boolean;
+}
+
+export function createInviteUrl(payload: InviteLinkPayload, options: InviteLinkOptions = {}): string {
+  validatePayload(payload, options);
   const url = new URL(OPENBOT_INVITE_PATH, OPENBOT_INVITE_ORIGIN);
   writePayload(url, payload);
   return url.toString();
 }
 
-export function createOpenBotInviteUrl(payload: InviteLinkPayload): string {
-  validatePayload(payload);
+export function createOpenBotInviteUrl(payload: InviteLinkPayload, options: InviteLinkOptions = {}): string {
+  validatePayload(payload, options);
   const url = new URL("openbot://join");
   writePayload(url, payload);
   return url.toString();
 }
 
-export function toOpenBotInviteUrl(value: string): string {
-  return createOpenBotInviteUrl(parseInviteUrl(value));
+export function toOpenBotInviteUrl(value: string, options: InviteLinkOptions = {}): string {
+  return createOpenBotInviteUrl(parseInviteUrl(value, options), options);
 }
 
-export function isCanonicalInviteUrl(value: string): boolean {
+export function isCanonicalInviteUrl(value: string, options: InviteLinkOptions = {}): boolean {
   try {
-    parseInviteUrl(value);
+    parseInviteUrl(value, options);
     const url = new URL(value);
     return url.origin === OPENBOT_INVITE_ORIGIN && url.pathname === OPENBOT_INVITE_PATH;
   } catch {
@@ -43,7 +47,7 @@ export function isCanonicalInviteUrl(value: string): boolean {
   }
 }
 
-export function parseInviteUrl(value: string): InviteLinkPayload {
+export function parseInviteUrl(value: string, options: InviteLinkOptions = {}): InviteLinkPayload {
   let url: URL;
   try {
     url = new URL(value);
@@ -72,31 +76,37 @@ export function parseInviteUrl(value: string): InviteLinkPayload {
     fingerprint: url.searchParams.get("fingerprint") ?? "",
     token: url.searchParams.get("invite") ?? "",
   };
-  validatePayload(payload);
+  validatePayload(payload, options);
   return payload;
 }
 
-export function isValidRemoteApiUrl(value: string): boolean {
+export function isValidRemoteApiUrl(value: string, options: InviteLinkOptions = {}): boolean {
   try {
     const url = new URL(value);
+    const localDevelopmentApi =
+      options.allowLocalDevelopmentApiUrl === true &&
+      url.protocol === "http:" &&
+      url.hostname === "localhost" &&
+      url.port !== "";
     return (
-      url.protocol === "https:" &&
       url.username === "" &&
       url.password === "" &&
-      url.port === "" &&
       url.pathname === "/" &&
       url.search === "" &&
       url.hash === "" &&
-      (TRY_CLOUDFLARE_HOST_PATTERN.test(url.hostname) || isOpenBotTeamApiHostname(url.hostname))
+      (localDevelopmentApi ||
+        (url.protocol === "https:" &&
+          url.port === "" &&
+          (TRY_CLOUDFLARE_HOST_PATTERN.test(url.hostname) || isOpenBotTeamApiHostname(url.hostname))))
     );
   } catch {
     return false;
   }
 }
 
-function validatePayload(payload: InviteLinkPayload): void {
+function validatePayload(payload: InviteLinkPayload, options: InviteLinkOptions): void {
   if (
-    !isValidRemoteApiUrl(payload.apiUrl) ||
+    !isValidRemoteApiUrl(payload.apiUrl, options) ||
     !UUID_PATTERN.test(payload.serverId) ||
     !BASE64URL_SECRET_PATTERN.test(payload.fingerprint) ||
     !BASE64URL_SECRET_PATTERN.test(payload.token)

--- a/packages/contracts/src/ipc-conversation.ts
+++ b/packages/contracts/src/ipc-conversation.ts
@@ -599,6 +599,7 @@ export interface ConversationMessage {
   delivery?: Pick<QueueDelivery, "id" | "status" | "position">;
   exchange?: AgentExchangeSummary;
   reaction?: MessageReaction | null;
+  reactions?: ConversationReaction[];
   routine?: {
     routineId: string;
     runId: string;
@@ -627,6 +628,9 @@ export function isConversationMessage(value: unknown): value is ConversationMess
       value.source === "routine") &&
     (value.senderBotId === undefined || isString(value.senderBotId)) &&
     (value.replyToMessageId === undefined || value.replyToMessageId === null || isString(value.replyToMessageId)) &&
+    (value.reaction === undefined || value.reaction === null || isMessageReaction(value.reaction)) &&
+    (value.reactions === undefined ||
+      (Array.isArray(value.reactions) && value.reactions.every(isConversationReaction))) &&
     (value.routine === undefined ||
       (isDynamicRecord(value.routine) &&
         isString(value.routine.routineId) &&
@@ -640,10 +644,28 @@ export function isConversationMessage(value: unknown): value is ConversationMess
 export const MESSAGE_REACTIONS = ["👍", "👎", "❤️", "😂", "🎉", "😮"] as const;
 export const MORE_MESSAGE_REACTIONS = ["🔥", "👏", "🙏", "🤔", "👀", "✅", "🚀", "💯"] as const;
 export const ALL_MESSAGE_REACTIONS = [...MESSAGE_REACTIONS, ...MORE_MESSAGE_REACTIONS] as const;
-export type MessageReaction = (typeof MESSAGE_REACTIONS)[number] | (typeof MORE_MESSAGE_REACTIONS)[number];
+export type MessageReaction = string;
+
+export type ConversationReactionActor = { kind: "user" } | { kind: "bot"; botId: string };
+
+export interface ConversationReaction {
+  emoji: MessageReaction;
+  actor: ConversationReactionActor;
+}
+
+// biome-ignore lint/complexity/useRegexLiterals: The v flag is supported at runtime but the contracts target predates ES2024.
+const RGI_EMOJI_PATTERN = new RegExp("^(?:\\p{RGI_Emoji})$", "v");
 
 export function isMessageReaction(value: unknown): value is MessageReaction {
-  return isOneOf(ALL_MESSAGE_REACTIONS, value);
+  return isString(value) && RGI_EMOJI_PATTERN.test(value);
+}
+
+export function isConversationReaction(value: unknown): value is ConversationReaction {
+  if (!isDynamicRecord(value) || !isMessageReaction(value.emoji) || !isDynamicRecord(value.actor)) return false;
+  return (
+    value.actor.kind === "user" ||
+    (value.actor.kind === "bot" && isString(value.actor.botId) && value.actor.botId.length > 0)
+  );
 }
 
 export interface AgentExchangeSummary {

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { isAgentEvent, isAvatarHue, isAvatarSeed, isBotMemory } from "./ipc";
+import { isAgentEvent, isAvatarHue, isAvatarSeed, isBotMemory, isMessageReaction } from "./ipc";
+
+describe("message reaction validation", () => {
+  it("accepts one complete Unicode emoji sequence", () => {
+    expect(isMessageReaction("😀")).toBe(true);
+    expect(isMessageReaction("👋🏽")).toBe(true);
+    expect(isMessageReaction("👨‍👩‍👧‍👦")).toBe(true);
+    expect(isMessageReaction("🇵🇱")).toBe(true);
+    expect(isMessageReaction("1️⃣")).toBe(true);
+  });
+
+  it("rejects text, whitespace, and multiple emoji", () => {
+    expect(isMessageReaction("hello")).toBe(false);
+    expect(isMessageReaction(" 😀 ")).toBe(false);
+    expect(isMessageReaction("😀😀")).toBe(false);
+    expect(isMessageReaction("")).toBe(false);
+  });
+});
 
 describe("avatar IPC validation", () => {
   it("accepts generated avatar seeds and rejects unsafe or oversized values", () => {

--- a/scripts/seed-dev-state.ts
+++ b/scripts/seed-dev-state.ts
@@ -569,8 +569,8 @@ async function seedConversations(
       `dev-seed:conversation:${botId}`,
     );
   }
-  await mailbox.setReaction("chief", "chief-assistant-plan", "🎉");
-  await mailbox.setReaction("research", "research-assistant", "✅");
+  await mailbox.setReaction("chief", "chief-assistant-plan", { kind: "user" }, "🎉");
+  await mailbox.setReaction("research", "research-assistant", { kind: "user" }, "✅");
 }
 
 async function seedAgentExchanges(mailbox: MailboxStore): Promise<void> {

--- a/src/backend/agent-service.test.ts
+++ b/src/backend/agent-service.test.ts
@@ -331,6 +331,8 @@ describe.sequential("AgentService", () => {
         "You may list, read, create, edit, move, and delete files and run local commands in both directories.",
       );
       expect(params.developerInstructions).toContain("openbot.create_routine");
+      expect(params.developerInstructions).toContain("sadness, disappointment, frustration, loneliness");
+      expect(params.developerInstructions).toContain("An emoji written inside your answer does not count");
       expect(params.developerInstructions).toContain("Omit botId to target yourself");
       expect(params.dynamicTools).toEqual(
         expect.arrayContaining([
@@ -347,6 +349,7 @@ describe.sequential("AgentService", () => {
               expect.objectContaining({ name: "update_routine" }),
               expect.objectContaining({ name: "delete_routine" }),
               expect.objectContaining({ name: "test_routine" }),
+              expect.objectContaining({ name: "react_to_user_message" }),
             ]),
           }),
         ]),
@@ -2102,6 +2105,82 @@ describe.sequential("AgentService", () => {
     );
   });
 
+  it("lets an agent react to the current user message without replacing the user's reaction", async () => {
+    const clients = new Map<AgentProvider, FakeAgentClient>();
+    const { store, mailbox } = stores();
+    service = new AgentService(store, mailbox, fakeBrowser(), null, 30_000, "codex", (provider) => {
+      const client = new FakeAgentClient(provider, "", false);
+      clients.set(provider, client);
+      return client;
+    });
+    await service.initialize();
+    const receipt = await service.sendMessage({ botId: "chief", text: "The launch is approved." });
+    await waitFor(() => service?.listQueue("chief").deliveries[0]?.status === "running");
+
+    const client = clients.get("codex");
+    const threadId = store.activeProviderSession("chief")?.externalSessionId;
+    const turnId = service.listQueue("chief").deliveries[0]?.turnId;
+    const messageId = receipt.deliveries[0]?.id;
+    if (!client || !threadId || !turnId || !messageId) throw new Error("The reaction test turn did not start.");
+
+    await service.setMessageReaction({ botId: "chief", messageId, emoji: "❤️" });
+    const first = await callOpenBotTool(client, threadId, "react_to_user_message", { emoji: "🎉" }, turnId);
+    expect(openBotToolPayload(first.result)).toMatchObject({ status: "reacted", messageId, emoji: "🎉" });
+    const second = await callOpenBotTool(client, threadId, "react_to_user_message", { emoji: "👨‍👩‍👧‍👦" }, turnId);
+    expect(openBotToolPayload(second.result)).toMatchObject({ emoji: "👨‍👩‍👧‍👦" });
+
+    const message = (await service.readConversation("chief")).messages.find((candidate) => candidate.id === messageId);
+    expect(message).toMatchObject({
+      reaction: "❤️",
+      reactions: [
+        { emoji: "❤️", actor: { kind: "user" } },
+        { emoji: "👨‍👩‍👧‍👦", actor: { kind: "bot", botId: "chief" } },
+      ],
+    });
+    await expectOpenBotToolError(
+      client,
+      threadId,
+      "react_to_user_message",
+      { emoji: "🎉🎉" },
+      "exactly one complete Unicode emoji",
+      turnId,
+    );
+  });
+
+  it("rejects an agent reaction when the current turn was not started by the user", async () => {
+    const clients = new Map<AgentProvider, FakeAgentClient>();
+    const { store, mailbox } = stores();
+    await store.initialize();
+    await mailbox.initialize();
+    await store.getOrCreate("chief");
+    await store.getOrCreate("research");
+    await mailbox.enqueue({
+      sender: { kind: "bot", botId: "research" },
+      recipientBotIds: ["chief"],
+      text: "Teammate update.",
+    });
+    service = new AgentService(store, mailbox, fakeBrowser(), null, 30_000, "codex", (provider) => {
+      const client = new FakeAgentClient(provider, "", false);
+      clients.set(provider, client);
+      return client;
+    });
+    await service.initialize();
+    await waitFor(() => service?.listQueue("chief").deliveries[0]?.status === "running");
+
+    const client = clients.get("codex");
+    const threadId = store.activeProviderSession("chief")?.externalSessionId;
+    const turnId = service.listQueue("chief").deliveries[0]?.turnId;
+    if (!client || !threadId || !turnId) throw new Error("The teammate reaction test turn did not start.");
+    await expectOpenBotToolError(
+      client,
+      threadId,
+      "react_to_user_message",
+      { emoji: "👍" },
+      "Only the current user message",
+      turnId,
+    );
+  });
+
   it("sends a teammate request only to the selected profile match", async () => {
     process.env.OPENBOT_FAKE_AGENT_TOOL_CALLS = JSON.stringify([
       { tool: "list_agents", arguments: {} },
@@ -2674,6 +2753,7 @@ async function callOpenBotTool(
   threadId: string,
   tool: string,
   args: unknown,
+  turnId = "routine-tool-turn",
 ): Promise<{ result?: unknown; error?: RpcError }> {
   const id = `openbot-tool-${randomUUID()}`;
   client.emit("request", {
@@ -2681,7 +2761,7 @@ async function callOpenBotTool(
     method: "item/tool/call",
     params: {
       threadId,
-      turnId: "routine-tool-turn",
+      turnId,
       callId: randomUUID(),
       namespace: "openbot",
       tool,
@@ -2712,8 +2792,9 @@ async function expectOpenBotToolError(
   tool: string,
   args: unknown,
   message: string,
+  turnId?: string,
 ): Promise<void> {
-  const result = await callOpenBotTool(client, threadId, tool, args);
+  const result = await callOpenBotTool(client, threadId, tool, args, turnId);
   expect(result.result).toBeUndefined();
   expect(result.error?.message).toContain(message);
 }

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -57,7 +57,12 @@ import type {
   UpdateQueuedMessageInput,
   UpdateRoutineInput,
 } from "@openbot/contracts/ipc";
-import { isImageGenerationAspectRatio, isReasoningEffort, isRoutineSchedule } from "@openbot/contracts/ipc";
+import {
+  isImageGenerationAspectRatio,
+  isMessageReaction,
+  isReasoningEffort,
+  isRoutineSchedule,
+} from "@openbot/contracts/ipc";
 import { type DynamicRecord, isBoolean, isNumber, isString } from "@openbot/contracts/runtime-values";
 import type { AgentClient, AgentProvider } from "./agent-client";
 import { AgentMemoryStore } from "./agent-memory-store";
@@ -980,7 +985,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     if (!current.messages.some((message) => message.id === input.messageId)) {
       throw new Error("The message is no longer available.");
     }
-    await this.#mailbox.setReaction(bot.id, input.messageId, input.emoji);
+    await this.#mailbox.setReaction(bot.id, input.messageId, { kind: "user" }, input.emoji);
     this.#syncMailboxMessages(current);
     this.#emitConversation(current);
   }
@@ -2198,6 +2203,27 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       };
     }
 
+    if (params.tool === "react_to_user_message") {
+      const args = params.arguments;
+      if (!isRecord(args) || !isMessageReaction(args.emoji)) {
+        throw new Error("emoji must be exactly one complete Unicode emoji.");
+      }
+      const delivery = this.#mailbox
+        .findDeliveriesByTurn(senderBotId, params.turnId)
+        .find((candidate) => candidate.delivery.sender.kind === "user");
+      if (!delivery) throw new Error("Only the current user message can receive an agent reaction.");
+      await this.#mailbox.setReaction(
+        senderBotId,
+        delivery.delivery.id,
+        { kind: "bot", botId: senderBotId },
+        args.emoji,
+      );
+      const snapshot = this.#ensureSnapshot(senderBotId, params.threadId);
+      this.#syncMailboxMessages(snapshot);
+      this.#emitConversation(snapshot);
+      return openBotToolResult({ status: "reacted", messageId: delivery.delivery.id, emoji: args.emoji });
+    }
+
     if (params.tool !== "send_message" || !isRecord(params.arguments)) {
       throw new Error(`Unsupported OpenBot tool: ${params.tool}`);
     }
@@ -2650,7 +2676,8 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     }
     const reactions = this.#mailbox.reactionsFor(snapshot.botId);
     for (const message of snapshot.messages) {
-      message.reaction = reactions.get(message.id) ?? null;
+      message.reactions = reactions.get(message.id) ?? [];
+      message.reaction = message.reactions.find((reaction) => reaction.actor.kind === "user")?.emoji ?? null;
     }
     sortConversationMessages(snapshot.messages);
   }
@@ -3908,6 +3935,7 @@ function developerInstructions(bot: BotSummary, sharedRoot: string, memories: Bo
     "Use openbot.update_profile with the target bot id to change a local agent's name, title, or description. The target id is required and may refer to any local agent.",
     "Use openbot.list_routines, openbot.create_routine, openbot.update_routine, openbot.delete_routine, and openbot.test_routine to manage scheduled work for yourself or another local agent when the user's request calls for it. Omit botId to target yourself. Before changing another agent's routines, call openbot.list_agents and select its stable id. Before updating, deleting, or testing a routine, call openbot.list_routines to obtain its stable routine id.",
     "Memory tools always apply to your own agent profile. They cannot change another agent's memories.",
+    "Use openbot.react_to_user_message when the user's message contains an obvious positive or negative emotional moment where a reaction would feel natural. Clear wins or celebrations, affection, gratitude, playful humor, sadness, disappointment, frustration, loneliness, empathy, and strong approval should normally receive one fitting reaction; do not be so conservative that you skip these obvious cases. Negative emotions deserve an empathetic reaction such as ❤️, 😔, or 🫂 rather than being excluded as sensitive. An emoji written inside your answer does not count as a message reaction: when you use an inline emoji to acknowledge the user's emotion, that is a strong signal that you should also call the reaction tool. Skip neutral, purely informational, or routine messages, and never react on every turn. A reaction never replaces, shortens, or changes your normal answer: always provide the same complete response you would give without it, and do not mention the reaction in that response.",
     "Use openbot.send_message to send asynchronous messages or local files to one or more teammates. Always set replyToMessageId when answering a teammate. Replies are never forwarded automatically.",
     "When you need clarification or the user asks you to ask a question, use openbot.ask_user with 1–3 short questions instead of writing the question as a normal assistant message. Use options for choices and wait for the tool result before continuing. Claude should use AskUserQuestion for the same purpose.",
     "OpenBot renders GitHub-flavored Markdown tables in your final responses. Use a table when structured data or a comparison is clearer than prose; include a header row, a separator row with at least three dashes per column, and at least one data row. For a feature-by-option comparison, use at least three columns and put exactly ✓ or — in every option cell; OpenBot will render that Markdown as a comparison table. Example: | Feature | Personal | Enterprise | followed by | --- | --- | --- | and rows such as | Priority support | — | ✓ |.",

--- a/src/backend/claude-client.test.ts
+++ b/src/backend/claude-client.test.ts
@@ -92,6 +92,7 @@ fi
           "update_routine",
           "delete_routine",
           "test_routine",
+          "react_to_user_message",
         ]),
       );
       return generator;

--- a/src/backend/claude-client.ts
+++ b/src/backend/claude-client.ts
@@ -588,6 +588,12 @@ export class ClaudeAgentClient extends EventEmitter<ClientEvents> {
             (args) => call("openbot", "forget_memory", args),
           ),
           tool(
+            "react_to_user_message",
+            "Add one emoji reaction for an obvious positive or negative emotional moment such as a win, affection, gratitude, humor, sadness, disappointment, frustration, empathy, or strong approval. Inline emoji do not count as reactions. Skip neutral messages and always provide the same complete normal answer.",
+            { emoji: z.string().min(1).max(64) },
+            (args) => call("openbot", "react_to_user_message", args),
+          ),
+          tool(
             "send_message",
             "Send an asynchronous message or local files to OpenBot teammates.",
             {

--- a/src/backend/conversation-read-store.test.ts
+++ b/src/backend/conversation-read-store.test.ts
@@ -137,7 +137,9 @@ describe("ConversationReadStore", () => {
         legacyDirectMessage.createdAt,
         JSON.stringify(legacyDirectMessage),
       );
-    migrateOpenBotDatabase(legacy, "2026-08-19T10:00:00.000Z");
+    migrateOpenBotDatabase(legacy, {
+      appliedAt: "2026-08-19T10:00:00.000Z",
+    });
     legacy.close();
 
     const database = new OpenBotDatabase(root);

--- a/src/backend/mailbox-store.test.ts
+++ b/src/backend/mailbox-store.test.ts
@@ -223,7 +223,7 @@ describe("MailboxStore", () => {
     await expect(readFile(statePath, "utf8")).resolves.toBe(unsupported);
   });
 
-  it("persists reply metadata and one local reaction per conversation message", async () => {
+  it("persists one reaction per actor without overwriting other actors", async () => {
     const receipt = await store.enqueue({
       sender: { kind: "user" },
       recipientBotIds: ["chief"],
@@ -236,12 +236,19 @@ describe("MailboxStore", () => {
       replyToMessageId: "assistant-1",
     });
 
-    await store.setReaction("chief", "assistant-1", "❤️");
+    await store.setReaction("chief", "assistant-1", { kind: "user" }, "❤️");
+    await store.setReaction("chief", "assistant-1", { kind: "bot", botId: "chief" }, "🎉");
     const restored = new MailboxStore(join(root, "user-data"), join(root, "Shared"));
     await restored.initialize();
     expect(restored.reactionFor("chief", "assistant-1")).toBe("❤️");
-    await restored.setReaction("chief", "assistant-1", null);
+    expect(restored.reactionFor("chief", "assistant-1", { kind: "bot", botId: "chief" })).toBe("🎉");
+    expect(restored.reactionsFor("chief").get("assistant-1")).toEqual([
+      { emoji: "❤️", actor: { kind: "user" } },
+      { emoji: "🎉", actor: { kind: "bot", botId: "chief" } },
+    ]);
+    await restored.setReaction("chief", "assistant-1", { kind: "user" }, null);
     expect(restored.reactionFor("chief", "assistant-1")).toBeNull();
+    expect(restored.reactionFor("chief", "assistant-1", { kind: "bot", botId: "chief" })).toBe("🎉");
   });
 
   it("tracks the initiating bot through a reply chain and detects explicit replies", async () => {

--- a/src/backend/mailbox-store.ts
+++ b/src/backend/mailbox-store.ts
@@ -14,6 +14,8 @@ import type {
   AttachmentPreviewKind,
   AttachmentSummary,
   ConversationMessage,
+  ConversationReaction,
+  ConversationReactionActor,
   DraftAttachment,
   MessageReaction,
   QueueDelivery,
@@ -83,6 +85,7 @@ interface StoredReaction {
   botId: string;
   messageId: string;
   emoji: MessageReaction;
+  actor: ConversationReactionActor;
   updatedAt: string;
 }
 
@@ -492,24 +495,40 @@ export class MailboxStore {
     return messages;
   }
 
-  reactionFor(botId: string, messageId: string): MessageReaction | null {
+  reactionFor(
+    botId: string,
+    messageId: string,
+    actor: ConversationReactionActor = { kind: "user" },
+  ): MessageReaction | null {
     return (
-      this.#state.reactions.find((reaction) => reaction.botId === botId && reaction.messageId === messageId)?.emoji ??
-      null
+      this.#state.reactions.find(
+        (reaction) =>
+          reaction.botId === botId && reaction.messageId === messageId && reactionActorsEqual(reaction.actor, actor),
+      )?.emoji ?? null
     );
   }
 
-  reactionsFor(botId: string): Map<string, MessageReaction> {
-    return new Map(
-      this.#state.reactions
-        .filter((reaction) => reaction.botId === botId)
-        .map((reaction) => [reaction.messageId, reaction.emoji]),
-    );
+  reactionsFor(botId: string): Map<string, ConversationReaction[]> {
+    const result = new Map<string, ConversationReaction[]>();
+    for (const reaction of this.#state.reactions) {
+      if (reaction.botId !== botId) continue;
+      const reactions = result.get(reaction.messageId) ?? [];
+      reactions.push({ emoji: reaction.emoji, actor: reaction.actor });
+      result.set(reaction.messageId, reactions);
+    }
+    for (const reactions of result.values()) reactions.sort(compareReactionActors);
+    return result;
   }
 
-  async setReaction(botId: string, messageId: string, emoji: MessageReaction | null): Promise<void> {
+  async setReaction(
+    botId: string,
+    messageId: string,
+    actor: ConversationReactionActor,
+    emoji: MessageReaction | null,
+  ): Promise<void> {
     const index = this.#state.reactions.findIndex(
-      (reaction) => reaction.botId === botId && reaction.messageId === messageId,
+      (reaction) =>
+        reaction.botId === botId && reaction.messageId === messageId && reactionActorsEqual(reaction.actor, actor),
     );
     if (emoji === null) {
       if (index < 0) return;
@@ -519,6 +538,7 @@ export class MailboxStore {
         botId,
         messageId,
         emoji,
+        actor,
         updatedAt: new Date().toISOString(),
       };
     } else {
@@ -526,6 +546,7 @@ export class MailboxStore {
         botId,
         messageId,
         emoji,
+        actor,
         updatedAt: new Date().toISOString(),
       });
     }
@@ -1262,6 +1283,10 @@ function normalizeStoredState(value: StoredState): StoredState {
     version: 3,
     generatedAttachments: value.generatedAttachments ?? [],
     deliveries,
+    reactions: value.reactions.map((reaction) => ({
+      ...reaction,
+      actor: reaction.actor ?? { kind: "user" },
+    })),
   };
 }
 
@@ -1371,8 +1396,26 @@ function isStoredReaction(value: unknown): value is StoredReaction {
     isString(value.botId) &&
     isString(value.messageId) &&
     isMessageReaction(value.emoji) &&
+    (value.actor === undefined || isStoredReactionActor(value.actor)) &&
     isString(value.updatedAt)
   );
+}
+
+function isStoredReactionActor(value: unknown): value is ConversationReactionActor {
+  return (
+    isRecord(value) &&
+    (value.kind === "user" || (value.kind === "bot" && isString(value.botId) && value.botId.length > 0))
+  );
+}
+
+function reactionActorsEqual(left: ConversationReactionActor, right: ConversationReactionActor): boolean {
+  return left.kind === right.kind && (left.kind === "user" || (right.kind === "bot" && left.botId === right.botId));
+}
+
+function compareReactionActors(left: ConversationReaction, right: ConversationReaction): number {
+  if (left.actor.kind !== right.actor.kind) return left.actor.kind === "user" ? -1 : 1;
+  if (left.actor.kind === "user" || right.actor.kind === "user") return 0;
+  return left.actor.botId.localeCompare(right.actor.botId);
 }
 
 function isWithin(root: string, path: string): boolean {

--- a/src/backend/openbot-database-schema.ts
+++ b/src/backend/openbot-database-schema.ts
@@ -1,9 +1,11 @@
 import type { DatabaseSync } from "node:sqlite";
 import { type DynamicRecord, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
 
-const SCHEMA_VERSION = 7;
+const BASELINE_SCHEMA_VERSION = 8;
 
-const SCHEMA_SQL = `
+// This is the frozen compatibility schema for every database that predates v8.
+// Future schema changes must update LATEST_SCHEMA_SQL and append a migration without editing this SQL.
+const BASELINE_V8_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS schema_migrations (
     version INTEGER PRIMARY KEY,
     applied_at TEXT NOT NULL
@@ -203,9 +205,11 @@ const SCHEMA_SQL = `
     agent_id TEXT NOT NULL,
     message_id TEXT NOT NULL,
     emoji TEXT NOT NULL,
+    actor_kind TEXT NOT NULL CHECK(actor_kind IN ('user', 'bot')),
+    actor_bot_id TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     last_event_sequence INTEGER NOT NULL,
-    PRIMARY KEY(agent_id, message_id)
+    PRIMARY KEY(agent_id, message_id, actor_kind, actor_bot_id)
   );
   CREATE TABLE IF NOT EXISTS projection_attachments (
     attachment_id TEXT PRIMARY KEY,
@@ -269,59 +273,250 @@ const SCHEMA_SQL = `
   );
 `;
 
-export function migrateOpenBotDatabase(db: DatabaseSync, appliedAt = new Date().toISOString()): void {
-  db.exec(SCHEMA_SQL);
-  const applied = db.prepare("SELECT version FROM schema_migrations WHERE version = ?").get(SCHEMA_VERSION);
-  if (applied) return;
-  const upgradingExistingDatabase = Boolean(db.prepare("SELECT 1 FROM schema_migrations LIMIT 1").get());
+// v9 and v10 change runtime state but not the schema, so the fresh schema still matches the v8 baseline.
+// Keep this separate once a later migration changes tables or indexes.
+const LATEST_SCHEMA_SQL = BASELINE_V8_SCHEMA_SQL;
 
+export interface OpenBotMigrationOptions {
+  appliedAt?: string;
+  warn?: (message: string, error: unknown) => void;
+}
+
+interface OpenBotMigration {
+  version: number;
+  disableForeignKeys?: boolean;
+  vacuumAfterCommit?: boolean;
+  up: (db: DatabaseSync, appliedAt: string) => void;
+}
+
+const MIGRATIONS: readonly OpenBotMigration[] = [
+  {
+    version: BASELINE_SCHEMA_VERSION,
+    disableForeignKeys: true,
+    vacuumAfterCommit: true,
+    up: migrateToBaselineV8,
+  },
+  {
+    version: 9,
+    up: refreshProviderSessionsForReactionTools,
+  },
+  {
+    version: 10,
+    up: refreshProviderSessionsForReactionTools,
+  },
+];
+
+const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1]?.version ?? BASELINE_SCHEMA_VERSION;
+
+export function migrateOpenBotDatabase(db: DatabaseSync, options: OpenBotMigrationOptions = {}): void {
+  validateMigrationRegistry();
+  const appliedAt = options.appliedAt ?? new Date().toISOString();
+  if (!hasExistingSchema(db)) {
+    createLatestDatabase(db, appliedAt);
+    assertQuickCheck(db);
+    return;
+  }
+
+  const appliedVersions = readAppliedVersions(db);
+  validateAppliedVersions(appliedVersions);
+  const currentVersion = latestAppliedVersion(appliedVersions);
+  const pending = MIGRATIONS.filter((migration) => migration.version > currentVersion);
+
+  for (const migration of pending) {
+    try {
+      runMigration(db, migration, appliedAt);
+    } catch (error) {
+      throw new Error(`OpenBot database migration to version ${migration.version} failed.`, {
+        cause: error,
+      });
+    }
+
+    if (migration.vacuumAfterCommit) {
+      try {
+        db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+        db.exec("VACUUM");
+        db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+      } catch (error) {
+        (options.warn ?? console.warn)(
+          `OpenBot database migration to version ${migration.version} succeeded, but VACUUM failed.`,
+          error,
+        );
+      }
+    }
+  }
+
+  assertQuickCheck(db);
+}
+
+function migrateToBaselineV8(db: DatabaseSync, appliedAt: string): void {
+  db.exec(BASELINE_V8_SCHEMA_SQL);
+  db.prepare(
+    `INSERT OR IGNORE INTO projection_thread_read_baselines (
+       thread_id, through_message_id, initialized_at
+     )
+     SELECT thread.thread_id,
+       (
+         SELECT message.message_id
+         FROM projection_thread_messages message
+         WHERE message.thread_id = thread.thread_id
+         ORDER BY message.created_at DESC, message.ordinal DESC, message.message_id DESC
+         LIMIT 1
+       ),
+       ?
+     FROM projection_threads thread`,
+  ).run(appliedAt);
+  db.prepare(
+    `INSERT OR IGNORE INTO projection_direct_reads (
+       thread_id, member_id, last_read_sequence, updated_at
+     )
+     SELECT thread_id, member_a_id, last_event_sequence, ?
+     FROM projection_direct_threads`,
+  ).run(appliedAt);
+  db.prepare(
+    `INSERT OR IGNORE INTO projection_direct_reads (
+       thread_id, member_id, last_read_sequence, updated_at
+     )
+     SELECT thread_id, member_b_id, last_event_sequence, ?
+     FROM projection_direct_threads`,
+  ).run(appliedAt);
+  compactConversationHistory(db);
+  compactMailboxHistory(db);
+  migrateProviderSessionsForGrok(db);
+  migrateReactionsForActors(db);
+}
+
+function refreshProviderSessionsForReactionTools(db: DatabaseSync, appliedAt: string): void {
+  db.prepare(
+    `UPDATE projection_provider_sessions
+     SET state = 'inactive', updated_at = ?
+     WHERE state = 'active'`,
+  ).run(appliedAt);
+}
+
+function validateMigrationRegistry(): void {
+  let expectedVersion = BASELINE_SCHEMA_VERSION;
+  for (const migration of MIGRATIONS) {
+    if (!Number.isInteger(migration.version) || migration.version !== expectedVersion) {
+      throw new Error(
+        `OpenBot database migrations must be contiguous from version ${BASELINE_SCHEMA_VERSION}; expected ${expectedVersion}.`,
+      );
+    }
+    expectedVersion += 1;
+  }
+}
+
+function hasExistingSchema(db: DatabaseSync): boolean {
+  return Boolean(
+    db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' LIMIT 1").get(),
+  );
+}
+
+function createLatestDatabase(db: DatabaseSync, appliedAt: string): void {
   db.exec("BEGIN IMMEDIATE");
   try {
-    db.prepare(
-      `INSERT OR IGNORE INTO projection_thread_read_baselines (
-         thread_id, through_message_id, initialized_at
-       )
-       SELECT thread.thread_id,
-         (
-           SELECT message.message_id
-           FROM projection_thread_messages message
-           WHERE message.thread_id = thread.thread_id
-           ORDER BY message.created_at DESC, message.ordinal DESC, message.message_id DESC
-           LIMIT 1
-         ),
-         ?
-       FROM projection_threads thread`,
-    ).run(appliedAt);
-    db.prepare(
-      `INSERT OR IGNORE INTO projection_direct_reads (
-         thread_id, member_id, last_read_sequence, updated_at
-       )
-       SELECT thread_id, member_a_id, last_event_sequence, ?
-       FROM projection_direct_threads`,
-    ).run(appliedAt);
-    db.prepare(
-      `INSERT OR IGNORE INTO projection_direct_reads (
-         thread_id, member_id, last_read_sequence, updated_at
-       )
-       SELECT thread_id, member_b_id, last_event_sequence, ?
-       FROM projection_direct_threads`,
-    ).run(appliedAt);
-    compactConversationHistory(db);
-    compactMailboxHistory(db);
+    db.exec(LATEST_SCHEMA_SQL);
+    const insertMigration = db.prepare("INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)");
+    for (const migration of MIGRATIONS) insertMigration.run(migration.version, appliedAt);
+    assertForeignKeys(db);
     db.exec("COMMIT");
   } catch (error) {
-    db.exec("ROLLBACK");
+    if (db.isTransaction) db.exec("ROLLBACK");
     throw error;
   }
+}
 
-  if (upgradingExistingDatabase) migrateProviderSessionsForGrok(db);
+function readAppliedVersions(db: DatabaseSync): number[] {
+  const hasMigrationTable = db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'")
+    .get();
+  if (!hasMigrationTable) return [];
+  return db
+    .prepare("SELECT version FROM schema_migrations ORDER BY version")
+    .all()
+    .map((row) => {
+      if (!isDynamicRecord(row) || !isNumber(row.version) || !Number.isInteger(row.version)) {
+        throw new Error("OpenBot database contains an invalid schema migration version.");
+      }
+      return row.version;
+    });
+}
 
-  if (upgradingExistingDatabase) {
-    db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-    db.exec("VACUUM");
-    db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+function validateAppliedVersions(versions: number[]): void {
+  const newestVersion = versions.at(-1) ?? 0;
+  if (newestVersion > LATEST_SCHEMA_VERSION) {
+    throw new Error(
+      `OpenBot database version ${newestVersion} is newer than this application supports (${LATEST_SCHEMA_VERSION}).`,
+    );
   }
-  db.prepare("INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)").run(SCHEMA_VERSION, appliedAt);
+
+  const baselineAndLater = versions.filter((version) => version >= BASELINE_SCHEMA_VERSION);
+  if (baselineAndLater.length === 0) return;
+  const applied = new Set(baselineAndLater);
+  for (let version = BASELINE_SCHEMA_VERSION; version <= newestVersion; version += 1) {
+    if (!applied.has(version)) {
+      throw new Error(`OpenBot database migration history is missing version ${version}.`);
+    }
+  }
+}
+
+function latestAppliedVersion(versions: number[]): number {
+  const baselineAndLater = versions.filter((version) => version >= BASELINE_SCHEMA_VERSION);
+  return baselineAndLater.at(-1) ?? BASELINE_SCHEMA_VERSION - 1;
+}
+
+function runMigration(db: DatabaseSync, migration: OpenBotMigration, appliedAt: string): void {
+  if (migration.disableForeignKeys) db.exec("PRAGMA foreign_keys = OFF");
+  try {
+    db.exec("BEGIN IMMEDIATE");
+    migration.up(db, appliedAt);
+    db.prepare("INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)").run(migration.version, appliedAt);
+    assertForeignKeys(db);
+    db.exec("COMMIT");
+  } catch (error) {
+    if (db.isTransaction) db.exec("ROLLBACK");
+    throw error;
+  } finally {
+    if (migration.disableForeignKeys) db.exec("PRAGMA foreign_keys = ON");
+  }
+}
+
+function assertForeignKeys(db: DatabaseSync): void {
+  const violations = db.prepare("PRAGMA foreign_key_check").all();
+  if (violations.length > 0) {
+    throw new Error(`OpenBot database migration produced ${violations.length} foreign-key violation(s).`);
+  }
+}
+
+function assertQuickCheck(db: DatabaseSync): void {
+  const result = db.prepare("PRAGMA quick_check").get();
+  if (isDynamicRecord(result) && result.quick_check === "ok") return;
+  throw new Error("OpenBot database failed its integrity check.");
+}
+
+function migrateReactionsForActors(db: DatabaseSync): void {
+  const columns = db.prepare("PRAGMA table_info(projection_reactions)").all();
+  if (columns.some((column) => isDynamicRecord(column) && isString(column.name) && column.name === "actor_kind")) {
+    return;
+  }
+  db.exec(`
+    CREATE TABLE projection_reactions_v8 (
+      agent_id TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      emoji TEXT NOT NULL,
+      actor_kind TEXT NOT NULL CHECK(actor_kind IN ('user', 'bot')),
+      actor_bot_id TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_event_sequence INTEGER NOT NULL,
+      PRIMARY KEY(agent_id, message_id, actor_kind, actor_bot_id)
+    );
+    INSERT INTO projection_reactions_v8 (
+      agent_id, message_id, emoji, actor_kind, actor_bot_id, updated_at, last_event_sequence
+    )
+    SELECT agent_id, message_id, emoji, 'user', '', updated_at, last_event_sequence
+    FROM projection_reactions;
+    DROP TABLE projection_reactions;
+    ALTER TABLE projection_reactions_v8 RENAME TO projection_reactions;
+  `);
 }
 
 function migrateProviderSessionsForGrok(db: DatabaseSync): void {
@@ -330,43 +525,33 @@ function migrateProviderSessionsForGrok(db: DatabaseSync): void {
     .get();
   if (!isDynamicRecord(row) || !isString(row.sql) || row.sql.includes("'grok'")) return;
 
-  db.exec("PRAGMA foreign_keys = OFF");
-  try {
-    db.exec(`
-      BEGIN IMMEDIATE;
-      CREATE TABLE projection_provider_sessions_v7 (
-        id TEXT PRIMARY KEY,
-        thread_id TEXT NOT NULL REFERENCES projection_threads(thread_id) ON DELETE CASCADE,
-        provider TEXT NOT NULL CHECK(provider IN ('codex', 'claude', 'grok')),
-        external_session_id TEXT NOT NULL,
-        model TEXT NOT NULL,
-        effort TEXT NOT NULL,
-        state TEXT NOT NULL CHECK(state IN ('active', 'inactive', 'failed')),
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        resume_cursor TEXT,
-        last_event_sequence INTEGER NOT NULL,
-        UNIQUE(provider, external_session_id)
-      );
-      INSERT INTO projection_provider_sessions_v7 (
-        id, thread_id, provider, external_session_id, model, effort, state,
-        created_at, updated_at, resume_cursor, last_event_sequence
-      ) SELECT
-        id, thread_id, provider, external_session_id, model, effort, state,
-        created_at, updated_at, resume_cursor, last_event_sequence
-      FROM projection_provider_sessions;
-      DROP TABLE projection_provider_sessions;
-      ALTER TABLE projection_provider_sessions_v7 RENAME TO projection_provider_sessions;
-      CREATE INDEX provider_sessions_thread
-        ON projection_provider_sessions(thread_id, provider, state);
-      COMMIT;
-    `);
-  } catch (error) {
-    if (db.isTransaction) db.exec("ROLLBACK");
-    throw error;
-  } finally {
-    db.exec("PRAGMA foreign_keys = ON");
-  }
+  db.exec(`
+    CREATE TABLE projection_provider_sessions_v7 (
+      id TEXT PRIMARY KEY,
+      thread_id TEXT NOT NULL REFERENCES projection_threads(thread_id) ON DELETE CASCADE,
+      provider TEXT NOT NULL CHECK(provider IN ('codex', 'claude', 'grok')),
+      external_session_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      effort TEXT NOT NULL,
+      state TEXT NOT NULL CHECK(state IN ('active', 'inactive', 'failed')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      resume_cursor TEXT,
+      last_event_sequence INTEGER NOT NULL,
+      UNIQUE(provider, external_session_id)
+    );
+    INSERT INTO projection_provider_sessions_v7 (
+      id, thread_id, provider, external_session_id, model, effort, state,
+      created_at, updated_at, resume_cursor, last_event_sequence
+    ) SELECT
+      id, thread_id, provider, external_session_id, model, effort, state,
+      created_at, updated_at, resume_cursor, last_event_sequence
+    FROM projection_provider_sessions;
+    DROP TABLE projection_provider_sessions;
+    ALTER TABLE projection_provider_sessions_v7 RENAME TO projection_provider_sessions;
+    CREATE INDEX provider_sessions_thread
+      ON projection_provider_sessions(thread_id, provider, state);
+  `);
 }
 
 interface SnapshotEventRow {

--- a/src/backend/openbot-database.test.ts
+++ b/src/backend/openbot-database.test.ts
@@ -58,6 +58,11 @@ describe("OpenBotDatabase", () => {
       journal_mode: "wal",
     });
     expect((await stat(database.path)).mode & 0o777).toBe(0o600);
+    expect(database.connection.prepare("SELECT version FROM schema_migrations ORDER BY version").all()).toEqual([
+      { version: 8 },
+      { version: 9 },
+      { version: 10 },
+    ]);
     database.close();
   });
 
@@ -379,7 +384,7 @@ describe("OpenBotDatabase", () => {
 
     const legacy = new DatabaseSync(database.path);
     legacy.exec("PRAGMA journal_mode = WAL");
-    legacy.prepare("DELETE FROM schema_migrations WHERE version = 7").run();
+    legacy.prepare("DELETE FROM schema_migrations WHERE version IN (8, 9, 10)").run();
     legacy
       .prepare("INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (3, ?)")
       .run("2026-08-20T10:00:00.000Z");
@@ -422,7 +427,13 @@ describe("OpenBotDatabase", () => {
     expect(snapshotEventCount(migrated, bot.threadId)).toBe(1);
     expect(migrated.readConversation(bot.id, bot.threadId).messages[0]?.text).toHaveLength(40_000);
     expect(migrated.connection.prepare("PRAGMA integrity_check").get()).toMatchObject({ integrity_check: "ok" });
-    expect(migrated.connection.prepare("SELECT 1 AS applied FROM schema_migrations WHERE version = 7").get()).toEqual({
+    expect(migrated.connection.prepare("SELECT 1 AS applied FROM schema_migrations WHERE version = 8").get()).toEqual({
+      applied: 1,
+    });
+    expect(migrated.connection.prepare("SELECT 1 AS applied FROM schema_migrations WHERE version = 9").get()).toEqual({
+      applied: 1,
+    });
+    expect(migrated.connection.prepare("SELECT 1 AS applied FROM schema_migrations WHERE version = 10").get()).toEqual({
       applied: 1,
     });
     migrated.close();
@@ -431,6 +442,177 @@ describe("OpenBotDatabase", () => {
     await reopened.initialize();
     expect(snapshotEventCount(reopened, bot.threadId)).toBe(1);
     reopened.close();
+  });
+
+  it("adds post-v4 agent memory and routine projections", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-db-v4-"));
+    roots.push(root);
+    const database = new OpenBotDatabase(root);
+    await database.initialize();
+    database.close();
+
+    const legacy = new DatabaseSync(database.path);
+    legacy.exec(`
+      DROP TABLE projection_routine_runs;
+      DROP TABLE projection_routine_triggers;
+      DROP TABLE projection_agent_routines;
+      DROP TABLE projection_agent_memories;
+      DELETE FROM schema_migrations WHERE version IN (8, 9, 10);
+      INSERT OR IGNORE INTO schema_migrations(version, applied_at)
+        VALUES (4, '2026-08-20T10:00:00.000Z');
+    `);
+    legacy.close();
+
+    const migrated = new OpenBotDatabase(root);
+    await migrated.initialize();
+    const tables = migrated.connection
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table' AND name IN (
+           'projection_agent_memories', 'projection_agent_routines',
+           'projection_routine_triggers', 'projection_routine_runs'
+         ) ORDER BY name`,
+      )
+      .all();
+    expect(tables).toEqual([
+      { name: "projection_agent_memories" },
+      { name: "projection_agent_routines" },
+      { name: "projection_routine_runs" },
+      { name: "projection_routine_triggers" },
+    ]);
+    expect(migrated.connection.prepare("SELECT version FROM schema_migrations ORDER BY version").all()).toEqual([
+      { version: 4 },
+      { version: 8 },
+      { version: 9 },
+      { version: 10 },
+    ]);
+    migrated.close();
+  });
+
+  it("migrates legacy reactions to user-owned rows and permits another actor", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-db-reactions-v7-"));
+    roots.push(root);
+    const database = new OpenBotDatabase(root);
+    await database.initialize();
+    database.close();
+
+    const legacy = new DatabaseSync(database.path);
+    downgradeReactionsToV7(legacy);
+    legacy.close();
+
+    const migrated = new OpenBotDatabase(root);
+    await migrated.initialize();
+    expect(
+      migrated.connection
+        .prepare(
+          "SELECT actor_kind, actor_bot_id FROM projection_reactions WHERE agent_id = 'chief' AND message_id = 'message-1'",
+        )
+        .get(),
+    ).toEqual({ actor_kind: "user", actor_bot_id: "" });
+    expect(() =>
+      migrated.connection
+        .prepare(
+          `INSERT INTO projection_reactions (
+             agent_id, message_id, emoji, actor_kind, actor_bot_id, updated_at, last_event_sequence
+           ) VALUES ('chief', 'message-1', '🎉', 'bot', 'chief', '2026-08-20T10:01:00.000Z', 2)`,
+        )
+        .run(),
+    ).not.toThrow();
+    migrated.close();
+  });
+
+  it("rolls back a failed baseline migration and succeeds on retry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-db-rollback-"));
+    roots.push(root);
+    const database = new OpenBotDatabase(root);
+    await database.initialize();
+    database.close();
+
+    const legacy = new DatabaseSync(database.path);
+    downgradeReactionsToV7(legacy);
+    legacy.exec("CREATE TABLE projection_reactions_v8 (blocker TEXT)");
+    legacy.close();
+
+    const failed = new OpenBotDatabase(root);
+    await expect(failed.initialize()).rejects.toThrow("migration to version 8 failed");
+
+    const rolledBack = new DatabaseSync(database.path);
+    expect(rolledBack.prepare("SELECT 1 FROM schema_migrations WHERE version = 8").get()).toBeUndefined();
+    expect(rolledBack.prepare("PRAGMA table_info(projection_reactions)").all()).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "actor_kind" })]),
+    );
+    rolledBack.exec("DROP TABLE projection_reactions_v8");
+    rolledBack.close();
+
+    const retried = new OpenBotDatabase(root);
+    await retried.initialize();
+    expect(retried.connection.prepare("SELECT version FROM schema_migrations ORDER BY version").all()).toEqual([
+      { version: 7 },
+      { version: 8 },
+      { version: 9 },
+      { version: 10 },
+    ]);
+    retried.close();
+  });
+
+  it("deactivates existing provider sessions when reaction guidance changes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-db-runtime-v9-"));
+    roots.push(root);
+    const database = new OpenBotDatabase(root);
+    await database.initialize();
+    const bot = testBot();
+    if (!bot.threadId) throw new Error("The test bot has no thread.");
+    database.replaceAgents("agents-import", [bot], "agents.imported");
+    database.bindProviderSession({
+      threadId: bot.threadId,
+      provider: "codex",
+      externalSessionId: "legacy-tool-session",
+      model: "gpt-5.6-luna",
+      effort: "medium",
+    });
+    database.close();
+
+    const legacy = new DatabaseSync(database.path);
+    legacy.prepare("DELETE FROM schema_migrations WHERE version = 10").run();
+    legacy.close();
+
+    const migrated = new OpenBotDatabase(root);
+    await migrated.initialize();
+    expect(migrated.activeProviderSession(bot.threadId, "codex")).toBeNull();
+    expect(migrated.listProviderSessions(bot.threadId)).toEqual([
+      expect.objectContaining({ externalSessionId: "legacy-tool-session", state: "inactive" }),
+    ]);
+    migrated.close();
+  });
+
+  it("rejects a database created by a newer application", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-db-newer-"));
+    roots.push(root);
+    const database = new OpenBotDatabase(root);
+    await database.initialize();
+    database.close();
+
+    const newer = new DatabaseSync(database.path);
+    newer.prepare("INSERT INTO schema_migrations(version, applied_at) VALUES (11, ?)").run("2026-08-20T10:00:00.000Z");
+    newer.close();
+
+    const downgradedApp = new OpenBotDatabase(root);
+    await expect(downgradedApp.initialize()).rejects.toThrow("newer than this application supports");
+  });
+
+  it("rejects modern migration history with a missing baseline", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-db-gap-"));
+    roots.push(root);
+    const database = new OpenBotDatabase(root);
+    await database.initialize();
+    database.close();
+
+    const incomplete = new DatabaseSync(database.path);
+    incomplete.prepare("DELETE FROM schema_migrations WHERE version = 8").run();
+    incomplete.close();
+
+    const reopened = new OpenBotDatabase(root);
+    await expect(reopened.initialize()).rejects.toThrow("migration history is missing version 8");
   });
 
   it("widens the provider-session constraint for Grok without losing Codex or Claude sessions", async () => {
@@ -480,7 +662,7 @@ describe("OpenBotDatabase", () => {
       ALTER TABLE projection_provider_sessions_v6 RENAME TO projection_provider_sessions;
       CREATE INDEX provider_sessions_thread
         ON projection_provider_sessions(thread_id, provider, state);
-      DELETE FROM schema_migrations WHERE version = 7;
+      DELETE FROM schema_migrations WHERE version IN (8, 9, 10);
       INSERT OR IGNORE INTO schema_migrations(version, applied_at)
         VALUES (6, '2026-08-20T10:00:00.000Z');
       PRAGMA foreign_keys = ON;
@@ -506,6 +688,27 @@ describe("OpenBotDatabase", () => {
     migrated.close();
   });
 });
+
+function downgradeReactionsToV7(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE projection_reactions_v7 (
+      agent_id TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      emoji TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_event_sequence INTEGER NOT NULL,
+      PRIMARY KEY(agent_id, message_id)
+    );
+    INSERT INTO projection_reactions_v7 VALUES (
+      'chief', 'message-1', '❤️', '2026-08-20T10:00:00.000Z', 1
+    );
+    DROP TABLE projection_reactions;
+    ALTER TABLE projection_reactions_v7 RENAME TO projection_reactions;
+    DELETE FROM schema_migrations WHERE version IN (8, 9, 10);
+    INSERT OR IGNORE INTO schema_migrations(version, applied_at)
+      VALUES (7, '2026-08-20T10:00:00.000Z');
+  `);
+}
 
 async function createDatabase(): Promise<OpenBotDatabase> {
   const root = await mkdtemp(join(tmpdir(), "openbot-db-"));

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -112,6 +112,7 @@ interface MailboxProjectionReaction {
   botId: string;
   messageId: string;
   emoji: string;
+  actor: { kind: "user" } | { kind: "bot"; botId: string };
   updatedAt: string;
 }
 
@@ -1228,13 +1229,16 @@ export class OpenBotDatabase {
         for (const botId of value.pausedBotIds) queueInsert.run(botId, 1, "{}", sequence);
         const reactionInsert = db.prepare(`
           INSERT INTO projection_reactions
-            (agent_id, message_id, emoji, updated_at, last_event_sequence) VALUES (?, ?, ?, ?, ?)
+            (agent_id, message_id, emoji, actor_kind, actor_bot_id, updated_at, last_event_sequence)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
         `);
         for (const reaction of value.reactions) {
           reactionInsert.run(
             String(reaction.botId),
             String(reaction.messageId),
             String(reaction.emoji),
+            reaction.actor.kind,
+            reaction.actor.kind === "bot" ? reaction.actor.botId : "",
             String(reaction.updatedAt),
             sequence,
           );
@@ -1321,11 +1325,17 @@ export class OpenBotDatabase {
       db.prepare("SELECT agent_id FROM projection_queue_state WHERE paused = 1").all(),
     ).map((row) => requiredStringColumn(row, "agent_id"));
     const reactions = databaseRows(
-      db.prepare("SELECT agent_id, message_id, emoji, updated_at FROM projection_reactions").all(),
+      db
+        .prepare("SELECT agent_id, message_id, emoji, actor_kind, actor_bot_id, updated_at FROM projection_reactions")
+        .all(),
     ).map((row) => ({
       botId: requiredStringColumn(row, "agent_id"),
       messageId: requiredStringColumn(row, "message_id"),
       emoji: requiredStringColumn(row, "emoji"),
+      actor:
+        requiredStringColumn(row, "actor_kind") === "bot"
+          ? { kind: "bot" as const, botId: requiredStringColumn(row, "actor_bot_id") }
+          : { kind: "user" as const },
       updatedAt: requiredStringColumn(row, "updated_at"),
     }));
     return {

--- a/src/backend/openbot-tools.ts
+++ b/src/backend/openbot-tools.ts
@@ -182,6 +182,25 @@ export const OPENBOT_DYNAMIC_TOOLS = {
     },
     {
       type: "function",
+      name: "react_to_user_message",
+      description:
+        "Add one emoji reaction to the current user message for an obvious positive or negative emotional moment, including wins, affection, gratitude, humor, sadness, disappointment, frustration, empathy, or strong approval. An emoji in the written answer does not count as a reaction. Skip neutral messages and never use the reaction instead of the normal answer.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          emoji: {
+            type: "string",
+            minLength: 1,
+            maxLength: 64,
+            description: "Exactly one complete Unicode emoji.",
+          },
+        },
+        required: ["emoji"],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
       name: "send_message",
       description:
         "Queue an asynchronous message and optional local files for one or more OpenBot agents. When replying, pass the original message id as replyToMessageId.",

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -66,6 +66,7 @@ interface HostServiceOptions {
   spawnProcess?: typeof spawn;
   tunnelTimeoutMs?: number;
   publicReadyTimeoutMs?: number;
+  allowLocalDevelopmentInvites?: boolean;
   logDirectory?: string;
   removeLegacyRemoteDesktopCredential?: () => Promise<void>;
   getSignedInUser: () => CentralAuthUser;
@@ -99,8 +100,16 @@ export function buildNamedTunnelEnvironment(token: string, base: NodeJS.ProcessE
 }
 
 export class HostService extends EventEmitter<HostEvents> {
-  readonly #options: Required<Pick<HostServiceOptions, "spawnProcess" | "tunnelTimeoutMs" | "publicReadyTimeoutMs">> &
-    Omit<HostServiceOptions, "spawnProcess" | "tunnelTimeoutMs" | "publicReadyTimeoutMs">;
+  readonly #options: Required<
+    Pick<
+      HostServiceOptions,
+      "spawnProcess" | "tunnelTimeoutMs" | "publicReadyTimeoutMs" | "allowLocalDevelopmentInvites"
+    >
+  > &
+    Omit<
+      HostServiceOptions,
+      "spawnProcess" | "tunnelTimeoutMs" | "publicReadyTimeoutMs" | "allowLocalDevelopmentInvites"
+    >;
   readonly #api: TeamApiServer;
   readonly #remoteScreen: RemoteScreenGateway;
   #tunnel: ChildProcess | null = null;
@@ -114,6 +123,7 @@ export class HostService extends EventEmitter<HostEvents> {
       spawnProcess: options.spawnProcess ?? spawn,
       tunnelTimeoutMs: options.tunnelTimeoutMs ?? 30_000,
       publicReadyTimeoutMs: options.publicReadyTimeoutMs ?? 30_000,
+      allowLocalDevelopmentInvites: options.allowLocalDevelopmentInvites ?? false,
     };
     const identity = options.store.getIdentity();
     this.#status = {
@@ -468,12 +478,15 @@ export class HostService extends EventEmitter<HostEvents> {
     const identity = this.#options.store.getIdentity();
     if (!identity) throw new Error("Name this OpenBot before publishing it.");
     const invite = await this.#options.store.createInvite(input.role, input.email);
-    const inviteUrl = createInviteUrl({
-      apiUrl: this.#status.apiUrl,
-      serverId: identity.serverId,
-      fingerprint: identity.fingerprint,
-      token: invite.token,
-    });
+    const inviteUrl = createInviteUrl(
+      {
+        apiUrl: this.#status.apiUrl,
+        serverId: identity.serverId,
+        fingerprint: identity.fingerprint,
+        token: invite.token,
+      },
+      { allowLocalDevelopmentApiUrl: this.#options.allowLocalDevelopmentInvites },
+    );
     const result: InviteSummary = {
       id: invite.id,
       role: input.role,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -151,6 +151,9 @@ const developmentRemoteRole =
     ? process.env.OPENBOT_DEV_REMOTE_ROLE
     : null;
 const developmentTestClientEnabled = !app.isPackaged && process.env.OPENBOT_DEV_TEST_CLIENT_ENABLED === "1";
+const developmentInviteLinkOptions = {
+  allowLocalDevelopmentApiUrl: developmentRemoteRole !== null,
+};
 if (!app.isPackaged && /^\d{4,5}$/u.test(process.env.OPENBOT_DEV_REMOTE_DEBUGGING_PORT ?? "")) {
   app.commandLine.appendSwitch("remote-debugging-port", process.env.OPENBOT_DEV_REMOTE_DEBUGGING_PORT);
   app.commandLine.appendSwitch("remote-debugging-address", "127.0.0.1");
@@ -1208,7 +1211,7 @@ function forwardCentralAuth(state: CentralAuthState): void {
 
 function acceptInviteUrl(value: string): void {
   try {
-    parseInviteUrl(value);
+    parseInviteUrl(value, developmentInviteLinkOptions);
   } catch {
     return;
   }
@@ -1228,7 +1231,7 @@ function acceptOpenbotUrl(value: string): void {
 function findInviteUrl(values: string[]): string | null {
   for (const value of values) {
     try {
-      parseInviteUrl(value);
+      parseInviteUrl(value, developmentInviteLinkOptions);
       return value;
     } catch {
       // Most command-line arguments are not invitations.
@@ -1239,7 +1242,7 @@ function findInviteUrl(values: string[]): string | null {
 
 app.on("open-url", (event, url) => {
   try {
-    parseInviteUrl(url);
+    parseInviteUrl(url, developmentInviteLinkOptions);
   } catch {
     return;
   }
@@ -1250,7 +1253,7 @@ app.on("open-url", (event, url) => {
 app.on("continue-activity", (event, type, _userInfo, details) => {
   if (type !== "NSUserActivityTypeBrowsingWeb" || !details.webpageURL) return;
   try {
-    parseInviteUrl(details.webpageURL);
+    parseInviteUrl(details.webpageURL, developmentInviteLinkOptions);
   } catch {
     return;
   }
@@ -1367,6 +1370,7 @@ if (!hasSingleInstanceLock) {
         mailbox: mailboxStore,
         browser: browserHost,
         chat: teamChatStore,
+        allowLocalDevelopmentInvites: developmentRemoteRole === "host",
         logDirectory: join(app.getPath("userData"), "logs", "remote"),
         removeLegacyRemoteDesktopCredential: async () => {
           const credentialPath = join(app.getPath("userData"), LEGACY_REMOTE_DESKTOP_CREDENTIAL_FILE);
@@ -1451,6 +1455,7 @@ if (!hasSingleInstanceLock) {
             return centralAuthManager.getSignedInUser().email;
           },
         },
+        { allowLocalDevelopmentInvites: developmentRemoteRole !== null },
       );
       await remoteServerManager.initialize();
       if (developmentRemoteRole === "host") {

--- a/src/main/ipc/input-parsers.test.ts
+++ b/src/main/ipc/input-parsers.test.ts
@@ -166,6 +166,11 @@ describe("agent IPC input parsing", () => {
       messageId: "message-1",
       emoji: "👍",
     });
+    expect(parseMessageReaction({ botId: "bot-1", messageId: "message-1", emoji: "👨‍👩‍👧‍👦" })).toEqual({
+      botId: "bot-1",
+      messageId: "message-1",
+      emoji: "👨‍👩‍👧‍👦",
+    });
     expect(parseInterrupt({ botId: "bot-1", turnId: "turn-1" })).toEqual({
       botId: "bot-1",
       turnId: "turn-1",

--- a/src/main/remote-server-manager.ts
+++ b/src/main/remote-server-manager.ts
@@ -114,6 +114,10 @@ interface CentralAccountSession {
   getEmail: () => string;
 }
 
+interface RemoteServerManagerOptions {
+  allowLocalDevelopmentInvites?: boolean;
+}
+
 export interface DevelopmentRemoteServerConnection {
   serverId: string;
   serverName: string;
@@ -142,6 +146,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   readonly #path: string;
   readonly #cipher: TokenCipher;
   readonly #centralAccount: CentralAccountSession;
+  readonly #allowLocalDevelopmentInvites: boolean;
   #state: StoredRemoteServers = { version: 2, activeServerId: "local", servers: [] };
   #states = new Map<string, ServerSummary["state"]>();
   #eventControllers = new Map<string, AbortController>();
@@ -149,11 +154,17 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   #presence = new Map<string, TeamPresenceSnapshot>();
   #writeChain = Promise.resolve();
 
-  constructor(path: string, cipher: TokenCipher, centralAccount: CentralAccountSession) {
+  constructor(
+    path: string,
+    cipher: TokenCipher,
+    centralAccount: CentralAccountSession,
+    options: RemoteServerManagerOptions = {},
+  ) {
     super();
     this.#path = path;
     this.#cipher = cipher;
     this.#centralAccount = centralAccount;
+    this.#allowLocalDevelopmentInvites = options.allowLocalDevelopmentInvites ?? false;
   }
 
   async initialize(): Promise<void> {
@@ -239,7 +250,9 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   }
 
   async join(input: JoinServerInput): Promise<ServerSummary> {
-    const invite = parseInviteUrl(input.inviteUrl);
+    const invite = parseInviteUrl(input.inviteUrl, {
+      allowLocalDevelopmentApiUrl: this.#allowLocalDevelopmentInvites,
+    });
     const verifiedIdentity = await this.#verifyIdentity(invite.apiUrl, invite.serverId, invite.fingerprint);
     const accountTicket = await this.#centralAccount.createTeamAuthTicket(invite.serverId);
     const result = await requestJson(invite.apiUrl, "/v1/join/account", decodeJoinResult, {
@@ -299,7 +312,9 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   }
 
   async previewInvite(input: JoinServerInput): Promise<InvitePreview> {
-    const invite = parseInviteUrl(input.inviteUrl);
+    const invite = parseInviteUrl(input.inviteUrl, {
+      allowLocalDevelopmentApiUrl: this.#allowLocalDevelopmentInvites,
+    });
     const identity = await this.#verifyIdentity(invite.apiUrl, invite.serverId, invite.fingerprint);
     const preview = await requestJson(invite.apiUrl, "/v1/invitations/preview", decodeInvitePreview, {
       method: "POST",

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -3584,6 +3584,43 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledWith("Ready to ship."));
   });
 
+  it("lets the user remove only their own reaction while keeping the agent reaction read-only", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    emitAgentEvent?.({
+      type: "conversation",
+      snapshot: {
+        botId: "chief",
+        threadId: "thread-chief",
+        activeTurnId: null,
+        revision: 1,
+        messages: [
+          {
+            id: "user-reactions",
+            author: "user",
+            text: "The launch is approved.",
+            createdAt: "2026-08-12T10:00:00.000Z",
+            status: "completed",
+            reaction: "❤️",
+            reactions: [
+              { emoji: "❤️", actor: { kind: "user" } },
+              { emoji: "🎉", actor: { kind: "bot", botId: "chief" } },
+            ],
+          },
+        ],
+      },
+    });
+
+    await screen.findByRole("img", { name: "Chief reacted with 🎉" });
+    await fireEvent.click(screen.getByRole("button", { name: "Remove your reaction ❤️" }));
+    expect(window.openbot.agent.setMessageReaction).toHaveBeenCalledWith({
+      botId: "chief",
+      messageId: "user-reactions",
+      emoji: null,
+    });
+    expect(screen.getByRole("img", { name: "Chief reacted with 🎉" })).toBeInTheDocument();
+  });
+
   it("keeps agent activity at the conversation bottom without replaying existing message entrances", async () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });

--- a/src/renderer/src/app-message-projection.ts
+++ b/src/renderer/src/app-message-projection.ts
@@ -38,6 +38,8 @@ export function toBotMessage(message: ConversationMessage): BotMessage {
     imageGeneration: message.imageGeneration,
     exchange: message.exchange,
     reaction: message.reaction,
+    reactions:
+      message.reactions ?? (message.reaction ? [{ emoji: message.reaction, actor: { kind: "user" as const } }] : []),
     routine: message.routine,
     status: message.exchange
       ? undefined
@@ -156,6 +158,7 @@ export function botMessagesEqual(left: BotMessage, right: BotMessage): boolean {
     left.senderBotId === right.senderBotId &&
     left.replyToMessageId === right.replyToMessageId &&
     left.reaction === right.reaction &&
+    JSON.stringify(left.reactions) === JSON.stringify(right.reactions) &&
     JSON.stringify(left.reactionSummary) === JSON.stringify(right.reactionSummary) &&
     JSON.stringify(left.attachments) === JSON.stringify(right.attachments) &&
     JSON.stringify(left.exchange) === JSON.stringify(right.exchange) &&

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -2370,11 +2370,16 @@ export function ConversationTimeline() {
                 const message = createMemo(() => props.messages[virtualRow.index]);
                 const initialMessage = untrack(message);
                 if (!initialMessage) return null;
-                const reactionSummary = createMemo(() => {
+                const displayedReactions = createMemo(() => {
                   const currentMessage = message();
-                  if (currentMessage?.reactionSummary) return currentMessage.reactionSummary;
-                  const reaction = currentMessage?.reaction;
-                  return reaction ? { emojis: [reaction] } : undefined;
+                  if (currentMessage?.reactions?.length) return currentMessage.reactions;
+                  if (currentMessage?.reaction) {
+                    return [{ emoji: currentMessage.reaction, actor: { kind: "user" as const } }];
+                  }
+                  return (currentMessage?.reactionSummary?.emojis ?? []).map((emoji) => ({
+                    emoji,
+                    actor: { kind: "user" as const },
+                  }));
                 });
                 const animateEntrance = initialMessage.animate === true && markMessageSeen(initialMessage.id);
                 return (
@@ -2446,33 +2451,52 @@ export function ConversationTimeline() {
                                         onOpenRoutine={openRoutineSettings}
                                       />
                                     </BubbleContent>
-                                    <Show when={reactionSummary()}>
-                                      {(summary) => (
-                                        <BubbleReactions
-                                          class="message-reaction-anchor"
-                                          align={message()?.author === "you" ? "start" : "end"}
-                                          overflowCount={summary().overflowCount}
-                                          role="group"
-                                          aria-label={`Reactions: ${summary().emojis.join(", ")}${
-                                            summary().overflowCount ? ` and ${summary().overflowCount} more` : ""
-                                          }`}
-                                        >
-                                          <Button
-                                            variant="ghost"
-                                            type="button"
-                                            class="message-reaction-pill"
-                                            aria-label={`Remove reaction ${message()?.reaction ?? summary().emojis[0]}`}
-                                            onClick={() => {
-                                              const currentMessage = message();
-                                              if (currentMessage) void reactToMessage(currentMessage, null);
-                                            }}
-                                          >
-                                            <For each={summary().emojis}>
-                                              {(emoji) => <span aria-hidden="true">{emoji}</span>}
-                                            </For>
-                                          </Button>
-                                        </BubbleReactions>
-                                      )}
+                                    <Show when={displayedReactions().length > 0}>
+                                      <BubbleReactions
+                                        class="message-reaction-anchor"
+                                        align={message()?.author === "you" ? "start" : "end"}
+                                        overflowCount={message()?.reactionSummary?.overflowCount}
+                                        role="group"
+                                        aria-label={`Reactions: ${displayedReactions()
+                                          .map((reaction) => reaction.emoji)
+                                          .join(", ")}`}
+                                      >
+                                        <For each={displayedReactions()}>
+                                          {(reaction) => (
+                                            <Show
+                                              when={reaction.actor.kind === "user"}
+                                              fallback={
+                                                <span
+                                                  class="message-reaction-pill message-reaction-pill-readonly"
+                                                  role="img"
+                                                  aria-label={`${
+                                                    props.bots.find(
+                                                      (bot) =>
+                                                        reaction.actor.kind === "bot" &&
+                                                        bot.id === reaction.actor.botId,
+                                                    )?.name ?? "Agent"
+                                                  } reacted with ${reaction.emoji}`}
+                                                >
+                                                  <span aria-hidden="true">{reaction.emoji}</span>
+                                                </span>
+                                              }
+                                            >
+                                              <Button
+                                                variant="ghost"
+                                                type="button"
+                                                class="message-reaction-pill"
+                                                aria-label={`Remove your reaction ${reaction.emoji}`}
+                                                onClick={() => {
+                                                  const currentMessage = message();
+                                                  if (currentMessage) void reactToMessage(currentMessage, null);
+                                                }}
+                                              >
+                                                <span aria-hidden="true">{reaction.emoji}</span>
+                                              </Button>
+                                            </Show>
+                                          )}
+                                        </For>
+                                      </BubbleReactions>
                                     </Show>
                                   </Bubble>
                                   <MessageActions

--- a/src/renderer/src/components/ServerSettingsModal.test.tsx
+++ b/src/renderer/src/components/ServerSettingsModal.test.tsx
@@ -2,6 +2,7 @@ import type { HostStatus, ServerSummary, TeamPresenceMember } from "@openbot/con
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { describe, expect, it, vi } from "vitest";
 import { ServerSettingsModal, type ServerSettingsModalProps } from "./ServerSettingsModal";
+import { Toaster } from "./ui";
 
 const localServer: ServerSummary = {
   id: "local",
@@ -133,13 +134,19 @@ describe("ServerSettingsModal", () => {
     const onSaveIdentity = vi.fn(async () => {
       throw new Error("The identity could not save.");
     });
-    render(() => <ServerSettingsModal {...props({ onSaveIdentity })} />);
+    render(() => (
+      <>
+        <ServerSettingsModal {...props({ onSaveIdentity })} />
+        <Toaster />
+      </>
+    ));
 
     const name = screen.getByRole("textbox", { name: "Server name" });
     await fireEvent.input(name, { target: { value: "Studio Team" } });
     await fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent("The identity could not save.");
+    expect(await screen.findByText("Server action failed")).toBeInTheDocument();
+    expect(screen.getByText("The identity could not save.")).toBeInTheDocument();
     expect(name).toHaveValue("Studio Team");
   });
 
@@ -333,9 +340,13 @@ describe("ServerSettingsModal", () => {
 
     await fireEvent.click(screen.getByRole("tab", { name: "Invite link" }));
     expect(screen.queryByText("Enter a valid email address.")).not.toBeInTheDocument();
+    const inviteLink = screen.getByRole("textbox", { name: "Invitation link" });
+    expect(inviteLink).toHaveValue("");
+    expect(inviteLink).toHaveAttribute("placeholder", "Create a private one-time link.");
     await fireEvent.click(screen.getByRole("button", { name: "Create link" }));
 
     await waitFor(() => expect(onCreateInvite).toHaveBeenCalledWith({ role: "member" }));
     expect(await screen.findByRole("button", { name: "Copy link" })).toBeInTheDocument();
+    await waitFor(() => expect(inviteLink).toHaveValue("https://studio.example.com/invite/new"));
   });
 });

--- a/src/renderer/src/components/ServerSettingsModal.tsx
+++ b/src/renderer/src/components/ServerSettingsModal.tsx
@@ -59,6 +59,7 @@ import {
   Tabs,
   Text,
   Trash2,
+  toast,
   UserRound,
   UsersRound,
 } from "./ui";
@@ -89,6 +90,7 @@ type InviteMode = "link" | "email";
 type InviteRole = Exclude<TeamRole, "owner">;
 
 const ROLE_OPTIONS = ["Member", "Admin"];
+const INVITE_LINK_PLACEHOLDER = "Create a private one-time link.";
 const sections: Record<Section, { title: string; description: string }> = {
   general: { title: "General", description: "Manage this server’s identity and published access." },
   members: { title: "Members", description: "Invite people and manage access to this server." },
@@ -106,13 +108,13 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   const [nameTouched, setNameTouched] = createSignal(false);
   const [nameShaking, setNameShaking] = createSignal(false);
   const [logoError, setLogoError] = createSignal<string | null>(null);
-  const [actionError, setActionError] = createSignal<string | null>(null);
   const [busy, setBusy] = createSignal<string | null>(null);
   const [inviteMode, setInviteMode] = createSignal<InviteMode>("email");
   const [inviteRole, setInviteRole] = createSignal<InviteRole>("member");
   const [inviteEmail, setInviteEmail] = createSignal("");
   const [inviteEmailError, setInviteEmailError] = createSignal<string | null>(null);
   const [inviteResult, setInviteResult] = createSignal<InviteSummary | null>(null);
+  const [inviteLinkValue, setInviteLinkValue] = createSignal("");
   const [memberSearch, setMemberSearch] = createSignal("");
   const [removeMemberId, setRemoveMemberId] = createSignal<string | null>(null);
   const [now, setNow] = createSignal(Date.now());
@@ -120,8 +122,10 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   let logoInput: HTMLInputElement | undefined;
   let nameInput: HTMLInputElement | undefined;
   let removeMemberTrigger: HTMLElement | undefined;
+  let inviteLinkInput: HTMLInputElement | undefined;
   let syncedServerId = "";
   let expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  let inviteLinkSwapTimer: ReturnType<typeof setTimeout> | undefined;
   const objectUrls: string[] = [];
 
   const local = () => props.server.kind === "local";
@@ -180,8 +184,8 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
         setNameTouched(false);
         setNameShaking(false);
         setMemberSearch("");
-        setActionError(null);
         setInviteResult(null);
+        resetInviteLink();
       }
       if (!editing) {
         setSavedName(name);
@@ -212,18 +216,47 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
 
   onCleanup(() => {
     if (expiryTimer) clearTimeout(expiryTimer);
+    if (inviteLinkSwapTimer) clearTimeout(inviteLinkSwapTimer);
     for (const url of objectUrls) URL.revokeObjectURL(url);
   });
+
+  function resetInviteLink(): void {
+    if (inviteLinkSwapTimer) clearTimeout(inviteLinkSwapTimer);
+    inviteLinkSwapTimer = undefined;
+    inviteLinkInput?.classList.remove("is-exit", "is-enter-start");
+    setInviteLinkValue("");
+  }
+
+  function swapInviteLink(next: string): void {
+    const element = inviteLinkInput;
+    if (!element || (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false)) {
+      setInviteLinkValue(next);
+      return;
+    }
+    if (inviteLinkSwapTimer) clearTimeout(inviteLinkSwapTimer);
+    const duration =
+      Number.parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--text-swap-dur")) || 150;
+    element.classList.add("is-exit");
+    inviteLinkSwapTimer = setTimeout(() => {
+      inviteLinkSwapTimer = undefined;
+      setInviteLinkValue(next);
+      element.classList.remove("is-exit");
+      element.classList.add("is-enter-start");
+      void element.offsetHeight;
+      element.classList.remove("is-enter-start");
+    }, duration);
+  }
 
   async function run(key: string, action: () => Promise<void>): Promise<boolean> {
     if (busy()) return false;
     setBusy(key);
-    setActionError(null);
     try {
       await action();
       return true;
     } catch (error) {
-      setActionError(error instanceof Error ? error.message : "The server action failed.");
+      toast.error("Server action failed", {
+        description: error instanceof Error ? error.message : "The server action failed.",
+      });
       return false;
     } finally {
       setBusy(null);
@@ -253,7 +286,6 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
     setNameTouched(false);
     setNameShaking(false);
     setLogoError(null);
-    setActionError(null);
   }
 
   function updateDraftName(value: string): void {
@@ -267,7 +299,6 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
     } else if (!nameError()) {
       setNameShaking(false);
     }
-    setActionError(null);
   }
 
   function restartNameShake(): void {
@@ -304,7 +335,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   }
 
   function showCopyError(): void {
-    setActionError("OpenBot could not copy this value.");
+    toast.error("Copy failed", { description: "OpenBot could not copy this value." });
   }
 
   async function createInvite(): Promise<void> {
@@ -319,6 +350,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
     });
     if (!saved || !result) return;
     setInviteResult(result);
+    if (!result.email) swapInviteLink(result.inviteUrl);
     setInviteEmailError(null);
     if (email) setInviteEmail("");
   }
@@ -342,6 +374,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
       if (value !== "link" && value !== "email") return;
       setInviteMode(value);
       setInviteResult(null);
+      resetInviteLink();
       setInviteEmailError(null);
     },
   };
@@ -359,7 +392,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
         restoreFocusTarget={props.restoreFocusTarget}
         onContentElement={(element) => (modalElement = element)}
         floatingContent={
-          <Show when={props.loadError || actionError()}>
+          <Show when={props.loadError}>
             <Alert
               class="server-settings-error-toast"
               data-with-save-bar={section() === "general" && identityDirty() ? "" : undefined}
@@ -370,23 +403,21 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 <ShieldCheck />
               </AlertIcon>
               <AlertContent>
-                <AlertTitle>Server action failed</AlertTitle>
-                <AlertDescription>{actionError() ?? props.loadError}</AlertDescription>
+                <AlertTitle>Server settings unavailable</AlertTitle>
+                <AlertDescription>{props.loadError}</AlertDescription>
               </AlertContent>
-              <Show when={props.loadError}>
-                <AlertActions>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    loading={props.loading}
-                    onClick={() => void run("retry", props.onRetry)}
-                  >
-                    <RefreshCw aria-hidden="true" />
-                    Retry
-                  </Button>
-                </AlertActions>
-              </Show>
+              <AlertActions>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  loading={props.loading}
+                  onClick={() => void run("retry", props.onRetry)}
+                >
+                  <RefreshCw aria-hidden="true" />
+                  Retry
+                </Button>
+              </AlertActions>
             </Alert>
           </Show>
         }
@@ -772,9 +803,17 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                   </Field>
                 </SlidingTabs.Content>
                 <SlidingTabs.Content value="link" class="server-settings-invite-mode-panel">
-                  <Text variant="body-sm" tone="secondary">
-                    Create a private one-time link.
-                  </Text>
+                  <Input
+                    ref={(element) => (inviteLinkInput = element)}
+                    class="server-settings-invite-link-input t-text-swap"
+                    size="md"
+                    readonly
+                    aria-label="Invitation link"
+                    placeholder={INVITE_LINK_PLACEHOLDER}
+                    value={inviteLinkValue()}
+                    title={inviteLinkValue() || undefined}
+                    onFocus={(event) => event.currentTarget.select()}
+                  />
                 </SlidingTabs.Content>
               </SlidingTabs.ContentSlot>
               <Select<string>
@@ -790,18 +829,35 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 </SelectTrigger>
                 <SelectContent />
               </Select>
-              <Button
-                type="button"
-                size="sm"
-                variant="default"
-                loading={busy() === "invite"}
-                disabled={!canInvite()}
-                onClick={() => void createInvite()}
+              <Show
+                when={inviteMode() === "link" && inviteResult() && !inviteResult()?.email ? inviteResult() : null}
+                fallback={
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="default"
+                    loading={busy() === "invite"}
+                    disabled={!canInvite()}
+                    onClick={() => void createInvite()}
+                  >
+                    {inviteMode() === "email" ? "Send invite" : "Create link"}
+                  </Button>
+                }
               >
-                {inviteMode() === "email" ? "Send invite" : "Create link"}
-              </Button>
+                {(result) => (
+                  <CopyButton
+                    class="server-settings-invite-copy"
+                    value={result().inviteUrl}
+                    label="Copy link"
+                    copiedLabel="Copied"
+                    size="sm"
+                    variant="default"
+                    onCopyError={showCopyError}
+                  />
+                )}
+              </Show>
             </div>
-            <Show when={inviteResult()}>
+            <Show when={inviteResult()?.email ? inviteResult() : null}>
               {(result) => (
                 <Alert class="server-settings-invite-result" tone="success" role="status">
                   <AlertIcon>
@@ -809,13 +865,8 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                   </AlertIcon>
                   <AlertContent>
                     <AlertTitle>{result().email ? "Invitation sent" : "Invitation link ready"}</AlertTitle>
-                    <AlertDescription>{result().email ?? "The private link is ready to share."}</AlertDescription>
+                    <AlertDescription>{result().email}</AlertDescription>
                   </AlertContent>
-                  <Show when={!result().email}>
-                    <AlertActions>
-                      <CopyButton value={result().inviteUrl} label="Copy link" onCopyError={showCopyError} />
-                    </AlertActions>
-                  </Show>
                 </Alert>
               )}
             </Show>

--- a/src/renderer/src/data.ts
+++ b/src/renderer/src/data.ts
@@ -6,6 +6,7 @@ import type {
   AttachmentSummary,
   BotAvatarHue,
   BotSummary,
+  ConversationReaction,
   ImageGenerationInfo,
   MessageReaction,
 } from "@openbot/contracts/ipc";
@@ -42,6 +43,7 @@ export interface BotMessage {
   citations?: MessageCitation[];
   exchange?: AgentExchangeSummary;
   reaction?: MessageReaction | null;
+  reactions?: ConversationReaction[];
   reactionSummary?: MessageReactionSummary;
   routine?: {
     routineId: string;

--- a/src/renderer/src/preview/mock-openbot.ts
+++ b/src/renderer/src/preview/mock-openbot.ts
@@ -752,7 +752,13 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
       setMessageReaction: async (input: SetMessageReactionInput) => {
         updateSnapshot(input.botId, (snapshot) => {
           const message = snapshot.messages.find((candidate) => candidate.id === input.messageId);
-          if (message) message.reaction = input.emoji;
+          if (message) {
+            message.reaction = input.emoji;
+            message.reactions = [
+              ...(message.reactions ?? []).filter((reaction) => reaction.actor.kind !== "user"),
+              ...(input.emoji ? [{ emoji: input.emoji, actor: { kind: "user" as const } }] : []),
+            ];
+          }
         });
       },
       listQueue: async (botId) => clone(queues.get(botId) ?? emptyQueue(botId)),

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -203,7 +203,9 @@
   --openbot-radius-dialog: 14px;
   --openbot-radius-xl: 20px;
   --openbot-radius-bubble: 22px;
+  --openbot-radius-bubble-inset: calc(var(--openbot-radius-bubble) - var(--openbot-space-3) - 1px);
   --openbot-radius-modal: 30px;
+  --openbot-radius-media-preview: calc(var(--openbot-radius-lg) - 1px);
   --openbot-radius-pill: 999px;
   --openbot-radius-logo: 20%;
   --openbot-control-xs: 24px;
@@ -230,6 +232,10 @@
   --openbot-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
   --openbot-ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
   --openbot-ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+  --text-swap-dur: 150ms;
+  --text-swap-translate-y: 4px;
+  --text-swap-blur: 2px;
+  --text-swap-ease: ease-in-out;
   --modal-open-dur: 250ms;
   --modal-close-dur: 150ms;
   --modal-scale: 0.96;

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -3465,6 +3465,11 @@
   padding-inline: 2px;
 }
 
+.ui-bubble-reactions.message-reaction-anchor:has(> .message-reaction-pill:only-child) > .message-reaction-pill {
+  width: var(--openbot-leading-lg);
+  border-radius: var(--openbot-radius-pill);
+}
+
 .message-reaction-anchor .ui-bubble-reaction-overflow {
   padding-right: 6px;
 }

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -3432,14 +3432,14 @@
 
 .message-reaction-pill {
   display: flex;
-  min-width: 24px;
-  height: 24px;
+  min-width: 0;
+  height: var(--openbot-leading-lg);
   align-items: center;
   justify-content: center;
   border: 0;
   border-radius: var(--openbot-radius-sm);
   background: transparent;
-  padding: 0 6px;
+  padding: 0;
   color: inherit;
   font-size: var(--openbot-text-lg);
   line-height: 1;
@@ -3456,12 +3456,20 @@
   border-radius: inherit;
 }
 
+.ui-bubble-reactions.message-reaction-anchor {
+  padding: 2px 6px;
+}
+
 .message-reaction-anchor .ui-bubble-reaction-overflow {
   padding-right: 6px;
 }
 
 .message-reaction-pill:hover {
   background: var(--openbot-hover);
+}
+
+.message-reaction-pill-readonly:hover {
+  background: transparent;
 }
 
 .message-reaction-anchor:has(.message-reaction-pill:focus-visible) {
@@ -6420,7 +6428,7 @@
 .composer-attachment[data-kind="image"] .composer-attachment-preview {
   width: 100%;
   height: 100%;
-  border-radius: calc(var(--openbot-radius-lg) - 1px);
+  border-radius: var(--openbot-radius-media-preview);
 }
 
 .composer-attachment-preview img {
@@ -6526,7 +6534,7 @@
   > [data-slot="bubble-content"]
   > .message-attachments:last-child
   .message-attachment {
-  border-radius: calc(var(--openbot-radius-bubble) - var(--openbot-space-3) - 1px);
+  border-radius: var(--openbot-radius-bubble-inset);
 }
 
 .ui-button.attachment-preview-button {
@@ -7731,11 +7739,22 @@
   background: var(--openbot-bg-canvas);
 }
 
-.message-reaction-pill,
 .composer-reply-preview {
   border-color: var(--openbot-border);
   background: var(--openbot-bg-surface);
   color: var(--openbot-text-primary);
+}
+
+.message-reaction-pill {
+  border-color: var(--openbot-border);
+  background: transparent;
+  color: var(--openbot-text-primary);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .message-reaction-pill:not(.message-reaction-pill-readonly):hover {
+    background: var(--openbot-hover);
+  }
 }
 
 .composer,

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -3460,6 +3460,11 @@
   padding: 2px 6px;
 }
 
+.ui-bubble-reactions.message-reaction-anchor:has(> .message-reaction-pill:only-child) {
+  width: var(--openbot-control-xs);
+  padding-inline: 2px;
+}
+
 .message-reaction-anchor .ui-bubble-reaction-overflow {
   padding-right: 6px;
 }

--- a/src/renderer/src/styles/server-settings-modal.css
+++ b/src/renderer/src/styles/server-settings-modal.css
@@ -282,7 +282,7 @@
 
 .server-settings-invite-composer {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 112px auto;
+  grid-template-columns: minmax(0, 1fr) 112px 104px;
   align-items: start;
   gap: var(--openbot-space-2);
 }
@@ -308,11 +308,20 @@
   white-space: nowrap;
 }
 
-.server-settings-invite-mode-panel .ui-text {
-  min-height: var(--openbot-control-md);
-  display: flex;
-  align-items: center;
-  padding-inline: var(--openbot-space-1);
+.server-settings-invite-link-input.ui-input {
+  font-family: var(--openbot-font-mono);
+  cursor: text;
+}
+
+.server-settings-invite-link-input.ui-input::placeholder {
+  font-family: var(--openbot-font-sans);
+}
+
+.server-settings-invite-copy > svg {
+  width: var(--openbot-icon-sm);
+  height: var(--openbot-icon-sm);
+  flex: 0 0 auto;
+  stroke-width: 1.75;
 }
 
 .server-settings-role-select {

--- a/src/renderer/src/styles/transitions.css
+++ b/src/renderer/src/styles/transitions.css
@@ -136,3 +136,32 @@
     transition: none !important;
   }
 }
+
+.t-text-swap {
+  display: inline-block;
+  transform: translateY(0);
+  filter: blur(0);
+  opacity: 1;
+  transition:
+    transform var(--text-swap-dur) var(--text-swap-ease),
+    filter var(--text-swap-dur) var(--text-swap-ease),
+    opacity var(--text-swap-dur) var(--text-swap-ease);
+  will-change: transform, filter, opacity;
+}
+.t-text-swap.is-exit {
+  transform: translateY(calc(var(--text-swap-translate-y) * -1));
+  filter: blur(var(--text-swap-blur));
+  opacity: 0;
+}
+.t-text-swap.is-enter-start {
+  transform: translateY(var(--text-swap-translate-y));
+  filter: blur(var(--text-swap-blur));
+  opacity: 0;
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-text-swap {
+    transition: none !important;
+  }
+}

--- a/src/renderer/stories/ServerSettingsModal.stories.tsx
+++ b/src/renderer/stories/ServerSettingsModal.stories.tsx
@@ -192,6 +192,19 @@ export const Members: Story = {
   },
 };
 
+export const InviteLinkReady: Story = {
+  play: async ({ userEvent }) => {
+    const body = within(document.body);
+    await body.findByRole("dialog", { name: "General" });
+    await userEvent.click(body.getByRole("tab", { name: "Members" }));
+    await userEvent.click(body.getByRole("tab", { name: "Invite link" }));
+    await userEvent.click(body.getByRole("button", { name: "Create link" }));
+    await expect(await body.findByRole("textbox", { name: "Invitation link" })).toHaveValue(
+      "https://team.example.com/invite/story",
+    );
+  },
+};
+
 export const MembersEmptyResults: Story = {
   play: async ({ userEvent }) => {
     const body = within(document.body);


### PR DESCRIPTION
## Summary

- add arbitrary Unicode emoji reactions owned independently by users and bots, including persistence, provider tools, agent guidance, and a Zaidan-style reaction capsule
- add safe SQLite migration handling for actor-aware reactions and refresh existing provider sessions so reaction tools and updated guidance take effect
- support explicit localhost invite URLs in development while preserving strict production validation
- refine server member and invitation settings with inline link creation, copy feedback, toast errors, and transition polish
- document migration safety and renderer contribution rules

## Validation

- bun run check:ui
- bun run lint
- bun run typecheck
- bun run test

Full Vitest result: 115 test files passed; 869 tests passed and 2 skipped.