### PR TITLE
Fix bot unread state after opening a chat

### DIFF
--- a/packages/contracts/src/ipc-desktop-apis.ts
+++ b/packages/contracts/src/ipc-desktop-apis.ts
@@ -160,7 +160,7 @@ export interface AgentDesktopApi {
   testRoutine: (input: TestRoutineInput) => Promise<RoutineRun>;
   listRoutineRuns: (input: ListRoutineRunsInput) => Promise<RoutineRun[]>;
   readConversation: (botId: string) => Promise<ConversationWithReadState>;
-  readConversationPage: (input: ReadConversationPageInput) => Promise<ConversationPage>;
+  readConversationPage: (input: ReadConversationPageInput, serverId?: string) => Promise<ConversationPage>;
   searchConversationMessages: (input: SearchConversationMessagesInput) => Promise<ConversationSearchPage>;
   listConversationReads: () => Promise<Record<string, ConversationReadState>>;
   markConversationRead: (input: MarkConversationReadInput, serverId?: string) => Promise<ConversationReadState>;

--- a/packages/contracts/src/ipc-desktop-apis.ts
+++ b/packages/contracts/src/ipc-desktop-apis.ts
@@ -163,7 +163,7 @@ export interface AgentDesktopApi {
   readConversationPage: (input: ReadConversationPageInput) => Promise<ConversationPage>;
   searchConversationMessages: (input: SearchConversationMessagesInput) => Promise<ConversationSearchPage>;
   listConversationReads: () => Promise<Record<string, ConversationReadState>>;
-  markConversationRead: (input: MarkConversationReadInput) => Promise<ConversationReadState>;
+  markConversationRead: (input: MarkConversationReadInput, serverId?: string) => Promise<ConversationReadState>;
   chooseAttachments: (input: ChooseAttachmentsInput) => Promise<DraftAttachment[]>;
   onAttachmentImport: (listener: (event: AttachmentImportEvent) => void) => () => void;
   discardDraftAttachment: (attachmentId: string) => Promise<void>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -75,7 +75,16 @@ function invokeAgent<TResult>(
   payload: unknown = null,
   decoder: (value: unknown) => TResult,
 ): Promise<TResult> {
-  const request: AgentIpcRequest = { serverId: selectedServerId, payload };
+  return invokeAgentForServer(selectedServerId, channel, payload, decoder);
+}
+
+function invokeAgentForServer<TResult>(
+  serverId: string,
+  channel: string,
+  payload: unknown,
+  decoder: (value: unknown) => TResult,
+): Promise<TResult> {
+  const request: AgentIpcRequest = { serverId, payload };
   return ipcRenderer.invoke(channel, request).then(decoder);
 }
 
@@ -886,7 +895,8 @@ const openbotApi: OpenBotDesktopApi = {
     searchConversationMessages: (input) =>
       invokeAgent(IPC_CHANNELS.agentSearchConversationMessages, input, decodeConversationSearchPage),
     listConversationReads: () => invokeAgent(IPC_CHANNELS.agentListConversationReads, null, decodeReadStates),
-    markConversationRead: (input) => invokeAgent(IPC_CHANNELS.agentMarkConversationRead, input, decodeReadState),
+    markConversationRead: (input, serverId = selectedServerId) =>
+      invokeAgentForServer(serverId, IPC_CHANNELS.agentMarkConversationRead, input, decodeReadState),
     chooseAttachments: (input) => invokeAgent(IPC_CHANNELS.agentChooseAttachments, input, decodeAttachments),
     onAttachmentImport: (listener) => {
       attachmentImportListeners.add(listener);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -891,7 +891,8 @@ const openbotApi: OpenBotDesktopApi = {
     testRoutine: (input) => invokeAgent(IPC_CHANNELS.agentTestRoutine, input, decodeRoutineRun),
     listRoutineRuns: (input) => invokeAgent(IPC_CHANNELS.agentListRoutineRuns, input, decodeRoutineRuns),
     readConversation: (botId) => invokeAgent(IPC_CHANNELS.agentReadConversation, botId, decodeConversation),
-    readConversationPage: (input) => invokeAgent(IPC_CHANNELS.agentReadConversationPage, input, decodeConversationPage),
+    readConversationPage: (input, serverId = selectedServerId) =>
+      invokeAgentForServer(serverId, IPC_CHANNELS.agentReadConversationPage, input, decodeConversationPage),
     searchConversationMessages: (input) =>
       invokeAgent(IPC_CHANNELS.agentSearchConversationMessages, input, decodeConversationSearchPage),
     listConversationReads: () => invokeAgent(IPC_CHANNELS.agentListConversationReads, null, decodeReadStates),

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5447,6 +5447,47 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
   });
 
+  it("keeps a successful realtime read when a pending reload resolves later", async () => {
+    let resolveInitialPage: ((page: ConversationPage) => void) | undefined;
+    vi.mocked(window.openbot.agent.listConversationReads).mockResolvedValueOnce({
+      chief: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null },
+    });
+    vi.mocked(window.openbot.agent.readConversationPage).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveInitialPage = resolve;
+        }),
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    await waitFor(() => expect(resolveInitialPage).toBeDefined());
+    const unreadPage = testConversationPage(
+      "chief",
+      [
+        {
+          id: "reply-reload-race",
+          author: "assistant",
+          text: "Reply before the reload resolves",
+          createdAt: "2026-08-30T02:02:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 2,
+        readState: { unreadCount: 1, firstUnreadMessageId: "reply-reload-race", throughMessageId: null },
+      },
+    );
+
+    emitAgentEvent?.({ type: "conversation-page", page: unreadPage });
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce());
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+
+    resolveInitialPage?.(unreadPage);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
+  });
+
   it("keeps a duplicate refreshed page read while persistence is pending", async () => {
     let resolveRead: ((state: NonNullable<ConversationPage["readState"]>) => void) | undefined;
     vi.mocked(window.openbot.agent.listConversationReads).mockResolvedValueOnce({

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5227,6 +5227,72 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.getByText("Newest visible reply")).toBeInTheDocument();
   });
 
+  it("retries an explicit chat-open reload when its page revision is stale", async () => {
+    const unreadState = {
+      unreadCount: 1,
+      firstUnreadMessageId: "reply-current-revision",
+      throughMessageId: null,
+    };
+    const currentPage = testConversationPage(
+      "chief",
+      [
+        {
+          id: "reply-current-revision",
+          author: "assistant",
+          text: "Current revision reply",
+          createdAt: "2026-08-30T02:03:00.000Z",
+          status: "completed",
+        },
+      ],
+      { revision: 2, readState: unreadState },
+    );
+    vi.mocked(window.openbot.agent.listConversationReads).mockResolvedValueOnce({ chief: unreadState });
+    vi.mocked(window.openbot.agent.readConversation).mockResolvedValue({
+      botId: "chief",
+      threadId: currentPage.threadId,
+      activeTurnId: null,
+      revision: currentPage.revision,
+      readState: unreadState,
+      messages: currentPage.messages,
+    });
+    render(() => <App />);
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+
+    vi.mocked(window.openbot.agent.readConversationPage)
+      .mockResolvedValueOnce(
+        testConversationPage(
+          "chief",
+          [
+            {
+              id: "reply-stale-revision",
+              author: "assistant",
+              text: "Stale revision reply",
+              createdAt: "2026-08-30T02:02:00.000Z",
+              status: "completed",
+            },
+          ],
+          {
+            revision: 1,
+            readState: { unreadCount: 1, firstUnreadMessageId: "reply-stale-revision", throughMessageId: null },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(currentPage);
+    await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
+
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
+        botId: "chief",
+        throughMessageId: "reply-current-revision",
+      }),
+    );
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalledWith({
+      botId: "chief",
+      throughMessageId: "reply-stale-revision",
+    });
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+  });
+
   it("rejects a permission approval and keeps the error visible", async () => {
     vi.mocked(window.openbot.agent.respondToApproval).mockRejectedValueOnce(
       new Error("This approval is no longer active."),

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5222,6 +5222,108 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
   });
 
+  it("does not carry a failed automatic read to the same bot on another server", async () => {
+    const local = testServer("local", true);
+    const remote = testServer("remote-1", false);
+    let selectedServerId = "local";
+    let rejectLocalRead: ((error: Error) => void) | undefined;
+    vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([local, remote]);
+    vi.mocked(window.openbot.servers.select).mockImplementationOnce(async () => {
+      selectedServerId = "remote-1";
+      return [
+        { ...local, active: false },
+        { ...remote, active: true },
+      ];
+    });
+    vi.mocked(window.openbot.agent.readConversationPage).mockImplementation(async (input) =>
+      selectedServerId === "remote-1"
+        ? testConversationPage(
+            input.botId,
+            [
+              {
+                id: "reply-remote-loaded",
+                author: "assistant",
+                text: "Remote loaded reply",
+                createdAt: "2026-08-30T02:02:30.000Z",
+                status: "completed",
+              },
+            ],
+            {
+              readState: { unreadCount: 1, firstUnreadMessageId: "reply-remote-loaded", throughMessageId: null },
+            },
+          )
+        : testConversationPage(input.botId),
+    );
+    vi.mocked(window.openbot.agent.listConversationReads)
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        chief: { unreadCount: 1, firstUnreadMessageId: "reply-remote", throughMessageId: null },
+      });
+    vi.mocked(window.openbot.agent.markConversationRead).mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectLocalRead = reject;
+        }),
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-local",
+            author: "assistant",
+            text: "Local visible reply",
+            createdAt: "2026-08-30T02:02:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-local", throughMessageId: null },
+        },
+      ),
+    });
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce());
+
+    await fireEvent.click(screen.getByRole("button", { name: "Studio Mac server" }));
+    await waitFor(() => expect(window.openbot.servers.select).toHaveBeenCalledWith("remote-1"));
+    await waitFor(() => expect(window.openbot.agent.listConversationReads).toHaveBeenCalledTimes(2));
+    await screen.findByText("Remote loaded reply");
+    expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    rejectLocalRead?.(new Error("Local read unavailable"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-remote",
+            author: "assistant",
+            text: "Remote unread reply",
+            createdAt: "2026-08-30T02:03:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-remote", throughMessageId: null },
+        },
+      ),
+    });
+    await screen.findByText("Remote unread reply");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce();
+    expect(screen.queryByText("Local read unavailable")).not.toBeInTheDocument();
+    expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument();
+  });
+
   it("does not mark an older boundary from a rejected conversation page", async () => {
     let resolveInitialPage: ((page: ConversationPage) => void) | undefined;
     vi.mocked(window.openbot.agent.readConversationPage).mockImplementation(

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5491,6 +5491,86 @@ describe("OpenBot connected desktop shell", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
+  it("restores a newer unread reply when its queued read fails", async () => {
+    let resolveFirstRead: ((state: NonNullable<ConversationPage["readState"]>) => void) | undefined;
+    let rejectSecondRead: ((error: Error) => void) | undefined;
+    vi.mocked(window.openbot.agent.listConversationReads).mockResolvedValueOnce({
+      chief: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null },
+    });
+    vi.mocked(window.openbot.agent.markConversationRead)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRead = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            rejectSecondRead = reject;
+          }),
+      );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-read-a",
+            author: "assistant",
+            text: "First queued reply",
+            createdAt: "2026-08-30T02:02:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-read-a", throughMessageId: null },
+        },
+      ),
+    });
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce());
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-read-a",
+            author: "assistant",
+            text: "First queued reply",
+            createdAt: "2026-08-30T02:02:00.000Z",
+            status: "completed",
+          },
+          {
+            id: "reply-read-b",
+            author: "assistant",
+            text: "Newer queued reply",
+            createdAt: "2026-08-30T02:03:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 3,
+          readState: { unreadCount: 2, firstUnreadMessageId: "reply-read-a", throughMessageId: null },
+        },
+      ),
+    });
+    await screen.findByText("Newer queued reply");
+    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce();
+
+    resolveFirstRead?.({ unreadCount: 0, firstUnreadMessageId: null, throughMessageId: "reply-read-a" });
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledTimes(2));
+    rejectSecondRead?.(new Error("Newer read unavailable"));
+
+    expect(await screen.findByText("Newer read unavailable")).toBeInTheDocument();
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+  });
+
   it("retries an automatic read for the same message after persistence fails", async () => {
     vi.mocked(window.openbot.agent.markConversationRead).mockRejectedValueOnce(new Error("Read unavailable"));
     render(() => <App />);
@@ -5534,38 +5614,61 @@ describe("OpenBot connected desktop shell", () => {
     const local = testServer("local", true);
     const remote = testServer("remote-1", false);
     let selectedServerId = "local";
+    let returningToLocal = false;
     let rejectLocalRead: ((error: Error) => void) | undefined;
     vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([local, remote]);
-    vi.mocked(window.openbot.servers.select).mockImplementationOnce(async () => {
-      selectedServerId = "remote-1";
+    vi.mocked(window.openbot.servers.select).mockImplementation(async (serverId) => {
+      selectedServerId = serverId;
+      returningToLocal = serverId === "local";
       return [
-        { ...local, active: false },
-        { ...remote, active: true },
+        { ...local, active: serverId === "local" },
+        { ...remote, active: serverId === "remote-1" },
       ];
     });
-    vi.mocked(window.openbot.agent.readConversationPage).mockImplementation(async (input) =>
-      selectedServerId === "remote-1"
-        ? testConversationPage(
-            input.botId,
-            [
-              {
-                id: "reply-remote-loaded",
-                author: "assistant",
-                text: "Remote loaded reply",
-                createdAt: "2026-08-30T02:02:30.000Z",
-                status: "completed",
-              },
-            ],
+    vi.mocked(window.openbot.agent.readConversationPage).mockImplementation(async (input) => {
+      if (selectedServerId === "remote-1") {
+        return testConversationPage(
+          input.botId,
+          [
             {
-              readState: { unreadCount: 1, firstUnreadMessageId: "reply-remote-loaded", throughMessageId: null },
+              id: "reply-remote-loaded",
+              author: "assistant",
+              text: "Remote loaded reply",
+              createdAt: "2026-08-30T02:02:30.000Z",
+              status: "completed",
             },
-          )
-        : testConversationPage(input.botId),
-    );
+          ],
+          {
+            readState: { unreadCount: 1, firstUnreadMessageId: "reply-remote-loaded", throughMessageId: null },
+          },
+        );
+      }
+      if (returningToLocal) {
+        return testConversationPage(
+          input.botId,
+          [
+            {
+              id: "reply-local",
+              author: "assistant",
+              text: "Local reply after returning",
+              createdAt: "2026-08-30T02:02:00.000Z",
+              status: "completed",
+            },
+          ],
+          {
+            readState: { unreadCount: 1, firstUnreadMessageId: "reply-local", throughMessageId: null },
+          },
+        );
+      }
+      return testConversationPage(input.botId);
+    });
     vi.mocked(window.openbot.agent.listConversationReads)
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({
         chief: { unreadCount: 1, firstUnreadMessageId: "reply-remote", throughMessageId: null },
+      })
+      .mockResolvedValueOnce({
+        chief: { unreadCount: 1, firstUnreadMessageId: "reply-local", throughMessageId: null },
       });
     vi.mocked(window.openbot.agent.markConversationRead).mockImplementationOnce(
       () =>
@@ -5630,6 +5733,18 @@ describe("OpenBot connected desktop shell", () => {
     expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce();
     expect(screen.queryByText("Local read unavailable")).not.toBeInTheDocument();
     expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Local server" }));
+    await waitFor(() => expect(window.openbot.agent.listConversationReads).toHaveBeenCalledTimes(3));
+    await screen.findByText("Local reply after returning");
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenNthCalledWith(
+        2,
+        { botId: "chief", throughMessageId: "reply-local" },
+        "local",
+      ),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
   });
 
   it("keeps a queued read scoped to its original server", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5851,8 +5851,8 @@ describe("OpenBot connected desktop shell", () => {
       }),
     );
     resolveInitialMark?.({
-      unreadCount: 0,
-      firstUnreadMessageId: null,
+      unreadCount: 1,
+      firstUnreadMessageId: "chief-newer-reply",
       throughMessageId: "chief-old-reply",
     });
     await waitFor(() => expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument());

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5281,6 +5281,50 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
   });
 
+  it("keeps a duplicate refreshed page read while persistence is pending", async () => {
+    let resolveRead: ((state: NonNullable<ConversationPage["readState"]>) => void) | undefined;
+    vi.mocked(window.openbot.agent.listConversationReads).mockResolvedValueOnce({
+      chief: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null },
+    });
+    vi.mocked(window.openbot.agent.markConversationRead).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    const duplicatePage = testConversationPage(
+      "chief",
+      [
+        {
+          id: "reply-pending-read",
+          author: "assistant",
+          text: "Reply with a pending read",
+          createdAt: "2026-08-30T02:02:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 2,
+        readState: { unreadCount: 1, firstUnreadMessageId: "reply-pending-read", throughMessageId: null },
+      },
+    );
+
+    emitAgentEvent?.({ type: "conversation-page", page: duplicatePage });
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
+
+    emitAgentEvent?.({ type: "conversation-page", page: duplicatePage });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
+
+    resolveRead?.({ unreadCount: 0, firstUnreadMessageId: null, throughMessageId: "reply-pending-read" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
   it("retries an automatic read for the same message after persistence fails", async () => {
     vi.mocked(window.openbot.agent.markConversationRead).mockRejectedValueOnce(new Error("Read unavailable"));
     render(() => <App />);

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5158,6 +5158,35 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument();
   });
 
+  it("does not persist a redundant read for an already-read refreshed page", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-already-read",
+            author: "assistant",
+            text: "Historical visible reply",
+            createdAt: "2026-08-30T02:02:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: "reply-already-read" },
+        },
+      ),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
+    expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument();
+  });
+
   it("retries an automatic read for the same message after persistence fails", async () => {
     vi.mocked(window.openbot.agent.markConversationRead).mockRejectedValueOnce(new Error("Read unavailable"));
     render(() => <App />);
@@ -5321,6 +5350,44 @@ describe("OpenBot connected desktop shell", () => {
       throughMessageId: "reply-stale-revision",
     });
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+  });
+
+  it("limits stale chat-open reloads to one retry", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-applied-revision",
+            author: "assistant",
+            text: "Applied revision reply",
+            createdAt: "2026-08-30T02:03:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: "reply-applied-revision" },
+        },
+      ),
+    });
+    await screen.findByText("Applied revision reply");
+    const stalePage = testConversationPage("chief", [], {
+      revision: 1,
+      readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null },
+    });
+    const callsBeforeOpen = vi.mocked(window.openbot.agent.readConversationPage).mock.calls.length;
+    vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValue(stalePage);
+
+    await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
+    await waitFor(() => expect(window.openbot.agent.readConversationPage).toHaveBeenCalledTimes(callsBeforeOpen + 2));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(window.openbot.agent.readConversationPage).toHaveBeenCalledTimes(callsBeforeOpen + 2);
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
   });
 
   it("rejects a permission approval and keeps the error visible", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5071,6 +5071,61 @@ describe("OpenBot connected desktop shell", () => {
     expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
   });
 
+  it("discards a chat-open reload that resolves during a server switch", async () => {
+    const local = testServer("local", true);
+    const remote = testServer("remote-1", false);
+    let resolveOldPage: ((page: ConversationPage) => void) | undefined;
+    let resolveRemoteBots: ((bots: BotSummary[]) => void) | undefined;
+    vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([local, remote]);
+    vi.mocked(window.openbot.servers.select).mockResolvedValueOnce([
+      { ...local, active: false },
+      { ...remote, active: true },
+    ]);
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    vi.mocked(window.openbot.agent.readConversationPage).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOldPage = resolve;
+        }),
+    );
+    vi.mocked(window.openbot.agent.listBots).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRemoteBots = resolve;
+        }),
+    );
+
+    await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
+    await waitFor(() => expect(resolveOldPage).toBeDefined());
+    await fireEvent.click(screen.getByRole("button", { name: "Studio Mac server" }));
+    await waitFor(() => expect(resolveRemoteBots).toBeDefined());
+    resolveOldPage?.(
+      testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-old-server",
+            author: "assistant",
+            text: "Reply from the old server",
+            createdAt: "2026-08-30T02:04:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-old-server", throughMessageId: null },
+        },
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(screen.queryByText("Reply from the old server")).not.toBeInTheDocument();
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
+    resolveRemoteBots?.(BOTS);
+    await screen.findByRole("heading", { name: "Chief" });
+  });
+
   it("merges a refreshed remote conversation page without dropping loaded messages", async () => {
     const message = (id: string, text: string) => ({
       id,

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5127,6 +5127,70 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
   });
 
+  it("does not mark an older boundary from a rejected conversation page", async () => {
+    let resolveInitialPage: ((page: ConversationPage) => void) | undefined;
+    vi.mocked(window.openbot.agent.readConversationPage).mockImplementation(
+      async (): Promise<ConversationPage> =>
+        await new Promise((resolve) => {
+          resolveInitialPage = resolve;
+        }),
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-newer-boundary",
+            author: "assistant",
+            text: "Newest visible reply",
+            createdAt: "2026-08-30T02:02:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-newer-boundary", throughMessageId: null },
+        },
+      ),
+    });
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
+        botId: "chief",
+        throughMessageId: "reply-newer-boundary",
+      }),
+    );
+
+    resolveInitialPage?.(
+      testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-older-boundary",
+            author: "assistant",
+            text: "Older reply",
+            createdAt: "2026-08-30T02:01:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 1,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-older-boundary", throughMessageId: null },
+        },
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalledWith({
+      botId: "chief",
+      throughMessageId: "reply-older-boundary",
+    });
+    expect(screen.getByText("Newest visible reply")).toBeInTheDocument();
+  });
+
   it("rejects a permission approval and keeps the error visible", async () => {
     vi.mocked(window.openbot.agent.respondToApproval).mockRejectedValueOnce(
       new Error("This approval is no longer active."),
@@ -5844,17 +5908,17 @@ describe("OpenBot connected desktop shell", () => {
     });
 
     expect(await screen.findByText("Newer visible reply")).toBeInTheDocument();
+    resolveInitialMark?.({
+      unreadCount: 1,
+      firstUnreadMessageId: "chief-newer-reply",
+      throughMessageId: "chief-old-reply",
+    });
     await waitFor(() =>
       expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
         botId: "chief",
         throughMessageId: "chief-newer-reply",
       }),
     );
-    resolveInitialMark?.({
-      unreadCount: 1,
-      firstUnreadMessageId: "chief-newer-reply",
-      throughMessageId: "chief-old-reply",
-    });
     await waitFor(() => expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument());
   });
 

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5128,6 +5128,41 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
   });
 
