### PR TITLE
Fix OpenPanel analytics attribution

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -18,11 +18,11 @@ Every event has these low-cardinality properties:
 
 - `surface`: `desktop`, `desktop_host`, or `landing`;
 - `environment`: currently `production` only;
-- `event_schema_version`: the integer schema generation, currently `2`;
+- `event_schema_version`: the integer schema generation, currently `3`;
 - `app_version` and `platform` on desktop surfaces;
 - `acquisition_source` on landing surfaces: `direct`, `search`, `social`, `github`, or `other`.
 
-Reports must filter to `event_schema_version = 2`. Historical events remain available but must not
+Reports must filter to `event_schema_version = 3`. Historical events remain available but must not
 be mixed into current conversion or reliability metrics.
 
 ## Identity
@@ -31,8 +31,10 @@ be mixed into current conversion or reliability metrics.
 - A local host emits one lifecycle event under its owner's account.
 - Clients observing a remote host do not re-emit host lifecycle.
 - Landing, invitation, and pre-authentication events are anonymous.
-- OpenPanel receives the central account ID as `profileId`. Email is not sent as an analytics profile
-  property.
+- OpenPanel receives the central account ID as `profileId` and the normalized account email as the
+  profile email. Email is not copied into individual event properties.
+- Existing profiles receive their email the next time the production app identifies them. There is
+  no historical backfill.
 - Local IDs for agents, servers, members, messages, threads, turns, files, or deliveries are never
   analytics properties.
 
@@ -73,6 +75,7 @@ lifecycle. A malformed preference fails closed; a missing preference uses the do
 | `voice_transcription` | Is local voice input reliable and fast? | Transcription returned text without sending it to analytics |
 | `reaction_action` | Are reactions used? | Reaction operation completed |
 | `maintenance_action` | Can accounts export data and diagnostics? | Export reported a saved artifact |
+| `screen_view` | Which public website routes are viewed in a session? | One safe view for `/` or `/join`, without a query or hash |
 | `landing_viewed` | How much qualified landing traffic arrives? | Non-automation production page view |
 | `landing_download_clicked` | Which safe channel/placement drives downloads? | Allowlisted download link clicked |
 | `landing_link_clicked` | Which public resources are useful? | Allowlisted public link clicked |
@@ -84,9 +87,10 @@ Payloads are validated at runtime as well as by TypeScript. String enums are all
 version values use bounded safe formats, arrays are filtered and capped, and numeric values reject
 non-finite, negative, or implausibly large inputs. Failure codes are static and allowlisted.
 
-Never send message content, prompts, answers, generated content, search terms, URLs, referrers, file
-names, paths, commands, tokens, invitation values, raw errors, or local identifiers. Session replay
-and automatic interaction capture remain disabled.
+Never send message content, prompts, answers, generated content, search terms, arbitrary URLs,
+referrers, file names, local paths, commands, tokens, invitation values, raw errors, or local
+identifiers. Website screen views use only the fixed paths `/` and `/join`. Session replay and
+automatic interaction capture remain disabled.
 
 ## Required dashboards
 
@@ -95,15 +99,20 @@ and automatic interaction capture remain disabled.
 2. Activation: app opened, onboarding completed, provider available, agent created, message sent,
    and first successful user-originated turn.
 3. Retention: W1 and W4 return to another successful user-originated turn.
-4. Growth: landing view to download and invitation view to open/download, segmented only by coarse
-   acquisition source, placement, and platform.
+4. Growth: landing view to download and invitation view to open/download, plus engaged sessions that
+   contain a download click, an allowlisted public-link click, or an invitation open/download action;
+   segment only by coarse acquisition source, placement, and platform.
 5. Reliability: failed outcomes, safe failure codes, P90/P99 durations, and update/provider health.
 
-Every dashboard must filter by the intended `surface` and `event_schema_version = 2`.
+Every dashboard must filter by the intended `surface` and `event_schema_version = 3`. Website bounce
+uses OpenPanel's standard single-`screen_view` definition. Do not emit synthetic screen views to
+change it; use the engaged-session report for meaningful landing activity.
 
 ## Quality checks
 
 - Anonymous SDK requests must not contain `profileId` after any account was identified.
+- Every identified profile request contains the central account ID and normalized email.
+- Website `screen_view` events contain only `/` or `/join` and never an invitation query or hash.
 - A duplicate host turn start produces one `system_turn_started` event.
 - A known stored turn origin wins over a completion payload whose origin is `unknown`.
 - `system_turn_completed` never exceeds starts for the same reporting window without a documented

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -10,30 +10,34 @@ analytics. Development builds, previews, tests, and Storybook do not send analyt
 
 ## Product analytics
 
