### PR TITLE
Fix notification state around app focus

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -6928,6 +6928,115 @@ describe("OpenBot connected desktop shell", () => {
     );
   });
 
+  it("keeps a queued snapshot unread when the app loses focus before rendering it", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    vi.mocked(window.openbot.agent.markConversationRead).mockClear();
+
+    emitAgentEvent?.({
+      type: "conversation",
+      snapshot: {
+        botId: "chief",
+        threadId: "thread-chief",
+        activeTurnId: null,
+        revision: 2,
+        messages: [
+          {
+            id: "agent-focus-race",
+            author: "assistant",
+            text: "Rendered after focus was lost",
+            createdAt: "2026-08-19T09:03:30.000Z",
+            status: "completed",
+          },
+        ],
+      },
+    });
+    window.dispatchEvent(new Event("blur"));
+
+    expect(await screen.findByText("Rendered after focus was lost")).toBeInTheDocument();
+    expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
+  });
+
+  it("extends an in-flight focus read to a newer visible agent reply", async () => {
+    const oldPage = testConversationPage(
+      "chief",
+      [
+        {
+          id: "agent-focus-old",
+          author: "assistant",
+          text: "Older background reply",
+          createdAt: "2026-08-19T09:03:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 2,
+        readState: { unreadCount: 1, firstUnreadMessageId: "agent-focus-old", throughMessageId: null },
+      },
+    );
+    const newPage = testConversationPage(
+      "chief",
+      [
+        ...oldPage.messages,
+        {
+          id: "agent-focus-new",
+          author: "assistant",
+          text: "Newer reply during focus read",
+          createdAt: "2026-08-19T09:04:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 3,
+        readState: { unreadCount: 2, firstUnreadMessageId: "agent-focus-old", throughMessageId: null },
+      },
+    );
+    let resolveFirstRead: ((state: NonNullable<ConversationPage["readState"]>) => void) | undefined;
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    window.dispatchEvent(new Event("blur"));
+    emitAgentEvent?.({ type: "conversation-page", page: oldPage });
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValue(oldPage);
+    vi.mocked(window.openbot.agent.markConversationRead)
+      .mockReset()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRead = resolve;
+          }),
+      )
+      .mockImplementation(async (input) => ({
+        unreadCount: 0,
+        firstUnreadMessageId: null,
+        throughMessageId: input.throughMessageId,
+      }));
+
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        { botId: "chief", throughMessageId: "agent-focus-old" },
+        "local",
+      ),
+    );
+    emitAgentEvent?.({ type: "conversation-page", page: newPage });
+    expect(await screen.findByText("Newer reply during focus read")).toBeInTheDocument();
+    resolveFirstRead?.({
+      unreadCount: 1,
+      firstUnreadMessageId: "agent-focus-new",
+      throughMessageId: "agent-focus-old",
+    });
+
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        { botId: "chief", throughMessageId: "agent-focus-new" },
+        "local",
+      ),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument());
+  });
+
   it("keeps another agent new until that agent is opened after focus returns", async () => {
     const unreadPage = testConversationPage(
       "sales-outbound",
@@ -7439,6 +7548,87 @@ describe("OpenBot connected desktop shell", () => {
       }),
     );
     await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+  });