+  it("retries an automatic read for the same message after persistence fails", async () => {
+    vi.mocked(window.openbot.agent.markConversationRead).mockRejectedValueOnce(new Error("Read unavailable"));
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    const page = testConversationPage(
+      "chief",
+      [
+        {
+          id: "reply-read-retry",
+          author: "assistant",
+          text: "Visible reply that needs a retry",
+          createdAt: "2026-08-30T02:02:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 2,
+        readState: { unreadCount: 1, firstUnreadMessageId: "reply-read-retry", throughMessageId: null },
+      },
+    );
+
+    emitAgentEvent?.({ type: "conversation-page", page });
+    expect(await screen.findByText("Read unavailable")).toBeInTheDocument();
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+
+    emitAgentEvent?.({ type: "conversation-page", page });
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenNthCalledWith(2, {
+        botId: "chief",
+        throughMessageId: "reply-read-retry",
+      }),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+  });
+
   it("does not mark an older boundary from a rejected conversation page", async () => {
     let resolveInitialPage: ((page: ConversationPage) => void) | undefined;
     vi.mocked(window.openbot.agent.readConversationPage).mockImplementation(

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -2718,6 +2718,7 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
     const trigger = screen.getByRole("button", { name: "Agent model: Luna" });
+    await waitFor(() => expect(trigger).toBeEnabled());
 
     emitAgentEvent?.({
       type: "turn-started",
@@ -5794,7 +5795,7 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
   });
 
-  it("clears unread messages when entering the already selected agent chat", async () => {
+  it("clears unread messages in the selected agent chat when queue loading fails", async () => {
     const unreadState = {
       unreadCount: 1,
       firstUnreadMessageId: "chief-new",
@@ -5817,6 +5818,7 @@ describe("OpenBot connected desktop shell", () => {
         },
       ],
     });
+    vi.mocked(window.openbot.agent.listQueue).mockRejectedValue(new Error("Queue unavailable"));
 
     render(() => <App />);
     expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
@@ -5831,6 +5833,70 @@ describe("OpenBot connected desktop shell", () => {
     );
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
+  });
+
+  it("preserves explicit read intent when an agent status change supersedes the page request", async () => {
+    const unreadState = {
+      unreadCount: 1,
+      firstUnreadMessageId: "chief-status-reply",
+      throughMessageId: null,
+    };
+    const unreadPage = testConversationPage(
+      "chief",
+      [
+        {
+          id: "chief-status-reply",
+          author: "assistant",
+          text: "Reply visible after status change",
+          createdAt: "2026-08-19T09:05:00.000Z",
+          status: "completed",
+        },
+      ],
+      { readState: unreadState },
+    );
+    vi.mocked(window.openbot.agent.listConversationReads).mockResolvedValueOnce({ chief: unreadState });
+    vi.mocked(window.openbot.agent.readConversation).mockResolvedValue({
+      botId: "chief",
+      threadId: unreadPage.threadId,
+      activeTurnId: null,
+      revision: unreadPage.revision,
+      readState: unreadState,
+      messages: unreadPage.messages,
+    });
+    render(() => <App />);
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+
+    let resolveFirstPage: ((page: ConversationPage) => void) | undefined;
+    let resolveSecondPage: ((page: ConversationPage) => void) | undefined;
+    vi.mocked(window.openbot.agent.readConversationPage)
+      .mockImplementationOnce(
+        async (): Promise<ConversationPage> =>
+          await new Promise((resolve) => {
+            resolveFirstPage = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        async (): Promise<ConversationPage> =>
+          await new Promise((resolve) => {
+            resolveSecondPage = resolve;
+          }),
+      );
+    await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
+    await waitFor(() => expect(resolveFirstPage).toBeDefined());
+
+    const currentStatus = await window.openbot.agent.getStatus();
+    emitAgentEvent?.({ type: "status", status: { ...currentStatus, phase: "starting" } });
+    await waitFor(() => expect(resolveSecondPage).toBeDefined());
+    resolveFirstPage?.(unreadPage);
+    resolveSecondPage?.(unreadPage);
+
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
+        botId: "chief",
+        throughMessageId: "chief-status-reply",
+      }),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
   });
 
   it("marks a newer reply that arrives while an opened agent chat is being marked read", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -3698,10 +3698,13 @@ describe("OpenBot connected desktop shell", () => {
       }),
     );
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "delivery-1",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "delivery-1",
+        },
+        "local",
+      ),
     );
     await waitFor(() => expect(composer).toHaveTextContent(""));
     expect(trackAnalytics).toHaveBeenCalledWith("message_send", {
@@ -5002,10 +5005,13 @@ describe("OpenBot connected desktop shell", () => {
     });
 
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "reply-island",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "reply-island",
+        },
+        "local",
+      ),
     );
     await waitFor(() =>
       expect(vi.mocked(window.openbot.dynamicIsland.publishPresentation).mock.calls.at(-1)?.[0]).toMatchObject({
@@ -5119,10 +5125,13 @@ describe("OpenBot connected desktop shell", () => {
 
     expect(await screen.findByText("Visible remote reply")).toBeInTheDocument();
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "reply-visible",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "reply-visible",
+        },
+        "local",
+      ),
     );
     expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
@@ -5187,6 +5196,36 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument();
   });
 
+  it("keeps a successful read when an equal-revision unread page arrives later", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    const delayedPage = testConversationPage(
+      "chief",
+      [
+        {
+          id: "reply-delayed-read-state",
+          author: "assistant",
+          text: "Reply from the delayed page",
+          createdAt: "2026-08-30T02:02:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 2,
+        readState: { unreadCount: 1, firstUnreadMessageId: "reply-delayed-read-state", throughMessageId: null },
+      },
+    );
+
+    emitAgentEvent?.({ type: "conversation-page", page: delayedPage });
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce());
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+
+    emitAgentEvent?.({ type: "conversation-page", page: delayedPage });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
+  });
+
   it("retries an automatic read for the same message after persistence fails", async () => {
     vi.mocked(window.openbot.agent.markConversationRead).mockRejectedValueOnce(new Error("Read unavailable"));
     render(() => <App />);
@@ -5214,10 +5253,14 @@ describe("OpenBot connected desktop shell", () => {
 
     emitAgentEvent?.({ type: "conversation-page", page });
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenNthCalledWith(2, {
-        botId: "chief",
-        throughMessageId: "reply-read-retry",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenNthCalledWith(
+        2,
+        {
+          botId: "chief",
+          throughMessageId: "reply-read-retry",
+        },
+        "local",
+      ),
     );
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
   });
@@ -5324,6 +5367,97 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument();
   });
 
+  it("keeps a queued read scoped to its original server", async () => {
+    const local = testServer("local", true);
+    const remote = testServer("remote-1", false);
+    let resolveFirstRead: ((state: NonNullable<ConversationPage["readState"]>) => void) | undefined;
+    vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([local, remote]);
+    vi.mocked(window.openbot.servers.select).mockResolvedValueOnce([
+      { ...local, active: false },
+      { ...remote, active: true },
+    ]);
+    vi.mocked(window.openbot.agent.markConversationRead)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRead = resolve;
+          }),
+      )
+      .mockImplementationOnce(async (input) => ({
+        unreadCount: 0,
+        firstUnreadMessageId: null,
+        throughMessageId: input.throughMessageId,
+      }));
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-first-local",
+            author: "assistant",
+            text: "First local reply",
+            createdAt: "2026-08-30T02:02:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-first-local", throughMessageId: null },
+        },
+      ),
+    });
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce());
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-first-local",
+            author: "assistant",
+            text: "First local reply",
+            createdAt: "2026-08-30T02:02:00.000Z",
+            status: "completed",
+          },
+          {
+            id: "reply-second-local",
+            author: "assistant",
+            text: "Second local reply",
+            createdAt: "2026-08-30T02:03:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 3,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-second-local", throughMessageId: null },
+        },
+      ),
+    });
+    await screen.findByText("Second local reply");
+    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Studio Mac server" }));
+    await waitFor(() => expect(window.openbot.agent.listConversationReads).toHaveBeenCalledTimes(2));
+    resolveFirstRead?.({
+      unreadCount: 1,
+      firstUnreadMessageId: "reply-second-local",
+      throughMessageId: "reply-first-local",
+    });
+
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledTimes(2));
+    expect(window.openbot.agent.markConversationRead).toHaveBeenNthCalledWith(
+      2,
+      { botId: "chief", throughMessageId: "reply-second-local" },
+      "local",
+    );
+  });
+
   it("does not mark an older boundary from a rejected conversation page", async () => {
     let resolveInitialPage: ((page: ConversationPage) => void) | undefined;
     vi.mocked(window.openbot.agent.readConversationPage).mockImplementation(
@@ -5355,10 +5489,13 @@ describe("OpenBot connected desktop shell", () => {
       ),
     });
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "reply-newer-boundary",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "reply-newer-boundary",
+        },
+        "local",
+      ),
     );
 
     resolveInitialPage?.(
@@ -5381,10 +5518,13 @@ describe("OpenBot connected desktop shell", () => {
     );
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalledWith({
-      botId: "chief",
-      throughMessageId: "reply-older-boundary",
-    });
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalledWith(
+      {
+        botId: "chief",
+        throughMessageId: "reply-older-boundary",
+      },
+      "local",
+    );
     expect(screen.getByText("Newest visible reply")).toBeInTheDocument();
   });
 