-The production website records page visits, download clicks, clicks on allowlisted public links, and
-anonymous views, download clicks, invitation validity, and open-app actions on invitation pages. The production desktop app records
-application, sign-in, onboarding, agent, message, turn, prompt, approval, queue, routine, team,
-browser, search, Remote Desktop, update, marketplace, memory, provider, voice transcription,
-reaction, maintenance, and confirmed application-version-change actions. Event properties are limited to metadata such as counts, result
+The production website records anonymous page views using only the fixed paths `/` and `/join`. It
+also records download clicks, clicks on allowlisted public links, invitation validity, and open-app
+actions on invitation pages. The production desktop app records application, sign-in, onboarding,
+agent, message, turn, prompt, approval, queue, routine, team, browser, search, Remote Desktop, update,
+marketplace, memory, provider, voice transcription, reaction, maintenance, and confirmed
+application-version-change actions. Event properties are limited to metadata such as counts, result
 states, timing, provider, model, reasoning effort, application version, operating system, and coarse
 failure codes.
 
 Analytics events do not contain message or direct-message text, prompts, replies, generated content,
-search queries, browser URLs or page titles, file names, local paths, commands, raw error messages, or
-local identifiers for agents, threads, turns, messages, servers, and team members. Session replay and
+search queries, embedded-browser URLs or page titles, file names, local paths, commands, raw error
+messages, or local identifiers for agents, threads, turns, messages, servers, and team members.
+Website page views do not contain query parameters, hashes, or invitation values. Session replay and
 automatic interaction capture are disabled.
 
-When a user signs in, OpenPanel receives the OpenBot account ID so UI actions can be
-associated with the account that started them. Agent lifecycle events are emitted once by the local
-host and associated with the host owner's account; clients that observe a remote host do not emit the
-lifecycle again. Sign-in attempts and website activity remain anonymous until an account has been
-verified. Landing-page attribution is reduced to an allowlisted source category and never includes a
-raw referrer or campaign URL. OpenPanel can also derive session, device, browser, operating-system, network, and
-approximate geographic metadata from a request. The analytics service runs on OpenBot's self-hosted
-infrastructure and receives events through `analytics.openbot.run`. Analytics is enabled in
-production by default. Desktop users can disable it under **Settings → General → Privacy → Share
-product analytics**. The preference is stored locally and disables both UI analytics and lifecycle
-analytics emitted by the local host. Website analytics does not use the desktop preference.
+When a user signs in, OpenPanel receives the OpenBot account ID and normalized account email so UI
+actions can be associated with the account that started them. The email is stored on the OpenPanel
+profile and is not copied into individual event properties. Agent lifecycle events are emitted once
+by the local host and associated with the host owner's account; clients that observe a remote host do
+not emit the lifecycle again. Sign-in attempts and website activity remain anonymous until an account
+has been verified. Landing-page attribution is reduced to an allowlisted source category and never
+includes a raw referrer or campaign URL. OpenPanel can also derive session, device, browser,
+operating-system, network, and approximate geographic metadata from a request. The analytics service
+runs on OpenBot's self-hosted infrastructure and receives events through `analytics.openbot.run`.
+Analytics is enabled in production by default. Desktop users can disable it under **Settings →
+General → Privacy → Share product analytics**. The preference is stored locally and disables both UI
+analytics and lifecycle analytics emitted by the local host. Website analytics does not use the
+desktop preference.
 
 OpenPanel event and profile data has no automatic retention limit. It remains stored until it is
 removed manually or the analytics project is deleted. OpenPanel analytics does not change where

--- a/apps/auth-api/src/lib/analytics.ts
+++ b/apps/auth-api/src/lib/analytics.ts
@@ -1,5 +1,5 @@
 import { isBoolean, isOneOf } from "@openbot/contracts/runtime-values";
-import { OpenPanel, type OpenPanelOptions } from "@openpanel/web";
+import { OpenPanel, OpenPanelBase, type OpenPanelOptions } from "@openpanel/web";
 import { OPENBOT_DOWNLOAD_LINKS, OPENBOT_LINKS } from "./landing-links";
 
 export const OPENPANEL_API_URL = "https://analytics.openbot.run/api";
@@ -34,9 +34,22 @@ type LandingDestination =
   | "codex"
   | "claude";
 
-type OpenPanelClient = Pick<OpenPanel, "screenView" | "setGlobalProperties" | "track">;
+type LandingScreenPath = "/" | "/join";
+
+type OpenPanelClient = Pick<OpenPanel, "setGlobalProperties" | "track"> & {
+  trackScreenView: (path: LandingScreenPath) => ReturnType<OpenPanelBase["track"]>;
+};
 
 type ClientFactory = (options: OpenPanelOptions) => OpenPanelClient;
