### PR TITLE
Preserve authentication across dev reseeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ bun run dev
 
 The seed adds agents, rich conversations, managed files and references, reactions, completed
 agent exchanges, and local team chat data. It does not add live queue items or start model turns.
+Existing embedded-browser sign-ins and the encrypted OpenBot account session are preserved. Browser
+tabs are reset with the rest of the showcase, and every agent can use the shared signed-in browser
+session. Use `bun run dev:reset` when you intentionally want to remove development authentication.
 Use `bun run dev:seed --dry-run` to inspect the target and fixture counts without changing files.
 
 ## Commands
@@ -131,7 +134,7 @@ Use `bun run dev:seed --dry-run` to inspect the target and fixture counts withou
 | `bun run api:deploy` | Build and deploy the account API to Cloudflare Workers. |
 | `bun run dev:all` | Start the API and the single local Electron instance. |
 | `bun run dev:test-client` | Start the API, the local instance, and an isolated second client for team testing. |
-| `bun run dev:seed` | Replace only the app development profile with deterministic showcase data. |
+| `bun run dev:seed` | Replace the app development profile with deterministic showcase data while preserving authentication. |
 | `bun run dev:reset` | Delete the local app, test-client, and legacy host development state. |
 | `bun run check` | Run Biome, both typechecks, offline tests, the browser smoke test, and the production build. |
 | `bun run test:backend` | Run backend tests only. |

--- a/scripts/seed-dev-state.test.ts
+++ b/scripts/seed-dev-state.test.ts
@@ -187,6 +187,54 @@ describe("development state seed", () => {
     }
   });
 
+  it("preserves browser and OpenBot account sessions while discarding other profile state", async () => {
+    const { appDataRoot, homeDirectory } = await createRoots();
+    await seedDevelopmentState({ appDataRoot, homeDirectory });
+    const profilePath = join(appDataRoot, developmentUserDataName("app"));
+    const cookiePath = join(profilePath, "Partitions", "openbot-browser", "Cookies");
+    const indexedDbPath = join(
+      profilePath,
+      "Partitions",
+      "openbot-browser",
+      "IndexedDB",
+      "https_example.com_0.indexeddb.leveldb",
+      "CURRENT",
+    );
+    const authPath = join(profilePath, "openbot-central-auth-v1.bin");
+    const browserStatePath = join(profilePath, "openbot-browser-state-v1.json");
+    const unrelatedPath = join(profilePath, "unrelated.txt");
+    await Promise.all([
+      writeSentinel(cookiePath, "cookie session"),
+      writeSentinel(indexedDbPath, "indexed db session"),
+      writeSentinel(authPath, "encrypted account session"),
+      writeSentinel(browserStatePath, "saved tabs"),
+      writeSentinel(unrelatedPath, "discard me"),
+    ]);
+
+    await seedDevelopmentState({ appDataRoot, homeDirectory });
+
+    await expect(readFile(cookiePath, "utf8")).resolves.toBe("cookie session");
+    await expect(readFile(indexedDbPath, "utf8")).resolves.toBe("indexed db session");
+    await expect(readFile(authPath, "utf8")).resolves.toBe("encrypted account session");
+    await expect(stat(browserStatePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(unrelatedPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("leaves the existing profile untouched when authentication cannot be preserved", async () => {
+    const { appDataRoot, homeDirectory } = await createRoots();
+    const profilePath = join(appDataRoot, developmentUserDataName("app"));
+    const sentinel = join(profilePath, "keep.txt");
+    await Promise.all([
+      writeSentinel(sentinel, "keep"),
+      writeSentinel(join(profilePath, "Partitions", "openbot-browser"), "not a browser directory"),
+    ]);
+
+    await expect(seedDevelopmentState({ appDataRoot, homeDirectory })).rejects.toThrow(
+      "Cannot preserve the embedded browser session",
+    );
+    await expect(readFile(sentinel, "utf8")).resolves.toBe("keep");
+  });
+
   it("blocks a live profile before it removes existing state", async () => {
     const { appDataRoot, homeDirectory } = await createRoots();
     const profilePath = join(appDataRoot, developmentUserDataName("app"));

--- a/scripts/seed-dev-state.ts
+++ b/scripts/seed-dev-state.ts
@@ -1,5 +1,17 @@
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, mkdtemp, readFile, readlink, rename, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  copyFile,
+  cp,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, parse, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -21,6 +33,8 @@ export const DEVELOPMENT_SEED_MANIFEST_FILE = "openbot-dev-seed-v1.json";
 
 const TEAM_FILE = "openbot-team-server-v1.json";
 const SETUP_FILE = "openbot-setup-v2.json";
+const BROWSER_PARTITION_DIRECTORY = join("Partitions", "openbot-browser");
+const CENTRAL_AUTH_FILE = "openbot-central-auth-v1.bin";
 const SEED_VERSION = 1;
 const SEEDED_AT = "2026-08-21T10:00:00.000Z";
 const SEED_AGENT_MODEL = "gpt-5.6-luna";
@@ -147,6 +161,7 @@ export async function seedDevelopmentState(options: DevelopmentSeedOptions = {})
   const newTransferDirectories: string[] = [];
   try {
     await buildSeedProfile(stagingProfile, homeDirectory, newTransferDirectories);
+    await preserveDevelopmentAuthentication(targetProfile, stagingProfile);
     if (await isDevelopmentProfileActive(targetProfile)) {
       throw new Error("Quit the OpenBot dev app before you seed its local state.");
     }
@@ -160,6 +175,39 @@ export async function seedDevelopmentState(options: DevelopmentSeedOptions = {})
   }
 
   return summary;
+}
+
+async function preserveDevelopmentAuthentication(sourceProfile: string, stagingProfile: string): Promise<void> {
+  const browserSource = join(sourceProfile, BROWSER_PARTITION_DIRECTORY);
+  const browserSourceStat = await optionalStat(browserSource);
+  if (browserSourceStat) {
+    if (!browserSourceStat.isDirectory()) {
+      throw new Error(`Cannot preserve the embedded browser session because ${browserSource} is not a directory.`);
+    }
+    const browserTarget = join(stagingProfile, BROWSER_PARTITION_DIRECTORY);
+    await mkdir(dirname(browserTarget), { recursive: true, mode: 0o700 });
+    await cp(browserSource, browserTarget, { recursive: true });
+  }
+
+  const authSource = join(sourceProfile, CENTRAL_AUTH_FILE);
+  const authSourceStat = await optionalStat(authSource);
+  if (authSourceStat) {
+    if (!authSourceStat.isFile()) {
+      throw new Error(`Cannot preserve the OpenBot account session because ${authSource} is not a file.`);
+    }
+    const authTarget = join(stagingProfile, CENTRAL_AUTH_FILE);
+    await copyFile(authSource, authTarget);
+    await chmod(authTarget, 0o600);
+  }
+}
+
+async function optionalStat(path: string): Promise<Awaited<ReturnType<typeof lstat>> | null> {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
 }
 
 export async function isDevelopmentProfileActive(profilePath: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- preserve the shared embedded-browser partition across `bun run dev:seed`
- preserve the OS-protected OpenBot account session with restrictive permissions
- keep browser tabs and unrelated showcase state reset
- abort safely without replacing the existing profile when authentication cannot be copied
- document that persisted browser authentication is shared by all agents

## Verification
- `bunx vitest run scripts/seed-dev-state.test.ts`
- `bunx biome check scripts/seed-dev-state.ts scripts/seed-dev-state.test.ts README.md`
- `bun run typecheck:node`
- commit hook: full repository type checks