@@ -5442,15 +5582,21 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
 
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "reply-current-revision",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "reply-current-revision",
+        },
+        "local",
+      ),
     );
-    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalledWith({
-      botId: "chief",
-      throughMessageId: "reply-stale-revision",
-    });
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalledWith(
+      {
+        botId: "chief",
+        throughMessageId: "reply-stale-revision",
+      },
+      "local",
+    );
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
   });
 
@@ -5998,10 +6144,13 @@ describe("OpenBot connected desktop shell", () => {
     expect(scrollTo).toHaveBeenCalledWith({ behavior: "smooth", top: 1080 });
 
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "agent-new-2",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "agent-new-2",
+        },
+        "local",
+      ),
     );
     await waitFor(() => expect(screen.queryByRole("status", { name: "2 new messages" })).not.toBeInTheDocument());
     await waitFor(() => expect(scrollTo).toHaveBeenLastCalledWith({ behavior: "smooth", top: 1080 }));
@@ -6036,10 +6185,13 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "agent-visible-answer",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "agent-visible-answer",
+        },
+        "local",
+      ),
     );
   });
 
@@ -6086,10 +6238,13 @@ describe("OpenBot connected desktop shell", () => {
 
     expect(await screen.findByText("A new sales reply")).toBeInTheDocument();
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "sales-outbound",
-        throughMessageId: "sales-new",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "sales-outbound",
+          throughMessageId: "sales-new",
+        },
+        "local",
+      ),
     );
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
@@ -6126,10 +6281,13 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
 
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "chief-new",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "chief-new",
+        },
+        "local",
+      ),
     );
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
@@ -6191,10 +6349,13 @@ describe("OpenBot connected desktop shell", () => {
     resolveSecondPage?.(unreadPage);
 
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "chief-status-reply",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "chief-status-reply",
+        },
+        "local",
+      ),
     );
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
   });
@@ -6240,10 +6401,13 @@ describe("OpenBot connected desktop shell", () => {
     expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
     await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "chief-old-reply",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "chief-old-reply",
+        },
+        "local",
+      ),
     );
 
     emitAgentEvent?.({
@@ -6280,10 +6444,13 @@ describe("OpenBot connected desktop shell", () => {
       throughMessageId: "chief-old-reply",
     });
     await waitFor(() =>
-      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-        botId: "chief",
-        throughMessageId: "chief-newer-reply",
-      }),
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "chief-newer-reply",
+        },
+        "local",
+      ),
     );
     await waitFor(() => expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument());
   });
@@ -6361,10 +6528,13 @@ describe("OpenBot connected desktop shell", () => {
     expect(await screen.findByText("Read state unavailable")).toBeInTheDocument();
     expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument();
     expect(screen.getByRole("separator", { name: "New messages" })).toBeInTheDocument();
-    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
-      botId: "chief",
-      throughMessageId: "agent-new",
-    });
+    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+      {
+        botId: "chief",
+        throughMessageId: "agent-new",
+      },
+      "local",
+    );
     await waitFor(() => expect(scrollTo).toHaveBeenLastCalledWith({ behavior: "smooth", top: 840 }));
     expect(scrollElement.scrollTop).toBe(840);
   });

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5083,12 +5083,30 @@ describe("OpenBot connected desktop shell", () => {
     ]);
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
-    vi.mocked(window.openbot.agent.readConversationPage).mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveOldPage = resolve;
-        }),
-    );
+    vi.mocked(window.openbot.agent.readConversationPage)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOldPage = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(
+        testConversationPage(
+          "chief",
+          [
+            {
+              id: "reply-new-server",
+              author: "assistant",
+              text: "Unread reply from the new server",
+              createdAt: "2026-08-30T02:05:00.000Z",
+              status: "completed",
+            },
+          ],
+          {
+            readState: { unreadCount: 1, firstUnreadMessageId: "reply-new-server", throughMessageId: null },
+          },
+        ),
+      );
     vi.mocked(window.openbot.agent.listBots).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
@@ -5124,6 +5142,9 @@ describe("OpenBot connected desktop shell", () => {
     expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
     resolveRemoteBots?.(BOTS);
     await screen.findByRole("heading", { name: "Chief" });
+    await screen.findByText("Unread reply from the new server");
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
+    expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument();
   });
 
   it("merges a refreshed remote conversation page without dropping loaded messages", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -6040,7 +6040,7 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
   });
 
