### PR TITLE
Improve browser takeover experience

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -271,6 +271,11 @@
   min-height: 0;
 }
 
+.browser-takeover-story-states {
+  display: grid;
+  align-content: start;
+}
+
 .chat-primitives-stage {
   width: min(820px, 100%);
   min-width: 0;

--- a/packages/contracts/src/ipc-browser.ts
+++ b/packages/contracts/src/ipc-browser.ts
@@ -7,6 +7,12 @@ export interface BrowserTab {
   ownerBotId: string | null;
 }
 
+export interface BrowserPreview {
+  dataUrl: string;
+  width: number;
+  height: number;
+}
+
 export type BrowserControlPhase = "acting" | "waiting";
 
 export type BrowserControlAction =

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -101,6 +101,7 @@ export const IPC_CHANNELS = {
   browserClose: "browser:close",
   browserListTabs: "browser:list-tabs",
   browserGetControlState: "browser:get-control-state",
+  browserCapturePreview: "browser:capture-preview",
   browserSetVisible: "browser:set-visible",
   serversList: "servers:list",
   serversSelect: "servers:select",

--- a/packages/contracts/src/ipc-desktop-apis.ts
+++ b/packages/contracts/src/ipc-desktop-apis.ts
@@ -16,6 +16,7 @@ import type {
   BrowserControlState,
   BrowserNavigateInput,
   BrowserOpenInput,
+  BrowserPreview,
   BrowserTab,
   BrowserVisibilityInput,
 } from "./ipc-browser";
@@ -190,6 +191,7 @@ export interface BrowserDesktopApi {
   close: (tabId: string) => Promise<void>;
   listTabs: () => Promise<BrowserTab[]>;
   getControlState: () => Promise<BrowserControlState>;
+  capturePreview: (tabId: string) => Promise<BrowserPreview>;
   setVisible: (input: BrowserVisibilityInput) => Promise<void>;
 }
 

--- a/scripts/team-connection-smoke.ts
+++ b/scripts/team-connection-smoke.ts
@@ -61,6 +61,9 @@ async function main(): Promise<void> {
       navigate: async () => undefined,
       reload: async () => undefined,
       close: async () => undefined,
+      capturePreview: async () => {
+        throw new Error("Browser preview is unavailable in the team smoke host.");
+      },
       setVisible: async () => undefined,
     };
     const chat = new TeamChatStore(database);

--- a/src/backend/browser-host.ts
+++ b/src/backend/browser-host.ts
@@ -9,6 +9,7 @@ import type {
   BrowserControlSession,
   BrowserControlState,
   BrowserNavigationDirection,
+  BrowserPreview,
   BrowserTab,
   BrowserVisibilityInput,
 } from "@openbot/contracts/ipc";
@@ -369,6 +370,31 @@ export class BrowserHost {
     return this.#enqueue(tabId, async (tab) => {
       const image = await withTimeout(tab.view.webContents.capturePage(), 10_000, "Browser screenshot timed out.");
       return image.toDataURL();
+    });
+  }
+
+  async capturePreview(tabId: string): Promise<BrowserPreview> {
+    return this.#enqueue(tabId, async (tab) => {
+      const image = await withTimeout(tab.view.webContents.capturePage(), 10_000, "Browser preview timed out.");
+      const size = image.getSize();
+      if (size.width <= 0 || size.height <= 0) throw new Error("Browser preview is empty.");
+
+      const targetAspectRatio = 16 / 10;
+      let cropWidth = size.width;
+      let cropHeight = Math.round(cropWidth / targetAspectRatio);
+      if (cropHeight > size.height) {
+        cropHeight = size.height;
+        cropWidth = Math.round(cropHeight * targetAspectRatio);
+      }
+      const cropped = image.crop({
+        x: Math.max(0, Math.floor((size.width - cropWidth) / 2)),
+        y: 0,
+        width: cropWidth,
+        height: cropHeight,
+      });
+      const preview = cropped.resize({ width: 960, height: 600, quality: "good" });
+      const dataUrl = `data:image/jpeg;base64,${preview.toJPEG(72).toString("base64")}`;
+      return { dataUrl, width: 960, height: 600 };
     });
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -133,6 +133,7 @@ import {
   decodeBotSummaries,
   decodeBotSummary,
   decodeBrowserControlState,
+  decodeBrowserPreview,
   decodeBrowserTab,
   decodeBrowserTabs,
   decodeQueuedMessageReceipt,
@@ -1038,6 +1039,17 @@ function registerIpcHandlers(
       ? browser.getControlState()
       : remoteServers.request("/v1/browser/control", {}, undefined, decodeBrowserControlState),
   );
+  handleTrusted(IPC_CHANNELS.browserCapturePreview, (tabId: unknown) => {
+    const parsedTabId = requireString(tabId, "tabId");
+    return remoteServers.activeServerId === "local"
+      ? browser.capturePreview(parsedTabId)
+      : remoteServers.request(
+          "/v1/browser/preview",
+          { method: "POST", body: { tabId: parsedTabId } },
+          undefined,
+          decodeBrowserPreview,
+        );
+  });
   handleTrusted(IPC_CHANNELS.browserSetVisible, async (input: unknown) => {
     const parsed = parseVisibility(input);
     if (remoteServers.activeServerId === "local") await browser.setVisible(parsed);

--- a/src/main/remote-server-manager.test.ts
+++ b/src/main/remote-server-manager.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import { parseInviteUrl } from "@openbot/contracts/invite-links";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  decodeBrowserPreview,
   decodeBrowserTab,
   isValidRemoteApiUrl,
   RemoteServerManager,
@@ -31,6 +32,23 @@ describe("remote browser responses", () => {
       }),
     ).toMatchObject({ id: "tab-1", url: "https://example.com/" });
     expect(() => decodeBrowserTab(undefined)).toThrowError("Invalid remote browser tab.");
+  });
+
+  it("accepts only bounded JPEG browser previews", () => {
+    expect(
+      decodeBrowserPreview({
+        dataUrl: "data:image/jpeg;base64,YWJj",
+        width: 960,
+        height: 600,
+      }),
+    ).toMatchObject({ width: 960, height: 600 });
+    expect(() =>
+      decodeBrowserPreview({
+        dataUrl: "data:image/png;base64,YWJj",
+        width: 960,
+        height: 600,
+      }),
+    ).toThrowError("Invalid remote browser preview.");
   });
 });
 

