### PR TITLE
Add effort selector to model picker

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -3323,11 +3323,112 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() =>
       expect(window.openbot.agent.updateBot).toHaveBeenCalledWith({
         botId: "chief",
+        model: "gpt-5.6-luna",
+        provider: "codex",
         reasoningEffort: "high",
       }),
     );
     expect(effort).toHaveTextContent("High");
     expect(picker).toBeInTheDocument();
+  });
+
+  it("persists rapid model and effort changes in order as complete settings", async () => {
+    let resolveModelUpdate!: (bot: BotSummary) => void;
+    vi.mocked(window.openbot.agent.updateBot).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveModelUpdate = resolve;
+        }),
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    const picker = screen.getByRole("dialog", { name: "Choose agent model" });
+    await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
+    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
+    const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
+    await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "High" }));
+
+    expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(1);
+    expect(effort).toHaveTextContent("High");
+    const chief = BOTS.find((bot) => bot.id === "chief");
+    if (!chief) throw new Error("Chief fixture is missing");
+    resolveModelUpdate({
+      ...chief,
+      provider: "claude",
+      model: "claude-opus-5",
+      reasoningEffort: "medium",
+    });
+
+    await waitFor(() => expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(2));
+    expect(window.openbot.agent.updateBot).toHaveBeenLastCalledWith({
+      botId: "chief",
+      provider: "claude",
+      model: "claude-opus-5",
+      reasoningEffort: "high",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(effort).toHaveTextContent("High");
+  });
+
+  it("does not roll back a newer effort when an older save fails", async () => {
+    let rejectFirstUpdate!: (error: Error) => void;
+    vi.mocked(window.openbot.agent.updateBot).mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectFirstUpdate = reject;
+        }),
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    const picker = screen.getByRole("dialog", { name: "Choose agent model" });
+    const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
+    await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "High" }));
+    await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "Low" }));
+
+    expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(1);
+    rejectFirstUpdate(new Error("Older effort failed"));
+    await waitFor(() => expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(2));
+    expect(window.openbot.agent.updateBot).toHaveBeenLastCalledWith({
+      botId: "chief",
+      provider: "codex",
+      model: "gpt-5.6-luna",
+      reasoningEffort: "low",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(effort).toHaveTextContent("Low");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not roll back or report an effort failure after switching agents", async () => {
+    let rejectUpdate!: (error: Error) => void;
+    vi.mocked(window.openbot.agent.updateBot).mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectUpdate = reject;
+        }),
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    const picker = screen.getByRole("dialog", { name: "Choose agent model" });
+    const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
+    await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "High" }));
+    await fireEvent.click(screen.getByRole("button", { name: /Sales Outbound/ }));
+    await screen.findByRole("heading", { name: "Sales Outbound" });
+
+    rejectUpdate(new Error("Chief effort failed"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Agent model: Luna" })).toBeEnabled();
   });
 
   it("rolls back a failed header effort change and reports the error", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -3299,13 +3299,51 @@ describe("OpenBot connected desktop shell", () => {
         reasoningEffort: "medium",
       }),
     );
-    expect(screen.queryByRole("dialog", { name: "Choose agent model" })).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Choose agent model" })).toBeInTheDocument();
     const claudeTrigger = await screen.findByRole("button", {
       name: "Agent model: Claude Opus 5",
     });
     expect(claudeTrigger).toBeEnabled();
     expect(claudeTrigger.querySelector(".provider-model-mark-claude")).toBeInTheDocument();
     expect(claudeTrigger.querySelector(".provider-model-mark-codex")).not.toBeInTheDocument();