+
+  it("extends an in-flight focus read to a newer visible private message", async () => {
+    let resolveFirstRead: ((state: NonNullable<DirectConversationSnapshot["readState"]>) => void) | undefined;
+    vi.mocked(window.openbot.servers.readDirectConversation).mockResolvedValueOnce({
+      threadId: "thread-member-alice",
+      otherMemberId: "member-alice",
+      revision: 1,
+      readState: { unreadCount: 1, firstUnreadMessageId: "direct-focus-old", throughSequence: 0 },
+      messages: [
+        {
+          id: "direct-focus-old",
+          threadId: "thread-member-alice",
+          senderMemberId: "member-alice",
+          recipientMemberId: "member-self",
+          text: "Older private background message",
+          createdAt: "2026-08-19T10:00:00.000Z",
+          sequence: 1,
+        },
+      ],
+    });
+    render(() => <App peopleEnabled />);
+    await screen.findByRole("heading", { name: "Chief" });
+    emitPresence?.({
+      serverId: "server-1",
+      updatedAt: "2026-08-19T10:00:00.000Z",
+      members: [
+        presenceMember("member-self", "person@example.com", "Person"),
+        presenceMember("member-alice", "alice@example.com", "Alice"),
+      ],
+    });
+    window.dispatchEvent(new Event("blur"));
+    await fireEvent.click(await screen.findByRole("button", { name: /Alice/ }));
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    vi.mocked(window.openbot.servers.markDirectRead)
+      .mockReset()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRead = resolve;
+          }),
+      )
+      .mockImplementation(async (input) => ({
+        unreadCount: 0,
+        firstUnreadMessageId: null,
+        throughSequence: input.throughSequence,
+      }));
+
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() =>
+      expect(window.openbot.servers.markDirectRead).toHaveBeenCalledWith({
+        memberId: "member-alice",
+        throughSequence: 1,
+      }),
+    );
+    emitDirectMessage?.({
+      type: "team-direct-message",
+      memberIds: ["member-alice", "member-self"],
+      message: {
+        id: "direct-focus-new",
+        threadId: "thread-member-alice",
+        senderMemberId: "member-alice",
+        recipientMemberId: "member-self",
+        text: "Newer private message during focus read",
+        createdAt: "2026-08-19T10:01:00.000Z",
+        sequence: 2,
+      },
+    });
+    resolveFirstRead?.({
+      unreadCount: 1,
+      firstUnreadMessageId: "direct-focus-new",
+      throughSequence: 1,
+    });
+
+    await waitFor(() =>
+      expect(window.openbot.servers.markDirectRead).toHaveBeenCalledWith({
+        memberId: "member-alice",
+        throughSequence: 2,
+      }),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument());
   });
 
   it("shows and clears the unread boundary in a private conversation", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -170,6 +170,10 @@ describe("OpenBot connected desktop shell", () => {
       value: defaultMatchMedia,
     });
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 1024 });
+    Object.defineProperty(document, "hasFocus", {
+      configurable: true,
+      value: vi.fn(() => true),
+    });
     Object.defineProperty(navigator, "mediaDevices", {
       configurable: true,
       value: { getUserMedia: vi.fn().mockRejectedValue(new DOMException("Denied", "NotAllowedError")) },
@@ -6865,6 +6869,152 @@ describe("OpenBot connected desktop shell", () => {
     expect(scrollElement.scrollTop).toBe(1080);
   });
 
+  it("keeps a reply unread while the open agent chat is in the background and clears it on focus", async () => {
+    const unreadPage = testConversationPage(
+      "chief",
+      [
+        {
+          id: "agent-background-answer",
+          author: "assistant",
+          text: "Ready while OpenBot was in the background",
+          createdAt: "2026-08-19T09:03:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 2,
+        readState: {
+          unreadCount: 1,
+          firstUnreadMessageId: "agent-background-answer",
+          throughMessageId: null,
+        },
+      },
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    await waitFor(() => expect(emitDynamicIslandAction).toBeDefined());
+    vi.mocked(window.openbot.agent.markConversationRead).mockClear();
+    vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValue(unreadPage);
+
+    window.dispatchEvent(new Event("blur"));
+    emitAgentEvent?.({ type: "conversation-page", page: unreadPage });
+
+    expect(await screen.findByText("Ready while OpenBot was in the background")).toBeInTheDocument();
+    expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(vi.mocked(window.openbot.dynamicIsland.publishPresentation).mock.calls.at(-1)?.[0]).toMatchObject({
+        mode: "message",
+        message: { messageId: "agent-background-answer" },
+      }),
+    );
+
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "chief",
+          throughMessageId: "agent-background-answer",
+        },
+        "local",
+      ),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(vi.mocked(window.openbot.dynamicIsland.publishPresentation).mock.calls.at(-1)?.[0]).toMatchObject({
+        mode: "idle",
+      }),
+    );
+  });
+
+  it("keeps another agent new until that agent is opened after focus returns", async () => {
+    const unreadPage = testConversationPage(
+      "sales-outbound",
+      [
+        {
+          id: "sales-background-answer",
+          author: "assistant",
+          text: "Sales result from the background",
+          createdAt: "2026-08-19T09:04:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 2,
+        readState: {
+          unreadCount: 1,
+          firstUnreadMessageId: "sales-background-answer",
+          throughMessageId: null,
+        },
+      },
+    );
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    vi.mocked(window.openbot.agent.markConversationRead).mockClear();
+
+    window.dispatchEvent(new Event("blur"));
+    emitAgentEvent?.({ type: "conversation-page", page: unreadPage });
+    window.dispatchEvent(new Event("focus"));
+
+    const sales = screen.getByRole("button", { name: /Sales Outbound/ });
+    await waitFor(() => expect(sales).toHaveTextContent("1 new reply"));
+    expect(window.openbot.agent.markConversationRead).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(vi.mocked(window.openbot.dynamicIsland.publishPresentation).mock.calls.at(-1)?.[0]).toMatchObject({
+        mode: "message",
+        message: { bot: { id: "sales-outbound" }, messageId: "sales-background-answer" },
+      }),
+    );
+
+    vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValue(unreadPage);
+    await fireEvent.click(sales);
+
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        {
+          botId: "sales-outbound",
+          throughMessageId: "sales-background-answer",
+        },
+        "local",
+      ),
+    );
+    await waitFor(() => expect(sales).not.toHaveTextContent("1 new reply"));
+    await waitFor(() =>
+      expect(vi.mocked(window.openbot.dynamicIsland.publishPresentation).mock.calls.at(-1)?.[0]).toMatchObject({
+        mode: "idle",
+      }),
+    );
+  });
+
+  it("shows a completed indicator only until the background app receives focus", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    const chief = screen.getByRole("button", { name: /Chief/ });
+
+    emitAgentEvent?.({
+      type: "turn-completed",
+      botId: "chief",
+      threadId: "thread-chief",
+      turnId: "turn-foreground",
+      status: "completed",
+    });
+    expect(chief).not.toHaveTextContent("Responded");
+
+    window.dispatchEvent(new Event("blur"));
+    emitAgentEvent?.({
+      type: "turn-completed",
+      botId: "chief",
+      threadId: "thread-chief",
+      turnId: "turn-background",
+      status: "completed",
+    });
+    expect(chief).toHaveTextContent("Responded");
+
+    window.dispatchEvent(new Event("focus"));
+    expect(chief).not.toHaveTextContent("Responded");
+  });
+
   it("keeps a message read when it arrives in the open agent chat", async () => {
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -7247,6 +7397,50 @@ describe("OpenBot connected desktop shell", () => {
     expect(scrollElement.scrollTop).toBe(840);
   });
 
+  it("keeps an open private message unread in the background and clears it on focus", async () => {
+    render(() => <App peopleEnabled />);
+    await screen.findByRole("heading", { name: "Chief" });
+    emitPresence?.({
+      serverId: "server-1",
+      updatedAt: "2026-08-19T10:00:00.000Z",
+      members: [
+        presenceMember("member-self", "person@example.com", "Person"),
+        presenceMember("member-alice", "alice@example.com", "Alice"),
+      ],
+    });
+    await fireEvent.click(await screen.findByRole("button", { name: /Alice/ }));
+    await waitFor(() => expect(window.openbot.servers.readDirectConversationPage).toHaveBeenCalled());
+    vi.mocked(window.openbot.servers.markDirectRead).mockClear();
+
+    window.dispatchEvent(new Event("blur"));
+    emitDirectMessage?.({
+      type: "team-direct-message",
+      memberIds: ["member-alice", "member-self"],
+      message: {
+        id: "direct-background",
+        threadId: "thread-member-alice",
+        senderMemberId: "member-alice",
+        recipientMemberId: "member-self",
+        text: "Private result from the background",
+        createdAt: "2026-08-19T10:01:00.000Z",
+        sequence: 1,
+      },
+    });
+
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    expect(window.openbot.servers.markDirectRead).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() =>
+      expect(window.openbot.servers.markDirectRead).toHaveBeenCalledWith({
+        memberId: "member-alice",
+        throughSequence: 1,
+      }),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument());
+  });
+
   it("shows and clears the unread boundary in a private conversation", async () => {
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -7283,6 +7477,7 @@ describe("OpenBot connected desktop shell", () => {
         presenceMember("member-alice", "alice@example.com", "Alice"),
       ],
     });
+    window.dispatchEvent(new Event("blur"));
     await fireEvent.click(await screen.findByRole("button", { name: /Alice/ }));
 
     expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -7082,6 +7082,90 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() => expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument());
   });
 