-  it("limits stale chat-open reloads to one retry", async () => {
+  it("uses the latest visible reply after one stale retry without reloading the queue", async () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
     emitAgentEvent?.({
@@ -6068,6 +6068,7 @@ describe("OpenBot connected desktop shell", () => {
       readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null },
     });
     const callsBeforeOpen = vi.mocked(window.openbot.agent.readConversationPage).mock.calls.length;
+    const queueCallsBeforeOpen = vi.mocked(window.openbot.agent.listQueue).mock.calls.length;
     vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValue(stalePage);
 
     await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
@@ -6075,7 +6076,11 @@ describe("OpenBot connected desktop shell", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(window.openbot.agent.readConversationPage).toHaveBeenCalledTimes(callsBeforeOpen + 2);
-    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
+    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+      { botId: "chief", throughMessageId: "reply-applied-revision" },
+      "local",
+    );
+    expect(window.openbot.agent.listQueue).toHaveBeenCalledTimes(queueCallsBeforeOpen);
   });
 
   it("rejects a permission approval and keeps the error visible", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5128,6 +5128,36 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
   });
 
+  it("does not mark an attachment-only conversation refresh as unread", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-attachment-only",
+            author: "assistant",
+            text: "",
+            createdAt: "2026-08-30T02:02:00.000Z",
+            status: "completed",
+            itemType: "agent_attachment",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null },
+        },
+      ),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
+    expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument();
+  });
+
   it("retries an automatic read for the same message after persistence fails", async () => {
     vi.mocked(window.openbot.agent.markConversationRead).mockRejectedValueOnce(new Error("Read unavailable"));
     render(() => <App />);

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5006,6 +5006,11 @@ describe("OpenBot connected desktop shell", () => {
         throughMessageId: "reply-island",
       }),
     );
+    await waitFor(() =>
+      expect(vi.mocked(window.openbot.dynamicIsland.publishPresentation).mock.calls.at(-1)?.[0]).toMatchObject({
+        mode: "idle",
+      }),
+    );
   });
 
   it("stops opening a Dynamic Island message when the active server changes", async () => {
@@ -5085,6 +5090,41 @@ describe("OpenBot connected desktop shell", () => {
 
     expect(await screen.findByText("Fresh remote reply")).toBeInTheDocument();
     expect(screen.getByText("Loaded earlier")).toBeInTheDocument();
+  });
+
+  it("keeps a refreshed conversation page read while its agent chat is open", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-visible",
+            author: "assistant",
+            text: "Visible remote reply",
+            createdAt: "2026-08-30T02:01:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-visible", throughMessageId: null },
+        },
+      ),
+    });
+
+    expect(await screen.findByText("Visible remote reply")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
+        botId: "chief",
+        throughMessageId: "reply-visible",
+      }),
+    );
+    expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
   });
 
   it("rejects a permission approval and keeps the error visible", async () => {
@@ -5688,6 +5728,134 @@ describe("OpenBot connected desktop shell", () => {
     );
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
     expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
+  });
+
+  it("clears unread messages when entering the already selected agent chat", async () => {
+    const unreadState = {
+      unreadCount: 1,
+      firstUnreadMessageId: "chief-new",
+      throughMessageId: null,
+    };
+    vi.mocked(window.openbot.agent.listConversationReads).mockResolvedValueOnce({ chief: unreadState });
+    vi.mocked(window.openbot.agent.readConversation).mockResolvedValue({
+      botId: "chief",
+      threadId: "thread-chief",
+      activeTurnId: null,
+      revision: 1,
+      readState: unreadState,
+      messages: [
+        {
+          id: "chief-new",
+          author: "assistant",
+          text: "A new reply from Chief",
+          createdAt: "2026-08-19T09:03:00.000Z",
+          status: "completed",
+        },
+      ],
+    });
+
+    render(() => <App />);
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    await screen.findByText("A new reply from Chief");
+    await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
+
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
+        botId: "chief",
+        throughMessageId: "chief-new",
+      }),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+    expect(screen.queryByRole("separator", { name: "New messages" })).not.toBeInTheDocument();
+  });
+
+  it("marks a newer reply that arrives while an opened agent chat is being marked read", async () => {
+    const unreadState = {
+      unreadCount: 1,
+      firstUnreadMessageId: "chief-old-reply",
+      throughMessageId: null,
+    };
+    vi.mocked(window.openbot.agent.listConversationReads).mockResolvedValueOnce({ chief: unreadState });
+    vi.mocked(window.openbot.agent.readConversation).mockResolvedValue({
+      botId: "chief",
+      threadId: "thread-chief",
+      activeTurnId: null,
+      revision: 1,
+      readState: unreadState,
+      messages: [
+        {
+          id: "chief-old-reply",
+          author: "assistant",
+          text: "First visible reply",
+          createdAt: "2026-08-19T09:03:00.000Z",
+          status: "completed",
+        },
+      ],
+    });
+    let resolveInitialMark: ((state: NonNullable<ConversationPage["readState"]>) => void) | undefined;
+    vi.mocked(window.openbot.agent.markConversationRead)
+      .mockImplementationOnce(
+        async (): Promise<NonNullable<ConversationPage["readState"]>> =>
+          await new Promise((resolve) => {
+            resolveInitialMark = resolve;
+          }),
+      )
+      .mockImplementation(async (input) => ({
+        unreadCount: 0,
+        firstUnreadMessageId: null,
+        throughMessageId: input.throughMessageId,
+      }));
+
+    render(() => <App />);
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
+        botId: "chief",
+        throughMessageId: "chief-old-reply",
+      }),
+    );
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "chief-old-reply",
+            author: "assistant",
+            text: "First visible reply",
+            createdAt: "2026-08-19T09:03:00.000Z",
+            status: "completed",
+          },
+          {
+            id: "chief-newer-reply",
+            author: "assistant",
+            text: "Newer visible reply",
+            createdAt: "2026-08-19T09:04:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 2, firstUnreadMessageId: "chief-old-reply", throughMessageId: null },
+        },
+      ),
+    });
+
+    expect(await screen.findByText("Newer visible reply")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith({
+        botId: "chief",
+        throughMessageId: "chief-newer-reply",
+      }),
+    );
+    resolveInitialMark?.({
+      unreadCount: 0,
+      firstUnreadMessageId: null,
+      throughMessageId: "chief-old-reply",
+    });
+    await waitFor(() => expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument());
   });
 
   it("keeps the agent unread state when marking it fails", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -6083,6 +6083,102 @@ describe("OpenBot connected desktop shell", () => {
     expect(window.openbot.agent.listQueue).toHaveBeenCalledTimes(queueCallsBeforeOpen);
   });
 
+  it("applies an explicit read after an older automatic read", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    const firstPage = testConversationPage(
+      "chief",
+      [
+        {
+          id: "reply-automatic-first",
+          author: "assistant",
+          text: "First automatic reply",
+          createdAt: "2026-08-30T02:03:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 2,
+        readState: { unreadCount: 1, firstUnreadMessageId: "reply-automatic-first", throughMessageId: null },
+      },
+    );
+    emitAgentEvent?.({ type: "conversation-page", page: firstPage });
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce());
+
+    await fireEvent.click(screen.getByRole("button", { name: /Sales Outbound/ }));
+    await screen.findByRole("heading", { name: "Sales Outbound" });
+    const newerPage = testConversationPage(
+      "chief",
+      [
+        ...firstPage.messages,
+        {
+          id: "reply-explicit-newer",
+          author: "assistant",
+          text: "Newer reply while closed",
+          createdAt: "2026-08-30T02:04:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 3,
+        readState: {
+          unreadCount: 1,
+          firstUnreadMessageId: "reply-explicit-newer",
+          throughMessageId: "reply-automatic-first",
+        },
+      },
+    );
+    emitAgentEvent?.({ type: "conversation-page", page: newerPage });
+    vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValueOnce(newerPage);
+
+    await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenNthCalledWith(
+        2,
+        { botId: "chief", throughMessageId: "reply-explicit-newer" },
+        "local",
+      ),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+  });
+
+  it("marks the latest visible reply when a chat-open reload fails", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    await fireEvent.click(screen.getByRole("button", { name: /Sales Outbound/ }));
+    await screen.findByRole("heading", { name: "Sales Outbound" });
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-before-load-failure",
+            author: "assistant",
+            text: "Visible reply before load failure",
+            createdAt: "2026-08-30T02:04:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-before-load-failure", throughMessageId: null },
+        },
+      ),
+    });
+    vi.mocked(window.openbot.agent.readConversationPage).mockRejectedValueOnce(new Error("Reload unavailable"));
+
+    await fireEvent.click(screen.getByRole("button", { name: /Chief/ }));
+    expect(await screen.findByText("Reload unavailable")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        { botId: "chief", throughMessageId: "reply-before-load-failure" },
+        "local",
+      ),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+  });
+
   it("rejects a permission approval and keeps the error visible", async () => {
     vi.mocked(window.openbot.agent.respondToApproval).mockRejectedValueOnce(
       new Error("This approval is no longer active."),

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5320,6 +5320,84 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.getByText("Loaded earlier")).toBeInTheDocument();
   });
 
+  it("keeps the current read state when an older page returns stale read data", async () => {
+    const latestMessage = {
+      id: "reply-latest-page",
+      author: "assistant" as const,
+      text: "Latest reply",
+      createdAt: "2026-08-30T02:02:00.000Z",
+      status: "completed" as const,
+    };
+    const latestPage = testConversationPage("chief", [latestMessage], {
+      readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null },
+      pageInfo: { hasOlder: true, olderCursor: "older" },
+    });
+    let resolveOlderPage: ((page: ConversationPage) => void) | undefined;
+    vi.mocked(window.openbot.agent.readConversationPage).mockImplementation(async (input) => {
+      if (input.anchor?.type !== "before") return latestPage;
+      return await new Promise((resolve) => {
+        resolveOlderPage = resolve;
+      });
+    });
+
+    function Harness() {
+      const controller = createAppController({});
+      return (
+        <AppControllerProvider controller={controller}>
+          <button type="button" onClick={() => void controller.loadOlderAgentMessages("chief")}>
+            Load older agent messages
+          </button>
+          <output data-testid="agent-read-state">
+            {controller.conversationReads().chief?.unreadCount ?? -1}|
+            {controller
+              .activeMessages()
+              .map((message) => message.id)
+              .join(",")}
+          </output>
+        </AppControllerProvider>
+      );
+    }
+
+    render(() => <Harness />);
+    await waitFor(() => expect(screen.getByTestId("agent-read-state")).toHaveTextContent("0|reply-latest-page"));
+    await fireEvent.click(screen.getByRole("button", { name: "Load older agent messages" }));
+    await waitFor(() => expect(resolveOlderPage).toBeDefined());
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage("chief", [latestMessage], {
+        revision: 2,
+        readState: { unreadCount: 1, firstUnreadMessageId: latestMessage.id, throughMessageId: null },
+        pageInfo: { hasOlder: true, olderCursor: "older" },
+      }),
+    });
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce());
+    await waitFor(() => expect(screen.getByTestId("agent-read-state")).toHaveTextContent("0|reply-latest-page"));
+
+    resolveOlderPage?.(
+      testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-older-page",
+            author: "assistant",
+            text: "Older reply",
+            createdAt: "2026-08-30T02:01:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 2,
+          readState: { unreadCount: 1, firstUnreadMessageId: latestMessage.id, throughMessageId: null },
+        },
+      ),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-read-state")).toHaveTextContent("0|reply-older-page,reply-latest-page"),
+    );
+  });
+
   it("keeps a refreshed conversation page read while its agent chat is open", async () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -5565,6 +5565,24 @@ describe("OpenBot connected desktop shell", () => {
 
     resolveFirstRead?.({ unreadCount: 0, firstUnreadMessageId: null, throughMessageId: "reply-read-a" });
     await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalledTimes(2));
+    vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValueOnce(
+      testConversationPage(
+        "chief",
+        [
+          {
+            id: "reply-read-b",
+            author: "assistant",
+            text: "Newer queued reply",
+            createdAt: "2026-08-30T02:03:00.000Z",
+            status: "completed",
+          },
+        ],
+        {
+          revision: 3,
+          readState: { unreadCount: 1, firstUnreadMessageId: "reply-read-b", throughMessageId: "reply-read-a" },
+        },
+      ),
+    );
     rejectSecondRead?.(new Error("Newer read unavailable"));
 
     expect(await screen.findByText("Newer read unavailable")).toBeInTheDocument();
@@ -5591,6 +5609,7 @@ describe("OpenBot connected desktop shell", () => {
         readState: { unreadCount: 1, firstUnreadMessageId: "reply-read-retry", throughMessageId: null },
       },
     );
+    vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValueOnce(page);
 
     emitAgentEvent?.({ type: "conversation-page", page });
     expect(await screen.findByText("Read unavailable")).toBeInTheDocument();

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1232,6 +1232,38 @@ export function createAppController(props: AppProps = {}) {
     return `${serverId}\0${botId}`;
   }
 
+  function refreshAgentReadStateAfterFailure(
+    botId: string,
+    messageId: string,
+    serverId: string,
+    minimumRevision: number,
+    fallbackState: ConversationReadState | null,
+  ): void {
+    const trackingKey = agentConversationKey(serverId, botId);
+    const applyFallback = () => {
+      if (activeServerSidebarKey() !== serverId || autoReadAgentMessages.has(trackingKey) || !fallbackState) return;
+      const latest = conversationReads()[botId];
+      if (latest?.unreadCount === 0 && latest.throughMessageId === messageId) {
+        applyConversationReadState(botId, fallbackState);
+      }
+    };
+    void window.openbot.agent
+      .readConversationPage({ botId, anchor: { type: "latest" }, limit: 1 }, serverId)
+      .then((page) => {
+        if (
+          activeServerSidebarKey() !== serverId ||
+          autoReadAgentMessages.has(trackingKey) ||
+          page.revision < minimumRevision ||
+          !page.readState
+        ) {
+          applyFallback();
+          return;
+        }
+        applyConversationReadState(botId, page.readState);
+      })
+      .catch(applyFallback);
+  }
+
   function autoMarkAgentMessageRead(botId: string, messageId: string, optimisticallyClearUnread = false): void {
     const serverId = activeServerSidebarKey();
     const trackingKey = agentConversationKey(serverId, botId);
@@ -1266,15 +1298,13 @@ export function createAppController(props: AppProps = {}) {
       autoReadAgentMessages.delete(trackingKey);
       agentChatsToRetryRead.add(trackingKey);
       if (activeServerSidebarKey() !== serverId) return;
-      const latest = conversationReads()[botId];
-      if (
-        optimisticallyCleared &&
-        rollbackState &&
-        latest?.unreadCount === 0 &&
-        latest.throughMessageId === messageId
-      ) {
-        applyConversationReadState(botId, rollbackState);
-      }
+      refreshAgentReadStateAfterFailure(
+        botId,
+        messageId,
+        serverId,
+        conversationRevisions()[botId] ?? -1,
+        optimisticallyCleared ? rollbackState : null,
+      );
       appendUiError(botId, error, "Read state failed");
     });
   }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -903,21 +903,7 @@ export function createAppController(props: AppProps = {}) {
                 setAgentChatOpenRevision((current) => current + 1);
               } else {
                 agentChatsToMarkRead.delete(trackingKey);
-                const latestIncomingMessage = liveMessages()
-                  [botId]?.filter(
-                    (message) =>
-                      message.author !== "you" &&
-                      message.itemType !== "commentary" &&
-                      message.itemType !== "agent_attachment" &&
-                      !message.id.startsWith("thinking:") &&
-                      !message.id.startsWith("ui-"),
-                  )
-                  .at(-1);
-                if (latestIncomingMessage) {
-                  void markAgentMessagesRead(botId, latestIncomingMessage.id, serverId).catch((error) =>
-                    appendUiError(botId, error, "Read state failed"),
-                  );
-                }
+                markLatestVisibleAgentMessageRead(botId, serverId);
               }
             }
             return;