+  });
+
+  it("changes reasoning effort from the header model picker without closing it", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    const picker = screen.getByRole("dialog", { name: "Choose agent model" });
+    const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
+    expect(effort).toHaveTextContent("Medium");
+
+    await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "High" }));
+
+    await waitFor(() =>
+      expect(window.openbot.agent.updateBot).toHaveBeenCalledWith({
+        botId: "chief",
+        reasoningEffort: "high",
+      }),
+    );
+    expect(effort).toHaveTextContent("High");
+    expect(picker).toBeInTheDocument();
+  });
+
+  it("rolls back a failed header effort change and reports the error", async () => {
+    vi.mocked(window.openbot.agent.updateBot).mockRejectedValueOnce(new Error("Effort failed"));
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    const picker = screen.getByRole("dialog", { name: "Choose agent model" });
+    const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
+    await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "High" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not change effort. Try again.");
+    expect(effort).toHaveTextContent("Medium");
+    expect(picker).toBeInTheDocument();
   });
 
   it("shows unavailable providers without allowing their models", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -3362,7 +3362,89 @@ describe("OpenBot connected desktop shell", () => {
       reasoningEffort: "medium",
     });
 
-    await waitFor(() => expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(vi.mocked(window.openbot.agent.updateBot).mock.calls).toEqual([
+        [
+          {
+            botId: "chief",
+            provider: "claude",
+            model: "claude-opus-5",
+            reasoningEffort: "medium",
+          },
+        ],
+        [
+          {
+            botId: "chief",
+            provider: "claude",
+            model: "claude-opus-5",
+            reasoningEffort: "high",
+          },
+        ],
+      ]),
+    );
+    expect(window.openbot.agent.updateBot).toHaveBeenLastCalledWith({
+      botId: "chief",
+      provider: "claude",
+      model: "claude-opus-5",
+      reasoningEffort: "high",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(effort).toHaveTextContent("High");
+  });
+
+  it("orders Agent Settings effort changes after pending header model changes", async () => {
+    let resolveHeaderUpdate!: (bot: BotSummary) => void;
+    vi.mocked(window.openbot.agent.updateBot).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveHeaderUpdate = resolve;
+        }),
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    const headerPicker = screen.getByRole("dialog", { name: "Choose agent model" });
+    await fireEvent.click(within(headerPicker).getByRole("tab", { name: /^Claude:/ }));
+    await fireEvent.click(within(headerPicker).getByRole("option", { name: "Claude Opus 5, default" }));
+    await fireEvent.click(screen.getByRole("button", { name: "View agent settings" }));
+
+    const settings = await screen.findByRole("complementary", { name: "Agent settings" });
+    expect(within(settings).getByRole("button", { name: "Agent model: Claude Opus 5" })).toBeEnabled();
+    const effort = within(settings).getByRole("button", { name: /Agent reasoning level/ });
+    await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "High" }));
+
+    expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(1);
+    const chief = BOTS.find((bot) => bot.id === "chief");
+    if (!chief) throw new Error("Chief fixture is missing");
+    resolveHeaderUpdate({
+      ...chief,
+      provider: "claude",
+      model: "claude-opus-5",
+      reasoningEffort: "medium",
+    });
+
+    await waitFor(() =>
+      expect(vi.mocked(window.openbot.agent.updateBot).mock.calls).toEqual([
+        [
+          {
+            botId: "chief",
+            provider: "claude",
+            model: "claude-opus-5",
+            reasoningEffort: "medium",
+          },
+        ],
+        [
+          {
+            botId: "chief",
+            provider: "claude",
+            model: "claude-opus-5",
+            reasoningEffort: "high",
+          },
+        ],
+      ]),
+    );
     expect(window.openbot.agent.updateBot).toHaveBeenLastCalledWith({
       botId: "chief",
       provider: "claude",
@@ -3574,6 +3656,8 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() =>
       expect(window.openbot.agent.updateBot).toHaveBeenLastCalledWith({
         botId: "chief",
+        provider: "codex",
+        model: "gpt-5.6-sol",
         reasoningEffort: "xhigh",
       }),
     );

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -3331,13 +3331,22 @@ describe("OpenBot connected desktop shell", () => {
   });
 
   it("persists rapid model and effort changes in order as complete settings", async () => {
+    const chief = BOTS.find((bot) => bot.id === "chief");
+    if (!chief) throw new Error("Chief fixture is missing");
     let resolveModelUpdate!: (bot: BotSummary) => void;
-    vi.mocked(window.openbot.agent.updateBot).mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveModelUpdate = resolve;
-        }),
-    );
+    vi.mocked(window.openbot.agent.updateBot)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveModelUpdate = resolve;
+          }),
+      )
+      .mockImplementationOnce(async (input) => ({
+        ...chief,
+        ...input,
+        provider: "claude",
+        model: "claude-opus-5",
+      }));
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
@@ -3351,8 +3360,6 @@ describe("OpenBot connected desktop shell", () => {
 
     expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(1);
     expect(effort).toHaveTextContent("High");
-    const chief = BOTS.find((bot) => bot.id === "chief");
-    if (!chief) throw new Error("Chief fixture is missing");
     resolveModelUpdate({
       ...chief,
       provider: "claude",
@@ -3383,17 +3390,85 @@ describe("OpenBot connected desktop shell", () => {
       reasoningEffort: "high",
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.getByRole("button", { name: "Agent model: Claude Opus 5" })).toBeEnabled();
     expect(effort).toHaveTextContent("High");
   });
 
-  it("orders Agent Settings effort changes after pending header model changes", async () => {
-    let resolveHeaderUpdate!: (bot: BotSummary) => void;
+  it("rolls back a queued effort when its model save fails", async () => {
+    let rejectModelUpdate!: (error: Error) => void;
+    vi.mocked(window.openbot.agent.updateBot).mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectModelUpdate = reject;
+        }),
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    const picker = screen.getByRole("dialog", { name: "Choose agent model" });
+    await fireEvent.click(within(picker).getByRole("option", { name: "Sol" }));
+    const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
+    await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "Extra high" }));
+
+    expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(1);
+    rejectModelUpdate(new Error("Model failed"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not change effort. Try again.");
+    expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Agent model: Luna" })).toBeEnabled();
+    expect(effort).toHaveTextContent("Medium");
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+  });
+
+  it("reconciles a concurrent model update after an effort save succeeds", async () => {
+    let resolveEffortUpdate!: (bot: BotSummary) => void;
     vi.mocked(window.openbot.agent.updateBot).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
-          resolveHeaderUpdate = resolve;
+          resolveEffortUpdate = resolve;
         }),
     );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    const picker = screen.getByRole("dialog", { name: "Choose agent model" });
+    const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
+    await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
+    await fireEvent.click(screen.getByRole("option", { name: "High" }));
+
+    const chief = BOTS.find((bot) => bot.id === "chief");
+    if (!chief) throw new Error("Chief fixture is missing");
+    const concurrentBot = { ...chief, model: "gpt-5.6-sol" as const, reasoningEffort: "high" as const };
+    emitAgentEvent?.({ type: "bots-changed", bots: BOTS.map((bot) => (bot.id === "chief" ? concurrentBot : bot)) });
+    expect(screen.getByRole("button", { name: "Agent model: Luna" })).toBeEnabled();
+
+    resolveEffortUpdate(concurrentBot);
+
+    expect(await screen.findByRole("button", { name: "Agent model: Sol" })).toBeEnabled();
+    expect(effort).toHaveTextContent("High");
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Sol" }));
+  });
+
+  it("orders Agent Settings effort changes after pending header model changes", async () => {
+    const chief = BOTS.find((bot) => bot.id === "chief");
+    if (!chief) throw new Error("Chief fixture is missing");
+    let resolveHeaderUpdate!: (bot: BotSummary) => void;
+    vi.mocked(window.openbot.agent.updateBot)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveHeaderUpdate = resolve;
+          }),
+      )
+      .mockImplementationOnce(async (input) => ({
+        ...chief,
+        ...input,
+        provider: "claude",
+        model: "claude-opus-5",
+      }));
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
@@ -3410,8 +3485,6 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(screen.getByRole("option", { name: "High" }));
 
     expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(1);