+  it("keeps a newer agent reply unread when an earlier focus read resolves in the background", async () => {
+    const oldPage = testConversationPage(
+      "chief",
+      [
+        {
+          id: "agent-stale-read-old",
+          author: "assistant",
+          text: "Reply visible before focus",
+          createdAt: "2026-08-19T09:03:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 2,
+        readState: { unreadCount: 1, firstUnreadMessageId: "agent-stale-read-old", throughMessageId: null },
+      },
+    );
+    const newPage = testConversationPage(
+      "chief",
+      [
+        ...oldPage.messages,
+        {
+          id: "agent-stale-read-new",
+          author: "assistant",
+          text: "Reply received after focus was lost",
+          createdAt: "2026-08-19T09:04:00.000Z",
+          status: "completed",
+        },
+      ],
+      {
+        revision: 3,
+        readState: { unreadCount: 2, firstUnreadMessageId: "agent-stale-read-old", throughMessageId: null },
+      },
+    );
+    let resolveFirstRead: ((state: NonNullable<ConversationPage["readState"]>) => void) | undefined;
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    window.dispatchEvent(new Event("blur"));
+    emitAgentEvent?.({ type: "conversation-page", page: oldPage });
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValue(oldPage);
+    vi.mocked(window.openbot.agent.markConversationRead)
+      .mockReset()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRead = resolve;
+          }),
+      )
+      .mockImplementation(async (input) => ({
+        unreadCount: 0,
+        firstUnreadMessageId: null,
+        throughMessageId: input.throughMessageId,
+      }));
+
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        { botId: "chief", throughMessageId: "agent-stale-read-old" },
+        "local",
+      ),
+    );
+    window.dispatchEvent(new Event("blur"));
+    emitAgentEvent?.({ type: "conversation-page", page: newPage });
+    expect(await screen.findByText("Reply received after focus was lost")).toBeInTheDocument();
+    resolveFirstRead?.({
+      unreadCount: 0,
+      firstUnreadMessageId: null,
+      throughMessageId: "agent-stale-read-old",
+    });
+
+    await waitFor(() => expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument());
+    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        { botId: "chief", throughMessageId: "agent-stale-read-new" },
+        "local",
+      ),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument());
+  });
+
   it("keeps another agent new until that agent is opened after focus returns", async () => {
     const unreadPage = testConversationPage(
       "sales-outbound",
@@ -7708,6 +7792,89 @@ describe("OpenBot connected desktop shell", () => {
       throughSequence: 1,
     });
 
+    await waitFor(() =>
+      expect(window.openbot.servers.markDirectRead).toHaveBeenCalledWith({
+        memberId: "member-alice",
+        throughSequence: 2,
+      }),
+    );
+    await waitFor(() => expect(screen.queryByRole("status", { name: /new messages?/ })).not.toBeInTheDocument());
+  });
+
+  it("keeps a newer private message unread when an earlier focus read resolves in the background", async () => {
+    let resolveFirstRead: ((state: NonNullable<DirectConversationSnapshot["readState"]>) => void) | undefined;
+    vi.mocked(window.openbot.servers.readDirectConversation).mockResolvedValueOnce({
+      threadId: "thread-member-alice",
+      otherMemberId: "member-alice",
+      revision: 1,
+      readState: { unreadCount: 1, firstUnreadMessageId: "direct-stale-read-old", throughSequence: 0 },
+      messages: [
+        {
+          id: "direct-stale-read-old",
+          threadId: "thread-member-alice",
+          senderMemberId: "member-alice",
+          recipientMemberId: "member-self",
+          text: "Private reply visible before focus",
+          createdAt: "2026-08-19T10:00:00.000Z",
+          sequence: 1,
+        },
+      ],
+    });
+    render(() => <App peopleEnabled />);
+    await screen.findByRole("heading", { name: "Chief" });
+    emitPresence?.({
+      serverId: "server-1",
+      updatedAt: "2026-08-19T10:00:00.000Z",
+      members: [
+        presenceMember("member-self", "person@example.com", "Person"),
+        presenceMember("member-alice", "alice@example.com", "Alice"),
+      ],
+    });
+    window.dispatchEvent(new Event("blur"));
+    await fireEvent.click(await screen.findByRole("button", { name: /Alice/ }));
+    expect(await screen.findByRole("status", { name: "1 new message" })).toBeInTheDocument();
+    vi.mocked(window.openbot.servers.markDirectRead)
+      .mockReset()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRead = resolve;
+          }),
+      )
+      .mockImplementation(async (input) => ({
+        unreadCount: 0,
+        firstUnreadMessageId: null,
+        throughSequence: input.throughSequence,
+      }));
+
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() =>
+      expect(window.openbot.servers.markDirectRead).toHaveBeenCalledWith({
+        memberId: "member-alice",
+        throughSequence: 1,
+      }),
+    );
+    window.dispatchEvent(new Event("blur"));
+    emitDirectMessage?.({
+      type: "team-direct-message",
+      memberIds: ["member-alice", "member-self"],
+      message: {
+        id: "direct-stale-read-new",
+        threadId: "thread-member-alice",
+        senderMemberId: "member-alice",
+        recipientMemberId: "member-self",
+        text: "Private reply received after focus was lost",
+        createdAt: "2026-08-19T10:01:00.000Z",
+        sequence: 2,
+      },
+    });
+    expect(await screen.findByText("Private reply received after focus was lost")).toBeInTheDocument();
+    resolveFirstRead?.({ unreadCount: 0, firstUnreadMessageId: null, throughSequence: 1 });
+
+    await waitFor(() => expect(screen.getByRole("status", { name: "1 new message" })).toBeInTheDocument());
+    expect(window.openbot.servers.markDirectRead).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new Event("focus"));
     await waitFor(() =>
       expect(window.openbot.servers.markDirectRead).toHaveBeenCalledWith({
         memberId: "member-alice",

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -3958,6 +3958,49 @@ describe("OpenBot connected desktop shell", () => {
     });
   });
 
+  it("does not read an earlier agent reply again after sending a message", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    emitAgentEvent?.({
+      type: "conversation",
+      snapshot: {
+        botId: "chief",
+        threadId: "thread-chief",
+        activeTurnId: null,
+        revision: 1,
+        messages: [
+          {
+            id: "assistant-before-send",
+            author: "assistant",
+            text: "Earlier agent reply",
+            createdAt: "2026-08-12T10:00:00.000Z",
+            status: "completed",
+          },
+        ],
+      },
+    });
+    await screen.findByText("Earlier agent reply");
+    await waitFor(() => expect(window.openbot.agent.markConversationRead).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    vi.mocked(window.openbot.agent.markConversationRead).mockClear();
+
+    const composer = screen.getByRole("textbox", { name: "Message Chief" });
+    composer.textContent = "Continue this work";
+    await fireEvent.input(composer);
+    await fireEvent.keyDown(composer, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(window.openbot.agent.markConversationRead).toHaveBeenCalledWith(
+        { botId: "chief", throughMessageId: "delivery-1" },
+        "local",
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(vi.mocked(window.openbot.agent.markConversationRead).mock.calls).toEqual([
+      [{ botId: "chief", throughMessageId: "delivery-1" }, "local"],
+    ]);
+  });
+
   it("publishes typing state", async () => {
     render(() => <App />);
     await confirmOnboardingModel();
@@ -5614,7 +5657,9 @@ describe("OpenBot connected desktop shell", () => {
 
     emitAgentEvent?.({ type: "conversation-page", page: delayedPage });
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(window.openbot.agent.markConversationRead).toHaveBeenCalledOnce();
+    expect(vi.mocked(window.openbot.agent.markConversationRead).mock.calls).toEqual([
+      [{ botId: "chief", throughMessageId: "reply-delayed-read-state" }, "local"],
+    ]);
     expect(screen.queryByRole("status", { name: "1 new message" })).not.toBeInTheDocument();
   });
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -360,10 +360,7 @@ export function createAppController(props: AppProps = {}) {
   const [remoteDesktopConnectingServerId, setRemoteDesktopConnectingServerId] = createSignal<string | null>(null);
   const [remoteDesktopConnectionError, setRemoteDesktopConnectionError] = createSignal<string | null>(null);
   const [remoteDesktopSessionEstablished, setRemoteDesktopSessionEstablished] = createSignal(false);
-  const pendingConversationSnapshots = new Map<
-    string,
-    { snapshot: ConversationSnapshot; markNewMessagesRead: boolean }
-  >();
+  const pendingConversationSnapshots = new Map<string, ConversationSnapshot>();
   const agentChatsToMarkRead = new Set<string>();
   const agentChatsRetriedOnOpen = new Set<string>();
   let explicitlyOpenedAgentChatId: string | null = null;
@@ -375,6 +372,7 @@ export function createAppController(props: AppProps = {}) {
   const agentChatsToRetryRead = new Set<string>();
   const conversationPageRequests = new Map<string, number>();
   const conversationReadOperations = new Map<string, Promise<void>>();
+  const directConversationReadOperations = new Map<string, Promise<void>>();
   const queueSnapshotRequests = new Map<string, number>();
   const completedTurnByBot = new Map<string, string>();
   const pendingProviderConnections = new Map<AgentProviderId, ReturnType<typeof desktopAnalytics.scope>>();
@@ -996,7 +994,7 @@ export function createAppController(props: AppProps = {}) {
         setSidebarLayout(event.layout);
         return;
       case "conversation":
-        scheduleConversation(event.snapshot, isAgentChatReadable(event.snapshot.botId));
+        scheduleConversation(event.snapshot);
         return;
       case "conversation-page":
         {
@@ -1240,26 +1238,20 @@ export function createAppController(props: AppProps = {}) {
     setUnreadReplies((current) => ({ ...current, [botId]: state.unreadCount }));
   }
 
-  function scheduleConversation(snapshot: ConversationSnapshot, markNewMessagesRead = false) {
+  function scheduleConversation(snapshot: ConversationSnapshot) {
     const botId = snapshot.botId;
     const appliedRevision = conversationRevisions()[botId] ?? -1;
     const pending = pendingConversationSnapshots.get(botId);
-    const pendingRevision = pending?.snapshot.revision ?? -1;
+    const pendingRevision = pending?.revision ?? -1;
     if (snapshot.revision < Math.max(appliedRevision, pendingRevision)) return;
-    pendingConversationSnapshots.set(botId, {
-      snapshot,
-      markNewMessagesRead: markNewMessagesRead || (pending?.markNewMessagesRead ?? false),
-    });
+    pendingConversationSnapshots.set(botId, snapshot);
     if (conversationFrame !== undefined) return;
     conversationFrame = requestAnimationFrame(() => {
       conversationFrame = undefined;
       const snapshots = [...pendingConversationSnapshots.values()];
       pendingConversationSnapshots.clear();
       for (const pendingSnapshot of snapshots) {
-        applyConversation(
-          pendingSnapshot.snapshot,
-          pendingSnapshot.markNewMessagesRead || isAgentChatReadable(pendingSnapshot.snapshot.botId),
-        );
+        applyConversation(pendingSnapshot, isAgentChatReadable(pendingSnapshot.botId));
       }
     });
   }
@@ -1276,19 +1268,25 @@ export function createAppController(props: AppProps = {}) {
     return `${serverId}\0${botId}`;
   }
 
+  function latestVisibleAgentMessageId(botId: string): string | null {
+    return (
+      liveMessages()
+        [botId]?.filter(
+          (message) =>
+            message.author !== "you" &&
+            message.itemType !== "commentary" &&
+            message.itemType !== "agent_attachment" &&
+            !message.id.startsWith("thinking:") &&
+            !message.id.startsWith("ui-"),
+        )
+        .at(-1)?.id ?? null
+    );
+  }
+
   function markLatestVisibleAgentMessageRead(botId: string, serverId: string): void {
-    const latestIncomingMessage = liveMessages()
-      [botId]?.filter(
-        (message) =>
-          message.author !== "you" &&
-          message.itemType !== "commentary" &&
-          message.itemType !== "agent_attachment" &&
-          !message.id.startsWith("thinking:") &&
-          !message.id.startsWith("ui-"),
-      )
-      .at(-1);
-    if (!latestIncomingMessage) return;
-    void markAgentMessagesRead(botId, latestIncomingMessage.id, serverId).catch((error) =>
+    const latestMessageId = latestVisibleAgentMessageId(botId);
+    if (!latestMessageId) return;
+    void markAgentMessagesRead(botId, latestMessageId, serverId).catch((error) =>
       appendUiError(botId, error, "Read state failed"),
     );
   }
@@ -1943,17 +1941,53 @@ export function createAppController(props: AppProps = {}) {
 
   async function markDirectMessagesRead(memberId = activeDirectMemberId(), throughSequence?: number): Promise<void> {
     if (!memberId) return;
+    const serverId = activeServerSidebarKey();
+    const requestKey = `${serverId}\0${memberId}`;
     const snapshot = directConversations()[memberId];
     const boundary = throughSequence ?? snapshot?.messages.at(-1)?.sequence ?? 0;
-    const readState = await window.openbot.servers.markDirectRead({
-      memberId,
-      throughSequence: boundary,
-    });
-    setDirectConversations((current) => {
-      const currentSnapshot = current[memberId];
-      return currentSnapshot ? { ...current, [memberId]: { ...currentSnapshot, readState } } : current;
-    });
-    await refreshDirectThreads();
+    const previousOperation = directConversationReadOperations.get(requestKey) ?? Promise.resolve();
+    const operation: Promise<void> = previousOperation
+      .catch(() => undefined)
+      .then(async () => {
+        if (activeServerSidebarKey() !== serverId) return;
+        const readState = await window.openbot.servers.markDirectRead({
+          memberId,
+          throughSequence: boundary,
+        });
+        if (activeServerSidebarKey() !== serverId) return;
+        setDirectConversations((current) => {
+          const currentSnapshot = current[memberId];
+          return currentSnapshot ? { ...current, [memberId]: { ...currentSnapshot, readState } } : current;
+        });
+        await refreshDirectThreads();
+        const latestSequence = directConversations()[memberId]?.messages.at(-1)?.sequence ?? boundary;
+        if (
+          directConversationReadOperations.get(requestKey) === operation &&
+          appFocused() &&
+          activeDirectMemberId() === memberId &&
+          latestSequence > boundary
+        ) {
+          queueMicrotask(() => {
+            const latestVisibleSequence = directConversations()[memberId]?.messages.at(-1)?.sequence ?? boundary;
+            if (
+              activeServerSidebarKey() === serverId &&
+              appFocused() &&
+              activeDirectMemberId() === memberId &&
+              latestVisibleSequence > boundary
+            ) {
+              void markDirectMessagesRead(memberId, latestVisibleSequence).catch(() => undefined);
+            }
+          });
+        }
+      });
+    directConversationReadOperations.set(requestKey, operation);
+    try {
+      await operation;
+    } finally {
+      if (directConversationReadOperations.get(requestKey) === operation) {
+        directConversationReadOperations.delete(requestKey);
+      }
+    }
   }
 
   function setDirectTyping(typing: boolean): void {
@@ -2266,7 +2300,7 @@ export function createAppController(props: AppProps = {}) {
         .at(-1)?.id ??
       null;
     const previousOperation = conversationReadOperations.get(requestKey) ?? Promise.resolve();
-    const operation = previousOperation
+    const operation: Promise<void> = previousOperation
       .catch(() => undefined)
       .then(async () => {
         const state: ConversationReadState = await window.openbot.agent.markConversationRead(
@@ -2283,6 +2317,28 @@ export function createAppController(props: AppProps = {}) {
         if (activeServerSidebarKey() === serverId && !supersededByAutoRead) {
           applyConversationReadState(botId, state);
           clearRecentReply(botId);
+        }
+        const latestMessageId = latestVisibleAgentMessageId(botId);
+        if (
+          conversationReadOperations.get(requestKey) === operation &&
+          activeServerSidebarKey() === serverId &&
+          isAgentChatReadable(botId) &&
+          latestMessageId &&
+          latestMessageId !== boundary
+        ) {
+          queueMicrotask(() => {
+            const latestVisibleMessageId = latestVisibleAgentMessageId(botId);
+            if (
+              activeServerSidebarKey() === serverId &&
+              isAgentChatReadable(botId) &&
+              latestVisibleMessageId &&
+              latestVisibleMessageId !== boundary
+            ) {
+              void markAgentMessagesRead(botId, latestVisibleMessageId, serverId).catch((error) =>
+                appendUiError(botId, error, "Read state failed"),
+              );
+            }
+          });
         }
       });
     conversationReadOperations.set(requestKey, operation);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -251,6 +251,7 @@ export function createAppController(props: AppProps = {}) {
   const [botList, setBotList] = createSignal<BotProfile[]>([]);
   const [modelOptions, setModelOptions] = createSignal<AgentModelOption[]>([]);
   const [activeBotId, setActiveBotId] = createSignal("");
+  const [appFocused, setAppFocused] = createSignal(document.hasFocus());
   const [agentChatOpenRevision, setAgentChatOpenRevision] = createSignal(0);
   const [liveMessages, setLiveMessages] = createSignal<Record<string, BotMessage[]>>({});
   const [uiErrors, setUiErrors] = createSignal<Record<string, BotMessage[]>>({});
@@ -372,7 +373,6 @@ export function createAppController(props: AppProps = {}) {
     | { messageId: string; status: "succeeded"; state: ConversationReadState }
   >();
   const agentChatsToRetryRead = new Set<string>();
-  const recentReplyTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const conversationPageRequests = new Map<string, number>();
   const conversationReadOperations = new Map<string, Promise<void>>();
   const queueSnapshotRequests = new Map<string, number>();
@@ -709,6 +709,26 @@ export function createAppController(props: AppProps = {}) {
       setGlobalSearchVisibility(!globalSearchOpen());
     };
     window.addEventListener("keydown", handleGlobalSearchShortcut);
+    const handleWindowBlur = () => flush(() => setAppFocused(false));
+    const handleWindowFocus = () => {
+      flush(() => {
+        setAppFocused(true);
+        setRecentReplies({});
+        const botId = activeBot()?.id;
+        if (botId && isAgentChatOpen(botId) && (conversationReads()[botId]?.unreadCount ?? 0) > 0) {
+          const trackingKey = agentConversationKey(activeServerSidebarKey(), botId);
+          agentChatsToMarkRead.add(trackingKey);
+          agentChatsRetriedOnOpen.delete(botId);
+          setAgentChatOpenRevision((current) => current + 1);
+        }
+        const memberId = activeDirectMemberId();
+        if (memberId && (directConversations()[memberId]?.readState?.unreadCount ?? 0) > 0) {
+          void markDirectMessagesRead(memberId).catch(() => undefined);
+        }
+      });
+    };
+    window.addEventListener("blur", handleWindowBlur);
+    window.addEventListener("focus", handleWindowFocus);
     const cleanup = () => {
       unsubscribe();
       unsubscribeScopedAgent();
@@ -723,9 +743,9 @@ export function createAppController(props: AppProps = {}) {
       unsubscribeHost();
       unsubscribeRemoteDesktop();
       window.removeEventListener("keydown", handleGlobalSearchShortcut);
+      window.removeEventListener("blur", handleWindowBlur);
+      window.removeEventListener("focus", handleWindowFocus);
       if (conversationFrame !== undefined) cancelAnimationFrame(conversationFrame);
-      for (const timer of recentReplyTimers.values()) clearTimeout(timer);
-      recentReplyTimers.clear();
       completedTurnByBot.clear();
       pendingProviderConnections.clear();
       if (authSuccessTimer !== undefined) clearTimeout(authSuccessTimer);
@@ -976,14 +996,14 @@ export function createAppController(props: AppProps = {}) {
         setSidebarLayout(event.layout);
         return;
       case "conversation":
-        scheduleConversation(event.snapshot, isAgentChatOpen(event.snapshot.botId));
+        scheduleConversation(event.snapshot, isAgentChatReadable(event.snapshot.botId));
         return;
       case "conversation-page":
         {
           const existingUnreadCount = conversationReads()[event.page.botId]?.unreadCount ?? 0;
           const trackingKey = agentConversationKey(activeServerSidebarKey(), event.page.botId);
           const markNewMessagesRead =
-            isAgentChatOpen(event.page.botId) &&
+            isAgentChatReadable(event.page.botId) &&
             (event.page.readState === undefined || event.page.readState.unreadCount > 0) &&
             (existingUnreadCount === 0 ||
               explicitlyOpenedAgentChatId === event.page.botId ||
@@ -1236,13 +1256,20 @@ export function createAppController(props: AppProps = {}) {
       const snapshots = [...pendingConversationSnapshots.values()];
       pendingConversationSnapshots.clear();
       for (const pendingSnapshot of snapshots) {
-        applyConversation(pendingSnapshot.snapshot, pendingSnapshot.markNewMessagesRead);
+        applyConversation(
+          pendingSnapshot.snapshot,
+          pendingSnapshot.markNewMessagesRead || isAgentChatReadable(pendingSnapshot.snapshot.botId),
+        );
       }
     });
   }
 
   function isAgentChatOpen(botId: string): boolean {
     return !botSetupOpen() && !activeDirectMemberId() && activeBot()?.id === botId;
+  }
+
+  function isAgentChatReadable(botId: string): boolean {
+    return appFocused() && isAgentChatOpen(botId);
   }
 
   function agentConversationKey(serverId: string, botId: string): string {
@@ -1375,7 +1402,7 @@ export function createAppController(props: AppProps = {}) {
         [event.botId]: [...(current[event.botId] ?? []), message],
       }));
       const readState = conversationReads()[event.botId];
-      if (isAgentChatOpen(event.botId)) {
+      if (isAgentChatReadable(event.botId)) {
         autoMarkAgentMessageRead(event.botId, event.messageId);
       } else if (readState) {
         applyConversationReadState(event.botId, {
@@ -1753,6 +1780,9 @@ export function createAppController(props: AppProps = {}) {
         [memberId]: snapshot,
       }));
       setDirectConversationPages((current) => ({ ...current, [memberId]: snapshot.pageInfo }));
+      if (appFocused() && (snapshot.readState?.unreadCount ?? 0) > 0) {
+        void markDirectMessagesRead(memberId, snapshot.messages.at(-1)?.sequence).catch(() => undefined);
+      }
     } catch (error) {
       if (request !== directConversationRequest) return;
       setDirectConversationError(error instanceof Error ? error.message : "The messages could not load.");
@@ -1940,6 +1970,7 @@ export function createAppController(props: AppProps = {}) {
     const markVisibleMessageRead =
       event.message.senderMemberId !== currentMemberId &&
       activeDirectMemberId() === otherMemberId &&
+      appFocused() &&
       (directConversations()[otherMemberId]?.readState?.unreadCount ?? 0) === 0;
     mergeDirectMessage(otherMemberId, event.message);
     if (markVisibleMessageRead) {
@@ -1976,7 +2007,7 @@ export function createAppController(props: AppProps = {}) {
       };
       const incomingUnread =
         message.senderMemberId !== currentTeamMember()?.id && message.sequence > readState.throughSequence;
-      const visibleIncomingMessage = incomingUnread && activeDirectMemberId() === memberId;
+      const visibleIncomingMessage = incomingUnread && activeDirectMemberId() === memberId && appFocused();
       let nextReadState = readState;
       if (visibleIncomingMessage && readState.unreadCount === 0) {
         nextReadState = {
@@ -2005,20 +2036,11 @@ export function createAppController(props: AppProps = {}) {
 
   function markReplyCompleted(botId: string) {
     clearRecentReply(botId);
+    if (appFocused()) return;
     setRecentReplies((current) => ({ ...current, [botId]: true }));
-    recentReplyTimers.set(
-      botId,
-      setTimeout(() => {
-        recentReplyTimers.delete(botId);
-        setRecentReplies((current) => ({ ...current, [botId]: false }));
-      }, 4000),
-    );
   }
 
   function clearRecentReply(botId: string) {
-    const timer = recentReplyTimers.get(botId);
-    if (timer) clearTimeout(timer);
-    recentReplyTimers.delete(botId);
     setRecentReplies((current) => (current[botId] ? { ...current, [botId]: false } : current));
   }
 
@@ -2151,9 +2173,6 @@ export function createAppController(props: AppProps = {}) {
       setQueues((current) => withoutBot(current, botId));
       setPendingPrompts((current) => withoutBot(current, botId));
       removePinnedSidebarItemEverywhere({ kind: "agent", id: botId });
-      const replyTimer = recentReplyTimers.get(botId);
-      if (replyTimer) clearTimeout(replyTimer);
-      recentReplyTimers.delete(botId);
       analytics.track("agent_action", { action: "delete", result: "succeeded", ...(properties ?? {}) });
       if (marketplaceAgent) {
         analytics.track("marketplace_action", { entity: "agent", action: "uninstall", result: "succeeded" });

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2293,6 +2293,7 @@ export function createAppController(props: AppProps = {}) {
   ): Promise<void> {
     if (!botId || activeServerSidebarKey() !== serverId) return;
     const requestKey = agentConversationKey(serverId, botId);
+    const visibleMessageIdAtStart = latestVisibleAgentMessageId(botId);
     const boundary =
       throughMessageId ??
       liveMessages()
@@ -2324,7 +2325,8 @@ export function createAppController(props: AppProps = {}) {
           activeServerSidebarKey() === serverId &&
           isAgentChatReadable(botId) &&
           latestMessageId &&
-          latestMessageId !== boundary
+          latestMessageId !== boundary &&
+          latestMessageId !== visibleMessageIdAtStart
         ) {
           queueMicrotask(() => {
             const latestVisibleMessageId = latestVisibleAgentMessageId(botId);
@@ -2332,7 +2334,8 @@ export function createAppController(props: AppProps = {}) {
               activeServerSidebarKey() === serverId &&
               isAgentChatReadable(botId) &&
               latestVisibleMessageId &&
-              latestVisibleMessageId !== boundary
+              latestVisibleMessageId !== boundary &&
+              latestVisibleMessageId !== visibleMessageIdAtStart
             ) {
               void markAgentMessagesRead(botId, latestVisibleMessageId, serverId).catch((error) =>
                 appendUiError(botId, error, "Read state failed"),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -161,6 +161,50 @@ function serverSupportsCapability(server: ServerSummary | undefined, capability:
 type PromptEvent = Extract<AgentEvent, { type: "prompt" }>;
 type BrowserTakeoverEvent = Extract<AgentEvent, { type: "browser-takeover-requested" }>;
 
+function preserveKnownAgentUnread(
+  state: ConversationReadState,
+  boundary: string | null,
+  messages: BotMessage[],
+): ConversationReadState {
+  const throughMessageId = state.throughMessageId ?? boundary;
+  const throughIndex = throughMessageId ? messages.findIndex((message) => message.id === throughMessageId) : -1;
+  if (throughMessageId && throughIndex < 0) return state;
+  const unread = messages
+    .slice(throughIndex + 1)
+    .filter(
+      (message) =>
+        message.author !== "you" &&
+        message.itemType !== "commentary" &&
+        message.itemType !== "agent_attachment" &&
+        !message.id.startsWith("thinking:") &&
+        !message.id.startsWith("ui-"),
+    );
+  if (unread.length <= state.unreadCount) return state;
+  return {
+    ...state,
+    unreadCount: unread.length,
+    firstUnreadMessageId: unread[0]?.id ?? null,
+  };
+}
+
+function preserveKnownDirectUnread(
+  state: NonNullable<DirectConversationSnapshot["readState"]>,
+  boundary: number,
+  messages: DirectMessage[],
+  currentMemberId: string | undefined,
+): NonNullable<DirectConversationSnapshot["readState"]> {
+  const throughSequence = Math.max(state.throughSequence, boundary);
+  const unread = messages.filter(
+    (message) => message.senderMemberId !== currentMemberId && message.sequence > throughSequence,
+  );
+  if (unread.length <= state.unreadCount) return state;
+  return {
+    ...state,
+    unreadCount: unread.length,
+    firstUnreadMessageId: unread[0]?.id ?? null,
+  };
+}
+
 function promptRequestKey(turnId: string | undefined, requestId: string | number | undefined): string | null {
   if (!turnId || requestId === undefined) return null;
   return JSON.stringify([turnId, String(requestId)]);
@@ -1989,7 +2033,12 @@ export function createAppController(props: AppProps = {}) {
         if (activeServerSidebarKey() !== serverId) return;
         setDirectConversations((current) => {
           const currentSnapshot = current[memberId];
-          return currentSnapshot ? { ...current, [memberId]: { ...currentSnapshot, readState } } : current;
+          if (!currentSnapshot) return current;
+          const nextReadState =
+            appFocused() && activeDirectMemberId() === memberId
+              ? readState
+              : preserveKnownDirectUnread(readState, boundary, currentSnapshot.messages, currentTeamMember()?.id);
+          return { ...current, [memberId]: { ...currentSnapshot, readState: nextReadState } };
         });
         await refreshDirectThreads();
         const latestSequence = directConversations()[memberId]?.messages.at(-1)?.sequence ?? boundary;
@@ -2345,12 +2394,15 @@ export function createAppController(props: AppProps = {}) {
           serverId,
         );
         agentChatsToRetryRead.delete(requestKey);
-        onSuccess?.(state);
+        const nextState = isAgentChatReadable(botId)
+          ? state
+          : preserveKnownAgentUnread(state, boundary, liveMessages()[botId] ?? []);
+        onSuccess?.(nextState);
         const trackedAutoRead = autoReadAgentMessages.get(requestKey);
         const supersededByAutoRead = Boolean(trackedAutoRead && trackedAutoRead.messageId !== boundary);
         if (activeServerSidebarKey() === serverId && !supersededByAutoRead) {
-          applyConversationReadState(botId, state);
-          clearRecentReply(botId);
+          applyConversationReadState(botId, nextState);
+          if (nextState.unreadCount === 0) clearRecentReply(botId);
         }
         const latestMessageId = latestVisibleAgentMessageId(botId);
         if (


### PR DESCRIPTION
## Summary

- keep new messages unread while OpenBot is in the background
- clear the active conversation when app focus returns, while other agents remain unread until opened
- keep completion indicators in the background until focus returns
- synchronize the same read state with Dynamic Island and direct messages

## Verification

- `bunx vitest run src/renderer/src/App.test.tsx` (159 tests)
- staged Biome checks
- project type checks