### PR TITLE
Center onboarding content vertically

### DIFF
--- a/src/renderer/src/styles/onboarding.css
+++ b/src/renderer/src/styles/onboarding.css
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 76px 24px 32px;
+  padding: 52px 24px;
   -webkit-app-region: no-drag;
 }
 
@@ -520,7 +520,7 @@
 
 @media (max-width: 620px) {
   .onboarding-shell {
-    padding: 74px 18px 24px;
+    padding: 48px 18px;
   }
 
   .onboarding-panel h1 {


### PR DESCRIPTION
## Summary

- Use symmetric vertical padding for the onboarding shell.
- Keep the existing width and internal component spacing.
- Preserve safe scrolling when the available height is smaller than the content.

## Verification

- UI foundation check
- Biome check for onboarding.css
- Manual Storybook check at the default viewport and 420 px width