### PR TITLE
Fix raw citation artifacts in agent messages

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -6903,6 +6903,47 @@ describe("OpenBot connected desktop shell", () => {
     );
   });
 
+  it("removes a citation marker split across streaming deltas", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: true }),
+    });
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    emitAgentEvent?.({
+      type: "conversation-delta",
+      botId: "chief",
+      threadId: "thread-chief",
+      turnId: "turn-live",
+      messageId: "agent-cited-answer",
+      delta: "Storms are likely.\u{e200}cite\u{e202}turn0fore",
+      createdAt: "2026-08-19T09:03:00.000Z",
+      revision: 1,
+    });
+
+    const message = await waitFor(() => {
+      const element = document.querySelector('[data-chat-search-message="agent-cited-answer"]');
+      expect(element).toHaveTextContent("Storms are likely.");
+      return element;
+    });
+    expect(message).not.toHaveTextContent("cite");
+
+    emitAgentEvent?.({
+      type: "conversation-delta",
+      botId: "chief",
+      threadId: "thread-chief",
+      turnId: "turn-live",
+      messageId: "agent-cited-answer",
+      delta: "cast0\u{e201} Take care.",
+      createdAt: "2026-08-19T09:03:00.000Z",
+      revision: 2,
+    });
+
+    await waitFor(() => expect(message).toHaveTextContent("Storms are likely. Take care."));
+    expect(message).not.toHaveTextContent("turn0forecast0");
+  });
+
   it("clears unread messages when entering an agent chat", async () => {
     const unreadState = {
       unreadCount: 1,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1161,10 +1161,15 @@ export function createAppController(props: AppProps = {}) {
       ...(snapshot.attentionComplete ? {} : current),
       ...Object.fromEntries(snapshot.pendingApprovals.map((approval) => [approval.botId, approval])),
     }));
+    for (const botId of new Set(snapshot.latestMessages.map((message) => message.botId))) {
+      deleteAgentMessageBodies(rawAgentMessageBodies, botId);
+    }
+    for (const message of snapshot.latestMessages) {
+      rawAgentMessageBodies.set(agentMessageKey(message.botId, message.id), message.text);
+    }
     setLiveMessages((current) => {
       const next = { ...current };
       for (const message of snapshot.latestMessages) {
-        rawAgentMessageBodies.set(agentMessageKey(message.botId, message.id), message.text);
         const messages = next[message.botId] ?? [];
         if (messages.some((candidate) => candidate.id === message.id)) continue;
         next[message.botId] = [

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -52,6 +52,7 @@ import {
   useContext,
 } from "solid-js";
 import { AppAccessGate } from "./AppView";
+import { cleanAgentMessageText } from "./agent-message-text";
 import { desktopAnalytics } from "./analytics";
 import {
   botMessagesEqual,
@@ -1158,7 +1159,7 @@ export function createAppController(props: AppProps = {}) {
           {
             id: message.id,
             author: "bot",
-            body: message.text,
+            body: cleanAgentMessageText(message.text),
             time: message.createdAt,
             createdAt: message.createdAt,
           },

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -238,6 +238,17 @@ function authFailureCode(value: string | undefined): string {
   }
 }
 
+function agentMessageKey(botId: string, messageId: string): string {
+  return `${botId}\0${messageId}`;
+}
+
+function deleteAgentMessageBodies(messages: Map<string, string>, botId: string): void {
+  const prefix = `${botId}\0`;
+  for (const key of messages.keys()) {
+    if (key.startsWith(prefix)) messages.delete(key);
+  }
+}
+
 export function createBotInitialMessage(draft: Pick<FirstBotDraft, "purpose">): string {
   return `Your ongoing role is: ${draft.purpose.trim()}`;
 }
@@ -262,6 +273,7 @@ export function createAppController(props: AppProps = {}) {
   const [conversationReferences, setConversationReferences] = createSignal<Record<string, Record<string, BotMessage>>>(
     {},
   );
+  const rawAgentMessageBodies = new Map<string, string>();
   const [conversationOlderLoading, setConversationOlderLoading] = createSignal<Record<string, boolean>>({});
   const [conversationOlderErrors, setConversationOlderErrors] = createSignal<Record<string, string | null>>({});
   const [activeTurns, setActiveTurns] = createSignal<Record<string, string | null>>({});
@@ -1152,6 +1164,7 @@ export function createAppController(props: AppProps = {}) {
     setLiveMessages((current) => {
       const next = { ...current };
       for (const message of snapshot.latestMessages) {
+        rawAgentMessageBodies.set(agentMessageKey(message.botId, message.id), message.text);
         const messages = next[message.botId] ?? [];
         if (messages.some((candidate) => candidate.id === message.id)) continue;
         next[message.botId] = [
@@ -1227,6 +1240,11 @@ export function createAppController(props: AppProps = {}) {
     const pending = pendingConversationSnapshots.get(botId);
     const pendingRevision = pending?.snapshot.revision ?? -1;
     if (snapshot.revision < Math.max(appliedRevision, pendingRevision)) return;
+    for (const message of snapshot.messages) {
+      const key = agentMessageKey(botId, message.id);
+      if (message.author !== "user" && message.status === "streaming") rawAgentMessageBodies.set(key, message.text);
+      else rawAgentMessageBodies.delete(key);
+    }
     pendingConversationSnapshots.set(botId, {
       snapshot,
       markNewMessagesRead: markNewMessagesRead || (pending?.markNewMessagesRead ?? false),
@@ -1353,10 +1371,13 @@ export function createAppController(props: AppProps = {}) {
     }));
 
     const existing = liveMessages()[event.botId]?.find((message) => message.id === event.messageId);
+    const messageKey = agentMessageKey(event.botId, event.messageId);
+    const rawBody = (rawAgentMessageBodies.get(messageKey) ?? existing?.body ?? "") + event.delta;
+    rawAgentMessageBodies.set(messageKey, rawBody);
     if (existing) {
       updateStored(existing, {
         ...existing,
-        body: existing.body + event.delta,
+        body: cleanAgentMessageText(rawBody),
         streaming: true,
       });
     } else {
@@ -1364,7 +1385,7 @@ export function createAppController(props: AppProps = {}) {
         id: event.messageId,
         turnId: event.turnId,
         author: "bot",
-        body: event.delta,
+        body: cleanAgentMessageText(rawBody),
         time: formatTime(event.createdAt),
         createdAt: event.createdAt,
         streaming: true,
@@ -1485,6 +1506,11 @@ export function createAppController(props: AppProps = {}) {
     windowMode?: "latest" | "around",
   ): boolean {
     if (page.revision < (conversationRevisions()[page.botId] ?? -1)) return false;
+    for (const message of page.messages) {
+      const key = agentMessageKey(page.botId, message.id);
+      if (message.author !== "user" && message.status === "streaming") rawAgentMessageBodies.set(key, message.text);
+      else rawAgentMessageBodies.delete(key);
+    }
     const mapped = toBotMessages(page.messages);
     setLiveMessages((current) => {
       const currentMessages = current[page.botId] ?? [];
@@ -2141,6 +2167,7 @@ export function createAppController(props: AppProps = {}) {
       setActiveBotId((current) => (current === botId ? (remaining[0]?.id ?? "") : current));
       setSettingsRequest((current) => (current?.botId === botId ? null : current));
       setLiveMessages((current) => withoutBot(current, botId));
+      deleteAgentMessageBodies(rawAgentMessageBodies, botId);
       setUiErrors((current) => withoutBot(current, botId));
       setConversationLoaded((current) => withoutBot(current, botId));
       setConversationRevisions((current) => withoutBot(current, botId));
@@ -2816,6 +2843,7 @@ export function createAppController(props: AppProps = {}) {
     setDirectConversations({});
     setDirectTypingMemberIds(new Set<string>());
     setLiveMessages({});
+    rawAgentMessageBodies.clear();
     setUiErrors({});
     setConversationLoaded({});
     setConversationRevisions({});

--- a/src/renderer/src/agent-message-text.ts
+++ b/src/renderer/src/agent-message-text.ts
@@ -1,0 +1,6 @@
+const COMPLETE_INTERNAL_CITATION = /\u{e200}cite(?:\u{e202}[^\u{e201}]*)?\u{e201}/gu;
+const STREAMING_INTERNAL_CITATION = /\u{e200}(?:c(?:i(?:t(?:e(?:\u{e202}[^\u{e201}]*)?)?)?)?)?$/u;
+
+export function cleanAgentMessageText(text: string): string {
+  return text.replace(COMPLETE_INTERNAL_CITATION, "").replace(STREAMING_INTERNAL_CITATION, "");
+}

--- a/src/renderer/src/app-message-projection.test.ts
+++ b/src/renderer/src/app-message-projection.test.ts
@@ -1,6 +1,6 @@
 import type { BotSummary, ConversationMessage } from "@openbot/contracts/ipc";
 import { describe, expect, it } from "vitest";
-import { botProfilesEqual, readStateForMessages, toBotProfile } from "./app-message-projection";
+import { botProfilesEqual, readStateForMessages, toBotMessage, toBotProfile } from "./app-message-projection";
 
 describe("toBotProfile", () => {
   it("preserves marketplace installation metadata for the renderer", () => {
@@ -65,6 +65,23 @@ describe("readStateForMessages", () => {
     expect(
       readStateForMessages({ unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null }, messages),
     ).toMatchObject({ unreadCount: 1, firstUnreadMessageId: "answer" });
+  });
+});
+
+describe("toBotMessage", () => {
+  it("removes internal citation markers from completed and streaming agent text", () => {
+    const message = {
+      id: "forecast",
+      author: "assistant",
+      text: "Storms are likely. \u{e200}cite\u{e202}turn0forecast0\u{e201}",
+      createdAt: "2026-08-31T10:00:00.000Z",
+      status: "completed",
+    } satisfies ConversationMessage;
+
+    expect(toBotMessage(message).body).toBe("Storms are likely. ");
+    expect(
+      toBotMessage({ ...message, text: "Storms are likely. \u{e200}cite\u{e202}turn0fore", status: "streaming" }).body,
+    ).toBe("Storms are likely. ");
   });
 });
 

--- a/src/renderer/src/app-message-projection.ts
+++ b/src/renderer/src/app-message-projection.ts
@@ -1,4 +1,5 @@
 import type { BotSummary, ConversationMessage, ConversationReadState } from "@openbot/contracts/ipc";
+import { cleanAgentMessageText } from "./agent-message-text";
 import type { BotMessage, BotProfile } from "./data";
 
 export function toBotProfile(stored: BotSummary): BotProfile {
@@ -28,7 +29,7 @@ export function toBotMessage(message: ConversationMessage): BotMessage {
     id: message.id,
     turnId: message.turnId,
     author: message.author === "user" ? "you" : "bot",
-    body: message.text,
+    body: message.author === "user" ? message.text : cleanAgentMessageText(message.text),
     time: formatTime(message.createdAt),
     createdAt: message.createdAt,
     streaming: message.status === "streaming",
@@ -71,11 +72,13 @@ export function toBotMessages(messages: ConversationMessage[]): BotMessage[] {
     const key = message.turnId ?? message.id;
     const existing = thinkingByTurn.get(key);
     if (existing) {
-      if (message.text.trim()) existing.items = [...(existing.items ?? []), message.text];
+      const text = cleanAgentMessageText(message.text);
+      if (text.trim()) existing.items = [...(existing.items ?? []), text];
       existing.streaming = existing.streaming || message.status === "streaming";
       continue;
     }
 
+    const text = cleanAgentMessageText(message.text);
     const thinking: BotMessage = {
       id: `thinking:${key}`,
       turnId: message.turnId,
@@ -86,7 +89,7 @@ export function toBotMessages(messages: ConversationMessage[]): BotMessage[] {
       streaming: message.status === "streaming",
       itemType: "commentary",
       kind: "thinking",
-      items: message.text.trim() ? [message.text] : [],
+      items: text.trim() ? [text] : [],
     };
     thinkingByTurn.set(key, thinking);
     result.push(thinking);
@@ -201,7 +204,7 @@ export function withoutBot<T>(values: Record<string, T>, botId: string): Record<
 }
 
 function cleanPreview(preview: string): string {
-  const cleaned = preview
+  const cleaned = cleanAgentMessageText(preview)
     .replace(/\binbox\s+at\s+zero\b[:,]?\s*/gi, "")
     .replace(/\s{2,}/g, " ")
     .trim();

--- a/src/renderer/src/dynamic-island-coordinator.test.ts
+++ b/src/renderer/src/dynamic-island-coordinator.test.ts
@@ -154,6 +154,56 @@ describe("DynamicIslandCoordinator", () => {
     });
   });
 
+  it("removes a citation marker split across Dynamic Island deltas", () => {
+    const coordinator = new DynamicIslandCoordinator();
+    seedBots(coordinator, "remote", [bot("research", "Research")]);
+    coordinator.applyEvent(scoped("remote", conversation("research", 0, [])), "local");
+    coordinator.applyEvent(
+      scoped(
+        "remote",
+        conversation("research", 1, [
+          { id: "message-1", text: "Storms are likely.", createdAt: "2026-08-29T10:00:00.000Z" },
+        ]),
+      ),
+      "local",
+    );
+    coordinator.applyEvent(
+      scoped("remote", {
+        type: "conversation-delta",
+        botId: "research",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        messageId: "message-1",
+        delta: "\u{e200}cite\u{e202}turn0fore",
+        createdAt: "2026-08-29T10:00:00.000Z",
+        revision: 2,
+      }),
+      "local",
+    );
+    expect(coordinator.presentation(["remote"])).toMatchObject({
+      mode: "message",
+      message: { text: "Storms are likely." },
+    });
+
+    coordinator.applyEvent(
+      scoped("remote", {
+        type: "conversation-delta",
+        botId: "research",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        messageId: "message-1",
+        delta: "cast0\u{e201} Take care.",
+        createdAt: "2026-08-29T10:00:00.000Z",
+        revision: 3,
+      }),
+      "local",
+    );
+    expect(coordinator.presentation(["remote"])).toMatchObject({
+      mode: "message",
+      message: { text: "Storms are likely. Take care." },
+    });
+  });
+
   it("does not count or display non-reply items from a full conversation", () => {
     const coordinator = new DynamicIslandCoordinator();
     seedBots(coordinator, "remote", [bot("research", "Research")]);

--- a/src/renderer/src/dynamic-island-coordinator.ts
+++ b/src/renderer/src/dynamic-island-coordinator.ts
@@ -6,6 +6,7 @@ import type {
   QueueSnapshot,
   ScopedAgentEvent,
 } from "@openbot/contracts/ipc";
+import { cleanAgentMessageText } from "./agent-message-text";
 import {
   countDynamicIslandAttention,
   createDynamicIslandPresentation,
@@ -279,7 +280,7 @@ export class DynamicIslandCoordinator {
       const converted = {
         id: message.id,
         author: "bot",
-        body: message.text,
+        body: cleanAgentMessageText(message.text),
         time: message.createdAt,
         createdAt: message.createdAt,
       };
@@ -416,5 +417,13 @@ function toDynamicIslandMessage(
   ) {
     return [];
   }
-  return [{ id: message.id, author: "bot", body: message.text, time: message.createdAt, createdAt: message.createdAt }];
+  return [
+    {
+      id: message.id,
+      author: "bot",
+      body: cleanAgentMessageText(message.text),
+      time: message.createdAt,
+      createdAt: message.createdAt,
+    },
+  ];
 }

--- a/src/renderer/src/dynamic-island-coordinator.ts
+++ b/src/renderer/src/dynamic-island-coordinator.ts
@@ -21,6 +21,7 @@ type ServerRuntime = DynamicIslandPresentationInput & {
   lastRecordedMessageIds: Map<string, string>;
   receivedConversations: Set<string>;
   resolvedPrompts: Map<string, string>;
+  rawMessageBodies: Map<string, string>;
   receivedRuntimeSnapshot: boolean;
 };
 
@@ -62,6 +63,13 @@ export class DynamicIslandCoordinator {
     for (const botId of completedBots) if (!botIds.has(botId)) completedBots.delete(botId);
     for (const botId of lastRecordedMessageIds.keys()) if (!botIds.has(botId)) lastRecordedMessageIds.delete(botId);
     const receivedConversations = [...(previous?.receivedConversations ?? [])].filter((botId) => botIds.has(botId));
+    const rawMessageBodies = new Map(previous?.rawMessageBodies);
+    for (const [botId, messages] of Object.entries(input.liveMessages)) {
+      for (const message of messages) {
+        const key = dynamicIslandMessageKey(botId, message.id);
+        if (!rawMessageBodies.has(key)) rawMessageBodies.set(key, message.body);
+      }
+    }
     this.#servers.set(input.serverId, {
       ...input,
       pendingApprovals,
@@ -72,6 +80,7 @@ export class DynamicIslandCoordinator {
       lastRecordedMessageIds,
       receivedConversations: new Set([...receivedConversations, ...Object.keys(input.liveMessages)]),
       resolvedPrompts,
+      rawMessageBodies,
       receivedRuntimeSnapshot: previous?.receivedRuntimeSnapshot ?? false,
     });
   }
@@ -95,6 +104,12 @@ export class DynamicIslandCoordinator {
         return;
       case "conversation": {
         runtime.activeTurns[event.snapshot.botId] = event.snapshot.activeTurnId;
+        for (const message of event.snapshot.messages) {
+          const key = dynamicIslandMessageKey(event.snapshot.botId, message.id);
+          if (message.author !== "user" && message.status === "streaming") {
+            runtime.rawMessageBodies.set(key, message.text);
+          } else runtime.rawMessageBodies.delete(key);
+        }
         const messages = event.snapshot.messages.flatMap(toDynamicIslandMessage);
         const anchorId = runtime.incomingMessageAnchors.get(event.snapshot.botId);
         const receivedConversation = runtime.receivedConversations.has(event.snapshot.botId);
@@ -123,7 +138,12 @@ export class DynamicIslandCoordinator {
       case "conversation-delta": {
         const messages = runtime.liveMessages[event.botId] ?? [];
         const existing = messages.find((message) => message.id === event.messageId);
-        if (existing) existing.body += event.delta;
+        if (existing) {
+          const key = dynamicIslandMessageKey(event.botId, event.messageId);
+          const rawBody = (runtime.rawMessageBodies.get(key) ?? existing.body) + event.delta;
+          runtime.rawMessageBodies.set(key, rawBody);
+          existing.body = cleanAgentMessageText(rawBody);
+        }
         return;
       }
       case "queue-changed":
@@ -235,6 +255,7 @@ export class DynamicIslandCoordinator {
       lastRecordedMessageIds: new Map(),
       receivedConversations: new Set(),
       resolvedPrompts: new Map(),
+      rawMessageBodies: new Map(),
       receivedRuntimeSnapshot: false,
     };
     this.#servers.set(serverId, runtime);
@@ -266,6 +287,9 @@ export class DynamicIslandCoordinator {
     for (const botId of Object.keys(runtime.liveMessages)) {
       if (!botIds.has(botId)) delete runtime.liveMessages[botId];
     }
+    for (const key of runtime.rawMessageBodies.keys()) {
+      if (!botIds.has(key.slice(0, key.indexOf("\0")))) runtime.rawMessageBodies.delete(key);
+    }
   }
 
   #replaceRuntimeSnapshot(
@@ -277,6 +301,7 @@ export class DynamicIslandCoordinator {
     const liveMessages: Record<string, DynamicIslandMessageSource[]> = {};
     const incomingMessageAnchors = new Map(runtime.incomingMessageAnchors);
     for (const message of snapshot.latestMessages) {
+      runtime.rawMessageBodies.set(dynamicIslandMessageKey(message.botId, message.id), message.text);
       const converted = {
         id: message.id,
         author: "bot",
@@ -321,6 +346,10 @@ export class DynamicIslandCoordinator {
     nextRuntime.incomingMessageAnchors = incomingMessageAnchors;
     nextRuntime.receivedRuntimeSnapshot = true;
   }
+}
+
+function dynamicIslandMessageKey(botId: string, messageId: string): string {
+  return `${botId}\0${messageId}`;
 }
 
 function compactLiveMessages(

--- a/src/renderer/src/dynamic-island-coordinator.ts
+++ b/src/renderer/src/dynamic-island-coordinator.ts
@@ -63,9 +63,10 @@ export class DynamicIslandCoordinator {
     for (const botId of completedBots) if (!botIds.has(botId)) completedBots.delete(botId);
     for (const botId of lastRecordedMessageIds.keys()) if (!botIds.has(botId)) lastRecordedMessageIds.delete(botId);
     const receivedConversations = [...(previous?.receivedConversations ?? [])].filter((botId) => botIds.has(botId));
+    const liveMessages = compactLiveMessages(input.liveMessages);
     const rawMessageBodies = new Map(previous?.rawMessageBodies);
     const retainedMessageKeys = new Set<string>();
-    for (const [botId, messages] of Object.entries(input.liveMessages)) {
+    for (const [botId, messages] of Object.entries(liveMessages)) {
       for (const message of messages) {
         const key = dynamicIslandMessageKey(botId, message.id);
         retainedMessageKeys.add(key);
@@ -79,7 +80,7 @@ export class DynamicIslandCoordinator {
       ...input,
       pendingApprovals,
       pendingPrompts,
-      liveMessages: compactLiveMessages(input.liveMessages),
+      liveMessages,
       incomingMessageAnchors,
       completedBots,
       lastRecordedMessageIds,

--- a/src/renderer/src/dynamic-island-coordinator.ts
+++ b/src/renderer/src/dynamic-island-coordinator.ts
@@ -64,11 +64,16 @@ export class DynamicIslandCoordinator {
     for (const botId of lastRecordedMessageIds.keys()) if (!botIds.has(botId)) lastRecordedMessageIds.delete(botId);
     const receivedConversations = [...(previous?.receivedConversations ?? [])].filter((botId) => botIds.has(botId));
     const rawMessageBodies = new Map(previous?.rawMessageBodies);
+    const retainedMessageKeys = new Set<string>();
     for (const [botId, messages] of Object.entries(input.liveMessages)) {
       for (const message of messages) {
         const key = dynamicIslandMessageKey(botId, message.id);
+        retainedMessageKeys.add(key);
         if (!rawMessageBodies.has(key)) rawMessageBodies.set(key, message.body);
       }
+    }
+    for (const key of rawMessageBodies.keys()) {
+      if (!retainedMessageKeys.has(key)) rawMessageBodies.delete(key);
     }
     this.#servers.set(input.serverId, {
       ...input,
@@ -104,6 +109,7 @@ export class DynamicIslandCoordinator {
         return;
       case "conversation": {
         runtime.activeTurns[event.snapshot.botId] = event.snapshot.activeTurnId;
+        deleteDynamicIslandMessageBodies(runtime.rawMessageBodies, event.snapshot.botId);
         for (const message of event.snapshot.messages) {
           const key = dynamicIslandMessageKey(event.snapshot.botId, message.id);
           if (message.author !== "user" && message.status === "streaming") {
@@ -300,6 +306,9 @@ export class DynamicIslandCoordinator {
   ): void {
     const liveMessages: Record<string, DynamicIslandMessageSource[]> = {};
     const incomingMessageAnchors = new Map(runtime.incomingMessageAnchors);
+    for (const botId of new Set(snapshot.latestMessages.map((message) => message.botId))) {
+      deleteDynamicIslandMessageBodies(runtime.rawMessageBodies, botId);
+    }
     for (const message of snapshot.latestMessages) {
       runtime.rawMessageBodies.set(dynamicIslandMessageKey(message.botId, message.id), message.text);
       const converted = {
@@ -350,6 +359,13 @@ export class DynamicIslandCoordinator {
 
 function dynamicIslandMessageKey(botId: string, messageId: string): string {
   return `${botId}\0${messageId}`;
+}
+
+function deleteDynamicIslandMessageBodies(messages: Map<string, string>, botId: string): void {
+  const prefix = `${botId}\0`;
+  for (const key of messages.keys()) {
+    if (key.startsWith(prefix)) messages.delete(key);
+  }
 }
 
 function compactLiveMessages(


### PR DESCRIPTION
## Summary

- remove internal citation transport markers before agent text reaches the UI
- handle complete markers and partial markers during streaming
- apply the cleanup to chat, previews, copied messages, and Dynamic Island content
- add regression coverage for completed and streaming messages

## Verification

- `bunx vitest run src/renderer/src/app-message-projection.test.ts`
- `bunx biome check src/renderer/src/agent-message-text.ts src/renderer/src/app-message-projection.ts src/renderer/src/app-message-projection.test.ts src/renderer/src/App.tsx src/renderer/src/dynamic-island-coordinator.ts`
- `bun run typecheck:renderer`
- pre-commit full type checks