### PR TITLE
Unify app settings and update flows

### DIFF
--- a/apps/auth-api/src/routeTree.gen.ts
+++ b/apps/auth-api/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as V1MeRouteImport } from './routes/v1/me'
 import { Route as V1AuthLogoutRouteImport } from './routes/v1/auth/logout'
 import { Route as V1AvatarsUserIdRouteImport } from './routes/v1/avatars/$userId'
 import { Route as V1MeAvatarRouteImport } from './routes/v1/me/avatar'
+import { Route as V1MeProfileRouteImport } from './routes/v1/me/profile'
 import { Route as V1SkillsIndexRouteImport } from './routes/v1/skills/index'
 import { Route as V1SkillsSkillIdRouteImport } from './routes/v1/skills/$skillId'
 import { Route as V1SkillsMineRouteImport } from './routes/v1/skills/mine'
@@ -107,6 +108,11 @@ const V1AvatarsUserIdRoute = V1AvatarsUserIdRouteImport.update({
 const V1MeAvatarRoute = V1MeAvatarRouteImport.update({
   id: '/avatar',
   path: '/avatar',
+  getParentRoute: () => V1MeRoute,
+} as any)
+const V1MeProfileRoute = V1MeProfileRouteImport.update({
+  id: '/profile',
+  path: '/profile',
   getParentRoute: () => V1MeRoute,
 } as any)
 const V1SkillsIndexRoute = V1SkillsIndexRouteImport.update({
@@ -265,6 +271,7 @@ export interface FileRoutesByFullPath {
   '/v1/auth/logout': typeof V1AuthLogoutRoute
   '/v1/avatars/$userId': typeof V1AvatarsUserIdRoute
   '/v1/me/avatar': typeof V1MeAvatarRoute
+  '/v1/me/profile': typeof V1MeProfileRoute
   '/v1/skills/$skillId': typeof V1SkillsSkillIdRouteWithChildren
   '/v1/skills/mine': typeof V1SkillsMineRoute
   '/v1/team-auth/redeem': typeof V1TeamAuthRedeemRoute
@@ -305,6 +312,7 @@ export interface FileRoutesByTo {
   '/v1/auth/logout': typeof V1AuthLogoutRoute
   '/v1/avatars/$userId': typeof V1AvatarsUserIdRoute
   '/v1/me/avatar': typeof V1MeAvatarRoute
+  '/v1/me/profile': typeof V1MeProfileRoute
   '/v1/skills/$skillId': typeof V1SkillsSkillIdRouteWithChildren
   '/v1/skills/mine': typeof V1SkillsMineRoute
   '/v1/team-auth/redeem': typeof V1TeamAuthRedeemRoute
@@ -346,6 +354,7 @@ export interface FileRoutesById {
   '/v1/auth/logout': typeof V1AuthLogoutRoute
   '/v1/avatars/$userId': typeof V1AvatarsUserIdRoute
   '/v1/me/avatar': typeof V1MeAvatarRoute
+  '/v1/me/profile': typeof V1MeProfileRoute
   '/v1/skills/$skillId': typeof V1SkillsSkillIdRouteWithChildren
   '/v1/skills/mine': typeof V1SkillsMineRoute
   '/v1/team-auth/redeem': typeof V1TeamAuthRedeemRoute
@@ -388,6 +397,7 @@ export interface FileRouteTypes {
     | '/v1/auth/logout'
     | '/v1/avatars/$userId'
     | '/v1/me/avatar'
+    | '/v1/me/profile'
     | '/v1/skills/$skillId'
     | '/v1/skills/mine'
     | '/v1/team-auth/redeem'
@@ -428,6 +438,7 @@ export interface FileRouteTypes {
     | '/v1/auth/logout'
     | '/v1/avatars/$userId'
     | '/v1/me/avatar'
+    | '/v1/me/profile'
     | '/v1/skills/$skillId'
     | '/v1/skills/mine'
     | '/v1/team-auth/redeem'
@@ -468,6 +479,7 @@ export interface FileRouteTypes {
     | '/v1/auth/logout'
     | '/v1/avatars/$userId'
     | '/v1/me/avatar'
+    | '/v1/me/profile'
     | '/v1/skills/$skillId'
     | '/v1/skills/mine'
     | '/v1/team-auth/redeem'
@@ -611,6 +623,13 @@ declare module '@tanstack/solid-router' {
       path: '/avatar'
       fullPath: '/v1/me/avatar'
       preLoaderRoute: typeof V1MeAvatarRouteImport
+      parentRoute: typeof V1MeRoute
+    }
+    '/v1/me/profile': {
+      id: '/v1/me/profile'
+      path: '/profile'
+      fullPath: '/v1/me/profile'
+      preLoaderRoute: typeof V1MeProfileRouteImport
       parentRoute: typeof V1MeRoute
     }
     '/v1/skills/': {
@@ -800,10 +819,12 @@ declare module '@tanstack/solid-router' {
 
 interface V1MeRouteChildren {
   V1MeAvatarRoute: typeof V1MeAvatarRoute
+  V1MeProfileRoute: typeof V1MeProfileRoute
 }
 
 const V1MeRouteChildren: V1MeRouteChildren = {
   V1MeAvatarRoute: V1MeAvatarRoute,
+  V1MeProfileRoute: V1MeProfileRoute,
 }
 
 const V1MeRouteWithChildren = V1MeRoute._addFileChildren(V1MeRouteChildren)

--- a/apps/auth-api/src/routes/v1/me/profile.ts
+++ b/apps/auth-api/src/routes/v1/me/profile.ts
@@ -1,0 +1,24 @@
+import { isString } from "@openbot/contracts/runtime-values";
+import { createFileRoute } from "@tanstack/solid-router";
+import { readJsonObject } from "../../../server/json-body";
+import { apiError, authErrorResponse, bearerToken, json, requestAuthService } from "../../../server/request-auth";
+
+export const Route = createFileRoute("/v1/me/profile")({
+  server: {
+    handlers: {
+      PATCH: async ({ request }) => {
+        try {
+          const token = bearerToken(request);
+          if (!token) return apiError(401, "unauthorized", "Sign in is required.");
+          const body = await readJsonObject(request);
+          if (!isString(body.name)) {
+            return apiError(400, "invalid_profile_name", "Enter a valid display name.");
+          }
+          return json(await requestAuthService().updateName(token, body.name));
+        } catch (error) {
+          return authErrorResponse(error);
+        }
+      },
+    },
+  },
+});

--- a/apps/auth-api/src/server/auth-service.ts
+++ b/apps/auth-api/src/server/auth-service.ts
@@ -131,8 +131,8 @@ export class AuthService {
     const name = normalizeAccountName(nameInput);
     if (
       hasUnsafeAccountNameCharacters(nameInput) ||
-      name.length < INPUT_LIMITS.accountNameMin ||
-      name.length > INPUT_LIMITS.accountName
+      name.length < INPUT_LIMITS.profileNameMin ||
+      name.length > INPUT_LIMITS.profileName
     ) {
       throw new AuthServiceError(400, "invalid_profile_name", "Enter a valid display name.");
     }

--- a/apps/auth-api/src/server/auth-service.ts
+++ b/apps/auth-api/src/server/auth-service.ts
@@ -1,12 +1,10 @@
-import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import {
-  hasUnsafeAccountNameCharacters,
   isUuidV4,
-  normalizeAccountName,
   normalizeEmailAddress,
   normalizeOneTimeCode as normalizeSharedOneTimeCode,
   ONE_TIME_CODE_ALPHABET,
   ONE_TIME_CODE_LENGTH,
+  validateProfileName,
 } from "@openbot/contracts/validation";
 
 import { randomToken, sha256 } from "./crypto";
@@ -128,17 +126,13 @@ export class AuthService {
   async updateName(sessionToken: string, nameInput: string): Promise<AuthUser> {
     const user = await this.authenticate(sessionToken);
     if (!user) throw new AuthServiceError(401, "unauthorized", "The session is invalid.");
-    const name = normalizeAccountName(nameInput);
-    if (
-      hasUnsafeAccountNameCharacters(nameInput) ||
-      name.length < INPUT_LIMITS.profileNameMin ||
-      name.length > INPUT_LIMITS.profileName
-    ) {
+    const validation = validateProfileName(nameInput);
+    if (validation.error) {
       throw new AuthServiceError(400, "invalid_profile_name", "Enter a valid display name.");
     }
     const now = this.#now();
     await this.#enforceRateLimit(`profile:user:${user.id}`, 20, now);
-    return this.#repository.updateUserName(user.id, name, now);
+    return this.#repository.updateUserName(user.id, validation.name, now);
   }
 
   async updateAvatar(

--- a/apps/auth-api/src/server/auth-service.ts
+++ b/apps/auth-api/src/server/auth-service.ts
@@ -1,5 +1,8 @@
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import {
+  hasUnsafeAccountNameCharacters,
   isUuidV4,
+  normalizeAccountName,
   normalizeEmailAddress,
   normalizeOneTimeCode as normalizeSharedOneTimeCode,
   ONE_TIME_CODE_ALPHABET,
@@ -120,6 +123,22 @@ export class AuthService {
 
   authenticate(sessionToken: string): Promise<AuthUser | null> {
     return this.#repository.authenticate(sessionToken, this.#now());
+  }
+
+  async updateName(sessionToken: string, nameInput: string): Promise<AuthUser> {
+    const user = await this.authenticate(sessionToken);
+    if (!user) throw new AuthServiceError(401, "unauthorized", "The session is invalid.");
+    const name = normalizeAccountName(nameInput);
+    if (
+      hasUnsafeAccountNameCharacters(nameInput) ||
+      name.length < INPUT_LIMITS.accountNameMin ||
+      name.length > INPUT_LIMITS.accountName
+    ) {
+      throw new AuthServiceError(400, "invalid_profile_name", "Enter a valid display name.");
+    }
+    const now = this.#now();
+    await this.#enforceRateLimit(`profile:user:${user.id}`, 20, now);
+    return this.#repository.updateUserName(user.id, name, now);
   }
 
   async updateAvatar(

--- a/apps/auth-api/src/server/d1-auth-repository.ts
+++ b/apps/auth-api/src/server/d1-auth-repository.ts
@@ -163,6 +163,19 @@ export class D1AuthRepository implements AuthRepository {
       .run();
   }
 
+  async updateUserName(userId: string, name: string, now: number): Promise<AuthUser> {
+    const row = await this.database
+      .prepare(
+        `UPDATE users SET name = ?, updated_at = ?
+         WHERE id = ?
+         RETURNING id, email, name, avatar_url`,
+      )
+      .bind(name, now, userId)
+      .first<UserRow>();
+    if (!row) throw new Error("User not found.");
+    return mapUser(row);
+  }
+
   async updateUserAvatar(
     userId: string,
     avatarUrl: string | null,

--- a/apps/auth-api/src/server/types.ts
+++ b/apps/auth-api/src/server/types.ts
@@ -110,6 +110,7 @@ export interface AuthRepository {
   ): Promise<{ allowed: boolean; count: number; windowStart: number }>;
   authenticate(sessionToken: string, now: number): Promise<AuthUser | null>;
   revokeSession(sessionToken: string, now: number): Promise<void>;
+  updateUserName(userId: string, name: string, now: number): Promise<AuthUser>;
   updateUserAvatar(
     userId: string,
     avatarUrl: string | null,

--- a/apps/auth-api/test/auth-service.test.ts
+++ b/apps/auth-api/test/auth-service.test.ts
@@ -184,13 +184,13 @@ describe("email one-time codes", () => {
       code: "invalid_profile_name",
     });
     await expect(
-      service.updateName(session.sessionToken, "x".repeat(INPUT_LIMITS.accountNameMin - 1)),
+      service.updateName(session.sessionToken, "x".repeat(INPUT_LIMITS.profileNameMin - 1)),
     ).rejects.toMatchObject({
       status: 400,
       code: "invalid_profile_name",
     });
     await expect(
-      service.updateName(session.sessionToken, "x".repeat(INPUT_LIMITS.accountName + 1)),
+      service.updateName(session.sessionToken, "x".repeat(INPUT_LIMITS.profileName + 1)),
     ).rejects.toMatchObject({
       status: 400,
       code: "invalid_profile_name",

--- a/apps/auth-api/test/auth-service.test.ts
+++ b/apps/auth-api/test/auth-service.test.ts
@@ -1,3 +1,4 @@
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import { describe, expect, it } from "vitest";
 import { AuthService, generateOneTimeCode, normalizeOneTimeCode } from "../src/server/auth-service";
 import type { AuthRepository, AuthUser, EmailVerificationResult } from "../src/server/types";
@@ -110,6 +111,13 @@ class MemoryAuthRepository implements AuthRepository {
     return session.user;
   }
 
+  async updateUserName(userId: string, name: string): Promise<AuthUser> {
+    const session = [...this.sessions.values()].find((item) => item.user.id === userId);
+    if (!session) throw new Error("User not found.");
+    session.user = { ...session.user, name };
+    return session.user;
+  }
+
   async createTeamAuthTicket(input: {
     ticketHash: string;
     userId: string;
@@ -168,12 +176,42 @@ describe("email one-time codes", () => {
     });
     expect(session.user.email).toBe("person@example.com");
     expect(await service.authenticate(session.sessionToken)).toEqual(session.user);
+    await expect(service.updateName(session.sessionToken, "  No\u0308rbert\u00a0\u00a0Bot  ")).resolves.toMatchObject({
+      name: "Nörbert Bot",
+    });
+    await expect(service.updateName(session.sessionToken, "   ")).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_profile_name",
+    });
+    await expect(
+      service.updateName(session.sessionToken, "x".repeat(INPUT_LIMITS.accountNameMin - 1)),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_profile_name",
+    });
+    await expect(
+      service.updateName(session.sessionToken, "x".repeat(INPUT_LIMITS.accountName + 1)),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_profile_name",
+    });
+    await expect(service.updateName(session.sessionToken, "Nor\nbert")).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_profile_name",
+    });
+    await expect(service.updateName("missing-session", "Norbert")).rejects.toMatchObject({
+      status: 401,
+      code: "unauthorized",
+    });
     const serverId = "00000000-0000-4000-8000-000000000000";
     const ticket = await service.issueTeamAuthTicket(session.sessionToken, serverId, "203.0.113.4");
     expect(
       await service.redeemTeamAuthTicket(ticket.ticket, "00000000-0000-4000-8000-000000000001", "203.0.113.5"),
     ).toBeNull();
-    expect(await service.redeemTeamAuthTicket(ticket.ticket, serverId, "203.0.113.5")).toEqual(session.user);
+    expect(await service.redeemTeamAuthTicket(ticket.ticket, serverId, "203.0.113.5")).toMatchObject({
+      id: session.user.id,
+      name: "Nörbert Bot",
+    });
     expect(await service.redeemTeamAuthTicket(ticket.ticket, serverId, "203.0.113.5")).toBeNull();
     await expect(service.updateAvatar(session.sessionToken, "/v1/avatars/user?v=avatar", null)).resolves.toMatchObject({
       avatarUrl: "/v1/avatars/user?v=avatar",

--- a/apps/auth-api/test/auth-service.test.ts
+++ b/apps/auth-api/test/auth-service.test.ts
@@ -176,6 +176,9 @@ describe("email one-time codes", () => {
     });
     expect(session.user.email).toBe("person@example.com");
     expect(await service.authenticate(session.sessionToken)).toEqual(session.user);
+    await expect(service.updateName(session.sessionToken, "👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦")).resolves.toMatchObject({
+      name: "👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦",
+    });
     await expect(service.updateName(session.sessionToken, "  No\u0308rbert\u00a0\u00a0Bot  ")).resolves.toMatchObject({
       name: "Nörbert Bot",
     });
@@ -196,6 +199,10 @@ describe("email one-time codes", () => {
       code: "invalid_profile_name",
     });
     await expect(service.updateName(session.sessionToken, "Nor\nbert")).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_profile_name",
+    });
+    await expect(service.updateName(session.sessionToken, "\u200d\u200d\u200d")).rejects.toMatchObject({
       status: 400,
       code: "invalid_profile_name",
     });

--- a/packages/contracts/src/input-limits.ts
+++ b/packages/contracts/src/input-limits.ts
@@ -1,7 +1,8 @@
 export const INPUT_LIMITS = {
   identifier: 128,
   email: 254,
-  accountName: 120,
+  accountNameMin: 3,
+  accountName: 20,
   serverNameMin: 6,
   serverName: 32,
   inviteUrl: 4_096,

--- a/packages/contracts/src/input-limits.ts
+++ b/packages/contracts/src/input-limits.ts
@@ -1,8 +1,9 @@
 export const INPUT_LIMITS = {
   identifier: 128,
   email: 254,
-  accountNameMin: 3,
-  accountName: 20,
+  accountName: 120,
+  profileNameMin: 3,
+  profileName: 20,
   serverNameMin: 6,
   serverName: 32,
   inviteUrl: 4_096,

--- a/packages/contracts/src/ipc-app-auth.ts
+++ b/packages/contracts/src/ipc-app-auth.ts
@@ -103,6 +103,7 @@ export interface CentralAuthDesktopApi {
   retry: () => Promise<CentralAuthState>;
   requestEmailCode: (email: string) => Promise<CentralAuthState>;
   verifyEmailCode: (challengeId: string, code: string) => Promise<CentralAuthState>;
+  updateName: (name: string) => Promise<CentralAuthState>;
   updateAvatar: (image: AvatarImageInput | null) => Promise<CentralAuthState>;
   logout: () => Promise<CentralAuthState>;
   onEvent: (listener: (state: CentralAuthState) => void) => () => void;

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -49,6 +49,7 @@ export const IPC_CHANNELS = {
   authRetry: "auth:retry",
   authRequestEmailCode: "auth:request-email-code",
   authVerifyEmailCode: "auth:verify-email-code",
+  authUpdateName: "auth:update-name",
   authUpdateAvatar: "auth:update-avatar",
   authLogout: "auth:logout",
   authEvent: "auth:event",

--- a/packages/contracts/src/ipc-team-host.test.ts
+++ b/packages/contracts/src/ipc-team-host.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { INPUT_LIMITS } from "./input-limits";
 import { isTeamRealtimeEvent } from "./ipc-team-host";
 
 describe("isTeamRealtimeEvent", () => {
@@ -48,6 +49,32 @@ describe("isTeamRealtimeEvent", () => {
         senderMemberId: "member-1",
         recipientMemberId: "member-2",
         typing: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts legacy account names in presence events", () => {
+    expect(
+      isTeamRealtimeEvent({
+        type: "team-presence",
+        snapshot: {
+          serverId: "server-1",
+          updatedAt: "2026-08-19T09:00:00.000Z",
+          members: [
+            {
+              id: "member-1",
+              username: "person@example.com",
+              email: "person@example.com",
+              name: "x".repeat(INPUT_LIMITS.accountName),
+              avatarUrl: null,
+              role: "member",
+              createdAt: "2026-08-19T08:00:00.000Z",
+              disabled: false,
+              online: true,
+              typingBotId: null,
+            },
+          ],
+        },
       }),
     ).toBe(true);
   });

--- a/packages/contracts/src/validation.test.ts
+++ b/packages/contracts/src/validation.test.ts
@@ -1,14 +1,26 @@
 import { describe, expect, it } from "vitest";
 import {
+  hasUnsafeAccountNameCharacters,
   isOpenBotTeamApiHostname,
   isUuidV4,
   isValidHostname,
+  normalizeAccountName,
   normalizeEmailAddress,
   normalizeOneTimeCode,
   slugifyTeamServerName,
 } from "./validation";
 
 describe("shared boundary validation", () => {
+  it("normalizes safe account names and rejects hidden control characters", () => {
+    expect(normalizeAccountName("  Jose\u0301\u00a0\u00a0Silva  ")).toBe("José Silva");
+    expect(hasUnsafeAccountNameCharacters("José Silva")).toBe(false);
+    expect(hasUnsafeAccountNameCharacters("Family 👨‍👩‍👧‍👦")).toBe(false);
+    expect(hasUnsafeAccountNameCharacters("Line\nbreak")).toBe(true);
+    expect(hasUnsafeAccountNameCharacters("Hidden\u0000value")).toBe(true);
+    expect(hasUnsafeAccountNameCharacters("Reversed\u202evalue")).toBe(true);
+    expect(hasUnsafeAccountNameCharacters("Zero\u200bwidth")).toBe(true);
+  });
+
   it("normalizes valid email addresses", () => {
     expect(normalizeEmailAddress(" User.Name+tag@Example.COM ")).toBe("user.name+tag@example.com");
   });

--- a/packages/contracts/src/validation.test.ts
+++ b/packages/contracts/src/validation.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeEmailAddress,
   normalizeOneTimeCode,
   slugifyTeamServerName,
+  validateProfileName,
 } from "./validation";
 
 describe("shared boundary validation", () => {
@@ -19,6 +20,16 @@ describe("shared boundary validation", () => {
     expect(hasUnsafeAccountNameCharacters("Hidden\u0000value")).toBe(true);
     expect(hasUnsafeAccountNameCharacters("Reversed\u202evalue")).toBe(true);
     expect(hasUnsafeAccountNameCharacters("Zero\u200bwidth")).toBe(true);
+    expect(hasUnsafeAccountNameCharacters("\u200d\u200d\u200d")).toBe(true);
+    expect(hasUnsafeAccountNameCharacters("می‌روم")).toBe(false);
+  });
+
+  it("counts profile name limits by visible Unicode characters", () => {
+    expect(validateProfileName("🤖🤖").error).toBe("too-short");
+    expect(validateProfileName("👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦").error).toBeNull();
+    expect(validateProfileName("🤖".repeat(20)).error).toBeNull();
+    expect(validateProfileName("🤖".repeat(21)).error).toBe("too-long");
+    expect(validateProfileName("\u200d\u200d\u200d").error).toBe("unsafe");
   });
 
   it("normalizes valid email addresses", () => {

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -11,6 +11,15 @@ const TEAM_HOST_SLUG_MAX_LENGTH = 44;
 const ACCOUNT_NAME_UNSAFE_CHARACTER_PATTERN = /[\p{Cc}\p{Cs}\p{Zl}\p{Zp}]/u;
 const ACCOUNT_NAME_FORMAT_CHARACTER_PATTERN = /\p{Cf}/u;
 const ACCOUNT_NAME_ALLOWED_FORMAT_CHARACTERS = new Set(["\u200c", "\u200d"]);
+const ACCOUNT_NAME_JOINER_NEIGHBOR_PATTERN = /[\p{L}\p{M}\p{N}\p{S}]/u;
+const ACCOUNT_NAME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+export type ProfileNameValidationError = "required" | "unsafe" | "too-short" | "too-long";
+
+export interface ProfileNameValidationResult {
+  name: string;
+  error: ProfileNameValidationError | null;
+}
 
 export function normalizeAccountName(value: string): string {
   return value
@@ -21,10 +30,31 @@ export function normalizeAccountName(value: string): string {
 
 export function hasUnsafeAccountNameCharacters(value: string): boolean {
   if (ACCOUNT_NAME_UNSAFE_CHARACTER_PATTERN.test(value)) return true;
-  return [...value].some(
-    (character) =>
-      ACCOUNT_NAME_FORMAT_CHARACTER_PATTERN.test(character) && !ACCOUNT_NAME_ALLOWED_FORMAT_CHARACTERS.has(character),
-  );
+  const characters = [...value];
+  return characters.some((character, index) => {
+    if (!ACCOUNT_NAME_FORMAT_CHARACTER_PATTERN.test(character)) return false;
+    if (!ACCOUNT_NAME_ALLOWED_FORMAT_CHARACTERS.has(character)) return true;
+    const previous = characters[index - 1];
+    const next = characters[index + 1];
+    return (
+      previous === undefined ||
+      next === undefined ||
+      !ACCOUNT_NAME_JOINER_NEIGHBOR_PATTERN.test(previous) ||
+      !ACCOUNT_NAME_JOINER_NEIGHBOR_PATTERN.test(next)
+    );
+  });
+}
+
+export function validateProfileName(value: string): ProfileNameValidationResult {
+  const name = normalizeAccountName(value);
+  if (hasUnsafeAccountNameCharacters(value)) return { name, error: "unsafe" };
+  const length = [...ACCOUNT_NAME_SEGMENTER.segment(name)].length;
+  if (length === 0) return { name, error: "required" };
+  if (length < INPUT_LIMITS.profileNameMin) return { name, error: "too-short" };
+  if (length > INPUT_LIMITS.profileName || name.length > INPUT_LIMITS.accountName) {
+    return { name, error: "too-long" };
+  }
+  return { name, error: null };
 }
 
 export function isValidHostname(value: string, requireDot = true): boolean {

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -8,6 +8,24 @@ const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}
 const TEAM_HOST_PATTERN = /^([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)-([a-z2-7]{8})-host\.openbot\.run$/u;
 const TEAM_HOST_SLUG_MIN_LENGTH = 6;
 const TEAM_HOST_SLUG_MAX_LENGTH = 44;
+const ACCOUNT_NAME_UNSAFE_CHARACTER_PATTERN = /[\p{Cc}\p{Cs}\p{Zl}\p{Zp}]/u;
+const ACCOUNT_NAME_FORMAT_CHARACTER_PATTERN = /\p{Cf}/u;
+const ACCOUNT_NAME_ALLOWED_FORMAT_CHARACTERS = new Set(["\u200c", "\u200d"]);
+
+export function normalizeAccountName(value: string): string {
+  return value
+    .normalize("NFC")
+    .replace(/\p{Zs}+/gu, " ")
+    .trim();
+}
+
+export function hasUnsafeAccountNameCharacters(value: string): boolean {
+  if (ACCOUNT_NAME_UNSAFE_CHARACTER_PATTERN.test(value)) return true;
+  return [...value].some(
+    (character) =>
+      ACCOUNT_NAME_FORMAT_CHARACTER_PATTERN.test(character) && !ACCOUNT_NAME_ALLOWED_FORMAT_CHARACTERS.has(character),
+  );
+}
 
 export function isValidHostname(value: string, requireDot = true): boolean {
   if (value.length === 0 || value.length > INPUT_LIMITS.hostname || (requireDot && !value.includes("."))) {

--- a/src/main/central-auth-manager.test.ts
+++ b/src/main/central-auth-manager.test.ts
@@ -487,6 +487,48 @@ describe("CentralAuthManager", () => {
     expect(requests.at(-1)?.method).toBe("DELETE");
   });
 
+  it("updates the signed-in account name", async () => {
+    const root = await createRoot();
+    const requests: Request[] = [];
+    const manager = new CentralAuthManager({
+      apiUrl: "https://api.openbot.run",
+      storagePath: join(root, "session.bin"),
+      encrypt: (value) => Buffer.from(value),
+      decrypt: (value) => value.toString(),
+      fetch: vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const request = new Request(input, init);
+        requests.push(request.clone());
+        const path = new URL(request.url).pathname;
+        if (path.endsWith("/start")) {
+          return Response.json({ challengeId: "challenge-1", expiresAt: 10_000 });
+        }
+        if (path.endsWith("/verify")) {
+          return Response.json({
+            sessionToken: "session-secret",
+            user: { id: "user-1", email: "person@example.com", name: null, avatarUrl: null },
+          });
+        }
+        return Response.json({
+          id: "user-1",
+          email: "person@example.com",
+          name: "Norbert",
+          avatarUrl: null,
+        });
+      }),
+    });
+    await manager.requestEmailCode("person@example.com");
+    await manager.verifyEmailCode("challenge-1", "ABCD-EFGH");
+
+    await expect(manager.updateName("Norbert")).resolves.toMatchObject({
+      status: "signed_in",
+      user: { name: "Norbert" },
+    });
+    expect(requests.at(-1)?.method).toBe("PATCH");
+    expect(requests.at(-1)?.headers.get("Content-Type")).toBe("application/json");
+    expect(requests.at(-1)?.headers.get("Authorization")).toBe("Bearer session-secret");
+    await expect(requests.at(-1)?.json()).resolves.toEqual({ name: "Norbert" });
+  });
+
   it("does not restore a signed-in state when an avatar request finishes after logout", async () => {
     const root = await createRoot();
     let finishAvatar: (() => void) | undefined;

--- a/src/main/central-auth-manager.test.ts
+++ b/src/main/central-auth-manager.test.ts
@@ -529,6 +529,80 @@ describe("CentralAuthManager", () => {
     await expect(requests.at(-1)?.json()).resolves.toEqual({ name: "Norbert" });
   });
 
+  it("keeps concurrent name and avatar updates in local state", async () => {
+    const root = await createRoot();
+    let finishAvatar: () => void = () => undefined;
+    let finishName: () => void = () => undefined;
+    const avatarResponse = new Promise<void>((resolve) => {
+      finishAvatar = resolve;
+    });
+    const nameResponse = new Promise<void>((resolve) => {
+      finishName = resolve;
+    });
+    const manager = new CentralAuthManager({
+      apiUrl: "https://api.openbot.run",
+      storagePath: join(root, "session.bin"),
+      encrypt: (value) => Buffer.from(value),
+      decrypt: (value) => value.toString(),
+      fetch: vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const path = new URL(input.toString()).pathname;
+        if (path.endsWith("/start")) {
+          return Response.json({ challengeId: "challenge-1", expiresAt: 10_000 });
+        }
+        if (path.endsWith("/verify")) {
+          return Response.json({
+            sessionToken: "session-secret",
+            user: {
+              id: "user-1",
+              email: "person@example.com",
+              name: "Old name",
+              avatarUrl: "/v1/avatars/user-1?v=old",
+            },
+          });
+        }
+        if (path === "/v1/me/avatar" && init?.method === "PUT") {
+          await avatarResponse;
+          return Response.json({
+            id: "user-1",
+            email: "person@example.com",
+            name: "Old name",
+            avatarUrl: "/v1/avatars/user-1?v=new",
+          });
+        }
+        if (path === "/v1/me/profile") {
+          await nameResponse;
+          return Response.json({
+            id: "user-1",
+            email: "person@example.com",
+            name: "New name",
+            avatarUrl: "/v1/avatars/user-1?v=old",
+          });
+        }
+        return new Response(null, { status: 404 });
+      }),
+    });
+    await manager.requestEmailCode("person@example.com");
+    await manager.verifyEmailCode("challenge-1", "ABCD-EFGH");
+
+    const nameUpdate = manager.updateName("New name");
+    const avatarUpdate = manager.updateAvatar({
+      mimeType: "image/png",
+      bytes: Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    });
+    finishAvatar();
+    await avatarUpdate;
+    finishName();
+    await nameUpdate;
+
+    expect(manager.getState()).toMatchObject({
+      status: "signed_in",
+      user: {
+        name: "New name",
+        avatarUrl: "https://api.openbot.run/v1/avatars/user-1?v=new",
+      },
+    });
+  });
+
   it("does not restore a signed-in state when an avatar request finishes after logout", async () => {
     const root = await createRoot();
     let finishAvatar: (() => void) | undefined;

--- a/src/main/central-auth-manager.ts
+++ b/src/main/central-auth-manager.ts
@@ -356,6 +356,22 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
     return this.#setState({ status: "signed_in", user: this.#resolveUserAvatar(user) });
   }
 
+  async updateName(name: string): Promise<CentralAuthState> {
+    const sessionToken = this.#sessionToken;
+    if (!sessionToken) throw new AuthApiError(401, "unauthorized", "Sign in is required.");
+    const user = await this.#authorizedRequest(
+      "/v1/me/profile",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      },
+      decodeCentralAuthUser,
+    );
+    if (this.#sessionToken !== sessionToken) return this.getState();
+    return this.#setState({ status: "signed_in", user: this.#resolveUserAvatar(user) });
+  }
+
   async #request<T>(path: string, init: RequestInit, decoder: (value: unknown) => T, timeoutMs = 10_000): Promise<T> {
     const response = await this.#options.fetch(new URL(path, this.#options.apiUrl), {
       ...init,

--- a/src/main/central-auth-manager.ts
+++ b/src/main/central-auth-manager.ts
@@ -352,8 +352,12 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
           },
           decodeCentralAuthUser,
         );
-    if (this.#sessionToken !== sessionToken) return this.getState();
-    return this.#setState({ status: "signed_in", user: this.#resolveUserAvatar(user) });
+    if (this.#sessionToken !== sessionToken || this.#state.status !== "signed_in") return this.getState();
+    const resolvedUser = this.#resolveUserAvatar(user);
+    return this.#setState({
+      status: "signed_in",
+      user: { ...this.#state.user, avatarUrl: resolvedUser.avatarUrl },
+    });
   }
 
   async updateName(name: string): Promise<CentralAuthState> {
@@ -368,8 +372,11 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
       },
       decodeCentralAuthUser,
     );
-    if (this.#sessionToken !== sessionToken) return this.getState();
-    return this.#setState({ status: "signed_in", user: this.#resolveUserAvatar(user) });
+    if (this.#sessionToken !== sessionToken || this.#state.status !== "signed_in") return this.getState();
+    return this.#setState({
+      status: "signed_in",
+      user: { ...this.#state.user, name: user.name },
+    });
   }
 
   async #request<T>(path: string, init: RequestInit, decoder: (value: unknown) => T, timeoutMs = 10_000): Promise<T> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -427,15 +427,15 @@ function registerIpcHandlers(
     );
   });
   handleTrusted(IPC_CHANNELS.authUpdateName, (input: unknown) => {
-    const rawName = requireString(input, "name", INPUT_LIMITS.accountName);
+    const rawName = requireString(input, "name", INPUT_LIMITS.profileName);
     const name = normalizeAccountName(rawName);
     if (
       hasUnsafeAccountNameCharacters(rawName) ||
-      name.length < INPUT_LIMITS.accountNameMin ||
-      name.length > INPUT_LIMITS.accountName
+      name.length < INPUT_LIMITS.profileNameMin ||
+      name.length > INPUT_LIMITS.profileName
     ) {
       throw new Error(
-        `name must contain ${INPUT_LIMITS.accountNameMin} to ${INPUT_LIMITS.accountName} safe characters.`,
+        `name must contain ${INPUT_LIMITS.profileNameMin} to ${INPUT_LIMITS.profileName} safe characters.`,
       );
     }
     return centralAuth.updateName(name);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import {
   type VoiceTranscriptionResult,
 } from "@openbot/contracts/ipc";
 import { isNumber, isString } from "@openbot/contracts/runtime-values";
+import { hasUnsafeAccountNameCharacters, normalizeAccountName } from "@openbot/contracts/validation";
 import {
   app,
   BrowserWindow,
@@ -424,6 +425,20 @@ function registerIpcHandlers(
       requireString(input.challengeId, "challengeId", INPUT_LIMITS.identifier),
       requireString(input.code, "code", 32),
     );
+  });
+  handleTrusted(IPC_CHANNELS.authUpdateName, (input: unknown) => {
+    const rawName = requireString(input, "name", INPUT_LIMITS.accountName);
+    const name = normalizeAccountName(rawName);
+    if (
+      hasUnsafeAccountNameCharacters(rawName) ||
+      name.length < INPUT_LIMITS.accountNameMin ||
+      name.length > INPUT_LIMITS.accountName
+    ) {
+      throw new Error(
+        `name must contain ${INPUT_LIMITS.accountNameMin} to ${INPUT_LIMITS.accountName} safe characters.`,
+      );
+    }
+    return centralAuth.updateName(name);
   });
   handleTrusted(IPC_CHANNELS.authUpdateAvatar, (input: unknown) => centralAuth.updateAvatar(parseAvatarImage(input)));
   handleTrusted(IPC_CHANNELS.authLogout, () => centralAuth.logout());

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,7 +31,7 @@ import {
   type VoiceTranscriptionResult,
 } from "@openbot/contracts/ipc";
 import { isNumber, isString } from "@openbot/contracts/runtime-values";
-import { hasUnsafeAccountNameCharacters, normalizeAccountName } from "@openbot/contracts/validation";
+import { validateProfileName } from "@openbot/contracts/validation";
 import {
   app,
   BrowserWindow,
@@ -427,18 +427,14 @@ function registerIpcHandlers(
     );
   });
   handleTrusted(IPC_CHANNELS.authUpdateName, (input: unknown) => {
-    const rawName = requireString(input, "name", INPUT_LIMITS.profileName);
-    const name = normalizeAccountName(rawName);
-    if (
-      hasUnsafeAccountNameCharacters(rawName) ||
-      name.length < INPUT_LIMITS.profileNameMin ||
-      name.length > INPUT_LIMITS.profileName
-    ) {
+    const rawName = requireString(input, "name", INPUT_LIMITS.accountName);
+    const validation = validateProfileName(rawName);
+    if (validation.error) {
       throw new Error(
         `name must contain ${INPUT_LIMITS.profileNameMin} to ${INPUT_LIMITS.profileName} safe characters.`,
       );
     }
-    return centralAuth.updateName(name);
+    return centralAuth.updateName(validation.name);
   });
   handleTrusted(IPC_CHANNELS.authUpdateAvatar, (input: unknown) => centralAuth.updateAvatar(parseAvatarImage(input)));
   handleTrusted(IPC_CHANNELS.authLogout, () => centralAuth.logout());

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -29,6 +29,19 @@ describe("TeamStore", () => {
     expect(store.configured).toBe(false);
   });
 
+  it("accepts legacy account names outside the editable profile limits", async () => {
+    const { store } = await createStore();
+
+    await store.configureWithAccount("Studio Mac", {
+      id: "owner-account",
+      email: "owner@example.com",
+      name: "x",
+      avatarUrl: null,
+    });
+
+    expect(store.listMembers()[0]?.name).toBe("x");
+  });
+
   it("creates an owner and authenticates without storing the password", async () => {
     const { store, path } = await createStore();
     const identity = await store.configure("Studio Mac", "owner", "correct horse battery");

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -21,12 +21,7 @@ import type {
   TeamSessionSummary,
 } from "@openbot/contracts/ipc";
 import { isDynamicRecord, isString } from "@openbot/contracts/runtime-values";
-import {
-  hasUnsafeAccountNameCharacters,
-  normalizeAccountName,
-  normalizeEmailAddress,
-  slugifyTeamServerName,
-} from "@openbot/contracts/validation";
+import { normalizeEmailAddress, slugifyTeamServerName } from "@openbot/contracts/validation";
 
 const scrypt = promisify(scryptCallback);
 const INVITE_TTL_MS = 24 * 60 * 60 * 1_000;
@@ -706,12 +701,7 @@ function normalizeEmail(value: string): string {
 }
 
 function normalizeName(value: string | null): string | null {
-  if (value === null) return null;
-  if (hasUnsafeAccountNameCharacters(value)) throw new TeamStoreError("Account name contains unsafe characters.");
-  const normalized = normalizeAccountName(value);
-  if (normalized && normalized.length < INPUT_LIMITS.accountNameMin) {
-    throw new TeamStoreError("Account name is too short.");
-  }
+  const normalized = value?.trim() ?? "";
   if (normalized.length > INPUT_LIMITS.accountName) throw new TeamStoreError("Account name is too long.");
   return normalized || null;
 }

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -21,7 +21,12 @@ import type {
   TeamSessionSummary,
 } from "@openbot/contracts/ipc";
 import { isDynamicRecord, isString } from "@openbot/contracts/runtime-values";
-import { normalizeEmailAddress, slugifyTeamServerName } from "@openbot/contracts/validation";
+import {
+  hasUnsafeAccountNameCharacters,
+  normalizeAccountName,
+  normalizeEmailAddress,
+  slugifyTeamServerName,
+} from "@openbot/contracts/validation";
 
 const scrypt = promisify(scryptCallback);
 const INVITE_TTL_MS = 24 * 60 * 60 * 1_000;
@@ -701,7 +706,12 @@ function normalizeEmail(value: string): string {
 }
 
 function normalizeName(value: string | null): string | null {
-  const normalized = value?.trim() ?? "";
+  if (value === null) return null;
+  if (hasUnsafeAccountNameCharacters(value)) throw new TeamStoreError("Account name contains unsafe characters.");
+  const normalized = normalizeAccountName(value);
+  if (normalized && normalized.length < INPUT_LIMITS.accountNameMin) {
+    throw new TeamStoreError("Account name is too short.");
+  }
   if (normalized.length > INPUT_LIMITS.accountName) throw new TeamStoreError("Account name is too long.");
   return normalized || null;
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -850,6 +850,7 @@ const openbotApi: OpenBotDesktopApi = {
     retry: () => ipcRenderer.invoke(IPC_CHANNELS.authRetry),
     requestEmailCode: (email) => ipcRenderer.invoke(IPC_CHANNELS.authRequestEmailCode, email),
     verifyEmailCode: (challengeId, code) => ipcRenderer.invoke(IPC_CHANNELS.authVerifyEmailCode, { challengeId, code }),
+    updateName: (name) => ipcRenderer.invoke(IPC_CHANNELS.authUpdateName, name),
     updateAvatar: (image) => ipcRenderer.invoke(IPC_CHANNELS.authUpdateAvatar, image),
     logout: () => ipcRenderer.invoke(IPC_CHANNELS.authLogout),
     onEvent: (listener) => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -327,6 +327,10 @@ describe("OpenBot connected desktop shell", () => {
             status: "signed_in",
             user: { id: "user-1", email: "person@example.com", name: null, avatarUrl: null },
           }),
+          updateName: vi.fn().mockResolvedValue({
+            status: "signed_in",
+            user: { id: "user-1", email: "person@example.com", name: "Norbert", avatarUrl: null },
+          }),
           updateAvatar: vi.fn().mockResolvedValue({
             status: "signed_in",
             user: { id: "user-1", email: "person@example.com", name: null, avatarUrl: null },

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2884,6 +2884,10 @@ export function createAppController(props: AppProps = {}) {
     applyCentralAuthState(await window.openbot.auth.updateAvatar(image));
   }
 
+  async function updateAccountName(name: string): Promise<void> {
+    applyCentralAuthState(await window.openbot.auth.updateName(name));
+  }
+
   async function runUpdateAction(): Promise<void> {
     const analytics = desktopAnalytics.scope();
     const phase = updateStatus().phase;
@@ -3819,6 +3823,7 @@ export function createAppController(props: AppProps = {}) {
     updateStatus,
     refreshAccountUsage,
     runUpdateAction,
+    updateAccountName,
     updateAccountAvatar,
     setPermissionsOpen,
     appSettingsOpen,

--- a/src/renderer/src/AppView.tsx
+++ b/src/renderer/src/AppView.tsx
@@ -674,6 +674,7 @@ function WorkspaceOverlays(props: {
     revokeServerInvite,
     updateStatus,
     runUpdateAction,
+    updateAccountName,
     updateAccountAvatar,
     providerRuntimeStatuses,
     providerRuntimeDownloadsAvailable,
@@ -779,6 +780,7 @@ function WorkspaceOverlays(props: {
           updateStatus={updateStatus()}
           onUpdateAction={runUpdateAction}
           account={props.account()}
+          onUpdateAccountName={updateAccountName}
           onUpdateAccountAvatar={updateAccountAvatar}
           agentStatus={agentStatus()}
           providerRuntimeStatuses={

--- a/src/renderer/src/components/ServerSettingsModal.tsx
+++ b/src/renderer/src/components/ServerSettingsModal.tsx
@@ -423,11 +423,11 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
         }
         footer={
           <Show when={section() === "general" && identityDirty()}>
-            <section class="server-settings-save-bar" aria-label="Unsaved changes">
+            <section class="settings-modal-save-bar" aria-label="Unsaved changes">
               <Text variant="caption" tone="muted">
                 Changes not saved
               </Text>
-              <div class="server-settings-save-actions">
+              <div class="settings-modal-save-actions">
                 <Button type="button" size="sm" variant="ghost" disabled={Boolean(busy())} onClick={resetIdentity}>
                   Reset
                 </Button>
@@ -549,7 +549,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
               event.currentTarget.value = "";
             }}
           />
-          <ItemGroup class="server-settings-general-card">
+          <ItemGroup class="settings-modal-card">
             <Show
               when={canEditIdentity()}
               fallback={
@@ -566,17 +566,17 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 </Item>
               }
             >
-              <Item class="server-settings-name-row">
+              <Item class="settings-identity-name-row">
                 <ItemContent>
                   <ItemTitle id="server-settings-name-label">Server name</ItemTitle>
                   <ItemDescription id="server-settings-name-description">
                     Shown in invitations and shared spaces.
                   </ItemDescription>
                 </ItemContent>
-                <ItemActions class="server-settings-name-control" data-invalid={visibleNameError() ? "" : undefined}>
+                <ItemActions class="settings-identity-name-control" data-invalid={visibleNameError() ? "" : undefined}>
                   <Input
                     ref={(element) => (nameInput = element)}
-                    class={nameShaking() ? "server-settings-name-input is-shaking" : "server-settings-name-input"}
+                    class={nameShaking() ? "settings-identity-name-input is-shaking" : "settings-identity-name-input"}
                     id="server-settings-name"
                     size="md"
                     maxlength={INPUT_LIMITS.serverName}
@@ -602,7 +602,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                   />
                   <span
                     id="server-settings-name-error"
-                    class="ui-field-error server-settings-name-error"
+                    class="ui-field-error settings-identity-name-error"
                     role="alert"
                     aria-hidden={visibleNameError() ? undefined : "true"}
                   >
@@ -611,7 +611,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 </ItemActions>
               </Item>
             </Show>
-            <Item class="server-settings-logo-row">
+            <Item class="settings-identity-image-row">
               <ItemContent>
                 <ItemTitle>Server logo</ItemTitle>
                 <ItemDescription class={logoError() ? "server-settings-item-error" : undefined}>
@@ -621,17 +621,17 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                       : "Only the server owner can change this logo.")}
                 </ItemDescription>
               </ItemContent>
-              <ItemActions class="server-settings-logo-control">
+              <ItemActions class="settings-identity-image-control">
                 <Show
                   when={canEditIdentity()}
                   fallback={<ServerLogo name={draftName() || props.server.name} url={draftLogoUrl()} />}
                 >
-                  <div class="server-settings-logo-picker ui-removable-image">
+                  <div class="settings-identity-image-picker ui-removable-image">
                     <Button
                       type="button"
                       variant="outline"
                       size="icon-lg"
-                      class="server-settings-logo-trigger"
+                      class="settings-identity-image-trigger server-settings-logo-trigger"
                       aria-label={draftLogoUrl() ? "Edit server logo" : "Add server logo"}
                       onClick={() => logoInput?.click()}
                     >
@@ -661,7 +661,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
           </ItemGroup>
         </SettingsSection>
         <SettingsSection title="Access">
-          <ItemGroup class="server-settings-general-card">
+          <ItemGroup class="settings-modal-card">
             <SwitchField
               class="server-settings-publish-setting"
               size="default"
@@ -740,10 +740,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
             </label>
           }
         >
-          <ItemGroup
-            class="server-settings-general-card server-settings-members-list"
-            data-testid="server-members-list"
-          >
+          <ItemGroup class="settings-modal-card server-settings-members-list" data-testid="server-members-list">
             <Show
               when={filteredMembers().length > 0}
               fallback={
@@ -920,7 +917,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
           </Text>
         }
       >
-        <ItemGroup class="server-settings-general-card server-settings-invites-list">
+        <ItemGroup class="settings-modal-card server-settings-invites-list">
           <Show
             when={activeInvites().length > 0}
             fallback={
@@ -963,7 +960,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   function DesktopPanel() {
     return (
       <SettingsSection title="Remote desktop access">
-        <ItemGroup class="server-settings-general-card server-settings-desktop-card">
+        <ItemGroup class="settings-modal-card server-settings-desktop-card">
           <Show when={local()} fallback={remoteDesktopConnection()}>
             <Item size="spacious">
               <ItemMedia class="server-settings-desktop-icon">

--- a/src/renderer/src/components/SettingsModal.test.tsx
+++ b/src/renderer/src/components/SettingsModal.test.tsx
@@ -242,6 +242,28 @@ describe("SettingsModal", () => {
     expect(input).toHaveValue("Nöra Bot");
   });
 
+  it("does not mark a normalized legacy display name as changed", async () => {
+    render(() => (
+      <SettingsModal
+        open
+        onOpenChange={() => undefined}
+        value={DEFAULT_GENERAL_SETTINGS}
+        onValueChange={() => undefined}
+        appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+        updateStatus={idleUpdateStatus}
+        onUpdateAction={vi.fn(async () => undefined)}
+        account={{ ...account, name: "Jose\u0301" }}
+        onUpdateAccountName={vi.fn(async () => undefined)}
+        onUpdateAccountAvatar={vi.fn(async () => undefined)}
+      />
+    ));
+
+    await fireEvent.click(screen.getByRole("tab", { name: "Profile" }));
+
+    expect(screen.getByRole("textbox", { name: "Display name" })).toHaveValue("Jose\u0301");
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+  });
+
   it("keeps an invalid display name focused and does not save it", async () => {
     const onUpdateAccountName = vi.fn(async () => undefined);
     render(() => (

--- a/src/renderer/src/components/SettingsModal.test.tsx
+++ b/src/renderer/src/components/SettingsModal.test.tsx
@@ -34,6 +34,7 @@ describe("SettingsModal", () => {
         updateStatus={idleUpdateStatus}
         onUpdateAction={vi.fn(async () => undefined)}
         account={account}
+        onUpdateAccountName={vi.fn(async () => undefined)}
         onUpdateAccountAvatar={vi.fn(async () => undefined)}
       />
     ));
@@ -65,6 +66,7 @@ describe("SettingsModal", () => {
           updateStatus={idleUpdateStatus}
           onUpdateAction={vi.fn(async () => undefined)}
           account={account}
+          onUpdateAccountName={vi.fn(async () => undefined)}
           onUpdateAccountAvatar={vi.fn(async () => undefined)}
           restoreFocusTarget={openTrigger}
         />
@@ -107,13 +109,58 @@ describe("SettingsModal", () => {
         updateStatus={status()}
         onUpdateAction={onUpdateAction}
         account={account}
+        onUpdateAccountName={vi.fn(async () => undefined)}
         onUpdateAccountAvatar={vi.fn(async () => undefined)}
       />
     ));
 
+    await fireEvent.click(screen.getByRole("tab", { name: "Updates" }));
     await fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
     await waitFor(() => expect(onUpdateAction).toHaveBeenCalledOnce());
-    expect(await screen.findByText("OpenBot is up to date.")).toBeInTheDocument();
+    expect(await screen.findByText("OpenBot is up to date on the Stable track.")).toBeInTheDocument();
+  });
+
+  it("shows the Stable track and the target update across download states", async () => {
+    const [status, setStatus] = createSignal<UpdateStatus>({
+      ...idleUpdateStatus,
+      phase: "available",
+      availableVersion: "0.3.0",
+    });
+
+    render(() => (
+      <SettingsModal
+        open
+        onOpenChange={() => undefined}
+        value={DEFAULT_GENERAL_SETTINGS}
+        onValueChange={() => undefined}
+        appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+        updateStatus={status()}
+        onUpdateAction={vi.fn(async () => undefined)}
+        account={account}
+        onUpdateAccountName={vi.fn(async () => undefined)}
+        onUpdateAccountAvatar={vi.fn(async () => undefined)}
+      />
+    ));
+
+    await fireEvent.click(screen.getByRole("tab", { name: "Updates" }));
+    await fireEvent.pointerDown(screen.getByRole("button", { name: /^Update track/ }), {
+      pointerType: "mouse",
+      button: 0,
+    });
+    expect(screen.getByRole("option", { name: "Stable" })).toHaveAttribute("aria-selected", "true");
+    await fireEvent.click(screen.getByRole("option", { name: "Stable" }));
+
+    expect(screen.getByText("Version 0.2.1")).toBeInTheDocument();
+    expect(screen.getByText("OpenBot v0.3.0 is available to download.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download update" })).toBeEnabled();
+
+    setStatus({ ...status(), phase: "downloading", progress: 42 });
+    expect(await screen.findByText("Downloading OpenBot v0.3.0 · 42%")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Downloading update…" })).toBeDisabled();
+
+    setStatus({ ...status(), phase: "ready", progress: 100 });
+    expect(await screen.findByText("OpenBot v0.3.0 is ready. Restart to apply.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Restart to update" })).toBeEnabled();
   });
 
   it("disables busy update actions and shows action failures", async () => {
@@ -130,10 +177,12 @@ describe("SettingsModal", () => {
         updateStatus={idleUpdateStatus}
         onUpdateAction={onUpdateAction}
         account={account}
+        onUpdateAccountName={vi.fn(async () => undefined)}
         onUpdateAccountAvatar={vi.fn(async () => undefined)}
       />
     ));
 
+    await fireEvent.click(screen.getByRole("tab", { name: "Updates" }));
     await fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
     expect(await screen.findByText("Update service is offline.")).toBeInTheDocument();
 
@@ -148,11 +197,114 @@ describe("SettingsModal", () => {
         updateStatus={{ ...idleUpdateStatus, phase: "checking" }}
         onUpdateAction={onUpdateAction}
         account={account}
+        onUpdateAccountName={vi.fn(async () => undefined)}
         onUpdateAccountAvatar={vi.fn(async () => undefined)}
       />
     ));
 
+    await fireEvent.click(screen.getByRole("tab", { name: "Updates" }));
     expect(screen.getByRole("button", { name: "Checking for updates…" })).toBeDisabled();
+  });
+
+  it("resets a display-name draft and saves its trimmed value", async () => {
+    const [currentAccount, setCurrentAccount] = createSignal({ ...account });
+    const onUpdateAccountName = vi.fn(async (name: string) => {
+      setCurrentAccount((current) => ({ ...current, name }));
+    });
+
+    render(() => (
+      <SettingsModal
+        open
+        onOpenChange={() => undefined}
+        value={DEFAULT_GENERAL_SETTINGS}
+        onValueChange={() => undefined}
+        appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+        updateStatus={idleUpdateStatus}
+        onUpdateAction={vi.fn(async () => undefined)}
+        account={currentAccount()}
+        onUpdateAccountName={onUpdateAccountName}
+        onUpdateAccountAvatar={vi.fn(async () => undefined)}
+      />
+    ));
+
+    await fireEvent.click(screen.getByRole("tab", { name: "Profile" }));
+    const input = screen.getByRole("textbox", { name: "Display name" });
+    await fireEvent.input(input, { target: { value: "Unsaved name" } });
+    await fireEvent.click(screen.getByRole("tab", { name: "Updates" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+    await fireEvent.click(screen.getByRole("tab", { name: "Profile" }));
+    expect(input).toHaveValue("Norbert");
+    expect(onUpdateAccountName).not.toHaveBeenCalled();
+
+    await fireEvent.input(input, { target: { value: "  No\u0308ra\u00a0\u00a0Bot  " } });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onUpdateAccountName).toHaveBeenCalledWith("Nöra Bot"));
+    expect(input).toHaveValue("Nöra Bot");
+  });
+
+  it("keeps an invalid display name focused and does not save it", async () => {
+    const onUpdateAccountName = vi.fn(async () => undefined);
+    render(() => (
+      <SettingsModal
+        open
+        onOpenChange={() => undefined}
+        value={DEFAULT_GENERAL_SETTINGS}
+        onValueChange={() => undefined}
+        appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+        updateStatus={idleUpdateStatus}
+        onUpdateAction={vi.fn(async () => undefined)}
+        account={account}
+        onUpdateAccountName={onUpdateAccountName}
+        onUpdateAccountAvatar={vi.fn(async () => undefined)}
+      />
+    ));
+
+    await fireEvent.click(screen.getByRole("tab", { name: "Profile" }));
+    const input = screen.getByRole("textbox", { name: "Display name" });
+    await fireEvent.input(input, { target: { value: " " } });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onUpdateAccountName).not.toHaveBeenCalled();
+    expect(await screen.findByRole("alert")).toHaveTextContent("Enter a display name.");
+    await waitFor(() => expect(input).toHaveFocus());
+
+    await fireEvent.input(input, { target: { value: "No" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onUpdateAccountName).not.toHaveBeenCalled();
+    expect(await screen.findByRole("alert")).toHaveTextContent("Use at least 3 characters.");
+
+    await fireEvent.input(input, { target: { value: "Nor\u200bbert" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onUpdateAccountName).not.toHaveBeenCalled();
+    expect(await screen.findByRole("alert")).toHaveTextContent("Remove line breaks and hidden or control characters.");
+  });
+
+  it("keeps the display-name draft after a save failure", async () => {
+    const onUpdateAccountName = vi.fn(async () => {
+      throw new Error("Profile service is offline.");
+    });
+    render(() => (
+      <SettingsModal
+        open
+        onOpenChange={() => undefined}
+        value={DEFAULT_GENERAL_SETTINGS}
+        onValueChange={() => undefined}
+        appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+        updateStatus={idleUpdateStatus}
+        onUpdateAction={vi.fn(async () => undefined)}
+        account={account}
+        onUpdateAccountName={onUpdateAccountName}
+        onUpdateAccountAvatar={vi.fn(async () => undefined)}
+      />
+    ));
+
+    await fireEvent.click(screen.getByRole("tab", { name: "Profile" }));
+    const input = screen.getByRole("textbox", { name: "Display name" });
+    await fireEvent.input(input, { target: { value: "Nora" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Profile service is offline.");
+    expect(input).toHaveValue("Nora");
   });
 
   it("updates and removes the signed-in account avatar from Profile settings", async () => {
@@ -174,6 +326,7 @@ describe("SettingsModal", () => {
         updateStatus={idleUpdateStatus}
         onUpdateAction={vi.fn(async () => undefined)}
         account={currentAccount()}
+        onUpdateAccountName={vi.fn(async () => undefined)}
         onUpdateAccountAvatar={onUpdateAccountAvatar}
         processAvatarFile={async () => ({
           mimeType: "image/webp",
@@ -190,7 +343,7 @@ describe("SettingsModal", () => {
     await waitFor(() =>
       expect(onUpdateAccountAvatar).toHaveBeenCalledWith(expect.objectContaining({ mimeType: "image/webp" })),
     );
-    await fireEvent.click(await screen.findByRole("button", { name: "Remove" }));
+    await fireEvent.click(await screen.findByRole("button", { name: "Remove profile photo" }));
     await waitFor(() => expect(onUpdateAccountAvatar).toHaveBeenLastCalledWith(null));
   });
 });

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -114,11 +114,11 @@ export function SettingsModal(props: SettingsModalProps) {
       return "Remove line breaks and hidden or control characters.";
     }
     if (!normalizedProfileName()) return "Enter a display name.";
-    if (normalizedProfileName().length < INPUT_LIMITS.accountNameMin) {
-      return `Use at least ${INPUT_LIMITS.accountNameMin} characters.`;
+    if (normalizedProfileName().length < INPUT_LIMITS.profileNameMin) {
+      return `Use at least ${INPUT_LIMITS.profileNameMin} characters.`;
     }
-    if (normalizedProfileName().length > INPUT_LIMITS.accountName) {
-      return `Use no more than ${INPUT_LIMITS.accountName} characters.`;
+    if (normalizedProfileName().length > INPUT_LIMITS.profileName) {
+      return `Use no more than ${INPUT_LIMITS.profileName} characters.`;
     }
     return null;
   };
@@ -232,8 +232,8 @@ export function SettingsModal(props: SettingsModalProps) {
     const normalized = normalizeAccountName(value);
     if (
       hasUnsafeAccountNameCharacters(value) ||
-      normalized.length < INPUT_LIMITS.accountNameMin ||
-      normalized.length > INPUT_LIMITS.accountName
+      normalized.length < INPUT_LIMITS.profileNameMin ||
+      normalized.length > INPUT_LIMITS.profileName
     )
       return;
     setProfileNameTouched(false);
@@ -496,8 +496,8 @@ export function SettingsModal(props: SettingsModalProps) {
                     class="settings-identity-name-input"
                     id="settings-profile-name"
                     size="md"
-                    minlength={INPUT_LIMITS.accountNameMin}
-                    maxlength={INPUT_LIMITS.accountName}
+                    minlength={INPUT_LIMITS.profileNameMin}
+                    maxlength={INPUT_LIMITS.profileName}
                     value={profileName()}
                     aria-labelledby="settings-profile-name-label"
                     aria-describedby={

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -8,7 +8,7 @@ import type {
   ProviderRuntimeStatus,
   UpdateStatus,
 } from "@openbot/contracts/ipc";
-import { hasUnsafeAccountNameCharacters, normalizeAccountName } from "@openbot/contracts/validation";
+import { normalizeAccountName, validateProfileName } from "@openbot/contracts/validation";
 import { createEffect, createMemo, createSignal, Show } from "solid-js";
 import type { GeneralSettingsValue } from "../app-settings";
 import { normalizeAvatarFile } from "../avatar-image";
@@ -101,26 +101,28 @@ export function SettingsModal(props: SettingsModalProps) {
     () => props.account.name,
     () => {
       const name = accountName();
-      setSavedProfileName(name);
+      setSavedProfileName(normalizeAccountName(name));
       setProfileName(name);
       setProfileNameTouched(false);
       setProfileSaveError(null);
     },
   );
 
-  const normalizedProfileName = () => normalizeAccountName(profileName());
+  const profileNameValidation = createMemo(() => validateProfileName(profileName()));
+  const normalizedProfileName = () => profileNameValidation().name;
   const profileNameError = () => {
-    if (hasUnsafeAccountNameCharacters(profileName())) {
-      return "Remove line breaks and hidden or control characters.";
+    switch (profileNameValidation().error) {
+      case "unsafe":
+        return "Remove line breaks and hidden or control characters.";
+      case "required":
+        return "Enter a display name.";
+      case "too-short":
+        return `Use at least ${INPUT_LIMITS.profileNameMin} characters.`;
+      case "too-long":
+        return `Use no more than ${INPUT_LIMITS.profileName} characters.`;
+      case null:
+        return null;
     }
-    if (!normalizedProfileName()) return "Enter a display name.";
-    if (normalizedProfileName().length < INPUT_LIMITS.profileNameMin) {
-      return `Use at least ${INPUT_LIMITS.profileNameMin} characters.`;
-    }
-    if (normalizedProfileName().length > INPUT_LIMITS.profileName) {
-      return `Use no more than ${INPUT_LIMITS.profileName} characters.`;
-    }
-    return null;
   };
   const visibleProfileNameError = () => profileSaveError() ?? (profileNameTouched() ? profileNameError() : null);
   const profileNameDirty = () => normalizedProfileName() !== savedProfileName();
@@ -229,13 +231,7 @@ export function SettingsModal(props: SettingsModalProps) {
   function updateProfileName(value: string): void {
     setProfileName(value);
     setProfileSaveError(null);
-    const normalized = normalizeAccountName(value);
-    if (
-      hasUnsafeAccountNameCharacters(value) ||
-      normalized.length < INPUT_LIMITS.profileNameMin ||
-      normalized.length > INPUT_LIMITS.profileName
-    )
-      return;
+    if (validateProfileName(value).error) return;
     setProfileNameTouched(false);
   }
 
@@ -496,8 +492,6 @@ export function SettingsModal(props: SettingsModalProps) {
                     class="settings-identity-name-input"
                     id="settings-profile-name"
                     size="md"
-                    minlength={INPUT_LIMITS.profileNameMin}
-                    maxlength={INPUT_LIMITS.profileName}
                     value={profileName()}
                     aria-labelledby="settings-profile-name-label"
                     aria-describedby={

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,3 +1,4 @@
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type {
   AgentProviderId,
   AgentStatus,
@@ -7,6 +8,7 @@ import type {
   ProviderRuntimeStatus,
   UpdateStatus,
 } from "@openbot/contracts/ipc";
+import { hasUnsafeAccountNameCharacters, normalizeAccountName } from "@openbot/contracts/validation";
 import { createEffect, createMemo, createSignal, Show } from "solid-js";
 import type { GeneralSettingsValue } from "../app-settings";
 import { normalizeAvatarFile } from "../avatar-image";
@@ -14,11 +16,9 @@ import { presentUpdateStatus } from "../update-status";
 import { ProviderPicker, type ProviderPickerOption } from "./ProviderPicker";
 import { SettingsDialogShell } from "./SettingsDialogShell";
 import {
-  Badge,
-  Bell,
   Button,
-  Card,
-  Field,
+  CircleArrowDown,
+  ImageRemoveButton,
   Input,
   Item,
   ItemActions,
@@ -26,7 +26,6 @@ import {
   ItemDescription,
   ItemGroup,
   ItemTitle,
-  Palette,
   Select,
   SelectContent,
   SelectItem,
@@ -34,7 +33,6 @@ import {
   SelectValue,
   Settings,
   SettingsSection,
-  SlidersHorizontal,
   SwitchField,
   Tabs,
   Text,
@@ -51,6 +49,7 @@ export interface SettingsModalProps {
   updateStatus: UpdateStatus;
   onUpdateAction: () => Promise<void>;
   account: CentralAuthUser;
+  onUpdateAccountName: (name: string) => Promise<void>;
   onUpdateAccountAvatar: (image: AvatarImageInput | null) => Promise<void>;
   processAvatarFile?: (file: File) => Promise<AvatarImageInput>;
   agentStatus?: AgentStatus;
@@ -61,55 +60,114 @@ export interface SettingsModalProps {
   restoreFocusTarget?: HTMLElement | null;
 }
 
-type SettingsTab = "general" | "profile";
+type SettingsTab = "general" | "profile" | "updates";
 
-type SettingsNavItem =
-  | { value: SettingsTab; label: string; icon: typeof Settings; enabled: true }
-  | {
-      value: "appearance" | "notifications" | "advanced";
-      label: string;
-      icon: typeof Settings;
-      enabled: false;
-    };
+type SettingsNavItem = { value: SettingsTab; label: string; icon: typeof Settings };
 
 const navItems: ReadonlyArray<SettingsNavItem> = [
-  { value: "general", label: "General", icon: Settings, enabled: true },
-  { value: "profile", label: "Profile", icon: UserRound, enabled: true },
-  { value: "appearance", label: "Appearance", icon: Palette, enabled: false },
-  { value: "notifications", label: "Notifications", icon: Bell, enabled: false },
-  { value: "advanced", label: "Advanced", icon: SlidersHorizontal, enabled: false },
+  { value: "general", label: "General", icon: Settings },
+  { value: "profile", label: "Profile", icon: UserRound },
+  { value: "updates", label: "Updates", icon: CircleArrowDown },
 ];
 
+const tabDetails: Record<SettingsTab, { title: string; description: string }> = {
+  general: { title: "General", description: "Control how OpenBot behaves on this computer." },
+  profile: { title: "Profile", description: "Manage how you appear in OpenBot." },
+  updates: { title: "Updates", description: "Keep OpenBot current on this computer." },
+};
+
 const linkTargetOptions: GeneralSettingsValue["externalLinkTarget"][] = ["Default browser", "OpenBot"];
+type UpdateTrack = "Stable";
+const updateTrackOptions: UpdateTrack[] = ["Stable"];
 
 export function SettingsModal(props: SettingsModalProps) {
   const [activeTab, setActiveTab] = createSignal<SettingsTab>("general");
+  const [savedProfileName, setSavedProfileName] = createSignal("");
   const [profileName, setProfileName] = createSignal("");
+  const [profileNameTouched, setProfileNameTouched] = createSignal(false);
+  const [profileNameBusy, setProfileNameBusy] = createSignal(false);
+  const [profileSaveError, setProfileSaveError] = createSignal<string | null>(null);
   const [avatarBusy, setAvatarBusy] = createSignal(false);
   const [avatarError, setAvatarError] = createSignal<string | null>(null);
   const [updateError, setUpdateError] = createSignal<string | null>(null);
   const [selectedProvider, setSelectedProvider] = createSignal<AgentProviderId | null>(null);
   let modalElement: HTMLElement | undefined;
   let avatarFileInput: HTMLInputElement | undefined;
+  let profileNameInput: HTMLInputElement | undefined;
 
   const accountName = () => props.account.name?.trim() || props.account.email.split("@")[0] || props.account.email;
 
   createEffect(
     () => props.account.name,
     () => {
-      setProfileName(accountName());
+      const name = accountName();
+      setSavedProfileName(name);
+      setProfileName(name);
+      setProfileNameTouched(false);
+      setProfileSaveError(null);
     },
   );
 
-  const title = () => (activeTab() === "general" ? "General" : "Profile");
-  const description = () =>
-    activeTab() === "general" ? "Control how OpenBot behaves on this computer." : "Manage how you appear in OpenBot.";
+  const normalizedProfileName = () => normalizeAccountName(profileName());
+  const profileNameError = () => {
+    if (hasUnsafeAccountNameCharacters(profileName())) {
+      return "Remove line breaks and hidden or control characters.";
+    }
+    if (!normalizedProfileName()) return "Enter a display name.";
+    if (normalizedProfileName().length < INPUT_LIMITS.accountNameMin) {
+      return `Use at least ${INPUT_LIMITS.accountNameMin} characters.`;
+    }
+    if (normalizedProfileName().length > INPUT_LIMITS.accountName) {
+      return `Use no more than ${INPUT_LIMITS.accountName} characters.`;
+    }
+    return null;
+  };
+  const visibleProfileNameError = () => profileSaveError() ?? (profileNameTouched() ? profileNameError() : null);
+  const profileNameDirty = () => normalizedProfileName() !== savedProfileName();
+
+  const title = () => tabDetails[activeTab()].title;
+  const description = () => tabDetails[activeTab()].description;
   const updatePresentation = createMemo(() => presentUpdateStatus(props.updateStatus));
   const installedVersion = () => props.updateStatus.currentVersion || props.appInfo?.version || "Unknown";
-  const updateMessage = () =>
-    updateError() ??
-    (props.updateStatus.phase === "error" ? props.updateStatus.message : null) ??
-    (props.updateStatus.phase === "up-to-date" ? "OpenBot is up to date." : "Installed version");
+  const targetUpdate = () =>
+    props.updateStatus.availableVersion
+      ? `OpenBot v${props.updateStatus.availableVersion}`
+      : "The latest OpenBot update";
+  const updateMessage = () => {
+    if (updateError()) return updateError();
+    switch (props.updateStatus.phase) {
+      case "idle":
+        return "Check for updates to find the latest Stable release.";
+      case "checking":
+        return "Checking the Stable track for updates…";
+      case "available":
+        return `${targetUpdate()} is available to download.`;
+      case "downloading":
+        return `Downloading ${targetUpdate()}${
+          props.updateStatus.progress === null ? "…" : ` · ${Math.round(props.updateStatus.progress)}%`
+        }`;
+      case "preparing":
+        return `Preparing ${targetUpdate()}…`;
+      case "ready":
+        return `${targetUpdate()} is ready. Restart to apply.`;
+      case "installing":
+        return `Restarting to apply ${targetUpdate()}…`;
+      case "up-to-date":
+        return "OpenBot is up to date on the Stable track.";
+      case "error":
+        return props.updateStatus.message ?? "OpenBot could not check for updates.";
+      case "unsupported":
+        return props.updateStatus.message ?? "Updates are unavailable in this build.";
+    }
+  };
+  const updateMessageClass = () => {
+    if (updateError() || props.updateStatus.phase === "error")
+      return "settings-modal-update-status settings-modal-error";
+    if (["available", "downloading", "preparing", "ready", "installing"].includes(props.updateStatus.phase)) {
+      return "settings-modal-update-status settings-modal-update-status-active";
+    }
+    return "settings-modal-update-status";
+  };
   const providerOptions = createMemo<ProviderPickerOption[]>(() =>
     (["codex", "claude", "grok"] as const).map((provider) => {
       const agent = props.agentStatus?.providers?.find((candidate) => candidate.id === provider);
@@ -135,7 +193,7 @@ export function SettingsModal(props: SettingsModalProps) {
       return activeTab();
     },
     onChange(value: string) {
-      if (value === "general" || value === "profile") setActiveTab(value);
+      if (value === "general" || value === "profile" || value === "updates") setActiveTab(value);
     },
     orientation: "vertical" as const,
     activationMode: "automatic" as const,
@@ -168,6 +226,49 @@ export function SettingsModal(props: SettingsModalProps) {
     }
   }
 
+  function updateProfileName(value: string): void {
+    setProfileName(value);
+    setProfileSaveError(null);
+    const normalized = normalizeAccountName(value);
+    if (
+      hasUnsafeAccountNameCharacters(value) ||
+      normalized.length < INPUT_LIMITS.accountNameMin ||
+      normalized.length > INPUT_LIMITS.accountName
+    )
+      return;
+    setProfileNameTouched(false);
+  }
+
+  function resetProfileName(): void {
+    setProfileName(savedProfileName());
+    setProfileNameTouched(false);
+    setProfileSaveError(null);
+  }
+
+  async function saveProfileName(): Promise<void> {
+    if (profileNameBusy()) return;
+    setProfileNameTouched(true);
+    setProfileSaveError(null);
+    if (profileNameError()) {
+      queueMicrotask(() => profileNameInput?.focus({ preventScroll: true }));
+      return;
+    }
+    if (!profileNameDirty()) return;
+    const name = normalizedProfileName();
+    setProfileNameBusy(true);
+    try {
+      await props.onUpdateAccountName(name);
+      setSavedProfileName(name);
+      setProfileName(name);
+      setProfileNameTouched(false);
+    } catch (error) {
+      setProfileSaveError(error instanceof Error ? error.message : "Could not update your display name.");
+      queueMicrotask(() => profileNameInput?.focus({ preventScroll: true }));
+    } finally {
+      setProfileNameBusy(false);
+    }
+  }
+
   async function uploadAvatar(file: File | undefined): Promise<void> {
     if (!file || avatarBusy()) return;
     setAvatarBusy(true);
@@ -194,6 +295,31 @@ export function SettingsModal(props: SettingsModalProps) {
         contentKey={activeTab()}
         restoreFocusTarget={props.restoreFocusTarget}
         onContentElement={(element) => (modalElement = element)}
+        footer={
+          <Show when={profileNameDirty()}>
+            <section class="settings-modal-save-bar" aria-label="Unsaved changes">
+              <Text variant="caption" tone="muted">
+                Changes not saved
+              </Text>
+              <div class="settings-modal-save-actions">
+                <Button type="button" size="sm" variant="ghost" disabled={profileNameBusy()} onClick={resetProfileName}>
+                  Reset
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="default"
+                  loading={profileNameBusy()}
+                  loadingLabel="Saving…"
+                  disabled={profileNameBusy()}
+                  onClick={() => void saveProfileName()}
+                >
+                  Save
+                </Button>
+              </div>
+            </section>
+          </Show>
+        }
         sidebar={
           <Tabs.List class="settings-modal-nav" aria-label="Settings sections">
             {navItems.map((item) => {
@@ -202,17 +328,10 @@ export function SettingsModal(props: SettingsModalProps) {
                 <Tabs.Trigger
                   class="settings-modal-nav-item"
                   value={item.value}
-                  disabled={!item.enabled}
-                  title={item.enabled ? undefined : "Coming soon"}
                   aria-current={activeTab() === item.value ? "page" : undefined}
                 >
                   <NavIcon aria-hidden="true" />
                   <span>{item.label}</span>
-                  {!item.enabled && (
-                    <span class="settings-modal-nav-status" aria-hidden="true">
-                      Soon
-                    </span>
-                  )}
                 </Tabs.Trigger>
               );
             })}
@@ -235,7 +354,7 @@ export function SettingsModal(props: SettingsModalProps) {
           </SettingsSection>
 
           <SettingsSection title="App behavior">
-            <ItemGroup class="settings-modal-card" surface="subtle">
+            <ItemGroup class="settings-modal-card">
               <SwitchField
                 checked={props.value.launchAtLogin}
                 onChange={(checked) => updateSetting("launchAtLogin", checked)}
@@ -252,7 +371,7 @@ export function SettingsModal(props: SettingsModalProps) {
           </SettingsSection>
 
           <SettingsSection title="Workspace">
-            <ItemGroup class="settings-modal-card" surface="subtle">
+            <ItemGroup class="settings-modal-card">
               <SwitchField
                 checked={props.value.restoreLastWorkspace}
                 onChange={(checked) => updateSetting("restoreLastWorkspace", checked)}
@@ -288,7 +407,7 @@ export function SettingsModal(props: SettingsModalProps) {
           </SettingsSection>
 
           <SettingsSection title="Notifications">
-            <ItemGroup class="settings-modal-card" surface="subtle">
+            <ItemGroup class="settings-modal-card">
               <SwitchField
                 checked={props.value.desktopNotifications}
                 onChange={(checked) => updateSetting("desktopNotifications", checked)}
@@ -306,7 +425,7 @@ export function SettingsModal(props: SettingsModalProps) {
 
           <Show when={props.appInfo?.platform === "darwin"}>
             <SettingsSection title="MacBook notch">
-              <ItemGroup class="settings-modal-card" surface="subtle">
+              <ItemGroup class="settings-modal-card">
                 <SwitchField
                   checked={props.value.macBookNotch}
                   onChange={(checked) => updateSetting("macBookNotch", checked)}
@@ -338,27 +457,153 @@ export function SettingsModal(props: SettingsModalProps) {
             </SettingsSection>
           </Show>
 
-          <SettingsSection title="Updates">
-            <ItemGroup class="settings-modal-card" surface="subtle">
+          <SettingsSection title="Privacy">
+            <ItemGroup class="settings-modal-card">
               <SwitchField
-                checked={props.value.autoDownloadUpdates}
-                onChange={(checked) => updateSetting("autoDownloadUpdates", checked)}
-                label="Automatically download updates"
-                description="Download new versions when they become available."
+                checked={props.value.productAnalytics}
+                onChange={(checked) => updateSetting("productAnalytics", checked)}
+                label="Share product analytics"
+                description="Send usage and reliability metadata with your account ID and email to OpenBot's self-hosted analytics."
               />
-              <Item class="settings-modal-row settings-modal-update-row">
+            </ItemGroup>
+          </SettingsSection>
+        </Tabs.Content>
+
+        <Tabs.Content value="profile" class="settings-modal-tab-panel" data-tab="profile">
+          <SettingsSection title="Identity">
+            <Input
+              ref={(element) => (avatarFileInput = element)}
+              class="sr-only"
+              type="file"
+              aria-label="Upload profile photo"
+              accept="image/png,image/jpeg,image/webp"
+              onChange={(event) => void uploadAvatar(event.currentTarget.files?.[0])}
+            />
+            <ItemGroup class="settings-modal-card">
+              <Item class="settings-identity-name-row">
                 <ItemContent>
-                  <ItemTitle>OpenBot version</ItemTitle>
-                  <ItemDescription
-                    class={updateError() || props.updateStatus.phase === "error" ? "settings-modal-error" : undefined}
-                  >
-                    {updateMessage()}
+                  <ItemTitle id="settings-profile-name-label">Display name</ItemTitle>
+                  <ItemDescription id="settings-profile-name-description">
+                    Visible in shared workspaces.
                   </ItemDescription>
                 </ItemContent>
+                <ItemActions
+                  class="settings-identity-name-control"
+                  data-invalid={visibleProfileNameError() ? "" : undefined}
+                >
+                  <Input
+                    ref={(element) => (profileNameInput = element)}
+                    class="settings-identity-name-input"
+                    id="settings-profile-name"
+                    size="md"
+                    minlength={INPUT_LIMITS.accountNameMin}
+                    maxlength={INPUT_LIMITS.accountName}
+                    value={profileName()}
+                    aria-labelledby="settings-profile-name-label"
+                    aria-describedby={
+                      visibleProfileNameError() ? "settings-profile-name-error" : "settings-profile-name-description"
+                    }
+                    aria-invalid={visibleProfileNameError() ? "true" : undefined}
+                    onValueChange={updateProfileName}
+                    onBlur={() => {
+                      if (!profileNameDirty()) return;
+                      setProfileNameTouched(true);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" || event.isComposing) return;
+                      event.preventDefault();
+                      void saveProfileName();
+                    }}
+                  />
+                  <span
+                    id="settings-profile-name-error"
+                    class="ui-field-error settings-identity-name-error"
+                    role="alert"
+                    aria-hidden={visibleProfileNameError() ? undefined : "true"}
+                  >
+                    {visibleProfileNameError() ?? ""}
+                  </span>
+                </ItemActions>
+              </Item>
+              <Item class="settings-identity-image-row">
+                <ItemContent>
+                  <ItemTitle>Profile photo</ItemTitle>
+                  <ItemDescription class={avatarError() ? "settings-modal-error" : undefined}>
+                    {avatarError() ?? "Shown with your profile in OpenBot."}
+                  </ItemDescription>
+                </ItemContent>
+                <ItemActions class="settings-identity-image-control">
+                  <div class="settings-identity-image-picker ui-removable-image">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon-lg"
+                      class="settings-identity-image-trigger settings-modal-profile-photo-trigger"
+                      aria-label={props.account.avatarUrl ? "Edit profile photo" : "Add profile photo"}
+                      disabled={avatarBusy()}
+                      onClick={() => avatarFileInput?.click()}
+                    >
+                      <UserAvatar user={props.account} class="settings-modal-avatar" decorative />
+                    </Button>
+                    <Show when={props.account.avatarUrl && !avatarBusy()}>
+                      <ImageRemoveButton label="Remove profile photo" onClick={() => void updateAvatar(null)} />
+                    </Show>
+                  </div>
+                </ItemActions>
+              </Item>
+            </ItemGroup>
+          </SettingsSection>
+
+          <SettingsSection title="Account">
+            <ItemGroup class="settings-modal-card">
+              <Item class="settings-modal-account-email-row">
+                <ItemContent>
+                  <ItemTitle>Email</ItemTitle>
+                  <ItemDescription>Used to sign in to OpenBot.</ItemDescription>
+                </ItemContent>
+                <ItemActions>
+                  <Text as="span" class="settings-modal-readonly-value" variant="body">
+                    {props.account.email}
+                  </Text>
+                </ItemActions>
+              </Item>
+            </ItemGroup>
+          </SettingsSection>
+        </Tabs.Content>
+
+        <Tabs.Content value="updates" class="settings-modal-tab-panel" data-tab="updates">
+          <SettingsSection title="OpenBot updates">
+            <ItemGroup class="settings-modal-card">
+              <Item class="settings-modal-row settings-modal-update-track-row">
+                <ItemContent>
+                  <ItemTitle>Update track</ItemTitle>
+                  <ItemDescription>Stable receives tested OpenBot releases.</ItemDescription>
+                </ItemContent>
+                <ItemActions>
+                  <Select<UpdateTrack>
+                    class="settings-modal-update-track-select"
+                    options={updateTrackOptions}
+                    value="Stable"
+                    onChange={() => undefined}
+                    placement="bottom-end"
+                    itemComponent={(selectProps) => (
+                      <SelectItem item={selectProps.item}>{selectProps.item.rawValue}</SelectItem>
+                    )}
+                  >
+                    <SelectTrigger size="sm" aria-label="Update track">
+                      <SelectValue<UpdateTrack>>{(state) => state.selectedOption()}</SelectValue>
+                    </SelectTrigger>
+                    <SelectContent mount={modalElement} />
+                  </Select>
+                </ItemActions>
+              </Item>
+              <Item class="settings-modal-row settings-modal-update-row">
+                <ItemContent>
+                  <ItemTitle>Version {installedVersion()}</ItemTitle>
+                  <ItemDescription>Updates follow the Stable track.</ItemDescription>
+                  <ItemDescription class={updateMessageClass()}>{updateMessage()}</ItemDescription>
+                </ItemContent>
                 <ItemActions class="settings-modal-update-actions">
-                  <Badge tone={props.updateStatus.phase === "up-to-date" ? "success" : "accent"}>
-                    v{installedVersion()}
-                  </Badge>
                   <Button
                     variant="outline"
                     type="button"
@@ -372,83 +617,13 @@ export function SettingsModal(props: SettingsModalProps) {
                   </Button>
                 </ItemActions>
               </Item>
-            </ItemGroup>
-          </SettingsSection>
-
-          <SettingsSection title="Privacy">
-            <ItemGroup class="settings-modal-card" surface="subtle">
               <SwitchField
-                checked={props.value.productAnalytics}
-                onChange={(checked) => updateSetting("productAnalytics", checked)}
-                label="Share product analytics"
-                description="Send usage and reliability metadata with your account ID and email to OpenBot's self-hosted analytics."
+                checked={props.value.autoDownloadUpdates}
+                onChange={(checked) => updateSetting("autoDownloadUpdates", checked)}
+                label="Automatically download updates"
+                description="Download new versions when they become available."
               />
             </ItemGroup>
-          </SettingsSection>
-        </Tabs.Content>
-
-        <Tabs.Content value="profile" class="settings-modal-tab-panel" data-tab="profile">
-          <SettingsSection title="Account">
-            <Card class="settings-modal-card settings-modal-profile-card">
-              <div class="settings-modal-profile-summary">
-                <UserAvatar user={props.account} class="settings-modal-avatar" decorative />
-                <div class="settings-modal-profile-copy">
-                  <span class="settings-modal-row-title">{accountName()}</span>
-                  <Text tone="muted" variant="caption">
-                    {props.account.email}
-                  </Text>
-                </div>
-                <div class="settings-modal-profile-actions">
-                  <Input
-                    ref={(element) => (avatarFileInput = element)}
-                    class="sr-only"
-                    type="file"
-                    aria-label="Upload profile photo"
-                    accept="image/png,image/jpeg,image/webp"
-                    onChange={(event) => void uploadAvatar(event.currentTarget.files?.[0])}
-                  />
-                  <Button
-                    variant="outline"
-                    type="button"
-                    size="sm"
-                    loading={avatarBusy()}
-                    loadingLabel="Updating…"
-                    onClick={() => avatarFileInput?.click()}
-                  >
-                    Change photo
-                  </Button>
-                  <Show when={props.account.avatarUrl}>
-                    <Button
-                      variant="destructive-ghost"
-                      type="button"
-                      size="sm"
-                      disabled={avatarBusy()}
-                      onClick={() => void updateAvatar(null)}
-                    >
-                      Remove
-                    </Button>
-                  </Show>
-                </div>
-              </div>
-              <Show when={avatarError()}>{(message) => <p class="settings-modal-profile-error">{message()}</p>}</Show>
-            </Card>
-          </SettingsSection>
-
-          <SettingsSection title="Profile details">
-            <Card class="settings-modal-card settings-modal-profile-fields">
-              <Field
-                label="Display name"
-                description="This name is visible in shared workspaces."
-                htmlFor="settings-profile-name"
-              >
-                <Input id="settings-profile-name" value={profileName()} onValueChange={setProfileName} />
-              </Field>
-              <SwitchField
-                defaultChecked
-                label="Show activity status"
-                description="Let workspace members see when you are active."
-              />
-            </Card>
           </SettingsSection>
         </Tabs.Content>
       </SettingsDialogShell>

--- a/src/renderer/src/preview/OpenBotPlayground.test.tsx
+++ b/src/renderer/src/preview/OpenBotPlayground.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@solidjs/testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { STORY_UPDATE_STATUS } from "./fixtures";
 import { createLandingDemoController } from "./landing-demo";
 import { createMockOpenBot } from "./mock-openbot";
 import { OpenBotPlayground } from "./OpenBotPlayground";
@@ -36,6 +37,25 @@ describe("OpenBotPlayground", () => {
     expect(dispose).toHaveBeenCalledOnce();
     expect(window.openbot).toBe(previousMock.api);
     previousMock.dispose();
+  });
+
+  it("advances a mocked update download until it is ready", async () => {
+    vi.useFakeTimers();
+    const mock = createMockOpenBot({ updateStatus: STORY_UPDATE_STATUS });
+    const listener = vi.fn();
+    const unsubscribe = mock.api.update.onEvent(listener);
+
+    await expect(mock.api.update.download()).resolves.toMatchObject({ phase: "downloading", progress: 0 });
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ phase: "downloading", progress: 0 }));
+
+    vi.advanceTimersByTime(700);
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ phase: "downloading", progress: 64 }));
+
+    vi.advanceTimersByTime(700);
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ phase: "ready", progress: 100 }));
+
+    unsubscribe();
+    mock.dispose();
   });
 
   it("reports ready and accepts a same-origin start message only from its parent", async () => {

--- a/src/renderer/src/preview/mock-openbot.ts
+++ b/src/renderer/src/preview/mock-openbot.ts
@@ -448,6 +448,12 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
         authState = { status: "signed_in", user };
         return clone(authState);
       },
+      updateName: async (name) => {
+        if (authState.status !== "signed_in") return clone(authState);
+        authState = { ...authState, user: { ...authState.user, name } };
+        emitAuthState(authState);
+        return clone(authState);
+      },
       updateAvatar: async (image) => {
         if (authState.status !== "signed_in") return clone(authState);
         const avatarUrl = image
@@ -959,6 +965,19 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
       download: async () => {
         updateStatus = { ...updateStatus, phase: "downloading", progress: 0 };
         emit(updateListeners, updateStatus);
+        const downloadSteps = [
+          { delay: 350, expectedPhase: "downloading", phase: "downloading", progress: 28 },
+          { delay: 700, expectedPhase: "downloading", phase: "downloading", progress: 64 },
+          { delay: 1_050, expectedPhase: "downloading", phase: "preparing", progress: 100 },
+          { delay: 1_400, expectedPhase: "preparing", phase: "ready", progress: 100 },
+        ] as const;
+        for (const step of downloadSteps) {
+          schedule(() => {
+            if (updateStatus.phase !== step.expectedPhase) return;
+            updateStatus = { ...updateStatus, phase: step.phase, progress: step.progress };
+            emit(updateListeners, updateStatus);
+          }, step.delay);
+        }
         return clone(updateStatus);
       },
       install: async () => {

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -2315,25 +2315,6 @@
   background: var(--openbot-hover);
 }
 
-.provider-picker-embedded {
-  border-bottom: 1px solid var(--openbot-border);
-}
-
-.provider-picker-embedded .provider-picker-list {
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-}
-
-.provider-picker-embedded .provider-picker-option {
-  min-height: 39px;
-  padding: 7px 12px;
-}
-
-.provider-picker-embedded .provider-picker-option + .provider-picker-option {
-  border-color: var(--openbot-border);
-}
-
 .agent-settings-model-option {
   min-width: 0;
 }

--- a/src/renderer/src/styles/server-settings-modal.css
+++ b/src/renderer/src/styles/server-settings-modal.css
@@ -2,12 +2,6 @@
   background: var(--openbot-bg-canvas);
 }
 
-@media (min-width: 721px) {
-  .server-settings-modal-shell .settings-modal-header {
-    padding: var(--openbot-space-4) var(--openbot-space-4) var(--openbot-space-6) var(--openbot-space-8);
-  }
-}
-
 .server-settings-modal-shell .settings-modal-scroll-frame::before {
   background: linear-gradient(
     to bottom,
@@ -37,19 +31,6 @@
   gap: var(--openbot-space-3);
 }
 
-.server-settings-general-card.ui-item-group {
-  width: 100%;
-  overflow: hidden;
-  border: 0;
-  border-radius: var(--openbot-radius-lg);
-  background: var(--openbot-bg-surface);
-  box-shadow: none;
-}
-
-.server-settings-general-card > .ui-item {
-  min-height: 64px;
-}
-
 .server-settings-logo {
   width: 40px;
   height: 40px;
@@ -75,26 +56,7 @@
   outline-offset: -1px;
 }
 
-.server-settings-logo-control {
-  gap: var(--openbot-space-2);
-}
-
-.server-settings-save-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--openbot-space-1);
-}
-
-.server-settings-logo-picker {
-  position: relative;
-  display: flex;
-}
-
 .server-settings-logo-trigger {
-  position: relative;
-  width: calc(var(--openbot-control-xl) + var(--openbot-space-2));
-  height: calc(var(--openbot-control-xl) + var(--openbot-space-2));
-  overflow: hidden;
   border-radius: var(--openbot-radius-md);
   color: var(--openbot-text-muted);
 }
@@ -116,8 +78,6 @@
   color: var(--openbot-danger);
 }
 
-.server-settings-name-row.ui-item,
-.server-settings-logo-row.ui-item,
 .server-settings-readonly-name.ui-item {
   min-height: 72px;
 }
@@ -128,46 +88,6 @@
 
 .server-settings-publish-setting.ui-switch-field {
   padding: var(--openbot-space-3) var(--openbot-space-4);
-}
-
-.server-settings-name-control {
-  --server-settings-name-error-reveal-duration: 280ms;
-  --server-settings-name-shake-distance: 6px;
-  --server-settings-name-shake-overshoot: 4px;
-  --server-settings-name-shake-ease: cubic-bezier(0.22, 1, 0.36, 1);
-  position: relative;
-  width: 220px;
-  height: var(--openbot-control-md);
-}
-
-.server-settings-name-input.ui-input {
-  width: 100%;
-  transition: border-color var(--openbot-duration-normal) ease-out;
-  will-change: transform;
-}
-
-.server-settings-name-input.is-shaking {
-  animation: server-settings-name-shake 280ms linear;
-}
-
-.server-settings-name-error {
-  position: absolute;
-  top: calc(100% + var(--openbot-space-0-5));
-  right: 0;
-  left: 0;
-  opacity: 0;
-  visibility: hidden;
-  transition:
-    opacity var(--server-settings-name-error-reveal-duration) ease-out,
-    visibility 0s linear var(--server-settings-name-error-reveal-duration);
-}
-
-.server-settings-name-control[data-invalid] .server-settings-name-error {
-  opacity: 1;
-  visibility: visible;
-  transition:
-    opacity var(--server-settings-name-error-reveal-duration) ease-out,
-    visibility 0s linear;
 }
 
 .server-settings-publish-setting.ui-switch-field {
@@ -220,17 +140,6 @@
 
 .server-settings-address-control[data-copied] {
   color: var(--openbot-success);
-}
-
-.server-settings-save-bar {
-  min-height: 60px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--openbot-space-4);
-  border-top: 1px solid var(--openbot-border);
-  background: var(--openbot-bg-surface);
-  padding: var(--openbot-space-3) var(--openbot-space-6);
 }
 
 .server-settings-error-toast {
@@ -488,49 +397,13 @@
   }
 }
 
-@keyframes server-settings-name-shake {
-  0% {
-    transform: translateX(0);
-    animation-timing-function: var(--server-settings-name-shake-ease);
-  }
-
-  28.57% {
-    transform: translateX(var(--server-settings-name-shake-distance));
-    animation-timing-function: var(--server-settings-name-shake-ease);
-  }
-
-  57.14% {
-    transform: translateX(calc(var(--server-settings-name-shake-distance) * -1));
-    animation-timing-function: var(--server-settings-name-shake-ease);
-  }
-
-  78.57% {
-    transform: translateX(var(--server-settings-name-shake-overshoot));
-    animation-timing-function: var(--server-settings-name-shake-ease);
-  }
-
-  100% {
-    transform: translateX(0);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .server-settings-name-input.is-shaking {
-    animation: none;
-    transform: none;
-  }
-}
-
 @media (max-width: 720px) {
-  .server-settings-logo-row,
-  .server-settings-name-row,
   .server-settings-address-setting,
   .server-settings-readonly-name {
     align-items: flex-start;
     flex-direction: column;
   }
 
-  .server-settings-logo-control,
   .server-settings-address-control,
   .server-settings-readonly-name .ui-item-actions {
     width: 100%;
@@ -544,27 +417,8 @@
     text-align: left;
   }
 
-  .server-settings-name-control {
-    width: min(320px, 100%);
-    max-width: 320px;
-    height: auto;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: var(--openbot-control-md) var(--openbot-leading-xs);
-    align-items: stretch;
-    row-gap: var(--openbot-space-0-5);
-  }
-
-  .server-settings-name-error {
-    position: static;
-  }
-
   .server-settings-address-control {
     width: 100%;
-  }
-
-  .server-settings-save-bar {
-    padding-inline: var(--openbot-space-4);
   }
 
   .server-settings-error-toast {
@@ -624,16 +478,6 @@
   .server-settings-invite-composer > .ui-button {
     width: 100%;
     grid-column: 1;
-  }
-
-  .server-settings-save-bar {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .server-settings-save-actions {
-    width: 100%;
-    justify-content: flex-end;
   }
 }
 

--- a/src/renderer/src/styles/settings-modal.css
+++ b/src/renderer/src/styles/settings-modal.css
@@ -18,7 +18,6 @@
 }
 
 .settings-modal {
-  --settings-divider-inset: var(--openbot-space-6);
   --openbot-bg-surface: var(--openbot-bg-control);
   --openbot-accent: var(--openbot-settings-accent);
   --openbot-accent-hover: var(--openbot-settings-accent-hover);
@@ -104,7 +103,7 @@
   font-weight: var(--openbot-weight-medium);
 }
 
-.settings-modal-nav-item:not(:disabled) {
+.settings-modal-nav-item {
   cursor: pointer;
 }
 
@@ -113,23 +112,11 @@
   box-shadow: var(--openbot-focus-ring);
 }
 
-.settings-modal-nav-item:disabled {
-  color: var(--openbot-text-dim);
-  cursor: default;
-}
-
 @media (hover: hover) and (pointer: fine) {
-  .settings-modal-nav-item:not(:disabled, [aria-current="page"]):hover {
+  .settings-modal-nav-item:not([aria-current="page"]):hover {
     background: var(--openbot-hover);
     color: var(--openbot-text-primary);
   }
-}
-
-.settings-modal-nav-status {
-  font-size: var(--openbot-text-2xs);
-  line-height: var(--openbot-leading-xs);
-  text-transform: uppercase;
-  letter-spacing: var(--openbot-tracking-wide);
 }
 
 .settings-modal-main {
@@ -231,26 +218,39 @@
   will-change: transform, opacity;
 }
 
+.settings-modal-tab-panel:not([data-selected]) {
+  display: none;
+}
+
 .settings-modal-group {
   display: grid;
   gap: var(--openbot-space-2);
 }
 
-.settings-modal-card.ui-card {
-  width: auto;
+.settings-modal-card:is(.ui-card, .ui-item-group) {
+  width: 100%;
   display: grid;
+  overflow: hidden;
+  border: 0;
+  border-radius: var(--openbot-radius-lg);
+  background: var(--openbot-bg-surface);
+  box-shadow: none;
+}
+
+.settings-modal-card.ui-card {
   padding: 0 var(--openbot-space-4);
-  background: var(--openbot-bg-control);
 }
 
 .settings-modal-card > .ui-switch-field,
+.settings-modal-card > .ui-item,
 .settings-modal-row {
-  min-height: 60px;
+  min-height: 64px;
 }
 
 .settings-modal-card > .ui-switch-field {
   width: 100%;
   justify-content: space-between;
+  padding: var(--openbot-space-3) var(--openbot-space-4);
 }
 
 .settings-modal-card > :not(:first-child) {
@@ -258,29 +258,15 @@
   border-top: 0;
 }
 
-.settings-modal-card > :not(:first-child)::before,
-.settings-modal .ui-item-group > :not(:first-child)::before {
+.settings-modal-card > :not(:first-child)::before {
   position: absolute;
   top: 0;
+  right: var(--openbot-space-4);
+  left: var(--openbot-space-4);
   height: 1px;
   background: var(--openbot-border);
   pointer-events: none;
   content: "";
-}
-
-.settings-modal-card > :not(:first-child)::before {
-  right: calc(var(--settings-divider-inset) - var(--openbot-space-4));
-  left: calc(var(--settings-divider-inset) - var(--openbot-space-4));
-}
-
-.settings-modal .ui-item-group > :not(:first-child) {
-  position: relative;
-  border-top: 0;
-}
-
-.settings-modal .ui-item-group > :not(:first-child)::before {
-  right: var(--settings-divider-inset);
-  left: var(--settings-divider-inset);
 }
 
 .settings-modal-row {
@@ -324,7 +310,7 @@
   gap: var(--openbot-space-0-5);
 }
 
-.settings-modal :where(.ui-button, .ui-input, .ui-textarea, .ui-native-select, .ui-select-trigger) {
+.settings-modal :where(.ui-button, .ui-input, .ui-textarea, .ui-native-select) {
   font-size: var(--openbot-text-lg);
   line-height: var(--openbot-leading-lg);
 }
@@ -363,7 +349,6 @@
 }
 
 :is(.app-settings-modal-shell, .server-settings-modal-shell).settings-modal {
-  --settings-divider-inset: var(--openbot-space-4);
   width: min(920px, calc(100vw - 48px));
   height: min(640px, calc(100dvh - 48px));
   grid-template-columns: 196px minmax(0, 1fr);
@@ -396,7 +381,7 @@
 
 :is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-header {
   align-items: center;
-  padding: var(--openbot-space-8);
+  padding: var(--openbot-space-4) var(--openbot-space-4) var(--openbot-space-6) var(--openbot-space-8);
 }
 
 :is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-title {
@@ -438,27 +423,68 @@
   line-height: var(--openbot-leading-md);
 }
 
-.app-settings-modal-shell .settings-modal-card.ui-item-group {
-  width: 100%;
+.provider-picker-embedded {
+  border: 0;
+}
+
+.provider-picker-embedded .provider-picker-list {
   overflow: hidden;
   border: 0;
   border-radius: var(--openbot-radius-lg);
-  background: var(--openbot-bg-control);
+  background: var(--openbot-bg-surface);
 }
 
-.app-settings-modal-shell .settings-modal-card > .ui-switch-field {
+.provider-picker-embedded .provider-picker-option {
+  position: relative;
   min-height: 64px;
-  padding: var(--openbot-space-3) var(--openbot-space-4);
+  border: 0;
+  background: transparent;
+  padding: 0 var(--openbot-space-4);
 }
 
-.app-settings-modal-shell .settings-modal-card > .ui-item {
+.provider-picker-embedded .provider-picker-option-selection {
   min-height: 64px;
+  padding: var(--openbot-space-3) 0;
 }
 
-.app-settings-modal-shell .settings-modal-card > :not(:first-child)::before,
-.app-settings-modal-shell .ui-item-group > :not(:first-child)::before {
+.provider-picker-embedded .provider-picker-option + .provider-picker-option {
+  border-top: 0;
+}
+
+.provider-picker-embedded .provider-picker-option + .provider-picker-option::before {
+  position: absolute;
+  top: 0;
   right: var(--openbot-space-4);
   left: var(--openbot-space-4);
+  height: 1px;
+  background: var(--openbot-border);
+  pointer-events: none;
+  content: "";
+}
+
+.provider-picker-embedded .provider-picker-install {
+  margin-right: 0;
+}
+
+.provider-picker-embedded .provider-picker-option:hover:not(.provider-picker-option-unavailable),
+.provider-picker-embedded .provider-picker-option:focus-within,
+.provider-picker-embedded .provider-picker-option-selected {
+  background: var(--openbot-bg-control-hover);
+}
+
+.settings-modal .provider-picker-name {
+  font-size: var(--openbot-text-lg);
+  font-weight: var(--openbot-weight-medium);
+  line-height: var(--openbot-leading-lg);
+}
+
+.settings-modal :where(.provider-picker-email, .provider-picker-check-error) {
+  font-size: var(--openbot-text-md);
+  line-height: var(--openbot-leading-md);
+}
+
+.settings-modal .provider-picker-status {
+  font-variant-numeric: tabular-nums;
 }
 
 .app-settings-modal-shell .settings-modal-select {
@@ -470,32 +496,121 @@
   color: var(--openbot-text-secondary);
 }
 
+.app-settings-modal-shell .settings-modal-update-track-select {
+  width: 112px;
+}
+
 .app-settings-modal-shell .settings-modal-update-actions {
   flex-wrap: wrap;
+}
+
+.app-settings-modal-shell .settings-modal-update-status {
+  text-wrap: pretty;
+}
+
+.app-settings-modal-shell .settings-modal-update-status-active {
+  color: var(--openbot-accent);
 }
 
 .app-settings-modal-shell .settings-modal-error {
   color: var(--openbot-danger);
 }
 
-.settings-modal-profile-card.ui-card {
-  padding-block: var(--openbot-space-4);
+.settings-identity-name-row.ui-item,
+.settings-identity-image-row.ui-item {
+  min-height: 72px;
 }
 
-.settings-modal-profile-summary {
-  min-height: 56px;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+.settings-identity-name-control {
+  --settings-identity-error-duration: 280ms;
+  position: relative;
+  width: 220px;
+  height: var(--openbot-control-md);
+}
+
+.settings-identity-name-input.ui-input {
+  width: 100%;
+  transition: border-color var(--openbot-duration-normal) ease-out;
+  will-change: transform;
+}
+
+.settings-identity-name-input.is-shaking {
+  animation: settings-identity-name-shake 280ms linear;
+}
+
+.settings-identity-name-error {
+  position: absolute;
+  top: calc(100% + var(--openbot-space-0-5));
+  right: 0;
+  left: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity var(--settings-identity-error-duration) ease-out,
+    visibility 0s linear var(--settings-identity-error-duration);
+}
+
+.settings-identity-name-control[data-invalid] .settings-identity-name-error {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity var(--settings-identity-error-duration) ease-out,
+    visibility 0s linear;
+}
+
+.settings-identity-image-control {
+  gap: var(--openbot-space-2);
+}
+
+.settings-identity-image-picker {
+  position: relative;
+  display: flex;
+}
+
+.settings-identity-image-trigger {
+  position: relative;
+  width: calc(var(--openbot-control-xl) + var(--openbot-space-2));
+  height: calc(var(--openbot-control-xl) + var(--openbot-space-2));
+  overflow: hidden;
+}
+
+.settings-modal-save-bar {
+  min-height: 60px;
+  display: flex;
   align-items: center;
-  gap: var(--openbot-space-3);
+  justify-content: space-between;
+  gap: var(--openbot-space-4);
+  border-top: 1px solid var(--openbot-border);
+  background: var(--openbot-bg-surface);
+  padding: var(--openbot-space-3) var(--openbot-space-6);
+}
+
+.settings-modal-save-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--openbot-space-1);
+}
+
+.settings-modal-readonly-value {
+  min-width: 180px;
+  max-width: 300px;
+  overflow-wrap: anywhere;
+  color: var(--openbot-text-primary);
+  font-weight: var(--openbot-weight-medium);
+  text-align: right;
+  user-select: text;
+}
+
+.settings-modal-profile-photo-trigger {
+  border-radius: var(--openbot-radius-pill);
 }
 
 .settings-modal-avatar {
-  width: 48px;
-  height: 48px;
+  width: 100%;
+  height: 100%;
   display: grid;
   place-items: center;
-  border: 1px solid var(--openbot-border-strong);
+  border: 0;
   border-radius: var(--openbot-radius-pill);
   background: var(--openbot-accent-soft);
   color: var(--openbot-accent-hover);
@@ -508,37 +623,27 @@
   height: 100%;
   border-radius: inherit;
   object-fit: cover;
+  outline: 1px solid var(--openbot-image-outline);
+  outline-offset: -1px;
 }
 
-.settings-modal-profile-copy {
-  min-width: 0;
-  display: grid;
-  gap: var(--openbot-space-1);
-}
+@keyframes settings-identity-name-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
 
-.settings-modal-profile-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--openbot-space-1);
-}
+  28.57% {
+    transform: translateX(6px);
+  }
 
-.settings-modal-profile-actions .ui-button-variant-destructive-ghost {
-  color: var(--openbot-settings-danger);
-}
+  57.14% {
+    transform: translateX(-6px);
+  }
 
-.settings-modal-profile-error {
-  margin: var(--openbot-space-3) 0 0;
-  color: var(--openbot-settings-danger);
-  font-size: var(--openbot-text-sm);
-  font-weight: var(--openbot-weight-medium);
-}
-
-.settings-modal-profile-fields > .ui-field {
-  padding-block: var(--openbot-space-4);
-}
-
-.settings-modal-profile-fields .ui-input {
-  max-width: 320px;
+  78.57% {
+    transform: translateX(4px);
+  }
 }
 
 @keyframes settings-modal-tab-in {
@@ -665,15 +770,55 @@
   :is(.app-settings-modal-shell, .server-settings-modal-shell) .settings-modal-content {
     padding: 0 calc(var(--openbot-space-4) - var(--openbot-scrollbar-size)) var(--openbot-space-4);
   }
+
+  .settings-identity-name-row,
+  .settings-identity-image-row,
+  .settings-modal-account-email-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .settings-identity-name-control {
+    width: min(320px, 100%);
+    max-width: 320px;
+    height: auto;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: var(--openbot-control-md) var(--openbot-leading-xs);
+    align-items: stretch;
+    row-gap: var(--openbot-space-0-5);
+  }
+
+  .settings-identity-name-error {
+    position: static;
+  }
+
+  .settings-identity-image-control,
+  .settings-modal-account-email-row .ui-item-actions {
+    width: 100%;
+    max-width: none;
+    justify-content: space-between;
+  }
+
+  .settings-modal-readonly-value {
+    min-width: 0;
+    max-width: none;
+    text-align: left;
+  }
+
+  .settings-modal-save-bar {
+    padding-inline: var(--openbot-space-4);
+  }
 }
 
 @media (max-width: 520px) {
-  .settings-modal-profile-summary {
-    grid-template-columns: auto minmax(0, 1fr);
+  .settings-modal-save-bar {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
-  .settings-modal-profile-actions {
-    grid-column: 1 / -1;
+  .settings-modal-save-actions {
+    width: 100%;
     justify-content: flex-end;
   }
 
@@ -683,12 +828,12 @@
   }
 
   .app-settings-modal-shell .settings-modal-row .ui-item-actions,
-  .app-settings-modal-shell .settings-modal-select {
+  .app-settings-modal-shell :is(.settings-modal-select, .settings-modal-update-track-select) {
     width: 100%;
   }
 
   .app-settings-modal-shell .settings-modal-update-actions {
-    justify-content: space-between;
+    justify-content: flex-end;
   }
 }
 
@@ -707,5 +852,10 @@
 
   .settings-modal-tab-panel {
     animation: none;
+  }
+
+  .settings-identity-name-input.is-shaking {
+    animation: none;
+    transform: none;
   }
 }

--- a/src/renderer/stories/SettingsModal.stories.tsx
+++ b/src/renderer/stories/SettingsModal.stories.tsx
@@ -28,6 +28,16 @@ const storyUpdateStatus: UpdateStatus = {
   message: null,
   errorCode: null,
 };
+const availableUpdateStatus: UpdateStatus = {
+  ...storyUpdateStatus,
+  phase: "available",
+  availableVersion: "0.3.0",
+};
+const readyUpdateStatus: UpdateStatus = {
+  ...availableUpdateStatus,
+  phase: "ready",
+  progress: 100,
+};
 const providerAgentStatus: AgentStatus = {
   phase: "blocked",
   cliVersion: null,
@@ -48,10 +58,15 @@ const providerRuntimeStatuses: ProviderRuntimeSnapshot["providers"] = {
   grok: { phase: "downloading", progress: 72, message: null, version: null },
 };
 
-function SettingsModalStory(props: { initialOpen: boolean; providerDownloads?: boolean }) {
+function SettingsModalStory(props: {
+  initialOpen: boolean;
+  initialUpdateStatus?: UpdateStatus;
+  mockDownloadUpdate?: boolean;
+  providerDownloads?: boolean;
+}) {
   const [open, setOpen] = createSignal(props.initialOpen);
   const [value, setValue] = createSignal({ ...DEFAULT_GENERAL_SETTINGS });
-  const [updateStatus, setUpdateStatus] = createSignal<UpdateStatus>(storyUpdateStatus);
+  const [updateStatus, setUpdateStatus] = createSignal<UpdateStatus>(props.initialUpdateStatus ?? storyUpdateStatus);
   const [account, setAccount] = createSignal<CentralAuthUser>({ ...storyAccount });
 
   async function updateAccountAvatar(image: AvatarImageInput | null): Promise<void> {
@@ -59,6 +74,26 @@ function SettingsModalStory(props: { initialOpen: boolean; providerDownloads?: b
       ? `data:${image.mimeType};base64,${btoa(Array.from(image.bytes, (byte) => String.fromCharCode(byte)).join(""))}`
       : null;
     setAccount((current) => ({ ...current, avatarUrl }));
+  }
+
+  async function updateAccountName(name: string): Promise<void> {
+    setAccount((current) => ({ ...current, name }));
+  }
+
+  async function runUpdateAction(): Promise<void> {
+    if (!props.mockDownloadUpdate || updateStatus().phase !== "available") {
+      setUpdateStatus({ ...storyUpdateStatus, phase: "up-to-date", checkedAt: new Date().toISOString() });
+      return;
+    }
+
+    const downloadingStatus = { ...updateStatus(), phase: "downloading", progress: 0 } as const;
+    setUpdateStatus(downloadingStatus);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    setUpdateStatus({ ...downloadingStatus, progress: 48 });
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    setUpdateStatus({ ...downloadingStatus, phase: "preparing", progress: 100 });
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    setUpdateStatus({ ...downloadingStatus, phase: "ready", progress: 100 });
   }
 
   return (
@@ -78,10 +113,9 @@ function SettingsModalStory(props: { initialOpen: boolean; providerDownloads?: b
         appInfo={storyAppInfo}
         updateStatus={updateStatus()}
         account={account()}
+        onUpdateAccountName={updateAccountName}
         onUpdateAccountAvatar={updateAccountAvatar}
-        onUpdateAction={async () => {
-          setUpdateStatus({ ...storyUpdateStatus, phase: "up-to-date", checkedAt: new Date().toISOString() });
-        }}
+        onUpdateAction={runUpdateAction}
         agentStatus={props.providerDownloads ? providerAgentStatus : undefined}
         providerRuntimeStatuses={props.providerDownloads ? providerRuntimeStatuses : undefined}
         onDownloadProvider={props.providerDownloads ? fn() : undefined}
@@ -104,6 +138,7 @@ const meta = {
     updateStatus: storyUpdateStatus,
     onUpdateAction: fn(async () => undefined),
     account: storyAccount,
+    onUpdateAccountName: fn(async () => undefined),
     onUpdateAccountAvatar: fn(async () => undefined),
   },
   parameters: {
@@ -145,6 +180,65 @@ export const ProviderDownloads: Story = {
   parameters: { viewport: { defaultViewport: "settingsPhone" } },
 };
 
+export const Profile: Story = {
+  render: () => <SettingsModalStory initialOpen />,
+  play: async ({ userEvent }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("tab", { name: "Profile" }));
+  },
+};
+
+export const Updates: Story = {
+  render: () => <SettingsModalStory initialOpen />,
+  play: async ({ userEvent }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("tab", { name: "Updates" }));
+  },
+};
+
+export const UpdateAvailable: Story = {
+  render: () => <SettingsModalStory initialOpen initialUpdateStatus={availableUpdateStatus} />,
+  play: async ({ userEvent }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("tab", { name: "Updates" }));
+  },
+};
+
+export const DownloadUpdateFlow: Story = {
+  render: () => <SettingsModalStory initialOpen initialUpdateStatus={availableUpdateStatus} mockDownloadUpdate />,
+  play: async ({ step, userEvent }) => {
+    const body = within(document.body);
+
+    await step("Open the available OpenBot update", async () => {
+      await userEvent.click(await body.findByRole("tab", { name: "Updates" }));
+      await expect(body.getByText("OpenBot v0.3.0 is available to download.")).toBeVisible();
+    });
+
+    await step("Start the mocked download", async () => {
+      const downloadButton = body.getByRole("button", { name: "Download update" });
+      await expect(downloadButton).toBeEnabled();
+      await userEvent.click(downloadButton);
+      await expect(await body.findByText("Downloading OpenBot v0.3.0 · 0%")).toBeVisible();
+      await expect(body.getByRole("button", { name: "Downloading update…" })).toBeDisabled();
+    });
+
+    await step("Finish the mocked download", async () => {
+      await waitFor(() => expect(body.getByText("Downloading OpenBot v0.3.0 · 48%")).toBeVisible());
+      await waitFor(() => expect(body.getByText("Preparing OpenBot v0.3.0…")).toBeVisible());
+      await waitFor(() => expect(body.getByText("OpenBot v0.3.0 is ready. Restart to apply.")).toBeVisible());
+      await expect(body.getByRole("button", { name: "Restart to update" })).toBeEnabled();
+    });
+  },
+};
+
+export const ReadyToInstall: Story = {
+  render: () => <SettingsModalStory initialOpen initialUpdateStatus={readyUpdateStatus} />,
+  play: async ({ userEvent }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("tab", { name: "Updates" }));
+  },
+};
+
 export const Interactive: Story = {
   render: () => <SettingsModalStory initialOpen={false} />,
   play: async ({ canvas, userEvent }) => {
@@ -155,9 +249,6 @@ export const Interactive: Story = {
     let dialog = await body.findByRole("dialog", { name: "General" });
     await waitFor(() => expect(dialog).toBeVisible());
     await expect(body.getByTestId("settings-modal-scroll-frame")).toHaveAttribute("data-scroll-down");
-    await expect(body.getByRole("tab", { name: "Appearance" })).toBeDisabled();
-    await expect(body.getByRole("tab", { name: "Notifications" })).toBeDisabled();
-    await expect(body.getByRole("tab", { name: "Advanced" })).toBeDisabled();
 
     const generalTab = body.getByRole("tab", { name: "General" });
     generalTab.focus();
@@ -166,6 +257,11 @@ export const Interactive: Story = {
     await expect(profileTab).toHaveAttribute("aria-selected", "true");
     await expect(body.getByRole("heading", { name: "Profile", level: 2 })).toBeVisible();
     await expect(body.getByRole("textbox", { name: "Display name" })).toHaveValue("Norbert");
+
+    await userEvent.keyboard("{ArrowDown}");
+    const updatesTab = body.getByRole("tab", { name: "Updates" });
+    await expect(updatesTab).toHaveAttribute("aria-selected", "true");
+    await expect(body.getByRole("heading", { name: "Updates", level: 2 })).toBeVisible();
 
     await userEvent.click(generalTab);
     await expect(generalTab).toHaveAttribute("aria-selected", "true");
@@ -181,8 +277,11 @@ export const Interactive: Story = {
     await userEvent.click(launchSwitch);
     await expect(launchSwitch).not.toBeChecked();
 
+    await userEvent.click(updatesTab);
     await userEvent.click(body.getByRole("button", { name: "Check for updates" }));
-    await expect(body.getByText("OpenBot is up to date.")).toBeVisible();
+    await expect(body.getByText("OpenBot is up to date on the Stable track.")).toBeVisible();
+
+    await userEvent.click(generalTab);
 
     await userEvent.click(body.getByRole("button", { name: "Close settings" }));
     await expect(dialog).toHaveAttribute("data-motion", "closing");


### PR DESCRIPTION
## What changed

- Align app settings cards, spacing, headers, and profile identity controls with server settings.
- Add the Updates tab with the Stable track selector, version-aware actions, live status, and working Storybook download progress.
- Add authenticated display-name updates through Auth API and desktop IPC, with shared 3–20 character validation and Unicode safety normalization.
- Keep unsaved profile actions stable across tabs and prevent the one-frame tab-panel overlap that caused layout jumps.

## Verification

- [ ] bun run check
- [x] bun run lint
- [x] bun run typecheck
- [x] 227 targeted desktop and renderer tests
- [x] 5 Auth API service tests
- [x] Manual Storybook smoke test for SettingsModal and Account dock / Discord Shelf
- [x] No credentials, private data, generated output, or real user files are included

## Risk and security impact

Adds the authenticated PATCH /v1/me/profile endpoint and authUpdateName IPC path. Display names are normalized, limited to 3–20 characters, and reject control, hidden, and bidirectional formatting characters. The change updates the existing users.name field and requires no database migration. No new permissions or dependencies are added.