@@ -941,7 +927,9 @@ export function createAppController(props: AppProps = {}) {
           }
         })
         .catch((error) => {
-          if (activeServerSidebarKey() === serverId) appendUiError(botId, error, "Load failed");
+          if (activeServerSidebarKey() !== serverId || conversationPageRequests.get(botId) !== pageRequest) return;
+          appendUiError(botId, error, "Load failed");
+          if (agentChatsToMarkRead.delete(trackingKey)) markLatestVisibleAgentMessageRead(botId, serverId);
         });
     },
   );
@@ -1256,6 +1244,23 @@ export function createAppController(props: AppProps = {}) {
 
   function agentConversationKey(serverId: string, botId: string): string {
     return `${serverId}\0${botId}`;
+  }
+
+  function markLatestVisibleAgentMessageRead(botId: string, serverId: string): void {
+    const latestIncomingMessage = liveMessages()
+      [botId]?.filter(
+        (message) =>
+          message.author !== "you" &&
+          message.itemType !== "commentary" &&
+          message.itemType !== "agent_attachment" &&
+          !message.id.startsWith("thinking:") &&
+          !message.id.startsWith("ui-"),
+      )
+      .at(-1);
+    if (!latestIncomingMessage) return;
+    void markAgentMessagesRead(botId, latestIncomingMessage.id, serverId).catch((error) =>
+      appendUiError(botId, error, "Read state failed"),
+    );
   }
 
   function refreshAgentReadStateAfterFailure(
@@ -1620,7 +1625,9 @@ export function createAppController(props: AppProps = {}) {
     }
     setActiveDirectMemberId(null);
     clearReplyIndicators(botId);
-    agentChatsToMarkRead.add(agentConversationKey(activeServerSidebarKey(), botId));
+    const trackingKey = agentConversationKey(activeServerSidebarKey(), botId);
+    autoReadAgentMessages.delete(trackingKey);
+    agentChatsToMarkRead.add(trackingKey);
     agentChatsRetriedOnOpen.delete(botId);
     explicitlyOpenedAgentChatId = botId;
     setActiveBotId(botId);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -891,17 +891,34 @@ export function createAppController(props: AppProps = {}) {
       const trackingKey = agentConversationKey(serverId, botId);
       const pageRequest = (conversationPageRequests.get(botId) ?? 0) + 1;
       conversationPageRequests.set(botId, pageRequest);
-      const queueRequest = (queueSnapshotRequests.get(botId) ?? 0) + 1;
-      queueSnapshotRequests.set(botId, queueRequest);
       void window.openbot.agent
         .readConversationPage({ botId, anchor: { type: "latest" }, limit: 50 }, serverId)
         .then((page) => {
           if (activeServerSidebarKey() !== serverId || conversationPageRequests.get(botId) !== pageRequest) return;
           const pageApplied = applyConversationPage(page, "replace", "latest");
           if (!pageApplied) {
-            if (agentChatsToMarkRead.has(trackingKey) && !agentChatsRetriedOnOpen.has(botId)) {
-              agentChatsRetriedOnOpen.add(botId);
-              setAgentChatOpenRevision((current) => current + 1);
+            if (agentChatsToMarkRead.has(trackingKey)) {
+              if (!agentChatsRetriedOnOpen.has(botId)) {
+                agentChatsRetriedOnOpen.add(botId);
+                setAgentChatOpenRevision((current) => current + 1);
+              } else {
+                agentChatsToMarkRead.delete(trackingKey);
+                const latestIncomingMessage = liveMessages()
+                  [botId]?.filter(
+                    (message) =>
+                      message.author !== "you" &&
+                      message.itemType !== "commentary" &&
+                      message.itemType !== "agent_attachment" &&
+                      !message.id.startsWith("thinking:") &&
+                      !message.id.startsWith("ui-"),
+                  )
+                  .at(-1);
+                if (latestIncomingMessage) {
+                  void markAgentMessagesRead(botId, latestIncomingMessage.id, serverId).catch((error) =>
+                    appendUiError(botId, error, "Read state failed"),
+                  );
+                }
+              }
             }
             return;
           }
@@ -926,6 +943,15 @@ export function createAppController(props: AppProps = {}) {
         .catch((error) => {
           if (activeServerSidebarKey() === serverId) appendUiError(botId, error, "Load failed");
         });
+    },
+  );
+
+  createEffect(
+    () => ({ botId: activeBotId(), agentPhase: agentStatus().phase, serverId: activeServerSidebarKey() }),
+    ({ botId, serverId }) => {
+      if (!botId) return;
+      const queueRequest = (queueSnapshotRequests.get(botId) ?? 0) + 1;
+      queueSnapshotRequests.set(botId, queueRequest);
       void window.openbot.agent
         .listQueue(botId)
         .then((queue) => {
@@ -3293,7 +3319,7 @@ export function createAppController(props: AppProps = {}) {
   }
 
   const activeServer = createMemo(() => servers().find((server) => server.active));
-  const activeServerSidebarKey = createMemo(() => activeServer()?.id ?? "local");
+  const activeServerSidebarKey: () => string = createMemo((): string => activeServer()?.id ?? "local");
 
   function dynamicIslandServerOrder(): string[] {
     const ids = servers()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -363,7 +363,8 @@ export function createAppController(props: AppProps = {}) {
   let explicitlyOpenedAgentChatId: string | null = null;
   const autoReadAgentMessages = new Map<
     string,
-    { messageId: string; status: "pending" } | { messageId: string; status: "succeeded"; state: ConversationReadState }
+    | { messageId: string; status: "pending"; optimisticState: ConversationReadState | null }
+    | { messageId: string; status: "succeeded"; state: ConversationReadState }
   >();
   const agentChatsToRetryRead = new Set<string>();
   const recentReplyTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -1164,26 +1165,26 @@ export function createAppController(props: AppProps = {}) {
     const current = conversationReads()[botId];
     const previousAutoRead = autoReadAgentMessages.get(trackingKey);
     if (previousAutoRead?.messageId === messageId) {
-      if (previousAutoRead.status === "succeeded") applyConversationReadState(botId, previousAutoRead.state);
+      const retainedState =
+        previousAutoRead.status === "succeeded" ? previousAutoRead.state : previousAutoRead.optimisticState;
+      if (retainedState) applyConversationReadState(botId, retainedState);
       return;
     }
     const hasUnread = Boolean(current && current.unreadCount > 0);
     const retryingRead = agentChatsToRetryRead.delete(trackingKey);
     if (!optimisticallyClearUnread && explicitlyOpenedAgentChatId !== botId && !retryingRead && hasUnread) return;
-    autoReadAgentMessages.set(trackingKey, { messageId, status: "pending" });
     const optimisticallyCleared = Boolean(current && (!hasUnread || optimisticallyClearUnread));
+    const optimisticState: ConversationReadState | null =
+      current && optimisticallyCleared
+        ? { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: messageId }
+        : null;
+    autoReadAgentMessages.set(trackingKey, { messageId, status: "pending", optimisticState });
     const rollbackState = current
       ? hasUnread
         ? current
         : { ...current, unreadCount: 1, firstUnreadMessageId: messageId }
       : null;
-    if (current && optimisticallyCleared) {
-      applyConversationReadState(botId, {
-        unreadCount: 0,
-        firstUnreadMessageId: null,
-        throughMessageId: messageId,
-      });
-    }
+    if (optimisticState) applyConversationReadState(botId, optimisticState);
     void markAgentMessagesRead(botId, messageId, serverId, (state) => {
       if (autoReadAgentMessages.get(trackingKey)?.messageId !== messageId) return;
       autoReadAgentMessages.set(trackingKey, { messageId, status: "succeeded", state });

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -246,6 +246,7 @@ export function createAppController(props: AppProps = {}) {
   const [botList, setBotList] = createSignal<BotProfile[]>([]);
   const [modelOptions, setModelOptions] = createSignal<AgentModelOption[]>([]);
   const [activeBotId, setActiveBotId] = createSignal("");
+  const [agentChatOpenRevision, setAgentChatOpenRevision] = createSignal(0);
   const [liveMessages, setLiveMessages] = createSignal<Record<string, BotMessage[]>>({});
   const [uiErrors, setUiErrors] = createSignal<Record<string, BotMessage[]>>({});
   const [conversationLoaded, setConversationLoaded] = createSignal<Record<string, boolean>>({});
@@ -358,6 +359,7 @@ export function createAppController(props: AppProps = {}) {
     { snapshot: ConversationSnapshot; markNewMessagesRead: boolean }
   >();
   const agentChatsToMarkRead = new Set<string>();
+  let explicitlyOpenedAgentChatId: string | null = null;
   const autoReadAgentMessageIds = new Map<string, string>();
   const recentReplyTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const conversationPageRequests = new Map<string, number>();
@@ -813,7 +815,7 @@ export function createAppController(props: AppProps = {}) {
   );
 
   createEffect(
-    () => ({ botId: activeBotId(), agentPhase: agentStatus().phase }),
+    () => ({ botId: activeBotId(), agentPhase: agentStatus().phase, openRevision: agentChatOpenRevision() }),
     ({ botId }) => {
       if (!botId) return;
       const markReadOnOpen = agentChatsToMarkRead.delete(botId);
@@ -865,7 +867,21 @@ export function createAppController(props: AppProps = {}) {
         scheduleConversation(event.snapshot, isAgentChatOpen(event.snapshot.botId));
         return;
       case "conversation-page":
-        applyConversationPage(event.page, "latest", "latest");
+        {
+          const existingUnreadCount = conversationReads()[event.page.botId]?.unreadCount ?? 0;
+          const markNewMessagesRead =
+            isAgentChatOpen(event.page.botId) &&
+            (existingUnreadCount === 0 || explicitlyOpenedAgentChatId === event.page.botId);
+          applyConversationPage(event.page, "latest", "latest");
+          const latestIncomingMessage = markNewMessagesRead
+            ? [...event.page.messages]
+                .reverse()
+                .find((message) => message.author !== "user" && message.itemType !== "commentary")
+            : undefined;
+          if (latestIncomingMessage) {
+            autoMarkAgentMessageRead(event.page.botId, latestIncomingMessage.id, existingUnreadCount === 0);
+          }
+        }
         return;
       case "conversation-invalidated":
         return;
@@ -1108,12 +1124,13 @@ export function createAppController(props: AppProps = {}) {
     return !botSetupOpen() && !activeDirectMemberId() && activeBot()?.id === botId;
   }
 
-  function autoMarkAgentMessageRead(botId: string, messageId: string): void {
+  function autoMarkAgentMessageRead(botId: string, messageId: string, optimisticallyClearUnread = false): void {
     if (autoReadAgentMessageIds.get(botId) === messageId) return;
     const current = conversationReads()[botId];
-    if (current && current.unreadCount > 0) return;
+    const hasUnread = Boolean(current && current.unreadCount > 0);
+    if (!optimisticallyClearUnread && explicitlyOpenedAgentChatId !== botId && hasUnread) return;
     autoReadAgentMessageIds.set(botId, messageId);
-    if (current) {
+    if (current && (!hasUnread || optimisticallyClearUnread)) {
       applyConversationReadState(botId, {
         unreadCount: 0,
         firstUnreadMessageId: null,
@@ -1370,6 +1387,7 @@ export function createAppController(props: AppProps = {}) {
     }
     setBotSetupDraft(createFirstBotDraft());
     setBotSetupError(null);
+    explicitlyOpenedAgentChatId = null;
     setBotSetupOpen(true);
   }
 
@@ -1393,7 +1411,9 @@ export function createAppController(props: AppProps = {}) {
     setActiveDirectMemberId(null);
     clearReplyIndicators(botId);
     agentChatsToMarkRead.add(botId);
+    explicitlyOpenedAgentChatId = botId;
     setActiveBotId(botId);
+    setAgentChatOpenRevision((current) => current + 1);
   }
 
   function setGlobalSearchVisibility(open: boolean): void {
@@ -1487,6 +1507,7 @@ export function createAppController(props: AppProps = {}) {
     if (!peopleEnabled || !currentTeamMember() || !directPeople().some((member) => member.id === memberId)) return;
     const previousBotId = activeBotId();
     if (previousBotId) pruneInactiveAgentHistory(previousBotId);
+    explicitlyOpenedAgentChatId = null;
     setBotSetupOpen(false);
     setBotSetupError(null);
     setSettingsRequest(null);
@@ -2542,6 +2563,7 @@ export function createAppController(props: AppProps = {}) {
     setBotSetupError(null);
     setSettingsRequest(null);
     setBotList([]);
+    explicitlyOpenedAgentChatId = null;
     setSidebarLayout(defaultSidebarLayout());
     setActiveBotId("");
     setActiveDirectMemberId(null);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -828,9 +828,13 @@ export function createAppController(props: AppProps = {}) {
         .readConversationPage({ botId, anchor: { type: "latest" }, limit: 50 })
         .then((page) => {
           if (conversationPageRequests.get(botId) !== pageRequest) return;
-          const markReadOnOpen = agentChatsToMarkRead.delete(botId);
           const pageApplied = applyConversationPage(page, "replace", "latest");
-          if (pageApplied && markReadOnOpen && (page.readState?.unreadCount ?? 0) > 0) {
+          if (!pageApplied) {
+            if (agentChatsToMarkRead.has(botId)) setAgentChatOpenRevision((current) => current + 1);
+            return;
+          }
+          const markReadOnOpen = agentChatsToMarkRead.delete(botId);
+          if (markReadOnOpen && (page.readState?.unreadCount ?? 0) > 0) {
             void markAgentMessagesRead(botId, page.messages.at(-1)?.id ?? null).catch((error) =>
               appendUiError(botId, error, "Read state failed"),
             );

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -824,14 +824,15 @@ export function createAppController(props: AppProps = {}) {
     () => ({ botId: activeBotId(), agentPhase: agentStatus().phase, openRevision: agentChatOpenRevision() }),
     ({ botId }) => {
       if (!botId) return;
+      const serverId = activeServerSidebarKey();
       const pageRequest = (conversationPageRequests.get(botId) ?? 0) + 1;
       conversationPageRequests.set(botId, pageRequest);
       const queueRequest = (queueSnapshotRequests.get(botId) ?? 0) + 1;
       queueSnapshotRequests.set(botId, queueRequest);
       void window.openbot.agent
-        .readConversationPage({ botId, anchor: { type: "latest" }, limit: 50 })
+        .readConversationPage({ botId, anchor: { type: "latest" }, limit: 50 }, serverId)
         .then((page) => {
-          if (conversationPageRequests.get(botId) !== pageRequest) return;
+          if (activeServerSidebarKey() !== serverId || conversationPageRequests.get(botId) !== pageRequest) return;
           const pageApplied = applyConversationPage(page, "replace", "latest");
           if (!pageApplied) {
             if (agentChatsToMarkRead.has(botId) && !agentChatsRetriedOnOpen.has(botId)) {
@@ -843,19 +844,23 @@ export function createAppController(props: AppProps = {}) {
           agentChatsRetriedOnOpen.delete(botId);
           const markReadOnOpen = agentChatsToMarkRead.delete(botId);
           if (markReadOnOpen && (page.readState?.unreadCount ?? 0) > 0) {
-            void markAgentMessagesRead(botId, page.messages.at(-1)?.id ?? null).catch((error) =>
+            void markAgentMessagesRead(botId, page.messages.at(-1)?.id ?? null, serverId).catch((error) =>
               appendUiError(botId, error, "Read state failed"),
             );
           }
         })
-        .catch((error) => appendUiError(botId, error, "Load failed"));
+        .catch((error) => {
+          if (activeServerSidebarKey() === serverId) appendUiError(botId, error, "Load failed");
+        });
       void window.openbot.agent
         .listQueue(botId)
         .then((queue) => {
-          if (queueSnapshotRequests.get(botId) !== queueRequest) return;
+          if (activeServerSidebarKey() !== serverId || queueSnapshotRequests.get(botId) !== queueRequest) return;
           setQueues((current) => ({ ...current, [botId]: queue }));
         })
-        .catch((error) => appendUiError(botId, error, "Queue load failed"));
+        .catch((error) => {
+          if (activeServerSidebarKey() === serverId) appendUiError(botId, error, "Queue load failed");
+        });
     },
   );
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -911,6 +911,16 @@ export function createAppController(props: AppProps = {}) {
             void markAgentMessagesRead(botId, page.messages.at(-1)?.id ?? null, serverId).catch((error) =>
               appendUiError(botId, error, "Read state failed"),
             );
+          } else if (agentChatsToRetryRead.has(trackingKey) && (page.readState?.unreadCount ?? 0) > 0) {
+            const latestIncomingMessage = [...page.messages]
+              .reverse()
+              .find(
+                (message) =>
+                  message.author !== "user" &&
+                  message.itemType !== "commentary" &&
+                  message.itemType !== "agent_attachment",
+              );
+            if (latestIncomingMessage) autoMarkAgentMessageRead(botId, latestIncomingMessage.id);
           }
         })
         .catch((error) => {
@@ -1254,8 +1264,8 @@ export function createAppController(props: AppProps = {}) {
     }).catch((error) => {
       if (autoReadAgentMessages.get(trackingKey)?.messageId !== messageId) return;
       autoReadAgentMessages.delete(trackingKey);
-      if (activeServerSidebarKey() !== serverId) return;
       agentChatsToRetryRead.add(trackingKey);
+      if (activeServerSidebarKey() !== serverId) return;
       const latest = conversationReads()[botId];
       if (
         optimisticallyCleared &&
@@ -2169,7 +2179,9 @@ export function createAppController(props: AppProps = {}) {
         );
         agentChatsToRetryRead.delete(requestKey);
         onSuccess?.(state);
-        if (activeServerSidebarKey() === serverId) {
+        const trackedAutoRead = autoReadAgentMessages.get(requestKey);
+        const supersededByAutoRead = Boolean(trackedAutoRead && trackedAutoRead.messageId !== boundary);
+        if (activeServerSidebarKey() === serverId && !supersededByAutoRead) {
           applyConversationReadState(botId, state);
           clearRecentReply(botId);
         }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -361,6 +361,7 @@ export function createAppController(props: AppProps = {}) {
   const agentChatsToMarkRead = new Set<string>();
   let explicitlyOpenedAgentChatId: string | null = null;
   const autoReadAgentMessageIds = new Map<string, string>();
+  const agentChatsToRetryRead = new Set<string>();
   const recentReplyTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const conversationPageRequests = new Map<string, number>();
   const conversationReadOperations = new Map<string, Promise<void>>();
@@ -874,7 +875,9 @@ export function createAppController(props: AppProps = {}) {
           const existingUnreadCount = conversationReads()[event.page.botId]?.unreadCount ?? 0;
           const markNewMessagesRead =
             isAgentChatOpen(event.page.botId) &&
-            (existingUnreadCount === 0 || explicitlyOpenedAgentChatId === event.page.botId);
+            (existingUnreadCount === 0 ||
+              explicitlyOpenedAgentChatId === event.page.botId ||
+              agentChatsToRetryRead.has(event.page.botId));
           const pageApplied = applyConversationPage(event.page, "latest", "latest");
           const latestIncomingMessage = markNewMessagesRead
             ? [...event.page.messages]
@@ -1131,16 +1134,37 @@ export function createAppController(props: AppProps = {}) {
     if (autoReadAgentMessageIds.get(botId) === messageId) return;
     const current = conversationReads()[botId];
     const hasUnread = Boolean(current && current.unreadCount > 0);
-    if (!optimisticallyClearUnread && explicitlyOpenedAgentChatId !== botId && hasUnread) return;
+    const retryingRead = agentChatsToRetryRead.delete(botId);
+    if (!optimisticallyClearUnread && explicitlyOpenedAgentChatId !== botId && !retryingRead && hasUnread) return;
     autoReadAgentMessageIds.set(botId, messageId);
-    if (current && (!hasUnread || optimisticallyClearUnread)) {
+    const optimisticallyCleared = Boolean(current && (!hasUnread || optimisticallyClearUnread));
+    const rollbackState = current
+      ? hasUnread
+        ? current
+        : { ...current, unreadCount: 1, firstUnreadMessageId: messageId }
+      : null;
+    if (current && optimisticallyCleared) {
       applyConversationReadState(botId, {
         unreadCount: 0,
         firstUnreadMessageId: null,
         throughMessageId: messageId,
       });
     }
-    void markAgentMessagesRead(botId, messageId).catch((error) => appendUiError(botId, error, "Read state failed"));
+    void markAgentMessagesRead(botId, messageId).catch((error) => {
+      if (autoReadAgentMessageIds.get(botId) !== messageId) return;
+      autoReadAgentMessageIds.delete(botId);
+      agentChatsToRetryRead.add(botId);
+      const latest = conversationReads()[botId];
+      if (
+        optimisticallyCleared &&
+        rollbackState &&
+        latest?.unreadCount === 0 &&
+        latest.throughMessageId === messageId
+      ) {
+        applyConversationReadState(botId, rollbackState);
+      }
+      appendUiError(botId, error, "Read state failed");
+    });
   }
 
   function applyConversationDelta(event: Extract<AgentEvent, { type: "conversation-delta" }>) {
@@ -2039,6 +2063,7 @@ export function createAppController(props: AppProps = {}) {
         });
         if (activeServerSidebarKey() !== serverId) return;
         applyConversationReadState(botId, state);
+        agentChatsToRetryRead.delete(botId);
         clearRecentReply(botId);
       });
     conversationReadOperations.set(requestKey, operation);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -361,7 +361,10 @@ export function createAppController(props: AppProps = {}) {
   const agentChatsToMarkRead = new Set<string>();
   const agentChatsRetriedOnOpen = new Set<string>();
   let explicitlyOpenedAgentChatId: string | null = null;
-  const autoReadAgentMessageIds = new Map<string, string>();
+  const autoReadAgentMessages = new Map<
+    string,
+    { messageId: string; status: "pending" } | { messageId: string; status: "succeeded"; state: ConversationReadState }
+  >();
   const agentChatsToRetryRead = new Set<string>();
   const recentReplyTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const conversationPageRequests = new Map<string, number>();
@@ -1153,12 +1156,16 @@ export function createAppController(props: AppProps = {}) {
   function autoMarkAgentMessageRead(botId: string, messageId: string, optimisticallyClearUnread = false): void {
     const serverId = activeServerSidebarKey();
     const trackingKey = agentConversationKey(serverId, botId);
-    if (autoReadAgentMessageIds.get(trackingKey) === messageId) return;
     const current = conversationReads()[botId];
+    const previousAutoRead = autoReadAgentMessages.get(trackingKey);
+    if (previousAutoRead?.messageId === messageId) {
+      if (previousAutoRead.status === "succeeded") applyConversationReadState(botId, previousAutoRead.state);
+      return;
+    }
     const hasUnread = Boolean(current && current.unreadCount > 0);
     const retryingRead = agentChatsToRetryRead.delete(trackingKey);
     if (!optimisticallyClearUnread && explicitlyOpenedAgentChatId !== botId && !retryingRead && hasUnread) return;
-    autoReadAgentMessageIds.set(trackingKey, messageId);
+    autoReadAgentMessages.set(trackingKey, { messageId, status: "pending" });
     const optimisticallyCleared = Boolean(current && (!hasUnread || optimisticallyClearUnread));
     const rollbackState = current
       ? hasUnread
@@ -1172,9 +1179,12 @@ export function createAppController(props: AppProps = {}) {
         throughMessageId: messageId,
       });
     }
-    void markAgentMessagesRead(botId, messageId, serverId).catch((error) => {
-      if (autoReadAgentMessageIds.get(trackingKey) !== messageId) return;
-      autoReadAgentMessageIds.delete(trackingKey);
+    void markAgentMessagesRead(botId, messageId, serverId, (state) => {
+      if (autoReadAgentMessages.get(trackingKey)?.messageId !== messageId) return;
+      autoReadAgentMessages.set(trackingKey, { messageId, status: "succeeded", state });
+    }).catch((error) => {
+      if (autoReadAgentMessages.get(trackingKey)?.messageId !== messageId) return;
+      autoReadAgentMessages.delete(trackingKey);
       if (activeServerSidebarKey() !== serverId) return;
       agentChatsToRetryRead.add(trackingKey);
       const latest = conversationReads()[botId];
@@ -2067,6 +2077,7 @@ export function createAppController(props: AppProps = {}) {
     botId = activeBot()?.id,
     throughMessageId?: string | null,
     serverId = activeServerSidebarKey(),
+    onSuccess?: (state: ConversationReadState) => void,
   ): Promise<void> {
     if (!botId || activeServerSidebarKey() !== serverId) return;
     const requestKey = agentConversationKey(serverId, botId);
@@ -2080,15 +2091,19 @@ export function createAppController(props: AppProps = {}) {
     const operation = previousOperation
       .catch(() => undefined)
       .then(async () => {
-        if (activeServerSidebarKey() !== serverId) return;
-        const state: ConversationReadState = await window.openbot.agent.markConversationRead({
-          botId,
-          throughMessageId: boundary,
-        });
-        if (activeServerSidebarKey() !== serverId) return;
-        applyConversationReadState(botId, state);
+        const state: ConversationReadState = await window.openbot.agent.markConversationRead(
+          {
+            botId,
+            throughMessageId: boundary,
+          },
+          serverId,
+        );
         agentChatsToRetryRead.delete(requestKey);
-        clearRecentReply(botId);
+        onSuccess?.(state);
+        if (activeServerSidebarKey() === serverId) {
+          applyConversationReadState(botId, state);
+          clearRecentReply(botId);
+        }
       });
     conversationReadOperations.set(requestKey, operation);
     try {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -819,20 +819,15 @@ export function createAppController(props: AppProps = {}) {
     () => ({ botId: activeBotId(), agentPhase: agentStatus().phase, openRevision: agentChatOpenRevision() }),
     ({ botId }) => {
       if (!botId) return;
-      const markReadOnOpen = agentChatsToMarkRead.delete(botId);
       const pageRequest = (conversationPageRequests.get(botId) ?? 0) + 1;
       conversationPageRequests.set(botId, pageRequest);
       const queueRequest = (queueSnapshotRequests.get(botId) ?? 0) + 1;
       queueSnapshotRequests.set(botId, queueRequest);
-      void Promise.all([
-        window.openbot.agent.readConversationPage({ botId, anchor: { type: "latest" }, limit: 50 }),
-        window.openbot.agent.listQueue(botId),
-      ])
-        .then(([page, queue]) => {
+      void window.openbot.agent
+        .readConversationPage({ botId, anchor: { type: "latest" }, limit: 50 })
+        .then((page) => {
           if (conversationPageRequests.get(botId) !== pageRequest) return;
-          if (queueSnapshotRequests.get(botId) === queueRequest) {
-            setQueues((current) => ({ ...current, [botId]: queue }));
-          }
+          const markReadOnOpen = agentChatsToMarkRead.delete(botId);
           const pageApplied = applyConversationPage(page, "replace", "latest");
           if (pageApplied && markReadOnOpen && (page.readState?.unreadCount ?? 0) > 0) {
             void markAgentMessagesRead(botId, page.messages.at(-1)?.id ?? null).catch((error) =>
@@ -841,6 +836,13 @@ export function createAppController(props: AppProps = {}) {
           }
         })
         .catch((error) => appendUiError(botId, error, "Load failed"));
+      void window.openbot.agent
+        .listQueue(botId)
+        .then((queue) => {
+          if (queueSnapshotRequests.get(botId) !== queueRequest) return;
+          setQueues((current) => ({ ...current, [botId]: queue }));
+        })
+        .catch((error) => appendUiError(botId, error, "Queue load failed"));
     },
   );
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -886,7 +886,12 @@ export function createAppController(props: AppProps = {}) {
           const latestIncomingMessage = markNewMessagesRead
             ? [...event.page.messages]
                 .reverse()
-                .find((message) => message.author !== "user" && message.itemType !== "commentary")
+                .find(
+                  (message) =>
+                    message.author !== "user" &&
+                    message.itemType !== "commentary" &&
+                    message.itemType !== "agent_attachment",
+                )
             : undefined;
           if (pageApplied && latestIncomingMessage) {
             autoMarkAgentMessageRead(event.page.botId, latestIncomingMessage.id, existingUnreadCount === 0);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -359,6 +359,7 @@ export function createAppController(props: AppProps = {}) {
     { snapshot: ConversationSnapshot; markNewMessagesRead: boolean }
   >();
   const agentChatsToMarkRead = new Set<string>();
+  const agentChatsRetriedOnOpen = new Set<string>();
   let explicitlyOpenedAgentChatId: string | null = null;
   const autoReadAgentMessageIds = new Map<string, string>();
   const agentChatsToRetryRead = new Set<string>();
@@ -830,9 +831,13 @@ export function createAppController(props: AppProps = {}) {
           if (conversationPageRequests.get(botId) !== pageRequest) return;
           const pageApplied = applyConversationPage(page, "replace", "latest");
           if (!pageApplied) {
-            if (agentChatsToMarkRead.has(botId)) setAgentChatOpenRevision((current) => current + 1);
+            if (agentChatsToMarkRead.has(botId) && !agentChatsRetriedOnOpen.has(botId)) {
+              agentChatsRetriedOnOpen.add(botId);
+              setAgentChatOpenRevision((current) => current + 1);
+            }
             return;
           }
+          agentChatsRetriedOnOpen.delete(botId);
           const markReadOnOpen = agentChatsToMarkRead.delete(botId);
           if (markReadOnOpen && (page.readState?.unreadCount ?? 0) > 0) {
             void markAgentMessagesRead(botId, page.messages.at(-1)?.id ?? null).catch((error) =>
@@ -879,6 +884,7 @@ export function createAppController(props: AppProps = {}) {
           const existingUnreadCount = conversationReads()[event.page.botId]?.unreadCount ?? 0;
           const markNewMessagesRead =
             isAgentChatOpen(event.page.botId) &&
+            (event.page.readState === undefined || event.page.readState.unreadCount > 0) &&
             (existingUnreadCount === 0 ||
               explicitlyOpenedAgentChatId === event.page.botId ||
               agentChatsToRetryRead.has(event.page.botId));
@@ -1448,6 +1454,7 @@ export function createAppController(props: AppProps = {}) {
     setActiveDirectMemberId(null);
     clearReplyIndicators(botId);
     agentChatsToMarkRead.add(botId);
+    agentChatsRetriedOnOpen.delete(botId);
     explicitlyOpenedAgentChatId = botId;
     setActiveBotId(botId);
     setAgentChatOpenRevision((current) => current + 1);
@@ -2614,6 +2621,7 @@ export function createAppController(props: AppProps = {}) {
     setBotSetupError(null);
     setSettingsRequest(null);
     setBotList([]);
+    agentChatsRetriedOnOpen.clear();
     explicitlyOpenedAgentChatId = null;
     setSidebarLayout(defaultSidebarLayout());
     setActiveBotId("");

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1518,7 +1518,7 @@ export function createAppController(props: AppProps = {}) {
       ...current,
       [page.botId]: completedTurnByBot.get(page.botId) === page.activeTurnId ? null : page.activeTurnId,
     }));
-    if (page.readState) {
+    if (page.readState && merge !== "older") {
       const trackedAutoRead = autoReadAgentMessages.get(agentConversationKey(activeServerSidebarKey(), page.botId));
       const latestIncomingMessage = [...page.messages]
         .reverse()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -826,6 +826,7 @@ export function createAppController(props: AppProps = {}) {
     ({ botId }) => {
       if (!botId) return;
       const serverId = activeServerSidebarKey();
+      const trackingKey = agentConversationKey(serverId, botId);
       const pageRequest = (conversationPageRequests.get(botId) ?? 0) + 1;
       conversationPageRequests.set(botId, pageRequest);
       const queueRequest = (queueSnapshotRequests.get(botId) ?? 0) + 1;
@@ -836,14 +837,14 @@ export function createAppController(props: AppProps = {}) {
           if (activeServerSidebarKey() !== serverId || conversationPageRequests.get(botId) !== pageRequest) return;
           const pageApplied = applyConversationPage(page, "replace", "latest");
           if (!pageApplied) {
-            if (agentChatsToMarkRead.has(botId) && !agentChatsRetriedOnOpen.has(botId)) {
+            if (agentChatsToMarkRead.has(trackingKey) && !agentChatsRetriedOnOpen.has(botId)) {
               agentChatsRetriedOnOpen.add(botId);
               setAgentChatOpenRevision((current) => current + 1);
             }
             return;
           }
           agentChatsRetriedOnOpen.delete(botId);
-          const markReadOnOpen = agentChatsToMarkRead.delete(botId);
+          const markReadOnOpen = agentChatsToMarkRead.delete(trackingKey);
           if (markReadOnOpen && (page.readState?.unreadCount ?? 0) > 0) {
             void markAgentMessagesRead(botId, page.messages.at(-1)?.id ?? null, serverId).catch((error) =>
               appendUiError(botId, error, "Read state failed"),
@@ -1477,7 +1478,7 @@ export function createAppController(props: AppProps = {}) {
     }
     setActiveDirectMemberId(null);
     clearReplyIndicators(botId);
-    agentChatsToMarkRead.add(botId);
+    agentChatsToMarkRead.add(agentConversationKey(activeServerSidebarKey(), botId));
     agentChatsRetriedOnOpen.delete(botId);
     explicitlyOpenedAgentChatId = botId;
     setActiveBotId(botId);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1487,7 +1487,21 @@ export function createAppController(props: AppProps = {}) {
       ...current,
       [page.botId]: completedTurnByBot.get(page.botId) === page.activeTurnId ? null : page.activeTurnId,
     }));
-    if (page.readState) applyConversationReadState(page.botId, page.readState);
+    if (page.readState) {
+      const trackedAutoRead = autoReadAgentMessages.get(agentConversationKey(activeServerSidebarKey(), page.botId));
+      const latestIncomingMessage = [...page.messages]
+        .reverse()
+        .find(
+          (message) =>
+            message.author !== "user" && message.itemType !== "commentary" && message.itemType !== "agent_attachment",
+        );
+      let retainedState: ConversationReadState | null = null;
+      if (trackedAutoRead && trackedAutoRead.messageId === latestIncomingMessage?.id) {
+        retainedState =
+          trackedAutoRead.status === "succeeded" ? trackedAutoRead.state : trackedAutoRead.optimisticState;
+      }
+      applyConversationReadState(page.botId, retainedState ?? page.readState);
+    }
     return true;
   }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -363,6 +363,7 @@ export function createAppController(props: AppProps = {}) {
   const autoReadAgentMessageIds = new Map<string, string>();
   const recentReplyTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const conversationPageRequests = new Map<string, number>();
+  const conversationReadRequests = new Map<string, number>();
   const queueSnapshotRequests = new Map<string, number>();
   const completedTurnByBot = new Map<string, string>();
   const pendingProviderConnections = new Map<AgentProviderId, ReturnType<typeof desktopAnalytics.scope>>();
@@ -2017,17 +2018,26 @@ export function createAppController(props: AppProps = {}) {
     serverId = activeServerSidebarKey(),
   ): Promise<void> {
     if (!botId || activeServerSidebarKey() !== serverId) return;
+    const requestKey = `${serverId}\0${botId}`;
+    const request = (conversationReadRequests.get(requestKey) ?? 0) + 1;
+    conversationReadRequests.set(requestKey, request);
     const boundary =
       throughMessageId ??
       liveMessages()
         [botId]?.filter((message) => !message.id.startsWith("thinking:") && !message.id.startsWith("ui-"))
         .at(-1)?.id ??
       null;
-    const state = await window.openbot.agent.markConversationRead({
-      botId,
-      throughMessageId: boundary,
-    });
-    if (activeServerSidebarKey() !== serverId) return;
+    let state: ConversationReadState;
+    try {
+      state = await window.openbot.agent.markConversationRead({
+        botId,
+        throughMessageId: boundary,
+      });
+    } catch (error) {
+      if (activeServerSidebarKey() !== serverId || conversationReadRequests.get(requestKey) !== request) return;
+      throw error;
+    }
+    if (activeServerSidebarKey() !== serverId || conversationReadRequests.get(requestKey) !== request) return;
     applyConversationReadState(botId, state);
     clearRecentReply(botId);
   }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -363,7 +363,7 @@ export function createAppController(props: AppProps = {}) {
   const autoReadAgentMessageIds = new Map<string, string>();
   const recentReplyTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const conversationPageRequests = new Map<string, number>();
-  const conversationReadRequests = new Map<string, number>();
+  const conversationReadOperations = new Map<string, Promise<void>>();
   const queueSnapshotRequests = new Map<string, number>();
   const completedTurnByBot = new Map<string, string>();
   const pendingProviderConnections = new Map<AgentProviderId, ReturnType<typeof desktopAnalytics.scope>>();
@@ -833,8 +833,8 @@ export function createAppController(props: AppProps = {}) {
           if (queueSnapshotRequests.get(botId) === queueRequest) {
             setQueues((current) => ({ ...current, [botId]: queue }));
           }
-          applyConversationPage(page, "replace", "latest");
-          if (markReadOnOpen && (page.readState?.unreadCount ?? 0) > 0) {
+          const pageApplied = applyConversationPage(page, "replace", "latest");
+          if (pageApplied && markReadOnOpen && (page.readState?.unreadCount ?? 0) > 0) {
             void markAgentMessagesRead(botId, page.messages.at(-1)?.id ?? null).catch((error) =>
               appendUiError(botId, error, "Read state failed"),
             );
@@ -873,13 +873,13 @@ export function createAppController(props: AppProps = {}) {
           const markNewMessagesRead =
             isAgentChatOpen(event.page.botId) &&
             (existingUnreadCount === 0 || explicitlyOpenedAgentChatId === event.page.botId);
-          applyConversationPage(event.page, "latest", "latest");
+          const pageApplied = applyConversationPage(event.page, "latest", "latest");
           const latestIncomingMessage = markNewMessagesRead
             ? [...event.page.messages]
                 .reverse()
                 .find((message) => message.author !== "user" && message.itemType !== "commentary")
             : undefined;
-          if (latestIncomingMessage) {
+          if (pageApplied && latestIncomingMessage) {
             autoMarkAgentMessageRead(event.page.botId, latestIncomingMessage.id, existingUnreadCount === 0);
           }
         }
@@ -1280,8 +1280,8 @@ export function createAppController(props: AppProps = {}) {
     page: ConversationPage,
     merge: "replace" | "older" | "latest",
     windowMode?: "latest" | "around",
-  ): void {
-    if (page.revision < (conversationRevisions()[page.botId] ?? -1)) return;
+  ): boolean {
+    if (page.revision < (conversationRevisions()[page.botId] ?? -1)) return false;
     const mapped = toBotMessages(page.messages);
     setLiveMessages((current) => {
       const currentMessages = current[page.botId] ?? [];
@@ -1320,6 +1320,7 @@ export function createAppController(props: AppProps = {}) {
       [page.botId]: completedTurnByBot.get(page.botId) === page.activeTurnId ? null : page.activeTurnId,
     }));
     if (page.readState) applyConversationReadState(page.botId, page.readState);
+    return true;
   }
 
   async function loadOlderAgentMessages(botId = activeBot()?.id): Promise<void> {
@@ -2019,27 +2020,31 @@ export function createAppController(props: AppProps = {}) {
   ): Promise<void> {
     if (!botId || activeServerSidebarKey() !== serverId) return;
     const requestKey = `${serverId}\0${botId}`;
-    const request = (conversationReadRequests.get(requestKey) ?? 0) + 1;
-    conversationReadRequests.set(requestKey, request);
     const boundary =
       throughMessageId ??
       liveMessages()
         [botId]?.filter((message) => !message.id.startsWith("thinking:") && !message.id.startsWith("ui-"))
         .at(-1)?.id ??
       null;
-    let state: ConversationReadState;
-    try {
-      state = await window.openbot.agent.markConversationRead({
-        botId,
-        throughMessageId: boundary,
+    const previousOperation = conversationReadOperations.get(requestKey) ?? Promise.resolve();
+    const operation = previousOperation
+      .catch(() => undefined)
+      .then(async () => {
+        if (activeServerSidebarKey() !== serverId) return;
+        const state: ConversationReadState = await window.openbot.agent.markConversationRead({
+          botId,
+          throughMessageId: boundary,
+        });
+        if (activeServerSidebarKey() !== serverId) return;
+        applyConversationReadState(botId, state);
+        clearRecentReply(botId);
       });
-    } catch (error) {
-      if (activeServerSidebarKey() !== serverId || conversationReadRequests.get(requestKey) !== request) return;
-      throw error;
+    conversationReadOperations.set(requestKey, operation);
+    try {
+      await operation;
+    } finally {
+      if (conversationReadOperations.get(requestKey) === operation) conversationReadOperations.delete(requestKey);
     }
-    if (activeServerSidebarKey() !== serverId || conversationReadRequests.get(requestKey) !== request) return;
-    applyConversationReadState(botId, state);
-    clearRecentReply(botId);
   }
 
   async function answerPrompt(answers: Record<string, string[]>): Promise<boolean> {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -882,12 +882,13 @@ export function createAppController(props: AppProps = {}) {
       case "conversation-page":
         {
           const existingUnreadCount = conversationReads()[event.page.botId]?.unreadCount ?? 0;
+          const trackingKey = agentConversationKey(activeServerSidebarKey(), event.page.botId);
           const markNewMessagesRead =
             isAgentChatOpen(event.page.botId) &&
             (event.page.readState === undefined || event.page.readState.unreadCount > 0) &&
             (existingUnreadCount === 0 ||
               explicitlyOpenedAgentChatId === event.page.botId ||
-              agentChatsToRetryRead.has(event.page.botId));
+              agentChatsToRetryRead.has(trackingKey));
           const pageApplied = applyConversationPage(event.page, "latest", "latest");
           const latestIncomingMessage = markNewMessagesRead
             ? [...event.page.messages]
@@ -1145,13 +1146,19 @@ export function createAppController(props: AppProps = {}) {
     return !botSetupOpen() && !activeDirectMemberId() && activeBot()?.id === botId;
   }
 
+  function agentConversationKey(serverId: string, botId: string): string {
+    return `${serverId}\0${botId}`;
+  }
+
   function autoMarkAgentMessageRead(botId: string, messageId: string, optimisticallyClearUnread = false): void {
-    if (autoReadAgentMessageIds.get(botId) === messageId) return;
+    const serverId = activeServerSidebarKey();
+    const trackingKey = agentConversationKey(serverId, botId);
+    if (autoReadAgentMessageIds.get(trackingKey) === messageId) return;
     const current = conversationReads()[botId];
     const hasUnread = Boolean(current && current.unreadCount > 0);
-    const retryingRead = agentChatsToRetryRead.delete(botId);
+    const retryingRead = agentChatsToRetryRead.delete(trackingKey);
     if (!optimisticallyClearUnread && explicitlyOpenedAgentChatId !== botId && !retryingRead && hasUnread) return;
-    autoReadAgentMessageIds.set(botId, messageId);
+    autoReadAgentMessageIds.set(trackingKey, messageId);
     const optimisticallyCleared = Boolean(current && (!hasUnread || optimisticallyClearUnread));
     const rollbackState = current
       ? hasUnread
@@ -1165,10 +1172,11 @@ export function createAppController(props: AppProps = {}) {
         throughMessageId: messageId,
       });
     }
-    void markAgentMessagesRead(botId, messageId).catch((error) => {
-      if (autoReadAgentMessageIds.get(botId) !== messageId) return;
-      autoReadAgentMessageIds.delete(botId);
-      agentChatsToRetryRead.add(botId);
+    void markAgentMessagesRead(botId, messageId, serverId).catch((error) => {
+      if (autoReadAgentMessageIds.get(trackingKey) !== messageId) return;
+      autoReadAgentMessageIds.delete(trackingKey);
+      if (activeServerSidebarKey() !== serverId) return;
+      agentChatsToRetryRead.add(trackingKey);
       const latest = conversationReads()[botId];
       if (
         optimisticallyCleared &&
@@ -2061,7 +2069,7 @@ export function createAppController(props: AppProps = {}) {
     serverId = activeServerSidebarKey(),
   ): Promise<void> {
     if (!botId || activeServerSidebarKey() !== serverId) return;
-    const requestKey = `${serverId}\0${botId}`;
+    const requestKey = agentConversationKey(serverId, botId);
     const boundary =
       throughMessageId ??
       liveMessages()
@@ -2079,7 +2087,7 @@ export function createAppController(props: AppProps = {}) {
         });
         if (activeServerSidebarKey() !== serverId) return;
         applyConversationReadState(botId, state);
-        agentChatsToRetryRead.delete(botId);
+        agentChatsToRetryRead.delete(requestKey);
         clearRecentReply(botId);
       });
     conversationReadOperations.set(requestKey, operation);


### PR DESCRIPTION
## Summary
- reload and mark a bot conversation read on every explicit chat entry, including the already selected bot
- keep visible replies read when refreshed conversation pages arrive from a remote host
- synchronize sidebar and Dynamic Island unread presentations after the read state changes

## Verification
- `bun run check`
- `bun vitest run src/renderer/src/App.test.tsx`
- end-to-end with seeded `bun run dev`: reopened the active Chief chat and confirmed its divider and badge cleared; opened Launch from Dynamic Island and confirmed the Launch badge cleared and Dynamic Island advanced to Research