### PR TITLE
release: prepare v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to OpenBot will be documented here. The project follows
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-08-27
+
 ### Changed
 
 - Download and verify the Whisper model on first voice use instead of shipping it in every application update.


### PR DESCRIPTION
Moves the current Unreleased changelog entries under the 0.3.5 release heading so the tag-triggered release workflow can validate and publish v0.3.5.