--- a/src/main/remote-server-manager.ts
+++ b/src/main/remote-server-manager.ts
@@ -12,6 +12,7 @@ import type {
   BotMemory,
   BotSummary,
   BrowserControlState,
+  BrowserPreview,
   BrowserTab,
   ConversationMessage,
   ConversationPage,
@@ -1151,6 +1152,28 @@ export function decodeBrowserTabs(value: unknown): BrowserTab[] {
 export function decodeBrowserTab(value: unknown): BrowserTab {
   if (!isBrowserTabValue(value)) throw new Error("Invalid remote browser tab.");
   return value;
+}
+
+export function decodeBrowserPreview(value: unknown): BrowserPreview {
+  if (!isBrowserPreviewValue(value)) throw new Error("Invalid remote browser preview.");
+  return value;
+}
+
+function isBrowserPreviewValue(value: unknown): value is BrowserPreview {
+  return (
+    isDynamicRecord(value) &&
+    isString(value.dataUrl) &&
+    value.dataUrl.length <= 2_000_000 &&
+    /^data:image\/jpeg;base64,[A-Za-z0-9+/]+={0,2}$/.test(value.dataUrl) &&
+    isNumber(value.width) &&
+    Number.isSafeInteger(value.width) &&
+    value.width > 0 &&
+    value.width <= 960 &&
+    isNumber(value.height) &&
+    Number.isSafeInteger(value.height) &&
+    value.height > 0 &&
+    value.height <= 600
+  );
 }
 
 function isBrowserTabValue(value: unknown): value is BrowserTab {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -99,7 +99,7 @@ function createMailbox(): TestMailbox {
   return { resolveAttachment: unimplemented };
 }
 
-function createBrowser(): TestBrowser {
+function createBrowser(overrides: Partial<TestBrowser> = {}): TestBrowser {
   return {
     listTabs: unimplemented,
     getControlState: unimplemented,
@@ -108,7 +108,9 @@ function createBrowser(): TestBrowser {
     navigate: unimplemented,
     reload: unimplemented,
     close: unimplemented,
+    capturePreview: unimplemented,
     setVisible: unimplemented,
+    ...overrides,
   };
 }
 
@@ -1114,6 +1116,43 @@ describe("TeamApiServer administration", () => {
         body: JSON.stringify({ requestId: 17, decision: "session" }),
       });
       expect(invalid.status).toBe(400);
+    } finally {
+      await api.stop();
+    }
+  });
+
+  it("returns a bounded browser preview to an authenticated client", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-team-api-browser-preview-"));
+    roots.push(root);
+    const store = new TeamStore(join(root, "team.json"));
+    await store.initialize();
+    await store.configure("Studio Mac", "owner", "correct horse battery");
+    const capturePreview = vi.fn(async () => ({
+      dataUrl: "data:image/jpeg;base64,YWJj",
+      width: 960,
+      height: 600,
+    }));
+    const api = new TeamApiServer({
+      store,
+      agents: createAgents(),
+      mailbox: createMailbox(),
+      browser: createBrowser({ capturePreview }),
+    });
+    const port = await api.start();
+    const base = `http://127.0.0.1:${port}`;
+
+    try {
+      const login = await jsonRequest<{ sessionToken: string }>(base, "/v1/auth/login", {
+        body: { username: "owner", password: "correct horse battery" },
+      });
+      const preview = await jsonRequest<{ dataUrl: string; width: number; height: number }>(
+        base,
+        "/v1/browser/preview",
+        { token: login.sessionToken, body: { tabId: "tab-login" } },
+      );
+
+      expect(capturePreview).toHaveBeenCalledWith("tab-login");
+      expect(preview).toEqual({ dataUrl: "data:image/jpeg;base64,YWJj", width: 960, height: 600 });
     } finally {
       await api.stop();
     }

--- a/src/main/team-api-server.ts
+++ b/src/main/team-api-server.ts
@@ -116,7 +116,15 @@ type TeamApiSidebarLayout = Pick<SidebarLayoutStore, "getSnapshot" | "mutate" | 
 };
 type TeamApiBrowser = Pick<
   BrowserHost,
-  "listTabs" | "getControlState" | "open" | "activate" | "navigate" | "reload" | "close" | "setVisible"
+  | "listTabs"
+  | "getControlState"
+  | "open"
+  | "activate"
+  | "navigate"
+  | "reload"
+  | "close"
+  | "capturePreview"
+  | "setVisible"
 >;
 type TeamApiRemoteScreen = Pick<
   RemoteScreenGateway,
@@ -649,6 +657,10 @@ export class TeamApiServer {
         const body = await readJson(request);
         await this.#options.browser.close(stringField(body, "tabId"));
         return this.#empty(response, 204);
+      }
+      if (method === "POST" && url.pathname === "/v1/browser/preview") {
+        const body = await readJson(request);
+        return this.#json(response, 200, await this.#options.browser.capturePreview(stringField(body, "tabId")));
       }
       if (method === "POST" && url.pathname === "/v1/browser/visible") {
         const body = await readJson(request);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,7 @@ import {
   type AttachmentImportEvent,
   type BotMemory,
   type BotSummary,
+  type BrowserPreview,
   type ConversationMessage,
   type ConversationPage,
   type ConversationReadState,
@@ -112,6 +113,26 @@ async function importFiles(files: File[]): Promise<void> {
 function record(value: unknown, label: string): DynamicRecord {
   if (!isDynamicRecord(value)) throw new Error(`Invalid ${label}.`);
   return value;
+}
+
+function decodeBrowserPreview(value: unknown): BrowserPreview {
+  const preview = record(value, "browser preview");
+  const dataUrl = requiredString(preview, "dataUrl");
+  const width = requiredNumber(preview, "width");
+  const height = requiredNumber(preview, "height");
+  if (
+    dataUrl.length > 2_000_000 ||
+    !/^data:image\/jpeg;base64,[A-Za-z0-9+/]+={0,2}$/.test(dataUrl) ||
+    !Number.isSafeInteger(width) ||
+    width <= 0 ||
+    width > 960 ||
+    !Number.isSafeInteger(height) ||
+    height <= 0 ||
+    height > 600
+  ) {
+    throw new Error("Invalid browser preview.");
+  }
+  return { dataUrl, width, height };
 }
 
 function nullableString(value: unknown, label: string): value is string | null {
@@ -853,6 +874,7 @@ const openbotApi: OpenBotDesktopApi = {
     close: (tabId) => ipcRenderer.invoke(IPC_CHANNELS.browserClose, tabId),
     listTabs: () => ipcRenderer.invoke(IPC_CHANNELS.browserListTabs),
     getControlState: () => ipcRenderer.invoke(IPC_CHANNELS.browserGetControlState),
+    capturePreview: (tabId) => ipcRenderer.invoke(IPC_CHANNELS.browserCapturePreview, tabId).then(decodeBrowserPreview),
     setVisible: (input) => ipcRenderer.invoke(IPC_CHANNELS.browserSetVisible, input),
   },
   update: {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -479,6 +479,11 @@ describe("OpenBot connected desktop shell", () => {
           close: vi.fn().mockResolvedValue(undefined),
           listTabs: vi.fn().mockResolvedValue([]),
           getControlState: vi.fn().mockResolvedValue({ sessions: [] }),
+          capturePreview: vi.fn().mockResolvedValue({
+            dataUrl: "data:image/jpeg;base64,YWJj",
+            width: 960,
+            height: 600,
+          }),
           setVisible: vi.fn().mockResolvedValue(undefined),
         },
         update: {
@@ -3011,15 +3016,16 @@ describe("OpenBot connected desktop shell", () => {
       },
     });
 
-    expect(await screen.findByRole("region", { name: "Browser takeover" })).toHaveTextContent("Take over");
-    expect(
-      screen.getByText("Complete the authorization in the open browser, then let the agent continue."),
-    ).toBeVisible();
+    expect(await screen.findByRole("region", { name: "Browser takeover" })).toHaveTextContent("Action required");
+    expect(screen.getByRole("heading", { name: "Complete the step on example.com" })).toBeVisible();
+    expect(await screen.findByRole("img", { name: "Preview of Sign in" })).toBeVisible();
     expect(await screen.findByRole("complementary", { name: "Browser" })).toBeVisible();
     await waitFor(() => expect(window.openbot.browser.activate).toHaveBeenCalledWith("tab-login"));
+    expect(window.openbot.browser.capturePreview).toHaveBeenCalledTimes(1);
+    expect(window.openbot.browser.capturePreview).toHaveBeenCalledWith("tab-login");
     expect(screen.queryByRole("textbox", { name: "Message Chief" })).not.toBeInTheDocument();
 
-    await fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    await fireEvent.click(screen.getByRole("button", { name: "I’m done" }));
     await waitFor(() =>
       expect(window.openbot.agent.respondToBrowserTakeover).toHaveBeenCalledWith({
         requestId: "takeover-1",
@@ -3027,6 +3033,56 @@ describe("OpenBot connected desktop shell", () => {
       }),
     );
     await waitFor(() => expect(screen.queryByRole("region", { name: "Browser takeover" })).not.toBeInTheDocument());
+    const completedCard = await screen.findByRole("region", { name: "Browser takeover complete" });
+    expect(completedCard).toHaveTextContent("Done");
+    expect(within(completedCard).getByRole("img", { name: "Preview of Sign in" })).toBeVisible();
+    expect(within(completedCard).queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Message Chief" })).toBeVisible();
+  });
+
+  it("keeps browser takeover actions available when the preview fails", async () => {
+    vi.mocked(window.openbot.browser.capturePreview).mockRejectedValueOnce(new Error("Preview unavailable"));
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    await confirmOnboardingModel();
+    await waitFor(() => expect(emitAgentEvent).toBeDefined());
+    emitAgentEvent?.({
+      type: "browser-changed",
+      tabs: [
+        {
+          id: "tab-login",
+          title: "Sign in",
+          url: "https://example.com/login",
+          loading: false,
+          ownerThreadId: "thread-chief",
+          ownerBotId: "chief",
+        },
+      ],
+      activeTabId: "tab-login",
+    });
+    emitAgentEvent?.({
+      type: "browser-takeover-requested",
+      request: {
+        requestId: "takeover-preview-failed",
+        botId: "chief",
+        threadId: "thread-chief",
+        turnId: "turn-preview-failed",
+        tabId: "tab-login",
+      },
+    });
+
+    const card = await screen.findByRole("region", { name: "Browser takeover" });
+    await waitFor(() => expect(within(card).queryByRole("img")).not.toBeInTheDocument());
+    await fireEvent.click(within(card).getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(window.openbot.agent.respondToBrowserTakeover).toHaveBeenCalledWith({
+        requestId: "takeover-preview-failed",
+        decision: "cancel",
+      }),
+    );
+    const cancelledCard = await screen.findByRole("region", { name: "Browser takeover cancelled" });
+    expect(cancelledCard).toHaveTextContent("Cancelled");
+    expect(within(cancelledCard).queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("closes browser tabs with the middle mouse button and Control W, then closes the panel", async () => {

--- a/src/renderer/src/components/ConversationPrompts.tsx
+++ b/src/renderer/src/components/ConversationPrompts.tsx
@@ -1,7 +1,7 @@
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
-import type { AgentApproval, AgentPromptQuestion } from "@openbot/contracts/ipc";
+import type { AgentApproval, AgentPromptQuestion, BrowserPreview, BrowserTab } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
-import { Button, Input, LogIn, RadioGroup } from "./ui";
+import { Badge, Button, Check, Input, Monitor, RadioGroup, Skeleton, TriangleAlert, X } from "./ui";
 
 export function ChoiceCard(props: {
   title: string;
@@ -368,53 +368,147 @@ export function ApprovalCard(props: {
   );
 }
 
-export function BrowserTakeoverCard(props: { onComplete: () => Promise<boolean>; onCancel: () => Promise<boolean> }) {
-  const [submitting, setSubmitting] = createSignal(false);
+export function BrowserTakeoverCard(props: {
+  botName: string;
+  tab: BrowserTab | undefined;
+  preview: BrowserPreview | null;
+  previewStatus: "idle" | "loading" | "ready" | "failed";
+  decision?: "complete" | "cancel" | null;
+  onComplete: () => Promise<boolean>;
+  onCancel: () => Promise<boolean>;
+}) {
+  const [submitting, setSubmitting] = createSignal<"complete" | "cancel" | null>(null);
+  const pageDetails = createMemo(() => browserPageDetails(props.tab));
+  const completed = () => props.decision === "complete";
+  const cancelled = () => props.decision === "cancel";
+  const accessibleLabel = () =>
+    completed() ? "Browser takeover complete" : cancelled() ? "Browser takeover cancelled" : "Browser takeover";
   const submit = async (decision: "complete" | "cancel") => {
-    if (submitting()) return;
-    setSubmitting(true);
+    if (submitting() || props.decision) return;
+    setSubmitting(decision);
     const completed = await (decision === "complete" ? props.onComplete() : props.onCancel());
-    if (!completed) setSubmitting(false);
+    if (!completed) setSubmitting(null);
   };
 
   return (
-    <section class="approval-card approval-card-takeover" aria-label="Browser takeover">
-      <header class="approval-card-header">
-        <span class="approval-card-icon" data-kind="takeover">
-          <LogIn aria-hidden="true" />
-        </span>
-        <div>
-          <strong>Take over</strong>
-        </div>
+    <section
+      class="browser-takeover-card"
+      data-decision={props.decision ?? undefined}
+      aria-label={accessibleLabel()}
+      aria-busy={submitting() ? "true" : undefined}
+    >
+      <header class="browser-takeover-header">
+        <span>Browser</span>
+        <Show
+          when={!props.decision}
+          fallback={
+            <Badge variant={completed() ? "success-light" : "secondary"}>
+              <Show when={completed()} fallback={<X data-icon="inline-start" aria-hidden="true" />}>
+                <Check data-icon="inline-start" aria-hidden="true" />
+              </Show>
+              {completed() ? "Done" : "Cancelled"}
+            </Badge>
+          }
+        >
+          <Badge variant="warning-light">
+            <TriangleAlert data-icon="inline-start" aria-hidden="true" />
+            Action required
+          </Badge>
+        </Show>
       </header>
-      <div class="approval-card-content">
-        <p class="approval-reason">Complete the authorization in the open browser, then let the agent continue.</p>
+      <div class="browser-takeover-copy">
+        <h2>
+          {completed()
+            ? `Step completed on ${pageDetails().host}`
+            : cancelled()
+              ? `Step cancelled on ${pageDetails().host}`
+              : `Complete the step on ${pageDetails().host}`}
+        </h2>
+        <p>
+          {completed()
+            ? `${props.botName} is continuing.`
+            : cancelled()
+              ? "The browser step was cancelled."
+              : `Finish the sign-in, verification, or consent in the open browser. Then let ${props.botName} continue.`}
+        </p>
       </div>
-      <footer class="approval-card-footer approval-card-footer-end">
-        <div class="approval-card-actions">
+
+      <figure class="browser-takeover-preview">
+        <figcaption class="browser-takeover-preview-bar">
+          <Monitor aria-hidden="true" />
+          <span title={pageDetails().title}>{pageDetails().title}</span>
+          <small title={pageDetails().host}>{pageDetails().host}</small>
+        </figcaption>
+        <div class="browser-takeover-preview-viewport">
+          <Show
+            when={props.previewStatus === "ready" ? props.preview : null}
+            fallback={
+              <Show
+                when={props.previewStatus === "loading" || props.previewStatus === "idle"}
+                fallback={
+                  <div class="browser-takeover-preview-fallback">
+                    <Monitor aria-hidden="true" />
+                    <strong>{pageDetails().title}</strong>
+                    <span>{pageDetails().host}</span>
+                  </div>
+                }
+              >
+                <Skeleton class="browser-takeover-preview-skeleton" />
+              </Show>
+            }
+          >
+            {(preview) => (
+              <img
+                src={preview().dataUrl}
+                width={preview().width}
+                height={preview().height}
+                alt={`Preview of ${pageDetails().title}`}
+              />
+            )}
+          </Show>
+        </div>
+      </figure>
+
+      <Show when={!props.decision}>
+        <footer class="browser-takeover-actions">
           <Button
             variant="ghost"
+            size="sm"
             type="button"
-            class="approval-button approval-button-ghost"
-            disabled={submitting()}
+            class="approval-button"
+            loading={submitting() === "cancel"}
+            loadingLabel="Cancelling…"
+            disabled={Boolean(submitting())}
             onClick={() => void submit("cancel")}
           >
             Cancel
           </Button>
           <Button
             variant="default"
+            size="sm"
             type="button"
-            class="approval-button approval-button-primary"
-            disabled={submitting()}
+            class="approval-button"
+            loading={submitting() === "complete"}
+            loadingLabel="Returning…"
+            disabled={Boolean(submitting())}
             onClick={() => void submit("complete")}
           >
-            {submitting() ? "Returning…" : "Done"}
-            <ReturnIcon />
+            I’m done
           </Button>
-        </div>
-      </footer>
+        </footer>
+      </Show>
     </section>
   );
+}
+
+function browserPageDetails(tab: BrowserTab | undefined): { title: string; host: string } {
+  const title = tab?.title.trim() || "Browser page";
+  if (!tab?.url) return { title, host: "the browser" };
+  try {
+    return { title, host: new URL(tab.url).hostname || "the browser" };
+  } catch {
+    return { title, host: tab.url };
+  }
 }
 
 function approvalTitle(approval: AgentApproval | undefined) {

--- a/src/renderer/src/components/ConversationPrompts.tsx
+++ b/src/renderer/src/components/ConversationPrompts.tsx
@@ -402,7 +402,7 @@ export function BrowserTakeoverCard(props: {
         <Show
           when={!props.decision}
           fallback={
-            <Badge variant={completed() ? "success-light" : "secondary"}>
+            <Badge variant={completed() ? "success-light" : "secondary"} role="status">
               <Show when={completed()} fallback={<X data-icon="inline-start" aria-hidden="true" />}>
                 <Check data-icon="inline-start" aria-hidden="true" />
               </Show>
@@ -410,7 +410,7 @@ export function BrowserTakeoverCard(props: {
             </Badge>
           }
         >
-          <Badge variant="warning-light">
+          <Badge variant="warning-light" role="status">
             <TriangleAlert data-icon="inline-start" aria-hidden="true" />
             Action required
           </Badge>

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -13,6 +13,7 @@ import type {
   AttachmentSummary,
   AvatarImageInput,
   BrowserControlState,
+  BrowserPreview,
   BrowserTab,
   DraftAttachment,
   FilePreview,
@@ -126,6 +127,19 @@ interface RenderedAgentActivity {
   bot: BotProfile | undefined;
   phase: "active" | "exiting";
   presentation: AgentActivityPresentation;
+}
+
+interface BrowserTakeoverPreviewState {
+  status: "idle" | "loading" | "ready" | "failed";
+  preview: BrowserPreview | null;
+}
+
+interface BrowserTakeoverResolutionState {
+  decision: "complete" | "cancel";
+  tab: BrowserTab | undefined;
+  preview: BrowserPreview | null;
+  previewStatus: BrowserTakeoverPreviewState["status"];
+  messageMarker: string | null;
 }
 
 interface RoutineSettingsRequest {
@@ -430,6 +444,83 @@ function createConversationViewScope(props: ConversationProps) {
   const activeBrowserTab = createMemo(
     () => browserTabs().find((tab) => tab.id === props.activeBrowserTabId) ?? browserTabs()[0],
   );
+  const browserTakeoverTab = createMemo(() => {
+    const tabId = props.browserTakeover?.tabId;
+    return tabId ? browserTabs().find((tab) => tab.id === tabId) : undefined;
+  });
+  const [browserTakeoverPreview, setBrowserTakeoverPreview] = createSignal<BrowserTakeoverPreviewState>({
+    status: "idle",
+    preview: null,
+  });
+  let browserTakeoverPreviewKey: string | null = null;
+  let browserTakeoverPreviewGeneration = 0;
+  createEffect(
+    () => ({ request: props.browserTakeover, tab: browserTakeoverTab() }),
+    ({ request, tab }) => {
+      if (!request) {
+        browserTakeoverPreviewKey = null;
+        browserTakeoverPreviewGeneration += 1;
+        setBrowserTakeoverPreview({ status: "idle", preview: null });
+        return;
+      }
+
+      const requestKey = String(request.requestId);
+      if (!tab) {
+        if (browserTakeoverPreviewKey !== requestKey) {
+          setBrowserTakeoverPreview({ status: "loading", preview: null });
+        }
+        return;
+      }
+      if (browserTakeoverPreviewKey === requestKey) return;
+
+      browserTakeoverPreviewKey = requestKey;
+      const generation = ++browserTakeoverPreviewGeneration;
+      setBrowserTakeoverPreview({ status: "loading", preview: null });
+      void window.openbot.browser
+        .capturePreview(tab.id)
+        .then((preview) => {
+          if (browserTakeoverPreviewGeneration !== generation) return;
+          setBrowserTakeoverPreview({ status: "ready", preview });
+        })
+        .catch(() => {
+          if (browserTakeoverPreviewGeneration !== generation) return;
+          setBrowserTakeoverPreview({ status: "failed", preview: null });
+        });
+    },
+  );
+  const latestMessageMarker = createMemo(() => {
+    const message = props.messages.at(-1);
+    return message
+      ? `${message.id}:${message.body.length}:${message.streaming === true ? "streaming" : "settled"}`
+      : null;
+  });
+  const [browserTakeoverResolution, setBrowserTakeoverResolution] = createSignal<BrowserTakeoverResolutionState | null>(
+    null,
+  );
+  createEffect(
+    () => props.browserTakeover?.requestId,
+    (requestId) => {
+      if (requestId !== undefined) setBrowserTakeoverResolution(null);
+    },
+  );
+  createEffect(latestMessageMarker, (messageMarker) => {
+    const resolution = untrack(browserTakeoverResolution);
+    if (resolution && resolution.messageMarker !== messageMarker) setBrowserTakeoverResolution(null);
+  });
+  const respondToBrowserTakeover = async (decision: "complete" | "cancel") => {
+    const request = props.browserTakeover;
+    if (!request) return false;
+    const resolution = {
+      decision,
+      tab: browserTakeoverTab(),
+      preview: browserTakeoverPreview().preview,
+      previewStatus: browserTakeoverPreview().status,
+      messageMarker: latestMessageMarker(),
+    } satisfies BrowserTakeoverResolutionState;
+    const completed = await props.onRespondToBrowserTakeover(decision);
+    if (completed && latestMessageMarker() === resolution.messageMarker) setBrowserTakeoverResolution(resolution);
+    return completed;
+  };
   let previousBrowserTabCount = 0;
   createEffect(
     () => ({ count: browserTabs().length, open: screenOpen() }),
@@ -1987,6 +2078,10 @@ function createConversationViewScope(props: ConversationProps) {
     activeActivityId,
     activeBrowserControl,
     activeBrowserTab,
+    browserTakeoverPreview,
+    browserTakeoverResolution,
+    browserTakeoverTab,
+    respondToBrowserTakeover,
     activeChatSearchIndex,
     activeDeliveries,
     activeRightPanel,
@@ -2315,6 +2410,9 @@ export function ConversationTimeline() {
     agentActivitySpaceReserved,
     agentReady,
     attachmentAction,
+    browserTakeoverPreview,
+    browserTakeoverResolution,
+    browserTakeoverTab,
     chatSearchMatches,
     chatSearchOpen,
     chatSearchQuery,
@@ -2343,6 +2441,7 @@ export function ConversationTimeline() {
     props,
     reactToMessage,
     renderedAgentActivity,
+    respondToBrowserTakeover,
     replyToMessage,
     scheduleUnreadDividerVisibilityUpdate,
     setChatSearchQuery,
@@ -2718,10 +2817,27 @@ export function ConversationTimeline() {
           <Show when={props.browserTakeover}>
             <Loading>
               <BrowserTakeoverCard
-                onComplete={() => props.onRespondToBrowserTakeover("complete")}
-                onCancel={() => props.onRespondToBrowserTakeover("cancel")}
+                botName={props.bot?.name ?? "the agent"}
+                tab={browserTakeoverTab()}
+                preview={browserTakeoverPreview().preview}
+                previewStatus={browserTakeoverPreview().status}
+                onComplete={() => respondToBrowserTakeover("complete")}
+                onCancel={() => respondToBrowserTakeover("cancel")}
               />
             </Loading>
+          </Show>
+          <Show when={!props.browserTakeover && browserTakeoverResolution()}>
+            {(resolution) => (
+              <BrowserTakeoverCard
+                botName={props.bot?.name ?? "the agent"}
+                tab={resolution().tab}
+                preview={resolution().preview}
+                previewStatus={resolution().previewStatus}
+                decision={resolution().decision}
+                onComplete={async () => false}
+                onCancel={async () => false}
+              />
+            )}
           </Show>
         </Show>
       </div>

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -242,7 +242,9 @@ function createSidebarAgentDragCard(source: HTMLElement): HTMLElement {
   const titleText = source.querySelector(".sidebar-pinned-title, .bot-role-badge")?.textContent?.trim();
   if (titleText) {
     const title = document.createElement("span");
-    title.className = "ui-badge sidebar-pinned-title";
+    title.className = "z-badge z-badge-variant-secondary sidebar-pinned-title";
+    title.dataset.slot = "badge";
+    title.dataset.variant = "secondary";
     title.dataset.size = "sm";
     const label = document.createElement("span");
     label.textContent = titleText;

--- a/src/renderer/src/components/ui/badge.tsx
+++ b/src/renderer/src/components/ui/badge.tsx
@@ -45,10 +45,11 @@ type BadgeProps<T extends ValidComponent = "span"> = PolymorphicProps<T, BadgeRo
     shape?: BadgeRadius;
     /** @deprecated Put a Lucide icon inside the badge. */
     dot?: boolean;
+    role?: JSX.HTMLAttributes<HTMLElement>["role"];
   } & Partial<Pick<ComponentProps<T>, "class" | "children">>;
 
 export function Badge<T extends ValidComponent = "span">(props: BadgeProps<T>): JSX.Element {
-  const others = omit(props, "class", "variant", "tone", "size", "shape", "dot", "children");
+  const others = omit(props, "class", "variant", "tone", "size", "shape", "dot", "children", "role");
   // biome-ignore lint/nursery/noUnsafeTypeAssertion: Solid 2's omit cannot preserve Kobalte's generic polymorphic props.
   const rootProps = others as PolymorphicProps<T, BadgeRootProps<T>>;
   const variant = () => props.variant ?? legacyBadgeVariant(props.tone);
@@ -60,6 +61,7 @@ export function Badge<T extends ValidComponent = "span">(props: BadgeProps<T>): 
       data-variant={variant()}
       data-size={props.size}
       data-shape={props.shape}
+      role={props.role ?? "presentation"}
       {...rootProps}
     >
       <Show when={props.dot}>

--- a/src/renderer/src/components/ui/badge.tsx
+++ b/src/renderer/src/components/ui/badge.tsx
@@ -1,33 +1,79 @@
-import type { JSX } from "@solidjs/web";
+import { type BadgeRootProps, Root } from "@kobalte/core/badge";
+import type { PolymorphicProps } from "@kobalte/core/polymorphic";
+import type { ComponentProps, JSX, ValidComponent } from "@solidjs/web";
+import { cva, type VariantProps } from "class-variance-authority";
 import { omit, Show } from "solid-js";
 import { cx } from "./utils";
+
+export const badgeVariants = cva("z-badge", {
+  variants: {
+    variant: {
+      default: "z-badge-variant-default",
+      secondary: "z-badge-variant-secondary",
+      destructive: "z-badge-variant-destructive",
+      outline: "z-badge-variant-outline",
+      ghost: "z-badge-variant-ghost",
+      link: "z-badge-variant-link",
+      "primary-light": "z-badge-variant-primary-light",
+      "destructive-light": "z-badge-variant-destructive-light",
+      "success-light": "z-badge-variant-success-light",
+      "warning-light": "z-badge-variant-warning-light",
+      "info-light": "z-badge-variant-info-light",
+      "primary-outline": "z-badge-variant-primary-outline",
+      "destructive-outline": "z-badge-variant-destructive-outline",
+      "success-outline": "z-badge-variant-success-outline",
+      "warning-outline": "z-badge-variant-warning-outline",
+      "info-outline": "z-badge-variant-info-outline",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
 
 export type BadgeTone = "neutral" | "accent" | "success" | "warning" | "danger";
 export type BadgeSize = "sm" | "md";
 export type BadgeRadius = "rounded" | "pill";
 
-export interface BadgeProps extends JSX.HTMLAttributes<HTMLSpanElement> {
-  tone?: BadgeTone;
-  size?: BadgeSize;
-  shape?: BadgeRadius;
-  dot?: boolean;
+type BadgeProps<T extends ValidComponent = "span"> = PolymorphicProps<T, BadgeRootProps<T>> &
+  VariantProps<typeof badgeVariants> & {
+    /** @deprecated Use a Zaidan `variant` instead. */
+    tone?: BadgeTone;
+    /** @deprecated Zaidan badges use one compact size. */
+    size?: BadgeSize;
+    /** @deprecated Zaidan badges use a pill shape. */
+    shape?: BadgeRadius;
+    /** @deprecated Put a Lucide icon inside the badge. */
+    dot?: boolean;
+  } & Partial<Pick<ComponentProps<T>, "class" | "children">>;
+
+export function Badge<T extends ValidComponent = "span">(props: BadgeProps<T>): JSX.Element {
+  const others = omit(props, "class", "variant", "tone", "size", "shape", "dot", "children");
+  // biome-ignore lint/nursery/noUnsafeTypeAssertion: Solid 2's omit cannot preserve Kobalte's generic polymorphic props.
+  const rootProps = others as PolymorphicProps<T, BadgeRootProps<T>>;
+  const variant = () => props.variant ?? legacyBadgeVariant(props.tone);
+
+  return (
+    <Root<T>
+      class={cx(badgeVariants({ variant: variant() }), props.class)}
+      data-slot="badge"
+      data-variant={variant()}
+      data-size={props.size}
+      data-shape={props.shape}
+      {...rootProps}
+    >
+      <Show when={props.dot}>
+        <span class="z-badge-dot" aria-hidden="true" />
+      </Show>
+      {props.children}
+    </Root>
+  );
 }
 
-export function Badge(props: BadgeProps): JSX.Element {
-  const local = props;
-  const others = omit(props, "tone", "size", "shape", "dot", "class", "children");
-  return (
-    <span
-      class={cx("ui-badge", local.class)}
-      data-tone={local.tone ?? "neutral"}
-      data-size={local.size ?? "md"}
-      data-shape={local.shape ?? "rounded"}
-      {...others}
-    >
-      <Show when={local.dot}>
-        <span class="ui-badge-dot" aria-hidden="true" />
-      </Show>
-      {local.children}
-    </span>
-  );
+function legacyBadgeVariant(tone: BadgeTone | undefined): NonNullable<VariantProps<typeof badgeVariants>["variant"]> {
+  if (tone === "accent") return "primary-light";
+  if (tone === "success") return "success-light";
+  if (tone === "warning") return "warning-light";
+  if (tone === "danger") return "destructive-light";
+  return "secondary";
 }

--- a/src/renderer/src/preview/mock-openbot.ts
+++ b/src/renderer/src/preview/mock-openbot.ts
@@ -10,6 +10,7 @@ import type {
   BotSummary,
   BrowserControlState,
   BrowserOpenInput,
+  BrowserPreview,
   BrowserTab,
   CentralAuthState,
   CentralAuthUser,
@@ -57,6 +58,7 @@ import type {
   UpdateTeamMemberInput,
 } from "@openbot/contracts/ipc";
 import { SIDEBAR_PEOPLE_SECTION_ID, SIDEBAR_UNASSIGNED_SECTION_ID } from "@openbot/contracts/ipc";
+import browserTakeoverPreviewUrl from "../../stories/assets/browser-takeover-preview.svg";
 import {
   STORY_AGENT_STATUS,
   STORY_APP_INFO,
@@ -91,6 +93,7 @@ export interface MockOpenBotOptions {
   snapshots?: Record<string, ConversationSnapshot>;
   browserTabs?: BrowserTab[];
   browserControlState?: BrowserControlState;
+  browserPreview?: BrowserPreview | null;
   servers?: ServerSummary[];
   presence?: TeamPresenceSnapshot;
   directThreads?: DirectThreadSummary[];
@@ -162,6 +165,10 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
   const snapshots = clone(options.snapshots ?? STORY_SNAPSHOTS);
   let browserTabs = clone(options.browserTabs ?? STORY_BROWSER_TABS);
   const browserControlState = clone(options.browserControlState ?? STORY_BROWSER_CONTROL);
+  const browserPreview =
+    options.browserPreview === undefined
+      ? { dataUrl: browserTakeoverPreviewUrl, width: 960, height: 600 }
+      : options.browserPreview;
   let servers = clone(options.servers ?? STORY_SERVERS);
   let presence = clone(options.presence ?? STORY_PRESENCE);
   let directThreads = clone(options.directThreads ?? STORY_DIRECT_THREADS);
@@ -866,6 +873,10 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
       },
       listTabs: async () => clone(browserTabs),
       getControlState: async () => clone(browserControlState),
+      capturePreview: async () => {
+        if (!browserPreview) throw new Error("Browser preview is unavailable.");
+        return clone(browserPreview);
+      },
       setVisible: async () => undefined,
     },
     update: {

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -7221,6 +7221,205 @@
   background: var(--openbot-border);
 }
 
+.browser-takeover-card {
+  display: flex;
+  width: min(460px, 100%);
+  box-sizing: border-box;
+  margin: var(--openbot-space-3) 0 20px;
+  flex-direction: column;
+  gap: var(--openbot-space-3);
+  border: 0;
+  border-radius: var(--openbot-radius-bubble);
+  background: var(--openbot-bg-surface);
+  box-shadow:
+    0 0 0 0.5px var(--openbot-border),
+    0 1px 2px var(--openbot-bg-overlay),
+    0 2px 4px var(--openbot-shadow-popover-key);
+  color: var(--openbot-text-primary);
+  padding: var(--openbot-space-3);
+  animation: browser-takeover-in var(--openbot-duration-slow) var(--openbot-ease-out) both;
+}
+
+.browser-takeover-header {
+  display: flex;
+  height: var(--openbot-control-xs);
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--openbot-space-3);
+}
+
+.browser-takeover-header > span {
+  overflow: hidden;
+  font-size: var(--openbot-text-sm);
+  font-weight: var(--openbot-weight-medium);
+  line-height: var(--openbot-leading-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.browser-takeover-header [data-slot="badge"] svg {
+  width: var(--openbot-icon-xs);
+  height: var(--openbot-icon-xs);
+  flex: 0 0 auto;
+  stroke-width: 2;
+}
+
+.browser-takeover-copy {
+  display: grid;
+  gap: var(--openbot-space-1);
+}
+
+.browser-takeover-copy h2,
+.browser-takeover-copy p {
+  margin: 0;
+}
+
+.browser-takeover-copy h2 {
+  font-size: var(--openbot-text-lg);
+  font-weight: var(--openbot-weight-medium);
+  line-height: var(--openbot-leading-lg);
+}
+
+.browser-takeover-copy p {
+  max-width: 54ch;
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-sm);
+  line-height: var(--openbot-leading-md);
+}
+
+.browser-takeover-preview {
+  min-width: 0;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--openbot-border);
+  border-radius: var(--openbot-radius-md);
+  background: var(--openbot-bg-canvas);
+}
+
+.browser-takeover-preview-bar {
+  display: flex;
+  height: var(--openbot-control-sm);
+  min-width: 0;
+  align-items: center;
+  gap: var(--openbot-space-1-5);
+  border-bottom: 1px solid var(--openbot-border);
+  background: var(--openbot-bg-control);
+  padding: 0 var(--openbot-space-3);
+  color: var(--openbot-text-secondary);
+}
+
+.browser-takeover-preview-bar svg {
+  width: var(--openbot-icon-sm);
+  height: var(--openbot-icon-sm);
+  flex: 0 0 auto;
+  stroke-width: 1.6;
+}
+
+.browser-takeover-preview-bar span,
+.browser-takeover-preview-bar small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.browser-takeover-preview-bar span {
+  min-width: 0;
+  flex: 1;
+  font-size: var(--openbot-text-xs);
+  font-weight: var(--openbot-weight-medium);
+}
+
+.browser-takeover-preview-bar small {
+  max-width: 42%;
+  color: var(--openbot-text-readable);
+  font-size: var(--openbot-text-2xs);
+}
+
+.browser-takeover-preview-viewport {
+  display: grid;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  place-items: stretch;
+  background: var(--openbot-bg-control);
+}
+
+.browser-takeover-preview-viewport img,
+.browser-takeover-preview-skeleton {
+  width: 100%;
+  height: 100%;
+}
+
+.browser-takeover-preview-viewport img {
+  display: block;
+  object-fit: cover;
+}
+
+.browser-takeover-preview-fallback {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: var(--openbot-space-1);
+  color: var(--openbot-text-muted);
+  padding: var(--openbot-space-6);
+  text-align: center;
+}
+
+.browser-takeover-preview-fallback svg {
+  width: var(--openbot-icon-lg);
+  height: var(--openbot-icon-lg);
+  margin-bottom: var(--openbot-space-1);
+  stroke-width: 1.4;
+}
+
+.browser-takeover-preview-fallback strong {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--openbot-text-secondary);
+  font-size: var(--openbot-text-sm);
+  font-weight: var(--openbot-weight-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.browser-takeover-preview-fallback span {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--openbot-text-readable);
+  font-size: var(--openbot-text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.browser-takeover-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--openbot-space-1-5);
+}
+
+.browser-takeover-actions .ui-button {
+  transition: transform var(--openbot-duration-fast) var(--openbot-ease-out);
+}
+
+.browser-takeover-actions .ui-button:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+@keyframes browser-takeover-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.99);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 .approval-card {
   display: flex;
   width: min(460px, 100%);

--- a/src/renderer/src/styles/primitives.css
+++ b/src/renderer/src/styles/primitives.css
@@ -320,60 +320,147 @@
   }
 }
 
-:where(.ui-badge) {
+:where(.z-badge) {
   width: fit-content;
+  height: 20px;
   min-width: 0;
   display: inline-flex;
+  overflow: hidden;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   gap: var(--openbot-space-1);
-  border: 1px solid var(--openbot-border);
-  border-radius: var(--openbot-radius-sm);
-  background: var(--openbot-bg-control);
-  color: var(--openbot-text-secondary);
+  border: 1px solid transparent;
+  border-radius: var(--openbot-radius-pill);
+  padding: var(--openbot-space-0-5) var(--openbot-space-2);
   font-size: var(--openbot-text-xs);
   font-weight: var(--openbot-weight-medium);
   line-height: var(--openbot-leading-xs);
+  transition:
+    border-color var(--openbot-duration-fast) var(--openbot-ease-out),
+    background-color var(--openbot-duration-fast) var(--openbot-ease-out),
+    color var(--openbot-duration-fast) var(--openbot-ease-out);
   white-space: nowrap;
 }
 
-:where(.ui-badge)[data-size="sm"] {
+:where(.z-badge) > svg {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  pointer-events: none;
+}
+
+:where(.z-badge):has(> [data-icon="inline-start"]) {
+  padding-left: var(--openbot-space-1-5);
+}
+
+:where(.z-badge):has(> [data-icon="inline-end"]) {
+  padding-right: var(--openbot-space-1-5);
+}
+
+:where(.z-badge)[data-size="sm"] {
   min-height: 16px;
+  height: 16px;
   padding: 0 var(--openbot-space-1);
   font-size: var(--openbot-text-2xs);
 }
 
-:where(.ui-badge)[data-size="md"] {
+:where(.z-badge)[data-size="md"] {
   min-height: 20px;
   padding: var(--openbot-space-0-5) var(--openbot-space-1-5);
 }
 
-:where(.ui-badge)[data-shape="pill"] {
-  border-radius: var(--openbot-radius-pill);
+:where(.z-badge)[data-shape="rounded"] {
+  border-radius: var(--openbot-radius-sm);
 }
 
-:where(.ui-badge)[data-tone="accent"] {
+:where(.z-badge-variant-default) {
+  background: var(--openbot-accent);
+  color: var(--openbot-text-primary);
+}
+
+:where(.z-badge-variant-secondary) {
+  background: var(--openbot-bg-control);
+  color: var(--openbot-text-secondary);
+}
+
+:where(.z-badge-variant-outline) {
+  border-color: var(--openbot-border-strong);
+  background: transparent;
+  color: var(--openbot-text-secondary);
+}
+
+:where(.z-badge-variant-ghost) {
+  background: transparent;
+  color: var(--openbot-text-secondary);
+}
+
+:where(.z-badge-variant-link) {
+  background: transparent;
+  color: var(--openbot-accent-text);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+:where(.z-badge-variant-primary-light) {
   border-color: var(--openbot-accent-strong);
   background: var(--openbot-accent-soft);
   color: var(--openbot-accent-text);
 }
 
-:where(.ui-badge)[data-tone="success"] {
+:where(.z-badge-variant-success-light) {
   border-color: var(--openbot-success-soft);
   background: var(--openbot-success-soft);
   color: var(--openbot-success);
 }
 
-:where(.ui-badge)[data-tone="warning"] {
+:where(.z-badge-variant-warning-light) {
   border-color: var(--openbot-warning-soft);
   background: var(--openbot-warning-soft);
   color: var(--openbot-warning);
 }
 
-:where(.ui-badge)[data-tone="danger"] {
+:where(.z-badge-variant-destructive),
+:where(.z-badge-variant-destructive-light) {
   border-color: var(--openbot-danger-soft);
   background: var(--openbot-danger-soft);
   color: var(--openbot-danger);
+}
+
+:where(.z-badge-variant-info-light) {
+  border-color: var(--openbot-settings-accent-soft);
+  background: var(--openbot-settings-accent-soft);
+  color: var(--openbot-settings-accent-text);
+}
+
+:where(.z-badge-variant-primary-outline) {
+  border-color: var(--openbot-border-strong);
+  background: transparent;
+  color: var(--openbot-accent-text);
+}
+
+:where(.z-badge-variant-success-outline) {
+  border-color: var(--openbot-border-strong);
+  background: transparent;
+  color: var(--openbot-success);
+}
+
+:where(.z-badge-variant-warning-outline) {
+  border-color: var(--openbot-border-strong);
+  background: transparent;
+  color: var(--openbot-warning);
+}
+
+:where(.z-badge-variant-destructive-outline) {
+  border-color: var(--openbot-border-strong);
+  background: transparent;
+  color: var(--openbot-danger);
+}
+
+:where(.z-badge-variant-info-outline) {
+  border-color: var(--openbot-border-strong);
+  background: transparent;
+  color: var(--openbot-settings-accent-text);
 }
 
 :where(.ui-checkbox) {
@@ -423,7 +510,7 @@
   stroke-width: 2.5;
 }
 
-.ui-badge-dot {
+.z-badge-dot {
   width: 6px;
   height: 6px;
   flex: 0 0 auto;

--- a/src/renderer/stories/Badge.stories.tsx
+++ b/src/renderer/stories/Badge.stories.tsx
@@ -16,23 +16,16 @@ export const Gallery: Story = {
         Badges
       </Heading>
       <div class="foundation-story-row">
-        <Badge tone="neutral">Neutral</Badge>
-        <Badge tone="accent">Accent</Badge>
-        <Badge tone="success" dot>
-          Connected
-        </Badge>
-        <Badge tone="warning" dot>
-          Waiting
-        </Badge>
-        <Badge tone="danger" dot>
-          Failed
-        </Badge>
+        <Badge variant="secondary">Secondary</Badge>
+        <Badge variant="primary-light">Primary</Badge>
+        <Badge variant="success-light">Success</Badge>
+        <Badge variant="warning-light">Warning</Badge>
+        <Badge variant="destructive-light">Destructive</Badge>
       </div>
       <div class="foundation-story-row">
-        <Badge size="sm" shape="rounded">
-          Small
-        </Badge>
-        <Badge shape="pill">Status pill</Badge>
+        <Badge variant="outline">Outline</Badge>
+        <Badge variant="success-outline">Success outline</Badge>
+        <Badge variant="warning-outline">Warning outline</Badge>
       </div>
     </main>
   ),

--- a/src/renderer/stories/BrowserTakeoverCard.stories.tsx
+++ b/src/renderer/stories/BrowserTakeoverCard.stories.tsx
@@ -1,0 +1,63 @@
+import type { BrowserPreview, BrowserTab } from "@openbot/contracts/ipc";
+import { fn } from "storybook/test";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { BrowserTakeoverCard } from "../src/components/ConversationPrompts";
+import browserTakeoverPreviewUrl from "./assets/browser-takeover-preview.svg";
+
+const tab: BrowserTab = {
+  id: "tab-login",
+  title: "Sign in",
+  url: "https://accounts.example.com/login",
+  loading: false,
+  ownerThreadId: "thread-chief",
+  ownerBotId: "chief",
+};
+
+const preview: BrowserPreview = {
+  dataUrl: browserTakeoverPreviewUrl,
+  width: 960,
+  height: 600,
+};
+
+const meta = {
+  title: "Conversation/BrowserTakeoverCard",
+  component: BrowserTakeoverCard,
+  args: {
+    botName: "Chief",
+    tab,
+    preview,
+    previewStatus: "ready",
+    onComplete: fn(async () => true),
+    onCancel: fn(async () => true),
+  },
+  parameters: { layout: "centered", a11y: { test: "error" } },
+} satisfies Meta<typeof BrowserTakeoverCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Ready: Story = {};
+
+export const Loading: Story = {
+  args: { preview: null, previewStatus: "loading" },
+};
+
+export const PreviewUnavailable: Story = {
+  args: { preview: null, previewStatus: "failed" },
+};
+
+export const Narrow: Story = {
+  render: (args) => (
+    <div style={{ width: "340px" }}>
+      <BrowserTakeoverCard {...args} />
+    </div>
+  ),
+};
+
+export const Completed: Story = {
+  args: { decision: "complete" },
+};
+
+export const Cancelled: Story = {
+  args: { decision: "cancel" },
+};

--- a/src/renderer/stories/Conversation.stories.tsx
+++ b/src/renderer/stories/Conversation.stories.tsx
@@ -7,7 +7,8 @@ import type {
   QueueSnapshot,
   UpdateBotInput,
 } from "@openbot/contracts/ipc";
-import { createEffect, createSignal, onCleanup, onSettled } from "solid-js";
+import { Portal } from "@solidjs/web";
+import { createEffect, createSignal, onCleanup, onSettled, Show } from "solid-js";
 import { expect, fireEvent, fn, waitFor, within } from "storybook/test";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import { clipboardFiles } from "../../preload/clipboard-files";
@@ -16,8 +17,10 @@ import {
   ConversationControllerProvider,
   createConversationController,
 } from "../src/components/Conversation";
+import { BrowserTakeoverCard } from "../src/components/ConversationPrompts";
 import { ConversationView } from "../src/components/ConversationView";
 import type { BotMessage as RendererBotMessage } from "../src/data";
+import browserTakeoverPreviewUrl from "./assets/browser-takeover-preview.svg";
 import {
   STORY_AGENT_STATUS,
   STORY_ATTACHMENTS,
@@ -773,12 +776,14 @@ function MockedConversation(props: {
   messages?: RendererBotMessage[];
   initialAttachments?: DraftAttachment[];
   voiceModelProgress?: number;
+  takeoverStateGallery?: boolean;
 }) {
   const previousApi = window.openbot;
   const mock = createMockOpenBot();
   const controller = createConversationController({ onTypingChange: props.args.onTypingChange });
   const previewUrls = new Set<string>();
   let storyFrameElement: HTMLDivElement | undefined;
+  let takeoverGalleryScrollTimer: number | undefined;
   const initialBotId = props.args.bot?.id;
   if (initialBotId && props.initialAttachments?.length) {
     onSettled(() => {
@@ -795,6 +800,7 @@ function MockedConversation(props: {
   }
   const [unreadCount, setUnreadCount] = createSignal(0);
   const [firstUnreadMessageId, setFirstUnreadMessageId] = createSignal<string | null>(null);
+  const [takeoverGalleryMount, setTakeoverGalleryMount] = createSignal<HTMLElement | null>(null);
   createEffect(
     () => [props.args.unreadCount, props.args.firstUnreadMessageId] as const,
     ([count, messageId]) => {
@@ -803,6 +809,15 @@ function MockedConversation(props: {
     },
   );
   window.openbot = mock.api;
+  if (props.takeoverStateGallery) {
+    onSettled(() => {
+      const mount = storyFrameElement?.querySelector<HTMLElement>(".conversation-scroll") ?? null;
+      setTakeoverGalleryMount(mount);
+      takeoverGalleryScrollTimer = window.setTimeout(() => {
+        if (mount) mount.scrollTop = 0;
+      }, 200);
+    });
+  }
   const handlePastedImages = (event: ClipboardEvent) => {
     const files = clipboardFiles(event.clipboardData).filter((file) => file.type.startsWith("image/"));
     if (files.length === 0) return;
@@ -838,6 +853,7 @@ function MockedConversation(props: {
   };
   onCleanup(() => {
     storyFrameElement?.removeEventListener("paste", handlePastedImages, true);
+    if (takeoverGalleryScrollTimer !== undefined) window.clearTimeout(takeoverGalleryScrollTimer);
     for (const previewUrl of previewUrls) URL.revokeObjectURL(previewUrl);
     mock.dispose();
     window.openbot = previousApi;
@@ -857,6 +873,30 @@ function MockedConversation(props: {
           }}
         />
       </ConversationControllerProvider>
+      <Show when={props.takeoverStateGallery && takeoverGalleryMount()}>
+        <Portal mount={takeoverGalleryMount() ?? undefined}>
+          <div class="browser-takeover-story-states">
+            <BrowserTakeoverCard
+              botName={props.args.bot?.name ?? "the agent"}
+              tab={props.args.browserTabs[0]}
+              preview={{ dataUrl: browserTakeoverPreviewUrl, width: 960, height: 600 }}
+              previewStatus="ready"
+              decision="complete"
+              onComplete={async () => false}
+              onCancel={async () => false}
+            />
+            <BrowserTakeoverCard
+              botName={props.args.bot?.name ?? "the agent"}
+              tab={props.args.browserTabs[0]}
+              preview={{ dataUrl: browserTakeoverPreviewUrl, width: 960, height: 600 }}
+              previewStatus="ready"
+              decision="cancel"
+              onComplete={async () => false}
+              onCancel={async () => false}
+            />
+          </div>
+        </Portal>
+      </Show>
     </div>
   );
 }
@@ -1257,6 +1297,13 @@ export const BrowserTakeover: Story = {
     ],
     activeBrowserTabId: "tab-login",
     activeTurnId: "turn-takeover",
+    messages: [],
+  },
+  render: (storyArgs) => <MockedConversation args={storyArgs} takeoverStateGallery />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("region", { name: "Browser takeover" })).toBeVisible();
+    await expect(canvas.getByRole("region", { name: "Browser takeover complete" })).toBeVisible();
+    await expect(canvas.getByRole("region", { name: "Browser takeover cancelled" })).toBeVisible();
   },
 };
 

--- a/src/renderer/stories/assets/browser-takeover-preview.svg
+++ b/src/renderer/stories/assets/browser-takeover-preview.svg
@@ -1,0 +1,16 @@
+<svg width="960" height="600" viewBox="0 0 960 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Example sign-in page</title>
+  <rect width="960" height="600" fill="#F5F5F3"/>
+  <rect x="280" y="82" width="400" height="436" rx="20" fill="white" stroke="#DEDEDA" stroke-width="2"/>
+  <rect x="324" y="126" width="48" height="48" rx="12" fill="#1F1F1F"/>
+  <path d="M339 151.5 348 160l11-17" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="324" y="202" width="238" height="18" rx="9" fill="#222222"/>
+  <rect x="324" y="234" width="308" height="12" rx="6" fill="#B8B8B2"/>
+  <rect x="324" y="256" width="272" height="12" rx="6" fill="#D0D0CB"/>
+  <rect x="324" y="306" width="312" height="54" rx="12" fill="#FAFAF8" stroke="#DEDEDA" stroke-width="2"/>
+  <rect x="342" y="325" width="112" height="14" rx="7" fill="#B8B8B2"/>
+  <rect x="324" y="378" width="312" height="54" rx="12" fill="#FAFAF8" stroke="#DEDEDA" stroke-width="2"/>
+  <rect x="342" y="397" width="148" height="14" rx="7" fill="#B8B8B2"/>
+  <rect x="324" y="456" width="138" height="38" rx="10" fill="#1F1F1F"/>
+  <rect x="344" y="469" width="98" height="12" rx="6" fill="white"/>
+</svg>


### PR DESCRIPTION
## Summary
- redesign the browser takeover card with a persistent page preview and compact bubble-aligned layout
- use the Zaidan badge primitive for Action required, Done, and Cancelled states
- add preview capture support across desktop IPC and the remote Team API
- keep the preview visible after completion or cancellation and remove the decision buttons
- add integrated and isolated Storybook states for active, completed, cancelled, loading, fallback, and narrow layouts

## Verification
- `bunx vitest run src/renderer/src/App.test.tsx src/renderer/src/components/ui/ui.test.tsx src/main/team-api-server.test.ts src/main/remote-server-manager.test.ts` (157 tests)
- `bun run typecheck`
- manual Storybook checks for standard and narrow layouts
- live development app started with `bun run dev`

## Main integration
- rebased onto current `origin/main`
- no merge conflicts