-    const chief = BOTS.find((bot) => bot.id === "chief");
-    if (!chief) throw new Error("Chief fixture is missing");
     resolveHeaderUpdate({
       ...chief,
       provider: "claude",
@@ -3442,6 +3515,7 @@ describe("OpenBot connected desktop shell", () => {
       reasoningEffort: "high",
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(within(settings).getByRole("button", { name: "Agent model: Claude Opus 5" })).toBeEnabled();
     expect(effort).toHaveTextContent("High");
   });
 

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -3323,8 +3323,6 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() =>
       expect(window.openbot.agent.updateBot).toHaveBeenCalledWith({
         botId: "chief",
-        model: "gpt-5.6-luna",
-        provider: "codex",
         reasoningEffort: "high",
       }),
     );
@@ -3375,8 +3373,6 @@ describe("OpenBot connected desktop shell", () => {
         [
           {
             botId: "chief",
-            provider: "claude",
-            model: "claude-opus-5",
             reasoningEffort: "high",
           },
         ],
@@ -3384,8 +3380,6 @@ describe("OpenBot connected desktop shell", () => {
     );
     expect(window.openbot.agent.updateBot).toHaveBeenLastCalledWith({
       botId: "chief",
-      provider: "claude",
-      model: "claude-opus-5",
       reasoningEffort: "high",
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -3438,8 +3432,6 @@ describe("OpenBot connected desktop shell", () => {
         [
           {
             botId: "chief",
-            provider: "claude",
-            model: "claude-opus-5",
             reasoningEffort: "high",
           },
         ],
@@ -3447,8 +3439,6 @@ describe("OpenBot connected desktop shell", () => {
     );
     expect(window.openbot.agent.updateBot).toHaveBeenLastCalledWith({
       botId: "chief",
-      provider: "claude",
-      model: "claude-opus-5",
       reasoningEffort: "high",
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -3479,8 +3469,6 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() => expect(window.openbot.agent.updateBot).toHaveBeenCalledTimes(2));
     expect(window.openbot.agent.updateBot).toHaveBeenLastCalledWith({
       botId: "chief",
-      provider: "codex",
-      model: "gpt-5.6-luna",
       reasoningEffort: "low",
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -3656,8 +3644,6 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() =>
       expect(window.openbot.agent.updateBot).toHaveBeenLastCalledWith({
         botId: "chief",
-        provider: "codex",
-        model: "gpt-5.6-sol",
         reasoningEffort: "xhigh",
       }),
     );

--- a/src/renderer/src/components/Conversation.tsx
+++ b/src/renderer/src/components/Conversation.tsx
@@ -47,6 +47,19 @@ interface ConversationResources {
     | undefined;
   voiceDisposed: boolean;
   filePreviewRequestGeneration: number;
+  runtimeSettingsSaveTails: Map<string, Promise<void>>;
+  runtimeSettingsAttempts: Map<
+    string,
+    {
+      generation: number;
+      pending: boolean;
+      settings: {
+        provider: AgentProviderId;
+        model: AgentModelId;
+        reasoningEffort: AgentReasoningEffort;
+      };
+    }
+  >;
 }
 
 /** @internal Stable owner for renderer state that must survive Conversation view HMR. */
@@ -110,6 +123,8 @@ export function createConversationController(props: Pick<ConversationProps, "onT
     voiceSubmitRequest: undefined,
     voiceDisposed: false,
     filePreviewRequestGeneration: 0,
+    runtimeSettingsSaveTails: new Map(),
+    runtimeSettingsAttempts: new Map(),
   };
 
   onCleanup(() => {

--- a/src/renderer/src/components/Conversation.tsx
+++ b/src/renderer/src/components/Conversation.tsx
@@ -1,4 +1,4 @@
-import type { AgentModelId, AgentReasoningEffort, BrowserBounds } from "@openbot/contracts/ipc";
+import type { AgentModelId, AgentProviderId, AgentReasoningEffort, BrowserBounds } from "@openbot/contracts/ipc";
 import { createContext, createSignal, onCleanup, type ParentProps, useContext } from "solid-js";
 import {
   type ComposerDraft,
@@ -72,6 +72,7 @@ export function createConversationController(props: Pick<ConversationProps, "onT
   const [selectionSending, setSelectionSending] = createSignal(false);
   const [dropActive, setDropActive] = createSignal(false);
   const [rightPanels, setRightPanels] = createSignal<Record<string, RightPanelMode>>({});
+  const [settingsProvider, setSettingsProvider] = createSignal<AgentProviderId>("codex");
   const [settingsModel, setSettingsModel] = createSignal<AgentModelId>("gpt-5.6-luna");
   const [settingsReasoning, setSettingsReasoning] = createSignal<AgentReasoningEffort>("medium");
   const [browserAddress, setBrowserAddress] = createSignal("https://www.google.com");
@@ -160,6 +161,8 @@ export function createConversationController(props: Pick<ConversationProps, "onT
     setDropActive,
     rightPanels,
     setRightPanels,
+    settingsProvider,
+    setSettingsProvider,
     settingsModel,
     setSettingsModel,
     settingsReasoning,

--- a/src/renderer/src/components/Conversation.tsx
+++ b/src/renderer/src/components/Conversation.tsx
@@ -47,7 +47,7 @@ interface ConversationResources {
     | undefined;
   voiceDisposed: boolean;
   filePreviewRequestGeneration: number;
-  runtimeSettingsSaveTails: Map<string, Promise<void>>;
+  runtimeSettingsSaveTails: Map<string, Promise<boolean>>;
   runtimeSettingsAttempts: Map<
     string,
     {

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -9,6 +9,7 @@ import type {
   AgentModelId,
   AgentModelOption,
   AgentProviderId,
+  AgentReasoningEffort,
   AgentStatus,
   AttachmentSummary,
   AvatarImageInput,
@@ -345,6 +346,8 @@ function createConversationViewScope(props: ConversationProps) {
     setDropActive,
     rightPanels,
     setRightPanels,
+    settingsProvider,
+    setSettingsProvider,
     settingsModel,
     setSettingsModel,
     settingsReasoning,
@@ -874,13 +877,16 @@ function createConversationViewScope(props: ConversationProps) {
       ? settingsReasoning()
       : option.defaultReasoningEffort;
     const previousModel = settingsModel();
+    const previousProvider = settingsProvider();
     const previousReasoning = settingsReasoning();
+    setSettingsProvider(provider);
     setSettingsModel(model);
     setSettingsReasoning(reasoningEffort);
     if (!persist) return true;
     if (reportComposerError) setComposerError(null);
     const saved = await saveBotPatch({ provider, model, reasoningEffort });
     if (saved) return true;
+    setSettingsProvider(previousProvider);
     setSettingsModel(previousModel);
     setSettingsReasoning(previousReasoning);
     if (reportComposerError) setComposerError("Could not change model. Try again.");
@@ -889,6 +895,19 @@ function createConversationViewScope(props: ConversationProps) {
 
   async function selectAndConfirmModel(model: AgentModelId, provider: AgentProviderId): Promise<void> {
     await selectModel(model, provider, true, true);
+  }
+
+  async function selectAndConfirmReasoning(effort: AgentReasoningEffort): Promise<void> {
+    const option = props.modelOptions.find(
+      (candidate) => candidate.provider === settingsProvider() && candidate.id === settingsModel(),
+    );
+    if (!option?.supportedReasoningEfforts.includes(effort)) return;
+    const previousReasoning = settingsReasoning();
+    setSettingsReasoning(effort);
+    setComposerError(null);
+    if (await saveBotPatch({ reasoningEffort: effort })) return;
+    setSettingsReasoning(previousReasoning);
+    setComposerError("Could not change effort. Try again.");
   }
 
   function updateScrollFade(element = scrollElement) {
@@ -1418,7 +1437,8 @@ function createConversationViewScope(props: ConversationProps) {
       const bot = props.bot;
       if (!bot) return null;
       return {
-        signature: [bot.id, bot.model, bot.reasoningEffort].join("\u0000"),
+        signature: [bot.id, bot.provider, bot.model, bot.reasoningEffort].join("\u0000"),
+        provider: bot.provider,
         model: bot.model,
         reasoningEffort: bot.reasoningEffort,
       };
@@ -1426,6 +1446,7 @@ function createConversationViewScope(props: ConversationProps) {
     (bot) => {
       if (!bot || bot.signature === lastRuntimeSettingsSignature) return;
       lastRuntimeSettingsSignature = bot.signature;
+      setSettingsProvider(bot.provider);
       setSettingsModel(bot.model);
       setSettingsReasoning(bot.reasoningEffort);
     },
@@ -2364,6 +2385,7 @@ function createConversationViewScope(props: ConversationProps) {
     scrollElement,
     scrollResizeObserver,
     selectAndConfirmModel,
+    selectAndConfirmReasoning,
     selectModel,
     selectionSending,
     sendSelectionInstruction,
@@ -2402,6 +2424,7 @@ function createConversationViewScope(props: ConversationProps) {
     setSidebarFilePreview,
     setSettingsModel,
     setSettingsPanelWidth,
+    setSettingsProvider,
     setSettingsReasoning,
     setShowComposerActions,
     setShowScrollToLatest,
@@ -2410,6 +2433,7 @@ function createConversationViewScope(props: ConversationProps) {
     setVoiceElapsedSeconds,
     setVoicePhase,
     settingsModel,
+    settingsProvider,
     settingsOpen,
     settingsPanelWidth,
     settingsReasoning,
@@ -2463,8 +2487,11 @@ export function ConversationHeader() {
     props,
     screenOpen,
     selectAndConfirmModel,
+    selectAndConfirmReasoning,
     setActiveRightPanel,
     settingsModel,
+    settingsProvider,
+    settingsReasoning,
     showBrowserPanel,
   } = useConversationViewScope();
   return (
@@ -2491,8 +2518,9 @@ export function ConversationHeader() {
       <div class="conversation-header-actions no-drag">
         <Show when={props.bot}>
           <ProviderModelPicker
-            provider={props.bot?.provider ?? "codex"}
+            provider={settingsProvider()}
             value={settingsModel()}
+            reasoningEffort={settingsReasoning()}
             modelOptions={props.modelOptions}
             agentStatus={props.agentStatus}
             runtimeStatuses={props.providerRuntimeStatuses}
@@ -2506,6 +2534,7 @@ export function ConversationHeader() {
                 : "Models are available after an agent CLI connects."
             }
             onChange={(model, provider) => void selectAndConfirmModel(model, provider)}
+            onReasoningEffortChange={(effort) => void selectAndConfirmReasoning(effort)}
           />
         </Show>
         <Show when={props.remoteDesktopEnabled !== false && props.server?.kind === "remote" ? props.server : undefined}>

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -55,6 +55,7 @@ import {
   nextAgentActivityPresentation,
   ThinkingDisclosure,
 } from "./conversation/AgentActivity";
+import type { AgentRuntimeSettings } from "./conversation/AgentSettingsPanel";
 import { AttachmentCards, fileBadge, formatFileSize } from "./conversation/AttachmentCards";
 import { attachmentReferenceTone } from "./conversation/AttachmentReference";
 import { ChatSearch } from "./conversation/ChatSearch";
@@ -153,13 +154,7 @@ interface RoutineSettingsRequest {
   nonce: number;
 }
 
-interface RuntimeSettingsTuple {
-  provider: AgentProviderId;
-  model: AgentModelId;
-  reasoningEffort: AgentReasoningEffort;
-}
-
-function runtimeSettingsEqual(left: RuntimeSettingsTuple, right: RuntimeSettingsTuple): boolean {
+function runtimeSettingsEqual(left: AgentRuntimeSettings, right: AgentRuntimeSettings): boolean {
   return (
     left.provider === right.provider && left.model === right.model && left.reasoningEffort === right.reasoningEffort
   );
@@ -877,8 +872,12 @@ function createConversationViewScope(props: ConversationProps) {
     }
   }
 
-  async function saveRuntimeSettings(settings: RuntimeSettingsTuple, errorMessage: string | null): Promise<boolean> {
-    const botId = props.bot?.id;
+  async function saveRuntimeSettings(
+    settings: AgentRuntimeSettings,
+    errorMessage: string | null,
+    targetBotId = props.bot?.id,
+  ): Promise<boolean> {
+    const botId = targetBotId;
     if (!botId) return false;
     const previousAttempt = resources.runtimeSettingsAttempts.get(botId);
     const generation = (previousAttempt?.generation ?? 0) + 1;
@@ -902,7 +901,7 @@ function createConversationViewScope(props: ConversationProps) {
       }
     }
     const latestAttempt = resources.runtimeSettingsAttempts.get(botId);
-    if (latestAttempt?.generation !== generation) return saved;
+    if (latestAttempt?.generation !== generation) return true;
     latestAttempt.pending = false;
     if (saved) return true;
 
@@ -918,6 +917,15 @@ function createConversationViewScope(props: ConversationProps) {
     setSettingsReasoning(activeBot.reasoningEffort);
     if (errorMessage) setComposerError(errorMessage);
     return false;
+  }
+
+  async function updateRuntimeSettings(botId: string, settings: AgentRuntimeSettings): Promise<boolean> {
+    if (props.bot?.id === botId) {
+      setSettingsProvider(settings.provider);
+      setSettingsModel(settings.model);
+      setSettingsReasoning(settings.reasoningEffort);
+    }
+    return saveRuntimeSettings(settings, null, botId);
   }
 
   async function selectModel(
@@ -2443,6 +2451,7 @@ function createConversationViewScope(props: ConversationProps) {
     rightPanels,
     routineSettingsRequest,
     saveBotPatch,
+    updateRuntimeSettings,
     saveQueuedMessageEdit,
     scheduleUnreadDividerVisibilityUpdate,
     screenOpen,
@@ -3496,6 +3505,10 @@ export function ConversationPanels() {
     sidebarFilePreview,
     settingsOpen,
     routineSettingsRequest,
+    settingsModel,
+    settingsProvider,
+    settingsReasoning,
+    updateRuntimeSettings,
   } = useConversationViewScope();
   return (
     <>
@@ -3566,6 +3579,11 @@ export function ConversationPanels() {
           <Loading>
             <AgentSettingsPanel
               bot={bot()}
+              runtimeSettings={{
+                provider: settingsProvider(),
+                model: settingsModel(),
+                reasoningEffort: settingsReasoning(),
+              }}
               agentStatus={props.agentStatus}
               providerRuntimeStatuses={props.providerRuntimeStatuses}
               onDownloadProvider={props.onDownloadProvider}
@@ -3585,6 +3603,7 @@ export function ConversationPanels() {
               onClose={() => setActiveRightPanel("none")}
               onWidthChange={setSettingsPanelWidth}
               onUpdateBot={props.onUpdateBot}
+              onUpdateRuntimeSettings={updateRuntimeSettings}
               onSetAgentAvatar={props.onSetAgentAvatar}
               routineSelectionRequest={routineSettingsRequest()?.botId === bot().id ? routineSettingsRequest() : null}
               onRoutineSelectionRequestHandled={handleRoutineSettingsRequest}

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -153,6 +153,18 @@ interface RoutineSettingsRequest {
   nonce: number;
 }
 
+interface RuntimeSettingsTuple {
+  provider: AgentProviderId;
+  model: AgentModelId;
+  reasoningEffort: AgentReasoningEffort;
+}
+
+function runtimeSettingsEqual(left: RuntimeSettingsTuple, right: RuntimeSettingsTuple): boolean {
+  return (
+    left.provider === right.provider && left.model === right.model && left.reasoningEffort === right.reasoningEffort
+  );
+}
+
 function rendererDuration(property: string, fallback: number): number {
   if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return 0;
   const value = getComputedStyle(document.documentElement).getPropertyValue(property).trim();
@@ -865,6 +877,49 @@ function createConversationViewScope(props: ConversationProps) {
     }
   }
 
+  async function saveRuntimeSettings(settings: RuntimeSettingsTuple, errorMessage: string | null): Promise<boolean> {
+    const botId = props.bot?.id;
+    if (!botId) return false;
+    const previousAttempt = resources.runtimeSettingsAttempts.get(botId);
+    const generation = (previousAttempt?.generation ?? 0) + 1;
+    resources.runtimeSettingsAttempts.set(botId, { generation, pending: true, settings });
+    if (errorMessage) setComposerError(null);
+
+    const previousSave = resources.runtimeSettingsSaveTails.get(botId);
+    let releaseSave!: () => void;
+    const saveTail = new Promise<void>((resolve) => {
+      releaseSave = resolve;
+    });
+    resources.runtimeSettingsSaveTails.set(botId, saveTail);
+    let saved: boolean;
+    try {
+      if (previousSave) await previousSave;
+      saved = await saveBotPatch(settings, botId);
+    } finally {
+      releaseSave();
+      if (resources.runtimeSettingsSaveTails.get(botId) === saveTail) {
+        resources.runtimeSettingsSaveTails.delete(botId);
+      }
+    }
+    const latestAttempt = resources.runtimeSettingsAttempts.get(botId);
+    if (latestAttempt?.generation !== generation) return saved;
+    latestAttempt.pending = false;
+    if (saved) return true;
+
+    const activeBot = props.bot;
+    const currentSettings = {
+      provider: settingsProvider(),
+      model: settingsModel(),
+      reasoningEffort: settingsReasoning(),
+    };
+    if (activeBot?.id !== botId || !runtimeSettingsEqual(currentSettings, settings)) return false;
+    setSettingsProvider(activeBot.provider);
+    setSettingsModel(activeBot.model);
+    setSettingsReasoning(activeBot.reasoningEffort);
+    if (errorMessage) setComposerError(errorMessage);
+    return false;
+  }
+
   async function selectModel(
     model: AgentModelId,
     provider: AgentProviderId,
@@ -876,21 +931,14 @@ function createConversationViewScope(props: ConversationProps) {
     const reasoningEffort = option.supportedReasoningEfforts.includes(settingsReasoning())
       ? settingsReasoning()
       : option.defaultReasoningEffort;
-    const previousModel = settingsModel();
-    const previousProvider = settingsProvider();
-    const previousReasoning = settingsReasoning();
     setSettingsProvider(provider);
     setSettingsModel(model);
     setSettingsReasoning(reasoningEffort);
     if (!persist) return true;
-    if (reportComposerError) setComposerError(null);
-    const saved = await saveBotPatch({ provider, model, reasoningEffort });
-    if (saved) return true;
-    setSettingsProvider(previousProvider);
-    setSettingsModel(previousModel);
-    setSettingsReasoning(previousReasoning);
-    if (reportComposerError) setComposerError("Could not change model. Try again.");
-    return false;
+    return saveRuntimeSettings(
+      { provider, model, reasoningEffort },
+      reportComposerError ? "Could not change model. Try again." : null,
+    );
   }
 
   async function selectAndConfirmModel(model: AgentModelId, provider: AgentProviderId): Promise<void> {
@@ -902,12 +950,13 @@ function createConversationViewScope(props: ConversationProps) {
       (candidate) => candidate.provider === settingsProvider() && candidate.id === settingsModel(),
     );
     if (!option?.supportedReasoningEfforts.includes(effort)) return;
-    const previousReasoning = settingsReasoning();
+    const settings = {
+      provider: settingsProvider(),
+      model: settingsModel(),
+      reasoningEffort: effort,
+    };
     setSettingsReasoning(effort);
-    setComposerError(null);
-    if (await saveBotPatch({ reasoningEffort: effort })) return;
-    setSettingsReasoning(previousReasoning);
-    setComposerError("Could not change effort. Try again.");
+    await saveRuntimeSettings(settings, "Could not change effort. Try again.");
   }
 
   function updateScrollFade(element = scrollElement) {
@@ -1444,7 +1493,22 @@ function createConversationViewScope(props: ConversationProps) {
       };
     },
     (bot) => {
-      if (!bot || bot.signature === lastRuntimeSettingsSignature) return;
+      if (!bot) return;
+      const pendingSettings = resources.runtimeSettingsAttempts.get(props.bot?.id ?? "");
+      if (
+        pendingSettings?.pending &&
+        !runtimeSettingsEqual(pendingSettings.settings, {
+          provider: bot.provider,
+          model: bot.model,
+          reasoningEffort: bot.reasoningEffort,
+        })
+      ) {
+        setSettingsProvider(pendingSettings.settings.provider);
+        setSettingsModel(pendingSettings.settings.model);
+        setSettingsReasoning(pendingSettings.settings.reasoningEffort);
+        return;
+      }
+      if (bot.signature === lastRuntimeSettingsSignature) return;
       lastRuntimeSettingsSignature = bot.signature;
       setSettingsProvider(bot.provider);
       setSettingsModel(bot.model);

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -160,6 +160,10 @@ function runtimeSettingsEqual(left: AgentRuntimeSettings, right: AgentRuntimeSet
   );
 }
 
+function isCompleteRuntimeSettingsPatch(updates: AgentRuntimeSettingsPatch): updates is AgentRuntimeSettings {
+  return "provider" in updates && "model" in updates;
+}
+
 function rendererDuration(property: string, fallback: number): number {
   if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return 0;
   const value = getComputedStyle(document.documentElement).getPropertyValue(property).trim();
@@ -886,17 +890,20 @@ function createConversationViewScope(props: ConversationProps) {
     if (errorMessage) setComposerError(null);
 
     const previousSave = resources.runtimeSettingsSaveTails.get(botId);
-    let releaseSave!: () => void;
-    const saveTail = new Promise<void>((resolve) => {
+    let releaseSave!: (baseValid: boolean) => void;
+    const saveTail = new Promise<boolean>((resolve) => {
       releaseSave = resolve;
     });
     resources.runtimeSettingsSaveTails.set(botId, saveTail);
     let saved: boolean;
+    let baseValid = true;
     try {
-      if (previousSave) await previousSave;
-      saved = await saveBotPatch(updates, botId);
+      if (previousSave) baseValid = await previousSave;
+      const completePatch = isCompleteRuntimeSettingsPatch(updates);
+      saved = baseValid || completePatch ? await saveBotPatch(updates, botId) : false;
+      if (completePatch) baseValid = saved;
     } finally {
-      releaseSave();
+      releaseSave(baseValid);
       if (resources.runtimeSettingsSaveTails.get(botId) === saveTail) {
         resources.runtimeSettingsSaveTails.delete(botId);
       }
@@ -904,7 +911,15 @@ function createConversationViewScope(props: ConversationProps) {
     const latestAttempt = resources.runtimeSettingsAttempts.get(botId);
     if (latestAttempt?.generation !== generation) return true;
     latestAttempt.pending = false;
-    if (saved) return true;
+    if (saved) {
+      const activeBot = props.bot;
+      if (activeBot?.id === botId) {
+        setSettingsProvider(activeBot.provider);
+        setSettingsModel(activeBot.model);
+        setSettingsReasoning(activeBot.reasoningEffort);
+      }
+      return true;
+    }
 
     const activeBot = props.bot;
     const currentSettings = {

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -55,7 +55,7 @@ import {
   nextAgentActivityPresentation,
   ThinkingDisclosure,
 } from "./conversation/AgentActivity";
-import type { AgentRuntimeSettings } from "./conversation/AgentSettingsPanel";
+import type { AgentRuntimeSettings, AgentRuntimeSettingsPatch } from "./conversation/AgentSettingsPanel";
 import { AttachmentCards, fileBadge, formatFileSize } from "./conversation/AttachmentCards";
 import { attachmentReferenceTone } from "./conversation/AttachmentReference";
 import { ChatSearch } from "./conversation/ChatSearch";
@@ -874,6 +874,7 @@ function createConversationViewScope(props: ConversationProps) {
 
   async function saveRuntimeSettings(
     settings: AgentRuntimeSettings,
+    updates: AgentRuntimeSettingsPatch,
     errorMessage: string | null,
     targetBotId = props.bot?.id,
   ): Promise<boolean> {
@@ -893,7 +894,7 @@ function createConversationViewScope(props: ConversationProps) {
     let saved: boolean;
     try {
       if (previousSave) await previousSave;
-      saved = await saveBotPatch(settings, botId);
+      saved = await saveBotPatch(updates, botId);
     } finally {
       releaseSave();
       if (resources.runtimeSettingsSaveTails.get(botId) === saveTail) {
@@ -919,13 +920,17 @@ function createConversationViewScope(props: ConversationProps) {
     return false;
   }
 
-  async function updateRuntimeSettings(botId: string, settings: AgentRuntimeSettings): Promise<boolean> {
+  async function updateRuntimeSettings(
+    botId: string,
+    settings: AgentRuntimeSettings,
+    updates: AgentRuntimeSettingsPatch,
+  ): Promise<boolean> {
     if (props.bot?.id === botId) {
       setSettingsProvider(settings.provider);
       setSettingsModel(settings.model);
       setSettingsReasoning(settings.reasoningEffort);
     }
-    return saveRuntimeSettings(settings, null, botId);
+    return saveRuntimeSettings(settings, updates, null, botId);
   }
 
   async function selectModel(
@@ -944,6 +949,7 @@ function createConversationViewScope(props: ConversationProps) {
     setSettingsReasoning(reasoningEffort);
     if (!persist) return true;
     return saveRuntimeSettings(
+      { provider, model, reasoningEffort },
       { provider, model, reasoningEffort },
       reportComposerError ? "Could not change model. Try again." : null,
     );
@@ -964,7 +970,7 @@ function createConversationViewScope(props: ConversationProps) {
       reasoningEffort: effort,
     };
     setSettingsReasoning(effort);
-    await saveRuntimeSettings(settings, "Could not change effort. Try again.");
+    await saveRuntimeSettings(settings, { reasoningEffort: effort }, "Could not change effort. Try again.");
   }
 
   function updateScrollFade(element = scrollElement) {

--- a/src/renderer/src/components/ProviderModelPicker.test.tsx
+++ b/src/renderer/src/components/ProviderModelPicker.test.tsx
@@ -1,5 +1,6 @@
 import type { AgentStatus } from "@openbot/contracts/ipc";
 import { fireEvent, render, within } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { describe, expect, it, vi } from "vitest";
 import { STORY_MODELS } from "../preview/fixtures";
 import { ProviderModelPicker } from "./ProviderModelPicker";
@@ -37,6 +38,48 @@ const agentStatus: AgentStatus = {
 };
 
 describe("ProviderModelPicker", () => {
+  it("changes model and effort without closing the combined picker", async () => {
+    const onChange = vi.fn();
+    const onReasoningEffortChange = vi.fn();
+    const [model, setModel] = createSignal("gpt-5.6-luna");
+    const [effort, setEffort] = createSignal<"medium" | "xhigh">("medium");
+    const view = render(() => (
+      <ProviderModelPicker
+        provider="codex"
+        value={model()}
+        reasoningEffort={effort()}
+        modelOptions={STORY_MODELS}
+        agentStatus={agentStatus}
+        onChange={(nextModel, provider) => {
+          setModel(nextModel);
+          onChange(nextModel, provider);
+        }}
+        onReasoningEffortChange={(nextEffort) => {
+          if (nextEffort === "medium" || nextEffort === "xhigh") setEffort(nextEffort);
+          onReasoningEffortChange(nextEffort);
+        }}
+      />
+    ));
+
+    await fireEvent.click(view.getByRole("button", { name: "Agent model: Luna" }));
+    const dialog = view.getByRole("dialog", { name: "Choose agent model" });
+    await fireEvent.click(within(dialog).getByRole("option", { name: "Sol" }));
+
+    expect(onChange).toHaveBeenCalledWith("gpt-5.6-sol", "codex");
+    expect(dialog).toBeInTheDocument();
+    const effortSelect = within(dialog).getByRole("button", { name: /Agent reasoning effort/ });
+    await fireEvent.pointerDown(effortSelect, { pointerType: "mouse", button: 0 });
+    const page = within(document.body);
+    expect(await page.findByRole("option", { name: "Medium" })).toBeInTheDocument();
+    expect(page.getByRole("option", { name: "High" })).toBeInTheDocument();
+    expect(page.queryByRole("option", { name: "Low" })).not.toBeInTheDocument();
+
+    await fireEvent.click(page.getByRole("option", { name: "Extra high" }));
+    expect(onReasoningEffortChange).toHaveBeenCalledWith("xhigh");
+    expect(effortSelect).toHaveTextContent("Extra high");
+    expect(dialog).toBeInTheDocument();
+  });
+
   it("shows the status of an unavailable provider when its rail button is selected", async () => {
     const onChange = vi.fn();
     const view = render(() => (

--- a/src/renderer/src/components/ProviderModelPicker.tsx
+++ b/src/renderer/src/components/ProviderModelPicker.tsx
@@ -4,11 +4,23 @@ import type {
   AgentModelOption,
   AgentProviderId,
   AgentProviderStatus,
+  AgentReasoningEffort,
   AgentStatus,
   ProviderRuntimeStatus,
 } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, For, onSettled, Show, untrack } from "solid-js";
-import { Button, Listbox, Popover, Progress, Tabs } from "./ui";
+import {
+  Button,
+  Listbox,
+  Popover,
+  Progress,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tabs,
+} from "./ui";
 
 interface ProviderModelPickerProps {
   provider: AgentProviderId;
@@ -18,6 +30,8 @@ interface ProviderModelPickerProps {
   variant?: "pill" | "field";
   ariaLabel?: string;
   label?: string;
+  reasoningEffort?: AgentReasoningEffort;
+  onReasoningEffortChange?: (effort: AgentReasoningEffort) => void;
   disabled?: boolean;
   disabledReason?: string;
   runtimeStatuses?: Partial<Record<AgentProviderId, ProviderRuntimeStatus>>;
@@ -54,7 +68,13 @@ export function ProviderModelPicker(props: ProviderModelPickerProps) {
   onSettled(() => {
     const closeOnOutsidePointer = (event: PointerEvent) => {
       const target = event.target;
-      if (!open() || (target instanceof Node && root?.contains(target))) return;
+      if (
+        !open() ||
+        (target instanceof Node && root?.contains(target)) ||
+        (target instanceof Element && target.closest(".provider-model-effort-content"))
+      ) {
+        return;
+      }
       setOpen(false);
     };
     window.addEventListener("pointerdown", closeOnOutsidePointer);
@@ -76,7 +96,7 @@ export function ProviderModelPicker(props: ProviderModelPickerProps) {
 
   function selectModel(model: AgentModelId, provider: AgentProviderId): void {
     if (providerAvailability(props.agentStatus, props.modelOptions, provider).state !== "available") return;
-    setOpen(false);
+    if (!showsReasoningEffort()) setOpen(false);
     props.onChange(model, provider);
   }
 
@@ -86,6 +106,7 @@ export function ProviderModelPicker(props: ProviderModelPickerProps) {
 
   const triggerModelName = () => displayModelName(selectedModel()?.name, props.value);
   const field = () => props.variant === "field";
+  const showsReasoningEffort = () => props.reasoningEffort !== undefined && props.onReasoningEffortChange !== undefined;
 
   return (
     <div
@@ -293,6 +314,36 @@ export function ProviderModelPicker(props: ProviderModelPickerProps) {
                         }}
                       />
                     </Show>
+                    <Show when={showsReasoningEffort() && provider === props.provider ? selectedModel() : undefined}>
+                      {(model) => (
+                        <div class="provider-model-effort">
+                          <span>Effort</span>
+                          <Select<AgentReasoningEffort>
+                            class="provider-model-effort-select"
+                            options={model().supportedReasoningEfforts}
+                            value={props.reasoningEffort}
+                            onChange={(effort) => {
+                              if (effort && effort !== props.reasoningEffort) {
+                                props.onReasoningEffortChange?.(effort);
+                              }
+                            }}
+                            itemComponent={(item) => (
+                              <SelectItem item={item.item}>{reasoningLabel(item.item.rawValue)}</SelectItem>
+                            )}
+                          >
+                            <SelectTrigger size="sm" aria-label="Agent reasoning effort">
+                              <SelectValue<AgentReasoningEffort>>
+                                {(state) => {
+                                  const effort = state.selectedOption();
+                                  return effort ? reasoningLabel(effort) : "Select effort";
+                                }}
+                              </SelectValue>
+                            </SelectTrigger>
+                            <SelectContent class="provider-model-effort-content" />
+                          </Select>
+                        </div>
+                      )}
+                    </Show>
                   </Tabs.Content>
                 );
               }}
@@ -359,6 +410,11 @@ function providerCliName(provider: AgentProviderId): "Claude Code" | "Codex CLI"
 
 function displayModelName(name: string | undefined, fallback: string): string {
   return name?.replace(/^[\s:–—-]+/, "") || fallback;
+}
+
+function reasoningLabel(effort: AgentReasoningEffort): string {
+  if (effort === "xhigh") return "Extra high";
+  return `${effort.slice(0, 1).toUpperCase()}${effort.slice(1)}`;
 }
 
 function ProviderMark(props: { provider: AgentProviderId; large?: boolean }) {

--- a/src/renderer/src/components/conversation/AgentSettingsPanel.test.tsx
+++ b/src/renderer/src/components/conversation/AgentSettingsPanel.test.tsx
@@ -44,6 +44,7 @@ describe("AgentSettingsPanel", () => {
     render(() => (
       <AgentSettingsPanel
         bot={bot}
+        runtimeSettings={{ provider: bot.provider, model: bot.model, reasoningEffort: bot.reasoningEffort }}
         agentStatus={STORY_AGENT_STATUS}
         modelOptions={STORY_MODELS}
         working={false}
@@ -51,6 +52,7 @@ describe("AgentSettingsPanel", () => {
         onClose={vi.fn()}
         onWidthChange={vi.fn()}
         onUpdateBot={vi.fn(async () => undefined)}
+        onUpdateRuntimeSettings={vi.fn(async () => true)}
         onSetAgentAvatar={vi.fn(async () => undefined)}
         routineSelectionRequest={{ routineId: routine.id, routineName: routine.name, nonce: 1 }}
         onRoutineSelectionRequestHandled={onRoutineSelectionRequestHandled}

--- a/src/renderer/src/components/conversation/AgentSettingsPanel.tsx
+++ b/src/renderer/src/components/conversation/AgentSettingsPanel.tsx
@@ -45,6 +45,8 @@ export interface AgentRuntimeSettings {
   reasoningEffort: AgentReasoningEffort;
 }
 
+export type AgentRuntimeSettingsPatch = AgentRuntimeSettings | Pick<AgentRuntimeSettings, "reasoningEffort">;
+
 interface AgentSettingsPanelProps {
   bot: BotProfile;
   runtimeSettings: AgentRuntimeSettings;
@@ -59,7 +61,11 @@ interface AgentSettingsPanelProps {
   onClose: () => void;
   onWidthChange: (width: number) => void;
   onUpdateBot: (botId: string, updates: Omit<UpdateBotInput, "botId">) => Promise<void>;
-  onUpdateRuntimeSettings: (botId: string, settings: AgentRuntimeSettings) => Promise<boolean>;
+  onUpdateRuntimeSettings: (
+    botId: string,
+    settings: AgentRuntimeSettings,
+    updates: AgentRuntimeSettingsPatch,
+  ) => Promise<boolean>;
   onSetAgentAvatar: (botId: string, image: AvatarImageInput | null) => Promise<void>;
   routineSelectionRequest?: RoutineSelectionRequest | null;
   onRoutineSelectionRequestHandled?: (nonce: number) => void;
@@ -191,10 +197,14 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
     }
   }
 
-  async function saveRuntimeSettings(settings: AgentRuntimeSettings, botId = props.bot.id): Promise<boolean> {
+  async function saveRuntimeSettings(
+    settings: AgentRuntimeSettings,
+    updates: AgentRuntimeSettingsPatch,
+    botId = props.bot.id,
+  ): Promise<boolean> {
     setSaveError(null);
     try {
-      const saved = await props.onUpdateRuntimeSettings(botId, settings);
+      const saved = await props.onUpdateRuntimeSettings(botId, settings, updates);
       if (!saved && props.bot.id === botId) setSaveError("Could not save agent settings.");
       return saved;
     } catch (error) {
@@ -289,7 +299,7 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
     setProvider(nextProvider);
     setModel(nextModel);
     setReasoning(nextReasoning);
-    if (await saveRuntimeSettings(settings, botId)) return;
+    if (await saveRuntimeSettings(settings, settings, botId)) return;
     if (
       props.bot.id !== botId ||
       provider() !== settings.provider ||
@@ -308,7 +318,7 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
     const previousReasoning = reasoning();
     const settings = { provider: provider(), model: model(), reasoningEffort: nextReasoning };
     setReasoning(nextReasoning);
-    if (await saveRuntimeSettings(settings, botId)) return;
+    if (await saveRuntimeSettings(settings, { reasoningEffort: nextReasoning }, botId)) return;
     if (
       props.bot.id === botId &&
       provider() === settings.provider &&

--- a/src/renderer/src/components/conversation/AgentSettingsPanel.tsx
+++ b/src/renderer/src/components/conversation/AgentSettingsPanel.tsx
@@ -39,8 +39,15 @@ const SETTINGS_PANEL_DEFAULT = 296;
 const SETTINGS_PANEL_MIN = 180;
 const SETTINGS_PANEL_MAX = 1600;
 
+export interface AgentRuntimeSettings {
+  provider: AgentProviderId;
+  model: AgentModelId;
+  reasoningEffort: AgentReasoningEffort;
+}
+
 interface AgentSettingsPanelProps {
   bot: BotProfile;
+  runtimeSettings: AgentRuntimeSettings;
   agentStatus: AgentStatus;
   modelOptions: AgentModelOption[];
   working: boolean;
@@ -52,6 +59,7 @@ interface AgentSettingsPanelProps {
   onClose: () => void;
   onWidthChange: (width: number) => void;
   onUpdateBot: (botId: string, updates: Omit<UpdateBotInput, "botId">) => Promise<void>;
+  onUpdateRuntimeSettings: (botId: string, settings: AgentRuntimeSettings) => Promise<boolean>;
   onSetAgentAvatar: (botId: string, image: AvatarImageInput | null) => Promise<void>;
   routineSelectionRequest?: RoutineSelectionRequest | null;
   onRoutineSelectionRequestHandled?: (nonce: number) => void;
@@ -103,23 +111,25 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
   createEffect(
     () => {
       const bot = props.bot;
+      const runtimeSettings = props.runtimeSettings;
       return {
         bot,
+        runtimeSettings,
         signature: [
           bot.id,
           bot.name,
           bot.title,
           bot.description,
           String(bot.notifications),
-          bot.provider,
-          bot.model,
-          bot.reasoningEffort,
+          runtimeSettings.provider,
+          runtimeSettings.model,
+          runtimeSettings.reasoningEffort,
           bot.avatarSeed,
           String(bot.avatarHue),
         ].join("\u0000"),
       };
     },
-    ({ bot, signature }) => {
+    ({ bot, runtimeSettings, signature }) => {
       if (signature === lastSignature) return;
       const botChanged = bot.id !== lastBotId;
       const currentDirty = botChanged ? { name: false, title: false, description: false } : dirty();
@@ -130,9 +140,9 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
       if (!currentDirty.title) setTitle(bot.title);
       if (!currentDirty.description) setDescription(bot.description);
       setNotifications(bot.notifications);
-      setProvider(bot.provider);
-      setModel(bot.model);
-      setReasoning(bot.reasoningEffort);
+      setProvider(runtimeSettings.provider);
+      setModel(runtimeSettings.model);
+      setReasoning(runtimeSettings.reasoningEffort);
       setAvatarSeed(bot.avatarSeed);
       setAvatarHue(bot.avatarHue);
       if (botChanged) {
@@ -177,6 +187,20 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
       return true;
     } catch (error) {
       setSaveError(error instanceof Error ? error.message : "Could not save agent settings.");
+      return false;
+    }
+  }
+
+  async function saveRuntimeSettings(settings: AgentRuntimeSettings, botId = props.bot.id): Promise<boolean> {
+    setSaveError(null);
+    try {
+      const saved = await props.onUpdateRuntimeSettings(botId, settings);
+      if (!saved && props.bot.id === botId) setSaveError("Could not save agent settings.");
+      return saved;
+    } catch (error) {
+      if (props.bot.id === botId) {
+        setSaveError(error instanceof Error ? error.message : "Could not save agent settings.");
+      }
       return false;
     }
   }
@@ -260,13 +284,39 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
     const previousModel = model();
     const previousProvider = provider();
     const previousReasoning = reasoning();
+    const botId = props.bot.id;
+    const settings = { provider: nextProvider, model: nextModel, reasoningEffort: nextReasoning };
     setProvider(nextProvider);
     setModel(nextModel);
     setReasoning(nextReasoning);
-    if (await saveBotPatch({ provider: nextProvider, model: nextModel, reasoningEffort: nextReasoning })) return;
+    if (await saveRuntimeSettings(settings, botId)) return;
+    if (
+      props.bot.id !== botId ||
+      provider() !== settings.provider ||
+      model() !== settings.model ||
+      reasoning() !== settings.reasoningEffort
+    ) {
+      return;
+    }
     setProvider(previousProvider);
     setModel(previousModel);
     setReasoning(previousReasoning);
+  }
+
+  async function selectReasoning(nextReasoning: AgentReasoningEffort): Promise<void> {
+    const botId = props.bot.id;
+    const previousReasoning = reasoning();
+    const settings = { provider: provider(), model: model(), reasoningEffort: nextReasoning };
+    setReasoning(nextReasoning);
+    if (await saveRuntimeSettings(settings, botId)) return;
+    if (
+      props.bot.id === botId &&
+      provider() === settings.provider &&
+      model() === settings.model &&
+      reasoning() === nextReasoning
+    ) {
+      setReasoning(previousReasoning);
+    }
   }
 
   return (
@@ -554,9 +604,8 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                   options={reasoningOptions()}
                   value={reasoning()}
                   onChange={(nextReasoning) => {
-                    if (!nextReasoning) return;
-                    setReasoning(nextReasoning);
-                    void saveBotPatch({ reasoningEffort: nextReasoning });
+                    if (!nextReasoning || nextReasoning === reasoning()) return;
+                    void selectReasoning(nextReasoning);
                   }}
                   itemComponent={(item) => (
                     <SelectItem item={item.item}>{reasoningLabel(item.item.rawValue)}</SelectItem>

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -2891,6 +2891,27 @@
   gap: 3px;
 }
 
+.provider-model-effort {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 9px 4px 0;
+  border-top: 1px solid var(--openbot-border);
+  padding-top: 10px;
+  color: var(--openbot-text-secondary);
+  font-size: var(--openbot-text-sm);
+  line-height: 17px;
+}
+
+.provider-model-effort-select {
+  width: 128px;
+}
+
+.provider-model-effort-select .ui-select-trigger {
+  background: var(--openbot-bg-sidebar);
+}
+
 .provider-model-option {
   display: flex;
   width: 100%;

--- a/src/renderer/stories/AgentMemories.stories.tsx
+++ b/src/renderer/stories/AgentMemories.stories.tsx
@@ -60,6 +60,11 @@ function AgentMemoriesStory(props: { memories: BotMemory[] }) {
     <main class="agent-memories-story-stage">
       <AgentSettingsPanel
         bot={STORY_BOTS[0]}
+        runtimeSettings={{
+          provider: STORY_BOTS[0].provider,
+          model: STORY_BOTS[0].model,
+          reasoningEffort: STORY_BOTS[0].reasoningEffort,
+        }}
         agentStatus={STORY_AGENT_STATUS}
         modelOptions={STORY_MODELS}
         working={false}
@@ -68,6 +73,10 @@ function AgentMemoriesStory(props: { memories: BotMemory[] }) {
         onWidthChange={fn()}
         onUpdateBot={async (botId, updates) => {
           await mock.api.agent.updateBot({ botId, ...updates });
+        }}
+        onUpdateRuntimeSettings={async (botId, settings) => {
+          await mock.api.agent.updateBot({ botId, ...settings });
+          return true;
         }}
         onSetAgentAvatar={async (botId, image) => {
           await mock.api.agent.setAvatar({ botId, image });

--- a/src/renderer/stories/AgentMemories.stories.tsx
+++ b/src/renderer/stories/AgentMemories.stories.tsx
@@ -74,8 +74,8 @@ function AgentMemoriesStory(props: { memories: BotMemory[] }) {
         onUpdateBot={async (botId, updates) => {
           await mock.api.agent.updateBot({ botId, ...updates });
         }}
-        onUpdateRuntimeSettings={async (botId, settings) => {
-          await mock.api.agent.updateBot({ botId, ...settings });
+        onUpdateRuntimeSettings={async (botId, _settings, updates) => {
+          await mock.api.agent.updateBot({ botId, ...updates });
           return true;
         }}
         onSetAgentAvatar={async (botId, image) => {

--- a/src/renderer/stories/AgentRoutines.stories.tsx
+++ b/src/renderer/stories/AgentRoutines.stories.tsx
@@ -92,6 +92,11 @@ function FullSettingsPanelStory() {
     <main class="agent-memories-story-stage">
       <AgentSettingsPanel
         bot={STORY_BOTS[0]}
+        runtimeSettings={{
+          provider: STORY_BOTS[0].provider,
+          model: STORY_BOTS[0].model,
+          reasoningEffort: STORY_BOTS[0].reasoningEffort,
+        }}
         agentStatus={STORY_AGENT_STATUS}
         modelOptions={STORY_MODELS}
         working={false}
@@ -100,6 +105,10 @@ function FullSettingsPanelStory() {
         onWidthChange={fn()}
         onUpdateBot={async (botId, updates) => {
           await mock.api.agent.updateBot({ botId, ...updates });
+        }}
+        onUpdateRuntimeSettings={async (botId, settings) => {
+          await mock.api.agent.updateBot({ botId, ...settings });
+          return true;
         }}
         onSetAgentAvatar={async (botId, image) => {
           await mock.api.agent.setAvatar({ botId, image });

--- a/src/renderer/stories/AgentRoutines.stories.tsx
+++ b/src/renderer/stories/AgentRoutines.stories.tsx
@@ -106,8 +106,8 @@ function FullSettingsPanelStory() {
         onUpdateBot={async (botId, updates) => {
           await mock.api.agent.updateBot({ botId, ...updates });
         }}
-        onUpdateRuntimeSettings={async (botId, settings) => {
-          await mock.api.agent.updateBot({ botId, ...settings });
+        onUpdateRuntimeSettings={async (botId, _settings, updates) => {
+          await mock.api.agent.updateBot({ botId, ...updates });
           return true;
         }}
         onSetAgentAvatar={async (botId, image) => {

--- a/src/renderer/stories/ProviderModelPicker.stories.tsx
+++ b/src/renderer/stories/ProviderModelPicker.stories.tsx
@@ -21,7 +21,9 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Pill: Story = {};
+export const Pill: Story = {
+  args: { reasoningEffort: "medium", onReasoningEffortChange: fn() },
+};
 
 export const Field: Story = {
   args: { variant: "field", label: "Model" },
@@ -32,6 +34,7 @@ export const Disabled: Story = {
 };
 
 export const Opens: Story = {
+  args: { reasoningEffort: "medium", onReasoningEffortChange: fn() },
   play: async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole("button", { name: /Agent model: Luna/ }));
     await canvas.findByRole("dialog", { name: "Choose agent model" });


### PR DESCRIPTION
## Summary
- add a model-specific effort selector to the conversation header model popup
- keep model and effort changes in the popup while persisting them immediately
- optimistically update provider/model/effort state and roll back failed saves
- preserve the existing Agent Settings reasoning control

## Verification
- bun run test -- src/renderer/src/components/ProviderModelPicker.test.tsx src/renderer/src/App.test.tsx
- bun run typecheck
- bun run lint