### PR TITLE
Fix sidebar title truncation priority

### DIFF
--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -1681,7 +1681,7 @@ export function Sidebar(props: SidebarProps) {
                   <Show when={title()}>
                     {(label) => (
                       <Badge class="bot-role-badge" size="sm" title={label()}>
-                        {label()}
+                        <span>{label()}</span>
                       </Badge>
                     )}
                   </Show>

--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -2956,6 +2956,15 @@ textarea {
   overflow: hidden;
 }
 
+.bot-row-title:has(.bot-role-badge) {
+  --bot-role-badge-collapsed-width: calc(2ch + 9px);
+
+  display: grid;
+  grid-template-columns:
+    fit-content(calc(100% - var(--bot-role-badge-collapsed-width) - 5px))
+    minmax(var(--bot-role-badge-collapsed-width), 1fr);
+}
+
 .bot-row-title strong,
 .person-row .bot-row-heading strong {
   min-width: 0;
@@ -2970,8 +2979,10 @@ textarea {
 
 .bot-role-badge {
   min-width: 0;
+  max-width: 100%;
   overflow: hidden;
   flex: 0 1 auto;
+  justify-self: start;
   border: 0.5px solid var(--openbot-border);
   border-radius: var(--openbot-radius-xs);
   background: var(--openbot-hover);
@@ -2980,6 +2991,12 @@ textarea {
   font-size: var(--openbot-text-xs);
   font-weight: 400;
   line-height: 16px;
+  white-space: nowrap;
+}
+
+.bot-role-badge > span {
+  min-width: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/src/renderer/stories/Sidebar.stories.tsx
+++ b/src/renderer/stories/Sidebar.stories.tsx
@@ -388,6 +388,32 @@ export const AgentTiles: Story = {
   },
 };
 
+export const AgentLongLabels: Story = {
+  args: {
+    bots: longLabelBots,
+    people: [],
+    directThreads: [],
+    agentStates: {},
+    pinnedItems: [],
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: "240px",
+          "min-width": "240px",
+          "max-width": "400px",
+          height: "100vh",
+          overflow: "hidden",
+          resize: "horizontal",
+        }}
+      >
+        {Story()}
+      </div>
+    ),
+  ],
+};
+
 export const AgentContextMenu: Story = {
   args: {
     people: [],


### PR DESCRIPTION
## Summary
- keep the agent name at full width while the title badge shortens
- preserve one visible title letter plus the ellipsis before the name starts to shorten
- add a resizable Storybook state for long agent labels

## Verification
- bunx biome check on the changed files
- bun run check:ui
- bun run typecheck:renderer
- bun run typecheck:storybook
- pre-commit type checks