### PR TITLE
Hide People communication by default

### DIFF
--- a/scripts/dev-services.ts
+++ b/scripts/dev-services.ts
@@ -184,30 +184,55 @@ async function main(): Promise<void> {
   process.once("SIGINT", () => void stopAll("SIGTERM").then(() => process.exit(130)));
   process.once("SIGTERM", () => void stopAll("SIGTERM").then(() => process.exit(143)));
 
-  for (const spec of specs) {
-    const child = spawn(spec.executable, spec.args, {
-      cwd: spec.cwd,
-      env: spec.env,
-      stdio: "inherit",
-      shell: false,
-      detached: process.platform !== "win32",
-    });
-    processes.set(spec.name, child);
-    child.once("error", (error) => {
-      console.error(`[${spec.name}] Could not start:`, error.message);
-      void stopAll("SIGTERM").then(() => {
-        process.exitCode = 1;
+  try {
+    for (const spec of specs) {
+      const child = spawn(spec.executable, spec.args, {
+        cwd: spec.cwd,
+        env: spec.env,
+        stdio: "inherit",
+        shell: false,
+        detached: process.platform !== "win32",
       });
-    });
-    child.once("exit", (code, signal) => {
-      if (stopping) return;
-      const result = signal ? `signal ${signal}` : `code ${code ?? 1}`;
-      console.log(`[${spec.name}] stopped with ${result}. Stopping the other services.`);
-      void stopAll("SIGTERM").then(() => {
-        process.exitCode = code ?? 1;
+      processes.set(spec.name, child);
+      child.once("error", (error) => {
+        console.error(`[${spec.name}] Could not start:`, error.message);
+        void stopAll("SIGTERM").then(() => {
+          process.exitCode = 1;
+        });
       });
-    });
+      child.once("exit", (code, signal) => {
+        if (stopping) return;
+        const result = signal ? `signal ${signal}` : `code ${code ?? 1}`;
+        console.log(`[${spec.name}] stopped with ${result}. Stopping the other services.`);
+        void stopAll("SIGTERM").then(() => {
+          process.exitCode = code ?? 1;
+        });
+      });
+      if (spec.name === "api") await waitForDevelopmentApi(spec.env.OPENBOT_API_PORT, child);
+    }
+  } catch (error) {
+    await stopAll("SIGTERM");
+    throw error;
   }
+}
+
+async function waitForDevelopmentApi(portValue: string | undefined, child: ChildProcess): Promise<void> {
+  const port = readPort(portValue);
+  if (!port) throw new Error("The development API port is missing.");
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error("The development Auth API stopped before it became ready.");
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health/live`, {
+        signal: AbortSignal.timeout(1_000),
+      });
+      if (response.ok) return;
+    } catch {
+      // The API can reject connections while Vite and the Worker runtime start.
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+  }
+  throw new Error(`The development Auth API did not become ready on port ${port}.`);
 }
 
 async function findAvailablePort(preferredPort: number, reservedPorts: Set<number>): Promise<number> {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -2104,7 +2104,7 @@ describe("OpenBot connected desktop shell", () => {
   });
 
   it("opens and cancels Bot creation from a private conversation", async () => {
-    render(() => <App />);
+    render(() => <App peopleEnabled />);
     await screen.findByRole("heading", { name: "Chief" });
     emitPresence?.({
       serverId: "server-1",
@@ -2127,6 +2127,26 @@ describe("OpenBot connected desktop shell", () => {
     });
     await fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(await screen.findByRole("main", { name: "Direct conversation with Alice" })).toBeInTheDocument();
+  });
+
+  it("hides People navigation and direct conversations by default", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    emitPresence?.({
+      serverId: "server-1",
+      updatedAt: "2026-08-19T10:00:00.000Z",
+      members: [
+        presenceMember("member-self", "person@example.com", "Person"),
+        presenceMember("member-alice", "alice@example.com", "Alice"),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "People" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Alice/ })).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole("main", { name: /Direct conversation/ })).not.toBeInTheDocument();
+    expect(window.openbot.servers.listDirectThreads).not.toHaveBeenCalled();
   });
 
   it("resizes and persists the left and right side panels", async () => {
@@ -3286,7 +3306,7 @@ describe("OpenBot connected desktop shell", () => {
 
   it("opens a private person thread and receives direct messages in real time", async () => {
     vi.mocked(window.openbot.servers.markDirectRead).mockRejectedValueOnce(new Error("Read state unavailable"));
-    render(() => <App />);
+    render(() => <App peopleEnabled />);
     await screen.findByRole("heading", { name: "Chief" });
     emitPresence?.({
       serverId: "server-1",
@@ -3420,7 +3440,7 @@ describe("OpenBot connected desktop shell", () => {
         revision: 1,
       });
     });
-    render(() => <App />);
+    render(() => <App peopleEnabled />);
     await screen.findByRole("heading", { name: "Chief" });
     emitPresence?.({
       serverId: "server-1",
@@ -4900,7 +4920,7 @@ describe("OpenBot connected desktop shell", () => {
         },
       ],
     });
-    render(() => <App />);
+    render(() => <App peopleEnabled />);
     await screen.findByRole("heading", { name: "Chief" });
     emitPresence?.({
       serverId: "server-1",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -223,9 +223,11 @@ export function createBotInitialMessage(draft: Pick<FirstBotDraft, "purpose">): 
 
 interface AppProps {
   landingPreview?: boolean;
+  peopleEnabled?: boolean;
 }
 
 export function createAppController(props: AppProps = {}) {
+  const peopleEnabled = props.peopleEnabled === true;
   const [botList, setBotList] = createSignal<BotProfile[]>([]);
   const [modelOptions, setModelOptions] = createSignal<AgentModelOption[]>([]);
   const [activeBotId, setActiveBotId] = createSignal("");
@@ -482,9 +484,11 @@ export function createAppController(props: AppProps = {}) {
     if (!currentMemberId) return [];
     return teamPresence().members.filter((member) => member.id !== currentMemberId && !member.disabled);
   });
-  const activeDirectMember = createMemo(() => directPeople().find((member) => member.id === activeDirectMemberId()));
+  const activeDirectMember = createMemo(() =>
+    peopleEnabled ? directPeople().find((member) => member.id === activeDirectMemberId()) : undefined,
+  );
   const activeBot = createMemo(() => {
-    if (activeDirectMemberId()) return undefined;
+    if (activeDirectMember()) return undefined;
     return botList().find((bot) => bot.id === activeBotId()) ?? botList()[0];
   });
   const activeMessages = createMemo(() => {
@@ -510,6 +514,7 @@ export function createAppController(props: AppProps = {}) {
   createEffect(
     () => currentTeamMember()?.id ?? null,
     (memberId) => {
+      if (!peopleEnabled) return;
       if (!memberId) {
         setDirectThreads([]);
         return;
@@ -534,12 +539,12 @@ export function createAppController(props: AppProps = {}) {
     });
     const unsubscribeServers = window.openbot.servers.onEvent((value) => flush(() => setServers(value)));
     const unsubscribePresence = window.openbot.servers.onPresence((snapshot) => flush(() => setTeamPresence(snapshot)));
-    const unsubscribeDirectMessage = window.openbot.servers.onDirectMessage((event) =>
-      flush(() => handleDirectMessageEvent(event)),
-    );
-    const unsubscribeDirectTyping = window.openbot.servers.onDirectTyping((event) =>
-      flush(() => handleDirectTypingEvent(event)),
-    );
+    const unsubscribeDirectMessage = peopleEnabled
+      ? window.openbot.servers.onDirectMessage((event) => flush(() => handleDirectMessageEvent(event)))
+      : () => undefined;
+    const unsubscribeDirectTyping = peopleEnabled
+      ? window.openbot.servers.onDirectTyping((event) => flush(() => handleDirectTypingEvent(event)))
+      : () => undefined;
     const receiveInvite = (inviteUrl: string) => {
       flush(() => {
         setPendingInviteUrl(inviteUrl);
@@ -1240,7 +1245,7 @@ export function createAppController(props: AppProps = {}) {
 
   async function selectDirectMember(memberId: string): Promise<void> {
     if (botSetupOpen() && creatingAgent()) return;
-    if (!currentTeamMember() || !directPeople().some((member) => member.id === memberId)) return;
+    if (!peopleEnabled || !currentTeamMember() || !directPeople().some((member) => member.id === memberId)) return;
     const previousBotId = activeBotId();
     if (previousBotId) pruneInactiveAgentHistory(previousBotId);
     setBotSetupOpen(false);
@@ -2901,6 +2906,7 @@ export function createAppController(props: AppProps = {}) {
     activeServer,
     botList,
     activeDirectMemberId,
+    peopleEnabled,
     activeBot,
     directPeople,
     directThreads,

--- a/src/renderer/src/AppView.tsx
+++ b/src/renderer/src/AppView.tsx
@@ -169,6 +169,7 @@ function WorkspaceShell(props: {
     activeServer,
     botList,
     activeDirectMemberId,
+    peopleEnabled,
     activeBot,
     directPeople,
     directThreads,
@@ -325,7 +326,8 @@ function WorkspaceShell(props: {
           if (server) openServerSettings(server.id, trigger);
         }}
         bots={botList()}
-        activeBotId={activeDirectMemberId() ? "" : (activeBot()?.id ?? "")}
+        activeBotId={activeDirectMember() ? "" : (activeBot()?.id ?? "")}
+        showPeople={peopleEnabled}
         people={directPeople()}
         directThreads={directThreads()}
         activeDirectMemberId={activeDirectMemberId()}
@@ -342,7 +344,7 @@ function WorkspaceShell(props: {
         onReorderPeople={reorderSidebarPeople}
         onSelectBot={selectBot}
         onSelectPerson={(memberId) => void selectDirectMember(memberId)}
-        onPreloadDirectConversation={() => void DirectConversation.preload()}
+        onPreloadDirectConversation={peopleEnabled ? () => void DirectConversation.preload() : undefined}
         onCreateBot={openBotSetup}
         onEditBot={editBot}
         onDeleteBot={deleteBot}
@@ -444,7 +446,7 @@ function WorkspaceShell(props: {
           onCancel={botList().length > 0 ? cancelBotSetup : undefined}
         />
       </Show>
-      <Show when={!botSetupOpen() && activeDirectMember()} keyed>
+      <Show when={peopleEnabled && !botSetupOpen() && activeDirectMember()} keyed>
         {(member) => (
           <Loading
             fallback={

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -39,6 +39,7 @@ interface SidebarProps {
   onOpenServerSettings: (trigger: HTMLElement) => void;
   bots: BotProfile[];
   activeBotId: string;
+  showPeople?: boolean;
   people: TeamPresenceMember[];
   directThreads: DirectThreadSummary[];
   activeDirectMemberId: string | null;
@@ -427,7 +428,7 @@ export function Sidebar(props: SidebarProps) {
   });
   const visibleSectionIds = createMemo(() =>
     props.layout.order.filter((sectionId) => {
-      if (sectionId === SIDEBAR_PEOPLE_SECTION_ID) return filteredPeople().length > 0;
+      if (sectionId === SIDEBAR_PEOPLE_SECTION_ID) return props.showPeople !== false && filteredPeople().length > 0;
       if (customSectionById().has(sectionId)) {
         return !normalizedQuery() || (filteredBotsBySection().get(sectionId)?.length ?? 0) > 0;
       }
@@ -1807,7 +1808,7 @@ export function Sidebar(props: SidebarProps) {
             when={
               resolvedPinnedItems().length > 0 ||
               filteredBots().length > 0 ||
-              filteredPeople().length > 0 ||
+              (props.showPeople !== false && filteredPeople().length > 0) ||
               sectionEditor()?.kind === "create"
             }
             fallback={
@@ -1953,7 +1954,7 @@ export function Sidebar(props: SidebarProps) {
               {(sectionId) => {
                 if (sectionId === SIDEBAR_PEOPLE_SECTION_ID) {
                   return (
-                    <Show when={filteredPeople().length > 0}>
+                    <Show when={props.showPeople !== false && filteredPeople().length > 0}>
                       <section
                         class={["sidebar-chat-group sidebar-section", sectionDragClasses(sectionId)]}
                         style={`--sidebar-section-drag-y: ${sectionDragOffset(sectionId)}px;`}


### PR DESCRIPTION
## Summary

- hide People communication and the People sidebar section by default
- keep the implementation behind an explicit opt-in for future use and test coverage
- wait for the local Auth API before Electron starts in development

## Verification

- seeded bun run dev smoke check
- 142 focused tests
- Node and renderer type checks
- Biome checks