### PR TITLE
Fix email code input expiry freeze

### DIFF
--- a/src/renderer/src/components/AccountLogin.test.tsx
+++ b/src/renderer/src/components/AccountLogin.test.tsx
@@ -146,6 +146,32 @@ describe("AccountLogin", () => {
     expect(onRequestEmailCode).toHaveBeenCalledWith("person@example.com");
   });
 
+  it("keeps the code input active after the local expiration time", async () => {
+    vi.useFakeTimers();
+    const onVerifyEmailCode = vi.fn().mockResolvedValue(undefined);
+    const view = renderLogin(
+      codeSentState({
+        expiresAt: Date.now() + 1_000,
+        resendAvailableAt: Date.now() - 1_000,
+      }),
+      { onVerifyEmailCode },
+    );
+
+    try {
+      const input = screen.getByRole("textbox", { name: "One-time code" });
+      await fireEvent.input(input, { target: { value: "ABCD" } });
+      await vi.advanceTimersByTimeAsync(2_000);
+      for (const key of "EFGH") await fireEvent.keyDown(input, { key });
+
+      expect(input).not.toHaveAttribute("readonly");
+      expect(view.container.querySelectorAll('.otp-input-slot[data-filled="true"]')).toHaveLength(8);
+      expect(onVerifyEmailCode).toHaveBeenCalledWith("challenge-1", "ABCD-EFGH");
+    } finally {
+      view.unmount();
+      vi.useRealTimers();
+    }
+  });
+
   it("exposes retry timing without allowing repeated requests", () => {
     renderLogin({
       status: "error",

--- a/src/renderer/src/components/AccountLogin.tsx
+++ b/src/renderer/src/components/AccountLogin.tsx
@@ -63,10 +63,9 @@ export function AccountLogin(props: AccountLoginProps) {
   const displayedIssue = () => (issueVisible() ? currentIssue() : undefined);
   const unavailable = () => props.state.status === "error" && props.state.issue.code === "auth_api_unavailable";
   const unavailableIssue = () => (unavailable() && props.state.status === "error" ? props.state.issue : undefined);
-  const codeExpiresIn = () => (props.state.status === "code_sent" ? secondsUntil(props.state.expiresAt, now()) : 0);
   const codeNeedsReplacement = () => {
     const issue = currentIssue();
-    return Boolean(issue && NEW_CODE_ISSUES.has(issue.code)) || (codeSent() && codeExpiresIn() === 0);
+    return Boolean(issue && NEW_CODE_ISSUES.has(issue.code));
   };
   const resendAvailableIn = () => {
     if (props.state.status !== "code_sent") return 0;


### PR DESCRIPTION
## What changed

- Keep the one-time code input active after the local `expiresAt` time passes.
- Let the account service decide if a code has expired. The existing replacement flow remains active after a server expiry response.
- Add a regression test that enters a partial code before local expiry and completes it after expiry.

## Verification

- [ ] `bun run check`
- [x] `bunx vitest run src/renderer/src/components/AccountLogin.test.tsx`
- [x] `bun run typecheck:renderer`
- [x] `bunx biome check src/renderer/src/components/AccountLogin.tsx src/renderer/src/components/AccountLogin.test.tsx`
- [x] Development app started with `bun run dev`
- [x] No credentials, private data, generated output, or real user files are included

## Risk and security impact

None. This does not change permissions, IPC, filesystem access, persistence, browser behavior, or network access.