+
+function createOpenPanelClient(options: OpenPanelOptions): OpenPanelClient {
+  const client = new OpenPanel(options);
+  return {
+    setGlobalProperties: (properties) => client.setGlobalProperties(properties),
+    track: (name, properties) => client.track(name, properties),
+    trackScreenView: (path) => OpenPanelBase.prototype.track.call(client, "screen_view", { __path: path }),
+  };
+}
 
 const LINK_DESTINATIONS = new Map<string, LandingDestination>([
   [OPENBOT_LINKS.download, "download_section"],
@@ -68,13 +81,10 @@ export class LandingAnalytics {
   readonly #createClient: ClientFactory;
   readonly #productionBuild: boolean;
   #client: OpenPanelClient | null = null;
-  #lastScreenPath: "/" | "/join" | null = null;
-  readonly #clickCleanup = new WeakMap<Document, () => void>();
+  #lastScreenPath: LandingScreenPath | null = null;
+  readonly #clickCleanup = new WeakMap<Document, (replacement: boolean) => void>();
 
-  constructor(
-    createClient: ClientFactory = (options) => new OpenPanel(options),
-    productionBuild = import.meta.env.PROD,
-  ) {
+  constructor(createClient: ClientFactory = createOpenPanelClient, productionBuild = import.meta.env.PROD) {
     this.#createClient = createClient;
     this.#productionBuild = productionBuild;
   }
@@ -86,7 +96,7 @@ export class LandingAnalytics {
     this.#screenView("/");
     this.#track("landing_viewed", {});
     const handleClick = (event: MouseEvent) => this.#handleClick(event);
-    return this.#replaceClickListener(document, handleClick);
+    return this.#replaceClickListener(document, handleClick, "/");
   }
 
   startJoin(
@@ -114,18 +124,26 @@ export class LandingAnalytics {
         });
       }
     };
-    return this.#replaceClickListener(document, handleClick);
+    return this.#replaceClickListener(document, handleClick, "/join");
   }
 
-  #replaceClickListener(document: Document, listener: (event: MouseEvent) => void): () => void {
-    this.#clickCleanup.get(document)?.();
+  #replaceClickListener(
+    document: Document,
+    listener: (event: MouseEvent) => void,
+    screenPath: LandingScreenPath,
+  ): () => void {
+    this.#clickCleanup.get(document)?.(true);
     document.addEventListener("click", listener);
-    const cleanup = () => {
+    let cleaned = false;
+    const cleanup = (replacement: boolean) => {
+      if (cleaned) return;
+      cleaned = true;
       document.removeEventListener("click", listener);
       if (this.#clickCleanup.get(document) === cleanup) this.#clickCleanup.delete(document);
+      if (!replacement && this.#lastScreenPath === screenPath) this.#lastScreenPath = null;
     };
     this.#clickCleanup.set(document, cleanup);
-    return cleanup;
+    return () => cleanup(false);
   }
 
   #ensureClient(hostname: string): boolean {
@@ -171,10 +189,11 @@ export class LandingAnalytics {
     if (destination) this.#track("landing_link_clicked", { destination, placement });
   }
 
-  #screenView(path: "/" | "/join"): void {
+  #screenView(path: LandingScreenPath): void {
     if (this.#lastScreenPath === path) return;
     try {
-      this.#client?.screenView(path);
+      const result = this.#client?.trackScreenView(path);
+      if (result instanceof Promise) void result.catch(() => undefined);
       this.#lastScreenPath = path;
     } catch {
       // Analytics must never change landing-page behavior.

--- a/apps/auth-api/src/lib/analytics.ts
+++ b/apps/auth-api/src/lib/analytics.ts
@@ -4,7 +4,7 @@ import { OPENBOT_DOWNLOAD_LINKS, OPENBOT_LINKS } from "./landing-links";
 
 export const OPENPANEL_API_URL = "https://analytics.openbot.run/api";
 const OPENPANEL_CLIENT_ID = "6c989975-87ef-4f0c-857e-ab449a65b5c2";
-const ANALYTICS_SCHEMA_VERSION = 2;
+const ANALYTICS_SCHEMA_VERSION = 3;
 
 export type LandingAcquisitionSource = "direct" | "search" | "social" | "github" | "other";
 
@@ -34,7 +34,7 @@ type LandingDestination =
   | "codex"
   | "claude";
 
-type OpenPanelClient = Pick<OpenPanel, "setGlobalProperties" | "track">;
+type OpenPanelClient = Pick<OpenPanel, "screenView" | "setGlobalProperties" | "track">;
 
 type ClientFactory = (options: OpenPanelOptions) => OpenPanelClient;
 
@@ -68,6 +68,7 @@ export class LandingAnalytics {
   readonly #createClient: ClientFactory;
   readonly #productionBuild: boolean;
   #client: OpenPanelClient | null = null;
+  #lastScreenPath: "/" | "/join" | null = null;
   readonly #clickCleanup = new WeakMap<Document, () => void>();
 
   constructor(
@@ -82,6 +83,7 @@ export class LandingAnalytics {
     if (isLikelyAutomation(document.defaultView?.navigator)) return () => undefined;
     if (!this.#ensureClient(hostname)) return () => undefined;
     this.#client?.setGlobalProperties({ acquisition_source: landingAcquisitionSource(document) });
+    this.#screenView("/");
     this.#track("landing_viewed", {});
     const handleClick = (event: MouseEvent) => this.#handleClick(event);
     return this.#replaceClickListener(document, handleClick);
@@ -95,6 +97,7 @@ export class LandingAnalytics {
     if (isLikelyAutomation(document.defaultView?.navigator)) return () => undefined;
     if (!this.#ensureClient(hostname)) return () => undefined;
     this.#client?.setGlobalProperties({ acquisition_source: landingAcquisitionSource(document) });
+    this.#screenView("/join");
     this.#track("join_page_action", { action: "view", valid_invite: options.validInvite });
     const handleClick = (event: MouseEvent) => {
       const target = event.target;
@@ -166,6 +169,16 @@ export class LandingAnalytics {
     }
     const destination = LINK_DESTINATIONS.get(href);
     if (destination) this.#track("landing_link_clicked", { destination, placement });
+  }
+
+  #screenView(path: "/" | "/join"): void {
+    if (this.#lastScreenPath === path) return;
+    try {
+      this.#client?.screenView(path);
+      this.#lastScreenPath = path;
+    } catch {
+      // Analytics must never change landing-page behavior.
+    }
   }
 
   #track<Name extends LandingEventName>(name: Name, properties: LandingAnalyticsEvents[Name]): void {

--- a/apps/auth-api/test/analytics.test.ts
+++ b/apps/auth-api/test/analytics.test.ts
@@ -22,9 +22,9 @@ describe("landing analytics", () => {
       <a id="private" href="https://private.example/secret">Private</a>
     `;
     const client = {
-      screenView: vi.fn(),
       setGlobalProperties: vi.fn(),
       track: vi.fn(),
+      trackScreenView: vi.fn(),
     };
     const createClient = vi.fn((_options: unknown) => client);
     const analytics = new LandingAnalytics(createClient, true);
@@ -50,8 +50,8 @@ describe("landing analytics", () => {
       environment: "production",
       event_schema_version: 3,
     });
-    expect(client.screenView).toHaveBeenCalledOnce();
-    expect(client.screenView).toHaveBeenCalledWith("/");
+    expect(client.trackScreenView).toHaveBeenCalledOnce();
+    expect(client.trackScreenView).toHaveBeenCalledWith("/");
     expect(client.track).toHaveBeenNthCalledWith(1, "landing_viewed", {});
     expect(client.track).toHaveBeenNthCalledWith(2, "landing_link_clicked", {
       destination: "contact",
@@ -76,7 +76,7 @@ describe("landing analytics", () => {
       <a id="open" href="openbot://join?invite=private">Open app</a>
       <a id="download" href="/download/macos">Download</a>
     `;
-    const client = { screenView: vi.fn(), setGlobalProperties: vi.fn(), track: vi.fn() };
+    const client = { setGlobalProperties: vi.fn(), track: vi.fn(), trackScreenView: vi.fn() };
     const analytics = new LandingAnalytics(() => client, true);
     const cleanup = analytics.startJoin(document, "openbot.run", { validInvite: true, platform: "macos" });
 
@@ -92,15 +92,15 @@ describe("landing analytics", () => {
       platform: "macos",
     });
     expect(client.track).toHaveBeenCalledTimes(3);
-    expect(client.screenView).toHaveBeenCalledOnce();
-    expect(client.screenView).toHaveBeenCalledWith("/join");
+    expect(client.trackScreenView).toHaveBeenCalledOnce();
+    expect(client.trackScreenView).toHaveBeenCalledWith("/join");
     expect(JSON.stringify(client.track.mock.calls)).not.toContain("profileId");
     expect(JSON.stringify(client.track.mock.calls)).not.toContain("private");
   });
 
   it("replaces an existing document listener instead of double tracking clicks", () => {
     document.body.innerHTML = '<a id="open" href="openbot://join">Open app</a>';
-    const client = { screenView: vi.fn(), setGlobalProperties: vi.fn(), track: vi.fn() };
+    const client = { setGlobalProperties: vi.fn(), track: vi.fn(), trackScreenView: vi.fn() };
     const analytics = new LandingAnalytics(() => client, true);
     analytics.startJoin(document, "openbot.run", { validInvite: false, platform: "windows" });
     const cleanup = analytics.startJoin(document, "openbot.run", { validInvite: true, platform: "windows" });
@@ -113,10 +113,15 @@ describe("landing analytics", () => {
       ["join_page_action", { action: "view", valid_invite: true }],
       ["join_page_action", { action: "open_app" }],
     ]);
-    expect(client.screenView).toHaveBeenCalledOnce();
+    expect(client.trackScreenView).toHaveBeenCalledOnce();
+
+    cleanup();
+    analytics.startJoin(document, "openbot.run", { validInvite: true, platform: "windows" });
+    expect(client.trackScreenView).toHaveBeenCalledTimes(2);
+    expect(client.trackScreenView).toHaveBeenLastCalledWith("/join");
   });
 
-  it("sends one anonymous screen view with a safe invitation path through the real SDK", async () => {
+  it("sends a safe anonymous screen view again after the invitation route remounts", async () => {
     window.history.replaceState({}, "", "/join?invite=private-token#secret");
     const requests: unknown[] = [];
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -126,13 +131,18 @@ describe("landing analytics", () => {
     vi.stubGlobal("fetch", fetchMock);
     try {
       const analytics = new LandingAnalytics(undefined, true);
-      analytics.startJoin(document, "openbot.run", { validInvite: true, platform: "macos" });
+      const cleanup = analytics.startJoin(document, "openbot.run", { validInvite: true, platform: "macos" });
 
       await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-      const screenViewRequest = requests.find(
+      cleanup();
+      analytics.startJoin(document, "openbot.run", { validInvite: true, platform: "macos" });
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+      const screenViewRequests = requests.filter(
         (candidate) =>
           isDynamicRecord(candidate) && isDynamicRecord(candidate.payload) && candidate.payload.name === "screen_view",
       );
+      expect(screenViewRequests).toHaveLength(2);
+      const screenViewRequest = screenViewRequests[0];
       const payload =
         isDynamicRecord(screenViewRequest) && isDynamicRecord(screenViewRequest.payload)
           ? screenViewRequest.payload

--- a/apps/auth-api/test/analytics.test.ts
+++ b/apps/auth-api/test/analytics.test.ts
@@ -1,3 +1,4 @@
+import { isDynamicRecord } from "@openbot/contracts/runtime-values";
 import { describe, expect, it, vi } from "vitest";
 import {
   isLikelyAutomation,
@@ -21,6 +22,7 @@ describe("landing analytics", () => {
       <a id="private" href="https://private.example/secret">Private</a>
     `;
     const client = {
+      screenView: vi.fn(),
       setGlobalProperties: vi.fn(),
       track: vi.fn(),
     };
@@ -46,8 +48,10 @@ describe("landing analytics", () => {
       __referrer: "",
       surface: "landing",
       environment: "production",
-      event_schema_version: 2,
+      event_schema_version: 3,
     });
+    expect(client.screenView).toHaveBeenCalledOnce();
+    expect(client.screenView).toHaveBeenCalledWith("/");
     expect(client.track).toHaveBeenNthCalledWith(1, "landing_viewed", {});
     expect(client.track).toHaveBeenNthCalledWith(2, "landing_link_clicked", {
       destination: "contact",
@@ -72,7 +76,7 @@ describe("landing analytics", () => {
       <a id="open" href="openbot://join?invite=private">Open app</a>
       <a id="download" href="/download/macos">Download</a>
     `;
-    const client = { setGlobalProperties: vi.fn(), track: vi.fn() };
+    const client = { screenView: vi.fn(), setGlobalProperties: vi.fn(), track: vi.fn() };
     const analytics = new LandingAnalytics(() => client, true);
     const cleanup = analytics.startJoin(document, "openbot.run", { validInvite: true, platform: "macos" });
 
@@ -88,13 +92,15 @@ describe("landing analytics", () => {
       platform: "macos",
     });
     expect(client.track).toHaveBeenCalledTimes(3);
+    expect(client.screenView).toHaveBeenCalledOnce();
+    expect(client.screenView).toHaveBeenCalledWith("/join");
     expect(JSON.stringify(client.track.mock.calls)).not.toContain("profileId");
     expect(JSON.stringify(client.track.mock.calls)).not.toContain("private");
   });
 
   it("replaces an existing document listener instead of double tracking clicks", () => {
     document.body.innerHTML = '<a id="open" href="openbot://join">Open app</a>';
-    const client = { setGlobalProperties: vi.fn(), track: vi.fn() };
+    const client = { screenView: vi.fn(), setGlobalProperties: vi.fn(), track: vi.fn() };
     const analytics = new LandingAnalytics(() => client, true);
     analytics.startJoin(document, "openbot.run", { validInvite: false, platform: "windows" });
     const cleanup = analytics.startJoin(document, "openbot.run", { validInvite: true, platform: "windows" });
@@ -107,6 +113,37 @@ describe("landing analytics", () => {
       ["join_page_action", { action: "view", valid_invite: true }],
       ["join_page_action", { action: "open_app" }],
     ]);
+    expect(client.screenView).toHaveBeenCalledOnce();
+  });
+
+  it("sends one anonymous screen view with a safe invitation path through the real SDK", async () => {
+    window.history.replaceState({}, "", "/join?invite=private-token#secret");
+    const requests: unknown[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const analytics = new LandingAnalytics(undefined, true);
+      analytics.startJoin(document, "openbot.run", { validInvite: true, platform: "macos" });
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      const screenViewRequest = requests.find(
+        (candidate) =>
+          isDynamicRecord(candidate) && isDynamicRecord(candidate.payload) && candidate.payload.name === "screen_view",
+      );
+      const payload =
+        isDynamicRecord(screenViewRequest) && isDynamicRecord(screenViewRequest.payload)
+          ? screenViewRequest.payload
+          : null;
+      expect(payload).toMatchObject({ properties: expect.objectContaining({ __path: "/join" }) });
+      expect(payload).not.toHaveProperty("profileId");
+      expect(JSON.stringify(requests)).not.toContain("private-token");
+      expect(JSON.stringify(requests)).not.toContain("#secret");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("derives only coarse acquisition sources and ignores automation", () => {

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 
 import type { BotSummary } from "@openbot/contracts/ipc";
+import { isDynamicRecord } from "@openbot/contracts/runtime-values";
+import { OpenPanelBase } from "@openpanel/web";
 import { describe, expect, it, vi } from "vitest";
 import { HostAnalytics, type HostOpenPanelClient, sanitizeHostEvent } from "./analytics";
 
@@ -46,7 +48,7 @@ describe("host analytics", () => {
     );
 
     expect(client.setGlobalProperties).toHaveBeenCalledWith(
-      expect.objectContaining({ event_schema_version: 2, surface: "desktop_host" }),
+      expect.objectContaining({ event_schema_version: 3, surface: "desktop_host" }),
     );
 
     analytics.handleAgentEvent({
@@ -66,7 +68,7 @@ describe("host analytics", () => {
     });
 
     expect(client.identify).toHaveBeenCalledOnce();
-    expect(client.identify).toHaveBeenCalledWith({ profileId: "owner-account" });
+    expect(client.identify).toHaveBeenCalledWith({ profileId: "owner-account", email: "owner@example.com" });
     expect(client.track).toHaveBeenCalledTimes(2);
     expect(client.track).toHaveBeenNthCalledWith(1, "system_turn_started", {
       provider: "codex",
@@ -127,6 +129,72 @@ describe("host analytics", () => {
     );
   });
 
+  it("updates the email for the same owner without clearing its session", () => {
+    const client = fakeClient();
+    let owner = { id: "owner-account", email: "old@example.com" };
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => owner,
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+    analytics.handleAgentEvent({ type: "error", code: "first_error", message: "private" });
+    vi.mocked(client.clear).mockClear();
+    vi.mocked(client.identify).mockClear();
+
+    owner = { id: "owner-account", email: "new@example.com" };
+    analytics.handleAgentEvent({ type: "error", code: "second_error", message: "private" });
+
+    expect(client.clear).not.toHaveBeenCalled();
+    expect(client.identify).toHaveBeenCalledWith({ profileId: "owner-account", email: "new@example.com" });
+  });
+
+  it("sends the owner email through the real SDK transport", async () => {
+    const requests: unknown[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const analytics = new HostAnalytics(
+        {
+          enabled: true,
+          appVersion: "1.2.3",
+          platform: "darwin",
+          resolveOwner: () => ({ id: "owner-account", email: "owner@example.com" }),
+          resolveBot: () => BOT,
+        },
+        (options) => new OpenPanelBase(options),
+      );
+      analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "private" });
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      const identifyRequest = requests.find((candidate) => isDynamicRecord(candidate) && candidate.type === "identify");
+      const trackRequest = requests.find(
+        (candidate) =>
+          isDynamicRecord(candidate) &&
+          isDynamicRecord(candidate.payload) &&
+          candidate.payload.name === "system_operation_failed",
+      );
+      expect(
+        isDynamicRecord(identifyRequest) && isDynamicRecord(identifyRequest.payload) ? identifyRequest.payload : null,
+      ).toMatchObject({ profileId: "owner-account", email: "owner@example.com" });
+      expect(
+        isDynamicRecord(trackRequest) && isDynamicRecord(trackRequest.payload)
+          ? trackRequest.payload.profileId
+          : undefined,
+      ).toBe("owner-account");
+      expect(JSON.stringify(trackRequest)).not.toContain("owner@example.com");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("drops unsafe runtime fields", () => {
     expect(
       sanitizeHostEvent("system_operation_failed", {
@@ -151,7 +219,7 @@ describe("host analytics", () => {
         enabled: true,
         appVersion: "1.2.3",
         platform: "darwin",
-        resolveOwner: () => ({ id: "owner-account" }),
+        resolveOwner: () => ({ id: "owner-account", email: "owner@example.com" }),
         resolveBot: () => BOT,
       },
       () => client,
@@ -188,7 +256,7 @@ describe("host analytics", () => {
         enabled: true,
         appVersion: "1.2.3",
         platform: "darwin",
-        resolveOwner: () => ({ id: "owner-account" }),
+        resolveOwner: () => ({ id: "owner-account", email: "owner@example.com" }),
         resolveBot: () => BOT,
       },
       () => client,
@@ -213,7 +281,7 @@ describe("host analytics", () => {
         trackingEnabled: false,
         appVersion: "1.2.3",
         platform: "darwin",
-        resolveOwner: () => ({ id: "owner-account" }),
+        resolveOwner: () => ({ id: "owner-account", email: "owner@example.com" }),
         resolveBot: () => BOT,
       },
       () => client,

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -14,9 +14,9 @@ export const OPENPANEL_CLIENT_ID = "6c989975-87ef-4f0c-857e-ab449a65b5c2";
 const MAX_PENDING_EVENTS = 100;
 const MAX_ACTIVE_TURNS = 1_000;
 const ACTIVE_TURN_TTL_MS = 24 * 60 * 60 * 1_000;
-const ANALYTICS_SCHEMA_VERSION = 2;
+const ANALYTICS_SCHEMA_VERSION = 3;
 
-type AnalyticsIdentity = Pick<CentralAuthUser, "id"> & Partial<Pick<CentralAuthUser, "email">>;
+type AnalyticsIdentity = Pick<CentralAuthUser, "id" | "email">;
 type HostEventName =
   | "system_turn_started"
   | "system_turn_completed"
@@ -59,7 +59,7 @@ export class HostAnalytics {
   readonly #resolveOwner: HostAnalyticsOptions["resolveOwner"];
   readonly #resolveBot: HostAnalyticsOptions["resolveBot"];
   readonly #client: HostOpenPanelClient | null;
-  #identifiedOwnerId: string | null = null;
+  #identifiedOwner: AnalyticsIdentity | null = null;
   #trackingEnabled: boolean;
   #pending: HostPendingEvent[] = [];
   readonly #activeTurns = new Map<string, ActiveTurn>();
@@ -165,7 +165,7 @@ export class HostAnalytics {
     if (!enabled) {
       this.#pending = [];
       this.#activeTurns.clear();
-      this.#identifiedOwnerId = null;
+      this.#identifiedOwner = null;
       this.#run(() => this.#client?.clear());
       return;
     }
@@ -187,10 +187,12 @@ export class HostAnalytics {
   }
 
   #identify(owner: AnalyticsIdentity): void {
-    if (!this.#client || this.#identifiedOwnerId === owner.id) return;
-    if (this.#identifiedOwnerId) this.#run(() => this.#client?.clear());
-    this.#identifiedOwnerId = owner.id;
-    this.#run(() => this.#client?.identify({ profileId: owner.id }));
+    if (!this.#client) return;
+    const previous = this.#identifiedOwner;
+    if (previous?.id === owner.id && previous.email === owner.email) return;
+    if (previous && previous.id !== owner.id) this.#run(() => this.#client?.clear());
+    this.#identifiedOwner = { ...owner };
+    this.#run(() => this.#client?.identify({ profileId: owner.id, email: owner.email }));
   }
 
   #send(name: HostEventName, properties: HostProperties, profileId: string, timestamp?: string): void {

--- a/src/renderer/src/analytics.test.ts
+++ b/src/renderer/src/analytics.test.ts
@@ -49,7 +49,7 @@ describe("desktop analytics", () => {
       __referrer: "",
       surface: "desktop",
       environment: "production",
-      event_schema_version: 2,
+      event_schema_version: 3,
       app_version: "1.2.3",
       platform: "darwin",
     });
@@ -63,7 +63,7 @@ describe("desktop analytics", () => {
 
     analytics.configure(PRODUCTION_APP);
 
-    expect(client.identify).toHaveBeenCalledWith({ profileId: "account-1" });
+    expect(client.identify).toHaveBeenCalledWith({ profileId: "account-1", email: "person@example.com" });
     expect(client.track).toHaveBeenCalledWith("agent_action", {
       action: "delete",
       result: "succeeded",
@@ -89,7 +89,21 @@ describe("desktop analytics", () => {
     analytics.setUser({ id: "account-2", email: "two@example.com" });
 
     expect(order).toEqual(["clear", "identify"]);
-    expect(client.identify).toHaveBeenLastCalledWith({ profileId: "account-2" });
+    expect(client.identify).toHaveBeenLastCalledWith({ profileId: "account-2", email: "two@example.com" });
+  });
+
+  it("updates the email for the same account without clearing its session", () => {
+    const client = fakeClient();
+    const analytics = new DesktopAnalytics(() => client, true);
+    analytics.configure(PRODUCTION_APP);
+    analytics.setUser({ id: "account-1", email: "old@example.com" });
+    vi.mocked(client.clear).mockClear();
+    vi.mocked(client.identify).mockClear();
+
+    analytics.setUser({ id: "account-1", email: "new@example.com" });
+
+    expect(client.clear).not.toHaveBeenCalled();
+    expect(client.identify).toHaveBeenCalledWith({ profileId: "account-1", email: "new@example.com" });
   });
 
   it("keeps the captured profile through a logout race", () => {
@@ -145,6 +159,39 @@ describe("desktop analytics", () => {
       expect(isDynamicRecord(request) && isDynamicRecord(request.payload) ? request.payload.profileId : undefined).toBe(
         undefined,
       );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("sends the account email through the real SDK transport", async () => {
+    const requests: unknown[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const analytics = new DesktopAnalytics((options) => new OpenPanelBase(options), true);
+      analytics.configure(PRODUCTION_APP);
+      analytics.setUser({ id: "account-1", email: "person@example.com" });
+      analytics.track("agent_action", { action: "delete", result: "succeeded" });
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      const identifyRequest = requests.find((candidate) => isDynamicRecord(candidate) && candidate.type === "identify");
+      const trackRequest = requests.find(
+        (candidate) =>
+          isDynamicRecord(candidate) && isDynamicRecord(candidate.payload) && candidate.payload.name === "agent_action",
+      );
+      expect(
+        isDynamicRecord(identifyRequest) && isDynamicRecord(identifyRequest.payload) ? identifyRequest.payload : null,
+      ).toMatchObject({ profileId: "account-1", email: "person@example.com" });
+      expect(
+        isDynamicRecord(trackRequest) && isDynamicRecord(trackRequest.payload)
+          ? trackRequest.payload.profileId
+          : undefined,
+      ).toBe("account-1");
+      expect(JSON.stringify(trackRequest)).not.toContain("person@example.com");
     } finally {
       vi.unstubAllGlobals();
     }
@@ -227,7 +274,10 @@ describe("desktop analytics", () => {
 
     analytics.setTrackingEnabled(true);
     analytics.track("agent_action", { action: "delete", result: "succeeded" });
-    expect(identifiedClient.identify).toHaveBeenCalledWith({ profileId: "account-1" });
+    expect(identifiedClient.identify).toHaveBeenCalledWith({
+      profileId: "account-1",
+      email: "person@example.com",
+    });
     expect(identifiedClient.track).toHaveBeenCalledOnce();
   });
 });

--- a/src/renderer/src/analytics.ts
+++ b/src/renderer/src/analytics.ts
@@ -14,7 +14,7 @@ import { OpenPanelBase, type OpenPanelOptions } from "@openpanel/web";
 export const OPENPANEL_API_URL = "https://analytics.openbot.run/api";
 export const OPENPANEL_CLIENT_ID = "6c989975-87ef-4f0c-857e-ab449a65b5c2";
 const MAX_PENDING_EVENTS = 100;
-export const ANALYTICS_SCHEMA_VERSION = 2;
+export const ANALYTICS_SCHEMA_VERSION = 3;
 
 export type ServerKind = "local" | "remote" | "unknown";
 export type AnalyticsResult = "succeeded" | "failed";
@@ -161,7 +161,7 @@ export type AnalyticsEventName = keyof DesktopAnalyticsEvents;
 export type OpenPanelClient = Pick<OpenPanelBase, "setGlobalProperties" | "track" | "identify" | "clear">;
 
 type ClientFactory = (options: OpenPanelOptions) => OpenPanelClient;
-type AnalyticsIdentity = Pick<CentralAuthUser, "id"> & Partial<Pick<CentralAuthUser, "email">>;
+type AnalyticsIdentity = Pick<CentralAuthUser, "id" | "email">;
 export interface DesktopAnalyticsScope {
   track<Name extends AnalyticsEventName>(name: Name, properties: DesktopAnalyticsEvents[Name]): void;
 }
@@ -479,7 +479,7 @@ export class DesktopAnalytics {
     if (previous?.id === user?.id && previous?.email === user?.email) return;
     this.#identity = user ? { ...user } : null;
     if (!this.#client || !this.#trackingEnabled) return;
-    if (previous) this.#run(() => this.#client?.clear());
+    if (previous && previous.id !== user?.id) this.#run(() => this.#client?.clear());
     if (user) this.#identifyClient(user);
   }
 
@@ -563,7 +563,7 @@ export class DesktopAnalytics {
   }
 
   #identifyClient(user: AnalyticsIdentity): void {
-    this.#run(() => this.#client?.identify({ profileId: user.id }));
+    this.#run(() => this.#client?.identify({ profileId: user.id, email: user.email }));
   }
 
   #run(operation: () => unknown): void {

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -381,7 +381,7 @@ export function SettingsModal(props: SettingsModalProps) {
                 checked={props.value.productAnalytics}
                 onChange={(checked) => updateSetting("productAnalytics", checked)}
                 label="Share product analytics"
-                description="Send privacy-safe usage and reliability metadata to OpenBot's self-hosted analytics."
+                description="Send usage and reliability metadata with your account ID and email to OpenBot's self-hosted analytics."
               />
             </ItemGroup>
           </SettingsSection>


### PR DESCRIPTION
## Summary
- identify signed-in desktop and host profiles with account ID and email
- emit privacy-safe screen views for the public landing and invitation routes
- move analytics reports to schema version 3 and document engaged-session reporting
- update privacy copy and transport-level regression coverage

## Tests
- bunx vitest run src/renderer/src/analytics.test.ts src/main/analytics.test.ts
- bunx vitest run --config vitest.client.config.ts test/analytics.test.ts (apps/auth-api)
- bun run typecheck:node
- bun run typecheck:renderer
- bun run typecheck:api
- staged Biome checks and all repository typecheck hooks