### PR TITLE
Preserve embedded browser sessions across shutdowns and updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to OpenBot will be documented here. The project follows
 ### Fixed
 
 - Restore embedded X sign-in with persistent cookie consent, a compatible browser identity, and current login routing.
+- Flush the embedded browser profile before restarts, system shutdowns, and application updates so authenticated sessions persist.
 
 ## [0.4.0] - 2026-08-30
 

--- a/scripts/browser-smoke-electron.ts
+++ b/scripts/browser-smoke-electron.ts
@@ -304,7 +304,19 @@ async function main(): Promise<void> {
 
     const persistedTab = await browser.open(`${origin}/cookie`, "persisted-thread", "persisted-bot");
     await browser.activate(persistedTab.id);
-    await browser.destroy();
+    const browserDestruction = browser.destroy();
+    if (browser.listTabs().length !== 0) {
+      throw new Error("BrowserHost kept views active while shutdown persistence was pending.");
+    }
+    await browserDestruction;
+    await browser
+      .open(`${origin}/cookie`, "late-thread")
+      .then(() => {
+        throw new Error("BrowserHost accepted a new tab after shutdown started.");
+      })
+      .catch((error) => {
+        if (!String(error).includes("shutting down")) throw error;
+      });
     const restoredWindow = new BrowserWindow({ show: false });
     window.destroy();
     const restoredBrowser = new BrowserHost(restoredWindow, downloadsRoot, statePath);
@@ -348,7 +360,6 @@ async function runPersistencePhase(root: string, origin: string, phase: string):
   await app.whenReady();
   const window = new BrowserWindow({ show: false });
   const browser = new BrowserHost(window, join(root, "downloads"), join(root, "browser-tabs.json"));
-  let storageFlushed = false;
   await browser.setVisible({ visible: true, bounds: { x: 0, y: 0, width: 800, height: 600 } });
   try {
     const tab = await browser.open(`${origin}/persistence?phase=${encodeURIComponent(phase)}`, "persistence-thread");
@@ -374,10 +385,9 @@ async function runPersistencePhase(root: string, origin: string, phase: string):
       process.stdout.write("BrowserHost: signed macOS app must verify encrypted cookie persistence.\n");
     }
     await browser.flushPersistentStorage();
-    storageFlushed = true;
   } finally {
     try {
-      await browser.destroy({ storageAlreadyFlushed: storageFlushed });
+      await browser.destroy();
     } finally {
       window.destroy();
     }

--- a/scripts/browser-smoke-electron.ts
+++ b/scripts/browser-smoke-electron.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,6 +8,13 @@ import { BrowserHost } from "../src/backend/browser-host";
 import { getString } from "../src/backend/protocol";
 
 let cachedPageVersion = 1;
+
+interface PersistenceSnapshot {
+  ready: true;
+  cookie: string;
+  localStorage: string | null;
+  indexedDb: string | null;
+}
 
 const server = createServer((request, response) => {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
@@ -68,9 +75,15 @@ void main().catch((error) => {
 async function main(): Promise<void> {
   const googleLive = process.argv.includes("--google-live");
   const xLive = process.argv.includes("--x-live");
-  const temporaryRoot = await mkdtemp(join(tmpdir(), "openbot-browser-smoke-"));
+  const configuredRoot = argumentValue("--smoke-root=");
+  const persistencePhase = argumentValue("--persistence-phase=");
+  const persistenceOrigin = argumentValue("--persistence-origin=");
+  const temporaryRoot = configuredRoot ?? (await mkdtemp(join(tmpdir(), "openbot-browser-smoke-")));
+  const userDataPath = join(temporaryRoot, "user-data");
+  await mkdir(userDataPath, { recursive: true });
   app.setName("OpenBot");
-  app.setPath("userData", join(temporaryRoot, "user-data"));
+  app.setPath("userData", userDataPath);
+  app.setPath("sessionData", userDataPath);
   const hardTimeout = setTimeout(
     () => {
       process.stderr.write("BrowserHost smoke test timed out.\n");
@@ -80,6 +93,11 @@ async function main(): Promise<void> {
   );
 
   try {
+    if (persistencePhase) {
+      if (!persistenceOrigin) throw new Error("A persistence origin is required.");
+      await runPersistencePhase(temporaryRoot, persistenceOrigin, persistencePhase);
+      return;
+    }
     await new Promise<void>((resolve, reject) => {
       server.once("error", reject);
       server.listen(0, "127.0.0.1", resolve);
@@ -317,10 +335,81 @@ async function main(): Promise<void> {
     process.stdout.write("BrowserHost smoke test passed.\n");
   } finally {
     clearTimeout(hardTimeout);
-    server.close();
-    await rm(temporaryRoot, { recursive: true, force: true });
+    if (server.listening) server.close();
+    if (!configuredRoot) await rm(temporaryRoot, { recursive: true, force: true });
     app.quit();
   }
+}
+
+async function runPersistencePhase(root: string, origin: string, phase: string): Promise<void> {
+  if (!new Set(["write", "read", "clear", "verify-cleared"]).has(phase)) {
+    throw new Error(`Unknown persistence phase: ${phase}`);
+  }
+  await app.whenReady();
+  const window = new BrowserWindow({ show: false });
+  const browser = new BrowserHost(window, join(root, "downloads"), join(root, "browser-tabs.json"));
+  let storageFlushed = false;
+  await browser.setVisible({ visible: true, bounds: { x: 0, y: 0, width: 800, height: 600 } });
+  try {
+    const tab = await browser.open(`${origin}/persistence?phase=${encodeURIComponent(phase)}`, "persistence-thread");
+    const snapshot = await waitForPersistenceSnapshot(browser, tab.id);
+    const expectedStored = phase === "write" || phase === "read";
+    const cookie = getString(snapshot, "cookie") ?? "";
+    const localStorageValue = getString(snapshot, "localStorage");
+    const indexedDbValue = getString(snapshot, "indexedDb");
+    // The npm macOS Electron binary does not have OpenBot's production signature or cookie-encryption fuse.
+    // Verify encrypted cookie persistence with the signed app; other platforms cover it in this process test.
+    const requireCrossProcessCookie = phase !== "read" || process.platform !== "darwin";
+    if (
+      (expectedStored &&
+        (localStorageValue !== "kept" ||
+          indexedDbValue !== "kept" ||
+          (requireCrossProcessCookie && !cookie.includes("openbot_persistence=kept")))) ||
+      (!expectedStored &&
+        (cookie.includes("openbot_persistence=kept") || localStorageValue !== null || indexedDbValue !== null))
+    ) {
+      throw new Error(`Browser persistence phase ${phase} returned invalid state: ${JSON.stringify(snapshot)}`);
+    }
+    if (expectedStored && !requireCrossProcessCookie && !cookie.includes("openbot_persistence=kept")) {
+      process.stdout.write("BrowserHost: signed macOS app must verify encrypted cookie persistence.\n");
+    }
+    await browser.flushPersistentStorage();
+    storageFlushed = true;
+  } finally {
+    try {
+      await browser.destroy({ storageAlreadyFlushed: storageFlushed });
+    } finally {
+      window.destroy();
+    }
+  }
+  process.stdout.write(`BrowserHost: persistence ${phase} phase passed.\n`);
+}
+
+async function waitForPersistenceSnapshot(browser: BrowserHost, tabId: string): Promise<PersistenceSnapshot> {
+  let latest = "";
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const snapshot = await browser.snapshot(tabId);
+    latest = snapshot.text;
+    try {
+      const parsed = JSON.parse(snapshot.text);
+      if (isDynamicRecord(parsed) && parsed.ready === true) {
+        return {
+          ready: true,
+          cookie: getString(parsed, "cookie") ?? "",
+          localStorage: getString(parsed, "localStorage"),
+          indexedDb: getString(parsed, "indexedDb"),
+        };
+      }
+    } catch {
+      // The page can still be initializing IndexedDB.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Persistence page did not become ready: ${latest}`);
+}
+
+function argumentValue(prefix: string): string | null {
+  return process.argv.find((argument) => argument.startsWith(prefix))?.slice(prefix.length) || null;
 }
 
 async function runGoogleLiveProbe(browser: BrowserHost): Promise<void> {

--- a/scripts/browser-smoke.ts
+++ b/scripts/browser-smoke.ts
@@ -1,14 +1,18 @@
 import { spawn } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { z } from "zod";
 
 const scriptsRoot = dirname(fileURLToPath(import.meta.url));
 const projectRoot = dirname(scriptsRoot);
 const outputRoot = await mkdtemp(join(tmpdir(), "openbot-browser-build-"));
 try {
   const outputPath = join(outputRoot, "browser-smoke.mjs");
+  const smokeRoot = join(outputRoot, "single-process");
+  const persistenceRoot = join(outputRoot, "cross-process");
   const buildCode = await run(process.execPath, [
     "build",
     join(scriptsRoot, "browser-smoke-electron.ts"),
@@ -20,10 +24,131 @@ try {
   if (buildCode !== 0) throw new Error("Unable to build browser smoke test.");
 
   const electron = join(projectRoot, "node_modules", ".bin", "electron");
-  const exitCode = await run(electron, [outputPath, ...process.argv.slice(2)], true);
-  if (exitCode !== 0) process.exitCode = exitCode;
+  const exitCode = await run(electron, [outputPath, `--smoke-root=${smokeRoot}`, ...process.argv.slice(2)], true);
+  if (exitCode !== 0) {
+    process.exitCode = exitCode;
+  } else {
+    const persistenceServer = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (url.pathname !== "/persistence") {
+        response.writeHead(404).end();
+        return;
+      }
+      const phase = url.searchParams.get("phase");
+      if (phase === "write") {
+        response.setHeader(
+          "set-cookie",
+          "openbot_persistence=kept; Max-Age=31536000; Expires=Tue, 19 Jan 2038 03:14:07 GMT; Path=/; SameSite=Lax",
+        );
+      } else if (phase === "clear") {
+        response.setHeader("set-cookie", "openbot_persistence=; Max-Age=0; Path=/; SameSite=Lax");
+      }
+      response.setHeader("content-type", "text/html; charset=utf-8");
+      response.end(persistencePage());
+    });
+    try {
+      const persistenceOrigin = await listen(persistenceServer);
+      for (const phase of ["write", "read", "clear", "verify-cleared"]) {
+        const phaseExitCode = await run(
+          electron,
+          [
+            outputPath,
+            `--smoke-root=${persistenceRoot}`,
+            `--persistence-origin=${persistenceOrigin}`,
+            `--persistence-phase=${phase}`,
+          ],
+          true,
+        );
+        if (phaseExitCode !== 0) {
+          process.exitCode = phaseExitCode;
+          break;
+        }
+      }
+    } finally {
+      await close(persistenceServer);
+    }
+  }
 } finally {
   await rm(outputRoot, { recursive: true, force: true });
+}
+
+function persistencePage(): string {
+  return `<!doctype html><body>loading<script>
+  const phase = new URL(location.href).searchParams.get("phase");
+  const databaseName = "openbot-persistence-smoke";
+  function openDatabase() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(databaseName, 1);
+      request.onupgradeneeded = () => request.result.createObjectStore("state");
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+  async function writeDatabase() {
+    const database = await openDatabase();
+    const transaction = database.transaction("state", "readwrite");
+    transaction.objectStore("state").put("kept", "session");
+    await new Promise((resolve, reject) => {
+      transaction.oncomplete = resolve;
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () => reject(transaction.error);
+    });
+    database.close();
+  }
+  async function readDatabase() {
+    const database = await openDatabase();
+    const transaction = database.transaction("state", "readonly");
+    const request = transaction.objectStore("state").get("session");
+    const value = await new Promise((resolve, reject) => {
+      request.onsuccess = () => resolve(request.result ?? null);
+      request.onerror = () => reject(request.error);
+    });
+    database.close();
+    return value;
+  }
+  function deleteDatabase() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.deleteDatabase(databaseName);
+      request.onsuccess = resolve;
+      request.onerror = () => reject(request.error);
+      request.onblocked = () => reject(new Error("IndexedDB deletion was blocked."));
+    });
+  }
+  async function main() {
+    if (phase === "write") {
+      localStorage.setItem("openbot-persistence", "kept");
+      await writeDatabase();
+    } else if (phase === "clear") {
+      localStorage.removeItem("openbot-persistence");
+      await deleteDatabase();
+    }
+    const indexedDbValue = phase === "clear" ? null : await readDatabase();
+    document.body.textContent = JSON.stringify({
+      ready: true,
+      cookie: document.cookie,
+      localStorage: localStorage.getItem("openbot-persistence"),
+      indexedDb: indexedDbValue,
+    });
+  }
+  main().catch((error) => {
+    document.body.textContent = JSON.stringify({ ready: false, error: String(error) });
+  });
+</script></body>`;
+}
+
+function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = z.object({ port: z.number().int() }).parse(server.address());
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+function close(server: ReturnType<typeof createServer>): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
 }
 
 function run(executable: string, arguments_: string[], filterExpectedElectronNoise = false): Promise<number> {

--- a/src/backend/browser-host.ts
+++ b/src/backend/browser-host.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, rename, rm, writeFile } from "node:fs/promises";
 import { basename, extname, join } from "node:path";
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type {
@@ -484,19 +484,22 @@ export class BrowserHost {
     }
   }
 
-  async destroy(): Promise<void> {
-    try {
-      await this.#persistState();
-    } finally {
-      for (const tab of this.#tabs.values()) {
-        this.#unmountView(tab.view);
-        tab.view.webContents.close();
-      }
-      this.#tabs.clear();
-      this.#listeners.clear();
-      this.clearControls();
-      this.#controlListeners.clear();
+  async destroy(options: { storageAlreadyFlushed?: boolean } = {}): Promise<void> {
+    if (!options.storageAlreadyFlushed) await this.flushPersistentStorage();
+    for (const tab of this.#tabs.values()) {
+      this.#unmountView(tab.view);
+      tab.view.webContents.close();
     }
+    this.#tabs.clear();
+    this.#listeners.clear();
+    this.clearControls();
+    this.#controlListeners.clear();
+  }
+
+  async flushPersistentStorage(): Promise<void> {
+    this.#session.flushStorageData();
+    await this.#session.cookies.flushStore();
+    await this.#persistState();
   }
 
   #createTab(id: string, requestedUrl: string, ownerThreadId: string | null, ownerBotId: string | null): InternalTab {
@@ -813,12 +816,18 @@ export class BrowserHost {
     };
     this.#persistQueue = this.#persistQueue
       .catch(() => undefined)
-      .then(() =>
-        writeFile(this.#statePath, `${JSON.stringify(state)}\n`, {
-          encoding: "utf8",
-          mode: 0o600,
-        }),
-      );
+      .then(async () => {
+        const temporaryPath = `${this.#statePath}.${randomUUID()}.tmp`;
+        try {
+          await writeFile(temporaryPath, `${JSON.stringify(state)}\n`, {
+            encoding: "utf8",
+            mode: 0o600,
+          });
+          await rename(temporaryPath, this.#statePath);
+        } finally {
+          await rm(temporaryPath, { force: true }).catch(() => undefined);
+        }
+      });
     return this.#persistQueue;
   }
 }

--- a/src/backend/browser-host.ts
+++ b/src/backend/browser-host.ts
@@ -166,6 +166,7 @@ export class BrowserHost {
   #target: BrowserViewTarget = "main";
   readonly #mountedViews = new Map<WebContentsView, BrowserWindow>();
   #persistQueue: Promise<void> = Promise.resolve();
+  #destroyPromise: Promise<void> | null = null;
 
   constructor(window: BrowserWindow, downloadsRoot: string, statePath: string) {
     this.#window = window;
@@ -484,8 +485,14 @@ export class BrowserHost {
     }
   }
 
-  async destroy(options: { storageAlreadyFlushed?: boolean } = {}): Promise<void> {
-    if (!options.storageAlreadyFlushed) await this.flushPersistentStorage();
+  destroy(): Promise<void> {
+    this.#destroyPromise ??= this.#destroyPersistentStorageAndViews();
+    return this.#destroyPromise;
+  }
+
+  async #destroyPersistentStorageAndViews(): Promise<void> {
+    const statePersistence = this.#persistState();
+    this.#session.flushStorageData();
     for (const tab of this.#tabs.values()) {
       this.#unmountView(tab.view);
       tab.view.webContents.close();
@@ -494,6 +501,8 @@ export class BrowserHost {
     this.#listeners.clear();
     this.clearControls();
     this.#controlListeners.clear();
+    this.#session.flushStorageData();
+    await Promise.all([this.#session.cookies.flushStore(), statePersistence]);
   }
 
   async flushPersistentStorage(): Promise<void> {
@@ -503,6 +512,7 @@ export class BrowserHost {
   }
 
   #createTab(id: string, requestedUrl: string, ownerThreadId: string | null, ownerBotId: string | null): InternalTab {
+    if (this.#destroyPromise) throw new Error("BrowserHost is shutting down.");
     const view = this.#createView();
     view.webContents.setUserAgent(embeddedBrowserUserAgentForUrl(this.#session.getUserAgent(), requestedUrl));
     this.#mountView(view);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2002,6 +2002,7 @@ app.on("before-quit", (event) => {
 });
 
 async function prepareForUpdateInstall(): Promise<void> {
+  await (browserHost?.flushPersistentStorage() ?? Promise.resolve());
   await destroyBrowserForShutdown();
   await prepareForShutdown(true);
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -274,8 +274,6 @@ const REMOTE_SERVERS_FILE = "openbot-remote-servers-v1.json";
 const CENTRAL_AUTH_FILE = "openbot-central-auth-v1.bin";
 const LEGACY_REMOTE_DESKTOP_CREDENTIAL_FILE = "openbot-remote-desktop-credential-v1.json";
 const REMOTE_DESKTOP_RUNTIME_SECRET_FILE = "openbot-remote-desktop-runtime-v1.json";
-const SYSTEM_SESSION_END_FLUSH_TIMEOUT_MS = 2_000;
-
 const EXTERNAL_DESTINATIONS: Record<ExternalDestination, string> = {
   "agent-setup": "https://github.com/NorbertBodziony/openbot/blob/main/docs/TROUBLESHOOTING.md",
   "claude-install": "https://code.claude.com/docs",
@@ -1175,19 +1173,16 @@ function createWindow(): BrowserWindow {
     }
   });
   if (process.platform === "win32") {
-    window.on("query-session-end", (event) => {
-      event.preventDefault();
+    window.on("query-session-end", () => {
       systemSessionEnding = true;
       isQuitting = true;
       if (systemSessionEndFlushStarted) return;
       systemSessionEndFlushStarted = true;
       updateService?.stop();
-      void flushBrowserStorageWithin(SYSTEM_SESSION_END_FLUSH_TIMEOUT_MS)
-        .catch((error) => console.error("Unable to flush browser storage before Windows session end:", error))
-        .finally(() => {
-          void providerRuntimeManager?.stop();
-          app.quit();
-        });
+      void browserHost
+        ?.flushPersistentStorage()
+        .catch((error) => console.error("Unable to flush browser storage before Windows session end:", error));
+      void providerRuntimeManager?.stop();
     });
     window.on("session-end", () => {
       systemSessionEnding = true;
@@ -2007,11 +2002,11 @@ app.on("before-quit", (event) => {
 });
 
 async function prepareForUpdateInstall(): Promise<void> {
-  await (browserHost?.flushPersistentStorage() ?? Promise.resolve());
+  await destroyBrowserForShutdown();
   await prepareForShutdown(true);
 }
 
-async function prepareForShutdown(browserStorageAlreadyFlushed = false): Promise<void> {
+async function prepareForShutdown(browserAlreadyDestroyed = false): Promise<void> {
   if (shutdownStarted) return;
   shutdownStarted = true;
   isQuitting = true;
@@ -2019,30 +2014,18 @@ async function prepareForShutdown(browserStorageAlreadyFlushed = false): Promise
   dynamicIslandController?.destroy();
   dynamicIslandController = null;
   macHapticFeedback.destroy();
+  if (!browserAlreadyDestroyed) await destroyBrowserForShutdown();
+  browserPictureInPicture?.destroy();
   await (providerRuntimeManager?.stop() ?? Promise.resolve());
   remoteServerManager?.stop();
   voiceTranscriptionService?.shutdown();
   await (remoteDesktopManager?.stop() ?? Promise.resolve());
   await (hostService?.shutdown() ?? Promise.resolve());
-  browserPictureInPicture?.destroy();
-  await (browserHost?.destroy({ storageAlreadyFlushed: browserStorageAlreadyFlushed }) ?? Promise.resolve());
   await (agentService?.stop() ?? Promise.resolve());
 }
 
-async function flushBrowserStorageWithin(timeoutMs: number): Promise<void> {
-  const flush = browserHost?.flushPersistentStorage();
-  if (!flush) return;
-  let timeout: ReturnType<typeof setTimeout> | null = null;
-  try {
-    await Promise.race([
-      flush,
-      new Promise<never>((_resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error("Browser storage flush timed out.")), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeout) clearTimeout(timeout);
-  }
+async function destroyBrowserForShutdown(): Promise<void> {
+  await (browserHost?.destroy() ?? Promise.resolve());
 }
 
 function configureRendererPermissions(): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -260,6 +260,7 @@ const macHapticFeedback = new MacHapticFeedback();
 let isQuitting = false;
 let shutdownStarted = false;
 let systemSessionEnding = false;
+let systemSessionEndFlushStarted = false;
 let pendingInviteUrl: string | null = findInviteUrl(process.argv);
 let inviteReceiverReady = false;
 
@@ -273,6 +274,7 @@ const REMOTE_SERVERS_FILE = "openbot-remote-servers-v1.json";
 const CENTRAL_AUTH_FILE = "openbot-central-auth-v1.bin";
 const LEGACY_REMOTE_DESKTOP_CREDENTIAL_FILE = "openbot-remote-desktop-credential-v1.json";
 const REMOTE_DESKTOP_RUNTIME_SECRET_FILE = "openbot-remote-desktop-runtime-v1.json";
+const SYSTEM_SESSION_END_FLUSH_TIMEOUT_MS = 2_000;
 
 const EXTERNAL_DESTINATIONS: Record<ExternalDestination, string> = {
   "agent-setup": "https://github.com/NorbertBodziony/openbot/blob/main/docs/TROUBLESHOOTING.md",
@@ -1173,14 +1175,26 @@ function createWindow(): BrowserWindow {
     }
   });
   if (process.platform === "win32") {
-    window.on("query-session-end", () => {
+    window.on("query-session-end", (event) => {
+      event.preventDefault();
       systemSessionEnding = true;
       isQuitting = true;
-      void providerRuntimeManager?.stop();
+      if (systemSessionEndFlushStarted) return;
+      systemSessionEndFlushStarted = true;
+      updateService?.stop();
+      void flushBrowserStorageWithin(SYSTEM_SESSION_END_FLUSH_TIMEOUT_MS)
+        .catch((error) => console.error("Unable to flush browser storage before Windows session end:", error))
+        .finally(() => {
+          void providerRuntimeManager?.stop();
+          app.quit();
+        });
     });
     window.on("session-end", () => {
       systemSessionEnding = true;
       isQuitting = true;
+      void browserHost
+        ?.flushPersistentStorage()
+        .catch((error) => console.error("Unable to flush browser storage during Windows session end:", error));
       void providerRuntimeManager?.stop();
     });
   }
@@ -1788,7 +1802,7 @@ if (!hasSingleInstanceLock) {
           app.isPackaged &&
           supportsInstalledUpdates(process.platform) &&
           existsSync(join(process.resourcesPath, "app-update.yml")),
-        beforeInstall: prepareForShutdown,
+        beforeInstall: prepareForUpdateInstall,
         platform: process.platform,
         nativeUpdater: nativeAutoUpdater,
         logDirectory: join(app.getPath("userData"), "logs", "update"),
@@ -1992,7 +2006,12 @@ app.on("before-quit", (event) => {
   void prepareForShutdown().finally(() => app.quit());
 });
 
-async function prepareForShutdown(): Promise<void> {
+async function prepareForUpdateInstall(): Promise<void> {
+  await (browserHost?.flushPersistentStorage() ?? Promise.resolve());
+  await prepareForShutdown(true);
+}
+
+async function prepareForShutdown(browserStorageAlreadyFlushed = false): Promise<void> {
   if (shutdownStarted) return;
   shutdownStarted = true;
   isQuitting = true;
@@ -2006,8 +2025,24 @@ async function prepareForShutdown(): Promise<void> {
   await (remoteDesktopManager?.stop() ?? Promise.resolve());
   await (hostService?.shutdown() ?? Promise.resolve());
   browserPictureInPicture?.destroy();
-  await (browserHost?.destroy() ?? Promise.resolve());
+  await (browserHost?.destroy({ storageAlreadyFlushed: browserStorageAlreadyFlushed }) ?? Promise.resolve());
   await (agentService?.stop() ?? Promise.resolve());
+}
+
+async function flushBrowserStorageWithin(timeoutMs: number): Promise<void> {
+  const flush = browserHost?.flushPersistentStorage();
+  if (!flush) return;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    await Promise.race([
+      flush,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error("Browser storage flush timed out.")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 function configureRendererPermissions(): void {


### PR DESCRIPTION
## Summary

- flush embedded browser DOM storage and cookies before shutdown
- write browser tab state atomically
- block update installation when browser persistence fails
- handle Windows session end with a bounded storage flush
- test localStorage, IndexedDB, logout, and expiry across separate Electron processes

## Verification

- `bun run test:browser`
- `bun run typecheck:node`
- `bun vitest run src/backend/openbot-database.test.ts src/main/central-auth-manager.test.ts src/main/update-service.test.ts` — 43 tests passed
- Biome staged checks and all repository type checks passed in the commit hook

## Manual verification still required

The npm Electron binary on macOS does not use the signed production cookie-encryption setup. Verify Discord cookie persistence with a signed macOS build and on Windows during release validation.

Closes #93