### PR TITLE
Fix escaped Windows file links

### DIFF
--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -56,7 +56,9 @@ function headingLevel(depth: number): 1 | 2 | 3 | 4 | 5 | 6 {
 }
 
 export function MarkdownMessageText(props: MarkdownMessageTextProps) {
-  const tokens = createMemo(() => marked.lexer(props.body, { breaks: true, gfm: true }));
+  const tokens = createMemo(() =>
+    marked.lexer(normalizeEscapedLocalFileLinks(props.body), { breaks: true, gfm: true }),
+  );
   const contentProps = (): MarkdownContentProps => ({
     bots: props.bots,
     attachments: props.attachments,
@@ -87,7 +89,9 @@ export function MarkdownMessageText(props: MarkdownMessageTextProps) {
 export function MarkdownInlineText(
   props: Omit<MarkdownMessageTextProps, "showCitationFooter" | "streaming" | "streamingTail">,
 ) {
-  const tokens = createMemo(() => marked.Lexer.lexInline(props.body, { breaks: true, gfm: true }));
+  const tokens = createMemo(() =>
+    marked.Lexer.lexInline(normalizeEscapedLocalFileLinks(props.body), { breaks: true, gfm: true }),
+  );
   const contentProps = (): MarkdownContentProps => ({
     bots: props.bots,
     attachments: props.attachments,
@@ -365,14 +369,14 @@ function MarkdownInline(props: { tokens: Token[]; content: MarkdownContentProps;
             ) : sharedPath && props.content.onOpenSharedFile ? (
               <LocalFileLink
                 path={sharedPath}
-                label={token.text}
+                label={markdownInlinePlainText(token.tokens) || token.text}
                 kind="shared"
                 onOpen={props.content.onOpenSharedFile}
               />
             ) : workspacePath && props.content.onOpenWorkspaceFile ? (
               <LocalFileLink
                 path={workspacePath}
-                label={token.text}
+                label={markdownInlinePlainText(token.tokens) || token.text}
                 kind="workspace"
                 onOpen={props.content.onOpenWorkspaceFile}
               />
@@ -439,6 +443,21 @@ function lastRenderableTokenIndex(tokens: Token[]): number {
   return -1;
 }
 
+function markdownInlinePlainText(tokens: Token[]): string {
+  return tokens
+    .map((token) => {
+      if (tokenIs(token, "strong")) return markdownInlinePlainText(token.tokens);
+      if (tokenIs(token, "em")) return markdownInlinePlainText(token.tokens);
+      if (tokenIs(token, "del")) return markdownInlinePlainText(token.tokens);
+      if (tokenIs(token, "link")) return markdownInlinePlainText(token.tokens);
+      if (tokenIs(token, "text")) return token.tokens ? markdownInlinePlainText(token.tokens) : token.text;
+      if (tokenIs(token, "codespan") || tokenIs(token, "escape") || tokenIs(token, "image")) return token.text;
+      if (token.type === "br") return "\n";
+      return token.raw;
+    })
+    .join("");
+}
+
 function LocalFileLink(props: {
   path: string;
   label: string;
@@ -471,6 +490,21 @@ function sharedFileTarget(value: string): string | null {
     normalized.includes("/OpenBot/Shared/")
     ? path
     : null;
+}
+
+function normalizeEscapedLocalFileLinks(body: string): string {
+  return body.replace(/(\[[^\]\r\n]+\])\\\(<([^<>\r\n]+)>(\\?\))/gu, (match, label: string, target: string) =>
+    localFileTarget(target) ? `${label}(<${target}>)` : match,
+  );
+}
+
+function localFileTarget(value: string): string | null {
+  const path = value.trim();
+  const shared = sharedFileTarget(path);
+  if (shared) return shared;
+  const workspace = workspaceFileTarget(path);
+  if (!workspace) return null;
+  return /^(?:~[/\\]|[/\\]|[A-Za-z]:[/\\])/u.test(path) || isFileMention(path) ? workspace : null;
 }
 
 function workspaceFileTarget(value: string): string | null {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -493,6 +493,7 @@ function sharedFileTarget(value: string): string | null {
 }
 
 function normalizeEscapedLocalFileLinks(body: string): string {
+  if (!body.includes("\\(<")) return body;
   return marked
     .lexer(body, { breaks: true, gfm: true })
     .map((token) =>
@@ -502,7 +503,9 @@ function normalizeEscapedLocalFileLinks(body: string): string {
 }
 
 function normalizeEscapedLocalFileLinksInline(body: string): string {
+  if (!body.includes("\\(<")) return body;
   const tokens = marked.Lexer.lexInline(body, { breaks: true, gfm: true });
+  if (tokens.some(markdownTokenContainsHtml)) return body;
   let result = "";
   let candidate = "";
   const flushCandidate = () => {
@@ -530,6 +533,15 @@ function markdownTokenContainsProtectedLiteral(token: Token): boolean {
   return tokenIs(token, "text") && Boolean(token.tokens?.some(markdownTokenContainsProtectedLiteral));
 }
 
+function markdownTokenContainsHtml(token: Token): boolean {
+  if (token.type === "html") return true;
+  if (tokenIs(token, "strong")) return token.tokens.some(markdownTokenContainsHtml);
+  if (tokenIs(token, "em")) return token.tokens.some(markdownTokenContainsHtml);
+  if (tokenIs(token, "del")) return token.tokens.some(markdownTokenContainsHtml);
+  if (tokenIs(token, "link")) return token.tokens.some(markdownTokenContainsHtml);
+  return tokenIs(token, "text") && Boolean(token.tokens?.some(markdownTokenContainsHtml));
+}
+
 function normalizeEscapedLocalFileLinkCandidate(value: string): string {
   return value.replace(/(\[[^\]\r\n]+\])\\\(<([^<>\r\n]+)>(\\?\))/gu, (match, label: string, target: string) =>
     localFileTarget(target) ? `${label}(<${target}>)` : match,
@@ -538,6 +550,7 @@ function normalizeEscapedLocalFileLinkCandidate(value: string): string {
 
 function localFileTarget(value: string): string | null {
   const path = value.trim();
+  if (path.startsWith("//")) return null;
   const workspace = workspaceFileTarget(path);
   if (!workspace) return null;
   const shared = sharedFileTarget(path);

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -42,6 +42,22 @@ interface MarkdownTokenByType {
   escape: Tokens.Escape;
 }
 
+const VOID_HTML_ELEMENTS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "source",
+  "track",
+  "wbr",
+]);
+
 function tokenIs<K extends keyof MarkdownTokenByType>(token: Token, type: K): token is MarkdownTokenByType[K] {
   return token.type === type;
 }
@@ -56,9 +72,7 @@ function headingLevel(depth: number): 1 | 2 | 3 | 4 | 5 | 6 {
 }
 
 export function MarkdownMessageText(props: MarkdownMessageTextProps) {
-  const tokens = createMemo(() =>
-    marked.lexer(normalizeEscapedLocalFileLinks(props.body), { breaks: true, gfm: true }),
-  );
+  const tokens = createMemo(() => marked.lexer(props.body, { breaks: true, gfm: true }));
   const contentProps = (): MarkdownContentProps => ({
     bots: props.bots,
     attachments: props.attachments,
@@ -89,9 +103,7 @@ export function MarkdownMessageText(props: MarkdownMessageTextProps) {
 export function MarkdownInlineText(
   props: Omit<MarkdownMessageTextProps, "showCitationFooter" | "streaming" | "streamingTail">,
 ) {
-  const tokens = createMemo(() =>
-    marked.Lexer.lexInline(normalizeEscapedLocalFileLinksInline(props.body), { breaks: true, gfm: true }),
-  );
+  const tokens = createMemo(() => marked.Lexer.lexInline(props.body, { breaks: true, gfm: true }));
   const contentProps = (): MarkdownContentProps => ({
     bots: props.bots,
     attachments: props.attachments,
@@ -295,7 +307,7 @@ function MarkdownTable(props: { token: Tokens.Table; content: MarkdownContentPro
 }
 
 function MarkdownInline(props: { tokens: Token[]; content: MarkdownContentProps; streamingTail?: boolean }) {
-  const tokens = createMemo(() => props.tokens);
+  const tokens = createMemo(() => repairEscapedLocalFileLinkTokens(props.tokens));
   const renderedTokens = createMemo(() => {
     const values = tokens();
     const lastTokenIndex = lastRenderableTokenIndex(values);
@@ -492,35 +504,34 @@ function sharedFileTarget(value: string): string | null {
     : null;
 }
 
-function normalizeEscapedLocalFileLinks(body: string): string {
-  if (!body.includes("\\(<")) return body;
-  return marked
-    .lexer(body, { breaks: true, gfm: true })
-    .map((token) =>
-      token.type === "code" || token.type === "html" ? token.raw : normalizeEscapedLocalFileLinksInline(token.raw),
-    )
-    .join("");
-}
-
-function normalizeEscapedLocalFileLinksInline(body: string): string {
-  if (!body.includes("\\(<")) return body;
-  const tokens = marked.Lexer.lexInline(body, { breaks: true, gfm: true });
-  if (tokens.some(markdownTokenContainsHtml)) return body;
-  let result = "";
-  let candidate = "";
-  const flushCandidate = () => {
-    result += normalizeEscapedLocalFileLinkCandidate(candidate);
-    candidate = "";
+function repairEscapedLocalFileLinkTokens(tokens: Token[]): Token[] {
+  const raw = tokens.map((token) => token.raw).join("");
+  if (!raw.includes("\\(<")) return tokens;
+  const result: Token[] = [];
+  let candidates: Token[] = [];
+  const openHtmlElements: string[] = [];
+  const flushCandidates = () => {
+    if (candidates.length === 0) return;
+    const source = candidates.map((token) => token.raw).join("");
+    const repaired = normalizeEscapedLocalFileLinkCandidate(source);
+    result.push(...(repaired === source ? candidates : marked.Lexer.lexInline(repaired, { breaks: true, gfm: true })));
+    candidates = [];
   };
   for (const token of tokens) {
-    if (!markdownTokenContainsProtectedLiteral(token)) {
-      candidate += token.raw;
+    if (token.type === "html") {
+      flushCandidates();
+      result.push(token);
+      updateOpenHtmlElements(openHtmlElements, token.raw);
       continue;
     }
-    flushCandidate();
-    result += token.raw;
+    if (openHtmlElements.length > 0 || markdownTokenContainsProtectedLiteral(token)) {
+      flushCandidates();
+      result.push(token);
+      continue;
+    }
+    candidates.push(token);
   }
-  flushCandidate();
+  flushCandidates();
   return result;
 }
 
@@ -533,13 +544,17 @@ function markdownTokenContainsProtectedLiteral(token: Token): boolean {
   return tokenIs(token, "text") && Boolean(token.tokens?.some(markdownTokenContainsProtectedLiteral));
 }
 
-function markdownTokenContainsHtml(token: Token): boolean {
-  if (token.type === "html") return true;
-  if (tokenIs(token, "strong")) return token.tokens.some(markdownTokenContainsHtml);
-  if (tokenIs(token, "em")) return token.tokens.some(markdownTokenContainsHtml);
-  if (tokenIs(token, "del")) return token.tokens.some(markdownTokenContainsHtml);
-  if (tokenIs(token, "link")) return token.tokens.some(markdownTokenContainsHtml);
-  return tokenIs(token, "text") && Boolean(token.tokens?.some(markdownTokenContainsHtml));
+function updateOpenHtmlElements(elements: string[], raw: string): void {
+  for (const match of raw.matchAll(/<\s*(\/?)\s*([A-Za-z][\w:-]*)\b[^>]*>/gu)) {
+    const name = (match[2] ?? "").toLowerCase();
+    if (!name) continue;
+    if (match[1]) {
+      const openingIndex = elements.lastIndexOf(name);
+      if (openingIndex >= 0) elements.splice(openingIndex);
+      continue;
+    }
+    if (!match[0].endsWith("/>") && !VOID_HTML_ELEMENTS.has(name)) elements.push(name);
+  }
 }
 
 function normalizeEscapedLocalFileLinkCandidate(value: string): string {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -513,7 +513,8 @@ function repairEscapedLocalFileLinkTokens(tokens: Token[]): Token[] {
   const flushCandidates = () => {
     if (candidates.length === 0) return;
     const source = candidates.map((token) => token.raw).join("");
-    const repaired = normalizeEscapedLocalFileLinkCandidate(source);
+    const maskedSource = candidates.map(maskProtectedMarkdownToken).join("");
+    const repaired = normalizeEscapedLocalFileLinkCandidate(source, maskedSource);
     result.push(...(repaired === source ? candidates : marked.Lexer.lexInline(repaired, { breaks: true, gfm: true })));
     candidates = [];
   };
@@ -524,7 +525,7 @@ function repairEscapedLocalFileLinkTokens(tokens: Token[]): Token[] {
       updateOpenHtmlElements(openHtmlElements, token.raw);
       continue;
     }
-    if (openHtmlElements.length > 0 || markdownTokenContainsProtectedLiteral(token)) {
+    if (openHtmlElements.length > 0) {
       flushCandidates();
       result.push(token);
       continue;
@@ -535,13 +536,28 @@ function repairEscapedLocalFileLinkTokens(tokens: Token[]): Token[] {
   return result;
 }
 
-function markdownTokenContainsProtectedLiteral(token: Token): boolean {
-  if (token.type === "html" || tokenIs(token, "codespan")) return true;
-  if (tokenIs(token, "strong")) return token.tokens.some(markdownTokenContainsProtectedLiteral);
-  if (tokenIs(token, "em")) return token.tokens.some(markdownTokenContainsProtectedLiteral);
-  if (tokenIs(token, "del")) return token.tokens.some(markdownTokenContainsProtectedLiteral);
-  if (tokenIs(token, "link")) return token.tokens.some(markdownTokenContainsProtectedLiteral);
-  return tokenIs(token, "text") && Boolean(token.tokens?.some(markdownTokenContainsProtectedLiteral));
+function maskProtectedMarkdownToken(token: Token): string {
+  if (token.type === "html" || tokenIs(token, "codespan")) return " ".repeat(token.raw.length);
+  const children =
+    tokenIs(token, "strong") ||
+    tokenIs(token, "em") ||
+    tokenIs(token, "del") ||
+    tokenIs(token, "link") ||
+    tokenIs(token, "text")
+      ? token.tokens
+      : undefined;
+  if (!children?.length) return token.raw;
+
+  let masked = token.raw;
+  let searchStart = 0;
+  for (const child of children) {
+    const childStart = token.raw.indexOf(child.raw, searchStart);
+    if (childStart < 0) continue;
+    const protectedChild = maskProtectedMarkdownToken(child);
+    masked = `${masked.slice(0, childStart)}${protectedChild}${masked.slice(childStart + child.raw.length)}`;
+    searchStart = childStart + child.raw.length;
+  }
+  return masked;
 }
 
 function updateOpenHtmlElements(elements: string[], raw: string): void {
@@ -558,10 +574,22 @@ function updateOpenHtmlElements(elements: string[], raw: string): void {
   }
 }
 
-function normalizeEscapedLocalFileLinkCandidate(value: string): string {
-  return value.replace(/(?<!!)(\[[^\]\r\n]+\])\\\(<([^<>\r\n]+)>(\\?\))/gu, (match, label: string, target: string) =>
-    localFileTarget(target) ? `${label}(<${target}>)` : match,
-  );
+function normalizeEscapedLocalFileLinkCandidate(value: string, maskedValue = value): string {
+  const pattern = /(?<!!)(\[[^\]\r\n]+\])\\\(<([^<>\r\n]+)>(\\?\))/gu;
+  let result = "";
+  let cursor = 0;
+  for (const match of maskedValue.matchAll(pattern)) {
+    const start = match.index;
+    const labelLength = match[1]?.length ?? 0;
+    const targetLength = match[2]?.length ?? 0;
+    const targetStart = start + labelLength + 3;
+    const target = value.slice(targetStart, targetStart + targetLength);
+    if (!localFileTarget(target)) continue;
+    const label = value.slice(start, start + labelLength);
+    result += `${value.slice(cursor, start)}${label}(<${target}>)`;
+    cursor = start + match[0].length;
+  }
+  return cursor === 0 ? value : result + value.slice(cursor);
 }
 
 function localFileTarget(value: string): string | null {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -545,6 +545,7 @@ function markdownTokenContainsProtectedLiteral(token: Token): boolean {
 }
 
 function updateOpenHtmlElements(elements: string[], raw: string): void {
+  if (/^\s*<(?:!--|!|\?)/u.test(raw)) return;
   for (const match of raw.matchAll(/<\s*(\/?)\s*([A-Za-z][\w:-]*)\b[^>]*>/gu)) {
     const name = (match[2] ?? "").toLowerCase();
     if (!name) continue;
@@ -558,7 +559,7 @@ function updateOpenHtmlElements(elements: string[], raw: string): void {
 }
 
 function normalizeEscapedLocalFileLinkCandidate(value: string): string {
-  return value.replace(/(\[[^\]\r\n]+\])\\\(<([^<>\r\n]+)>(\\?\))/gu, (match, label: string, target: string) =>
+  return value.replace(/(?<!!)(\[[^\]\r\n]+\])\\\(<([^<>\r\n]+)>(\\?\))/gu, (match, label: string, target: string) =>
     localFileTarget(target) ? `${label}(<${target}>)` : match,
   );
 }

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -90,7 +90,7 @@ export function MarkdownInlineText(
   props: Omit<MarkdownMessageTextProps, "showCitationFooter" | "streaming" | "streamingTail">,
 ) {
   const tokens = createMemo(() =>
-    marked.Lexer.lexInline(normalizeEscapedLocalFileLinks(props.body), { breaks: true, gfm: true }),
+    marked.Lexer.lexInline(normalizeEscapedLocalFileLinksInline(props.body), { breaks: true, gfm: true }),
   );
   const contentProps = (): MarkdownContentProps => ({
     bots: props.bots,
@@ -493,17 +493,55 @@ function sharedFileTarget(value: string): string | null {
 }
 
 function normalizeEscapedLocalFileLinks(body: string): string {
-  return body.replace(/(\[[^\]\r\n]+\])\\\(<([^<>\r\n]+)>(\\?\))/gu, (match, label: string, target: string) =>
+  return marked
+    .lexer(body, { breaks: true, gfm: true })
+    .map((token) =>
+      token.type === "code" || token.type === "html" ? token.raw : normalizeEscapedLocalFileLinksInline(token.raw),
+    )
+    .join("");
+}
+
+function normalizeEscapedLocalFileLinksInline(body: string): string {
+  const tokens = marked.Lexer.lexInline(body, { breaks: true, gfm: true });
+  let result = "";
+  let candidate = "";
+  const flushCandidate = () => {
+    result += normalizeEscapedLocalFileLinkCandidate(candidate);
+    candidate = "";
+  };
+  for (const token of tokens) {
+    if (!markdownTokenContainsProtectedLiteral(token)) {
+      candidate += token.raw;
+      continue;
+    }
+    flushCandidate();
+    result += token.raw;
+  }
+  flushCandidate();
+  return result;
+}
+
+function markdownTokenContainsProtectedLiteral(token: Token): boolean {
+  if (token.type === "html" || tokenIs(token, "codespan")) return true;
+  if (tokenIs(token, "strong")) return token.tokens.some(markdownTokenContainsProtectedLiteral);
+  if (tokenIs(token, "em")) return token.tokens.some(markdownTokenContainsProtectedLiteral);
+  if (tokenIs(token, "del")) return token.tokens.some(markdownTokenContainsProtectedLiteral);
+  if (tokenIs(token, "link")) return token.tokens.some(markdownTokenContainsProtectedLiteral);
+  return tokenIs(token, "text") && Boolean(token.tokens?.some(markdownTokenContainsProtectedLiteral));
+}
+
+function normalizeEscapedLocalFileLinkCandidate(value: string): string {
+  return value.replace(/(\[[^\]\r\n]+\])\\\(<([^<>\r\n]+)>(\\?\))/gu, (match, label: string, target: string) =>
     localFileTarget(target) ? `${label}(<${target}>)` : match,
   );
 }
 
 function localFileTarget(value: string): string | null {
   const path = value.trim();
-  const shared = sharedFileTarget(path);
-  if (shared) return shared;
   const workspace = workspaceFileTarget(path);
   if (!workspace) return null;
+  const shared = sharedFileTarget(path);
+  if (shared) return shared;
   return /^(?:~[/\\]|[/\\]|[A-Za-z]:[/\\])/u.test(path) || isFileMention(path) ? workspace : null;
 }
 

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -440,7 +440,10 @@ describe("MessageBody", () => {
         message={{
           id: "message-escaped-web-link",
           author: "bot",
-          body: String.raw`[OpenAI]\(<https://example.com/OpenBot/Shared/docs.xlsx>\)`,
+          body: [
+            String.raw`[OpenAI]\(<https://example.com/OpenBot/Shared/docs.xlsx>\)`,
+            String.raw`[Report]\(<//example.com/OpenBot/Shared/report.xlsx>\)`,
+          ].join("\n"),
           time: "10:00",
         }}
         bots={bots}
@@ -456,6 +459,8 @@ describe("MessageBody", () => {
     expect(screen.queryByRole("button", { name: /Open (?:shared|workspace) file/u })).toBeNull();
     expect(container).toHaveTextContent("[OpenAI](");
     expect(container).toHaveTextContent("https://example.com/OpenBot/Shared/docs.xlsx");
+    expect(container).toHaveTextContent("[Report](");
+    expect(container).toHaveTextContent("//example.com/OpenBot/Shared/report.xlsx");
     expect(onOpenSharedFile).not.toHaveBeenCalled();
     expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
   });
@@ -463,7 +468,7 @@ describe("MessageBody", () => {
   it("keeps escaped local-file syntax literal inside code and HTML", () => {
     const inlineCode = String.raw`[inline]\(<C:\tmp\inline.txt>\)`;
     const fencedCode = String.raw`[fenced]\(<C:\tmp\fenced.txt>\)`;
-    const html = String.raw`<div>[html]\(<C:\tmp\html.txt>\)</div>`;
+    const html = String.raw`<code>[html]\(<C:\tmp\html.txt>\)</code>`;
     const { container } = render(() => (
       <MarkdownMessageText
         body={[`Inline: \`${inlineCode}\``, "", "```md", fencedCode, "```", "", html].join("\n")}
@@ -477,7 +482,7 @@ describe("MessageBody", () => {
 
     expect(container).toHaveTextContent(inlineCode);
     expect(container).toHaveTextContent(fencedCode);
-    expect(container).toHaveTextContent(html);
+    expect(container).toHaveTextContent(String.raw`<code>[html](<C:\tmp\html.txt>)</code>`);
     expect(container.querySelector(".message-file-reference")).toBeNull();
   });
 

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -432,9 +432,10 @@ describe("MessageBody", () => {
     expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
   });
 
-  it("does not repair escaped Markdown delimiters around web links", () => {
+  it("does not repair escaped Markdown delimiters around web links or images", () => {
     const onOpenSharedFile = vi.fn();
     const onOpenWorkspaceFile = vi.fn();
+    const imagePath = String.raw`C:\tmp\preview.png`;
     const { container } = render(() => (
       <MessageBody
         message={{
@@ -443,6 +444,7 @@ describe("MessageBody", () => {
           body: [
             String.raw`[OpenAI]\(<https://example.com/OpenBot/Shared/docs.xlsx>\)`,
             String.raw`[Report]\(<//example.com/OpenBot/Shared/report.xlsx>\)`,
+            String.raw`![Preview]\(<${imagePath}>\)`,
           ].join("\n"),
           time: "10:00",
         }}
@@ -461,6 +463,9 @@ describe("MessageBody", () => {
     expect(container).toHaveTextContent("https://example.com/OpenBot/Shared/docs.xlsx");
     expect(container).toHaveTextContent("[Report](");
     expect(container).toHaveTextContent("//example.com/OpenBot/Shared/report.xlsx");
+    expect(container).toHaveTextContent("![Preview](");
+    expect(container).toHaveTextContent(imagePath);
+    expect(container.querySelector(".message-markdown-image")).toBeNull();
     expect(onOpenSharedFile).not.toHaveBeenCalled();
     expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
   });
@@ -471,6 +476,7 @@ describe("MessageBody", () => {
     const html = String.raw`<code>[html]\(<C:\tmp\html.txt>\)</code>`;
     const nestedCode = String.raw`[nested]\(<C:\tmp\nested.txt>\)`;
     const reportPath = String.raw`C:\tmp\report.xlsx`;
+    const commentReportPath = String.raw`C:\tmp\comment-report.xlsx`;
     const onOpenWorkspaceFile = vi.fn();
     const { container } = render(() => (
       <MarkdownMessageText
@@ -482,6 +488,8 @@ describe("MessageBody", () => {
           "```",
           "",
           `${html} then ${String.raw`[report]\(<${reportPath}>\)`}`,
+          "",
+          `Before <!-- <div> --> then ${String.raw`[comment report]\(<${commentReportPath}>\)`}`,
           "",
           `>     ${nestedCode}`,
         ].join("\n")}
@@ -498,9 +506,12 @@ describe("MessageBody", () => {
     expect(container).toHaveTextContent(String.raw`<code>[html](<C:\tmp\html.txt>)</code>`);
     expect(container).toHaveTextContent(nestedCode);
     const reportLink = screen.getByRole("button", { name: "Open workspace file report.xlsx" });
-    expect(container.querySelectorAll(".message-file-reference")).toHaveLength(1);
+    const commentReportLink = screen.getByRole("button", { name: "Open workspace file comment-report.xlsx" });
+    expect(container.querySelectorAll(".message-file-reference")).toHaveLength(2);
     await fireEvent.click(reportLink);
-    expect(onOpenWorkspaceFile).toHaveBeenCalledWith(reportPath);
+    await fireEvent.click(commentReportLink);
+    expect(onOpenWorkspaceFile).toHaveBeenNthCalledWith(1, reportPath);
+    expect(onOpenWorkspaceFile).toHaveBeenNthCalledWith(2, commentReportPath);
   });
 
   it("turns filenames listed after a Shared directory into preview references", async () => {

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -465,25 +465,42 @@ describe("MessageBody", () => {
     expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
   });
 
-  it("keeps escaped local-file syntax literal inside code and HTML", () => {
+  it("keeps code and HTML literal while repairing a later file link", async () => {
     const inlineCode = String.raw`[inline]\(<C:\tmp\inline.txt>\)`;
     const fencedCode = String.raw`[fenced]\(<C:\tmp\fenced.txt>\)`;
     const html = String.raw`<code>[html]\(<C:\tmp\html.txt>\)</code>`;
+    const nestedCode = String.raw`[nested]\(<C:\tmp\nested.txt>\)`;
+    const reportPath = String.raw`C:\tmp\report.xlsx`;
+    const onOpenWorkspaceFile = vi.fn();
     const { container } = render(() => (
       <MarkdownMessageText
-        body={[`Inline: \`${inlineCode}\``, "", "```md", fencedCode, "```", "", html].join("\n")}
+        body={[
+          `Inline: \`${inlineCode}\``,
+          "",
+          "```md",
+          fencedCode,
+          "```",
+          "",
+          `${html} then ${String.raw`[report]\(<${reportPath}>\)`}`,
+          "",
+          `>     ${nestedCode}`,
+        ].join("\n")}
         bots={bots}
         onSelectAgent={vi.fn()}
         onOpenLink={vi.fn()}
         onOpenSharedFile={vi.fn()}
-        onOpenWorkspaceFile={vi.fn()}
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
       />
     ));
 
     expect(container).toHaveTextContent(inlineCode);
     expect(container).toHaveTextContent(fencedCode);
     expect(container).toHaveTextContent(String.raw`<code>[html](<C:\tmp\html.txt>)</code>`);
-    expect(container.querySelector(".message-file-reference")).toBeNull();
+    expect(container).toHaveTextContent(nestedCode);
+    const reportLink = screen.getByRole("button", { name: "Open workspace file report.xlsx" });
+    expect(container.querySelectorAll(".message-file-reference")).toHaveLength(1);
+    await fireEvent.click(reportLink);
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith(reportPath);
   });
 
   it("turns filenames listed after a Shared directory into preview references", async () => {

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { BotMessage, BotProfile } from "../../data";
 import { triggerResize } from "../../setupTests";
 import { ImageGeneration } from "./ImageGeneration";
+import { MarkdownMessageText } from "./MarkdownMessageText";
 import { ExchangeSystemRow, MessageBody } from "./MessageRendering";
 
 const bots: BotProfile[] = [
@@ -434,12 +435,12 @@ describe("MessageBody", () => {
   it("does not repair escaped Markdown delimiters around web links", () => {
     const onOpenSharedFile = vi.fn();
     const onOpenWorkspaceFile = vi.fn();
-    render(() => (
+    const { container } = render(() => (
       <MessageBody
         message={{
           id: "message-escaped-web-link",
           author: "bot",
-          body: String.raw`[OpenAI]\(<https://openai.com/docs.xlsx>\)`,
+          body: String.raw`[OpenAI]\(<https://example.com/OpenBot/Shared/docs.xlsx>\)`,
           time: "10:00",
         }}
         bots={bots}
@@ -453,8 +454,31 @@ describe("MessageBody", () => {
     ));
 
     expect(screen.queryByRole("button", { name: /Open (?:shared|workspace) file/u })).toBeNull();
+    expect(container).toHaveTextContent("[OpenAI](");
+    expect(container).toHaveTextContent("https://example.com/OpenBot/Shared/docs.xlsx");
     expect(onOpenSharedFile).not.toHaveBeenCalled();
     expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps escaped local-file syntax literal inside code and HTML", () => {
+    const inlineCode = String.raw`[inline]\(<C:\tmp\inline.txt>\)`;
+    const fencedCode = String.raw`[fenced]\(<C:\tmp\fenced.txt>\)`;
+    const html = String.raw`<div>[html]\(<C:\tmp\html.txt>\)</div>`;
+    const { container } = render(() => (
+      <MarkdownMessageText
+        body={[`Inline: \`${inlineCode}\``, "", "```md", fencedCode, "```", "", html].join("\n")}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onOpenSharedFile={vi.fn()}
+        onOpenWorkspaceFile={vi.fn()}
+      />
+    ));
+
+    expect(container).toHaveTextContent(inlineCode);
+    expect(container).toHaveTextContent(fencedCode);
+    expect(container).toHaveTextContent(html);
+    expect(container.querySelector(".message-file-reference")).toBeNull();
   });
 
   it("turns filenames listed after a Shared directory into preview references", async () => {

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -432,6 +432,26 @@ describe("MessageBody", () => {
     expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
   });
 
+  it("repairs an escaped local file link with inline code in its label", async () => {
+    const onOpenWorkspaceFile = vi.fn();
+    const path = String.raw`C:\tmp\report.xlsx`;
+    render(() => (
+      <MarkdownMessageText
+        body={`[Open \`report.xlsx\`]\\(<${path}>\\)`}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onOpenSharedFile={vi.fn()}
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+      />
+    ));
+
+    const fileLink = screen.getByRole("button", { name: "Open workspace file report.xlsx" });
+    expect(fileLink).toHaveTextContent("Open report.xlsx");
+    await fireEvent.click(fileLink);
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith(path);
+  });
+
   it("does not repair escaped Markdown delimiters around web links or images", () => {
     const onOpenSharedFile = vi.fn();
     const onOpenWorkspaceFile = vi.fn();

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -384,6 +384,79 @@ describe("MessageBody", () => {
     expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
   });
 
+  it("repairs escaped Markdown delimiters around Windows file links", async () => {
+    const onOpenSharedFile = vi.fn();
+    const onOpenWorkspaceFile = vi.fn();
+    const forwardSlashPath = "C:/Users/julia/OpenBot/Shared/Outputs/FineRite-Krakow-social-links-final.xlsx";
+    const backslashPath = String.raw`C:\Users\julia\OpenBot\Shared\Outputs\FineRite-Krakow-social-links-backslash.xlsx`;
+    render(() => (
+      <MessageBody
+        message={{
+          id: "message-windows-shared-paths",
+          author: "bot",
+          body: [
+            String.raw`[**Pobierz aktualny plik Excel**]\(<${forwardSlashPath}>)`,
+            String.raw`[Pobierz drugi plik]\(<${backslashPath}>\)`,
+          ].join("\n\n"),
+          time: "10:00",
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+        onOpenSharedFile={onOpenSharedFile}
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+      />
+    ));
+
+    const forwardSlashLink = screen.getByRole("button", {
+      name: "Open shared file FineRite-Krakow-social-links-final.xlsx",
+    });
+    const backslashLink = screen.getByRole("button", {
+      name: "Open shared file FineRite-Krakow-social-links-backslash.xlsx",
+    });
+    expect(forwardSlashLink).toHaveTextContent("Pobierz aktualny plik Excel");
+    expect(backslashLink).toHaveTextContent("Pobierz drugi plik");
+    expect(forwardSlashLink).not.toHaveTextContent("**");
+    expect(forwardSlashLink).not.toHaveTextContent(forwardSlashPath);
+    expect(backslashLink).not.toHaveTextContent(backslashPath);
+    expect(forwardSlashLink).not.toHaveTextContent(/[[\]\\()]/u);
+    expect(backslashLink).not.toHaveTextContent(/[[\]\\()]/u);
+
+    await fireEvent.click(forwardSlashLink);
+    await fireEvent.click(backslashLink);
+    expect(onOpenSharedFile).toHaveBeenNthCalledWith(1, forwardSlashPath);
+    expect(onOpenSharedFile).toHaveBeenNthCalledWith(2, backslashPath);
+    expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
+  });
+
+  it("does not repair escaped Markdown delimiters around web links", () => {
+    const onOpenSharedFile = vi.fn();
+    const onOpenWorkspaceFile = vi.fn();
+    render(() => (
+      <MessageBody
+        message={{
+          id: "message-escaped-web-link",
+          author: "bot",
+          body: String.raw`[OpenAI]\(<https://openai.com/docs.xlsx>\)`,
+          time: "10:00",
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+        onOpenSharedFile={onOpenSharedFile}
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+      />
+    ));
+
+    expect(screen.queryByRole("button", { name: /Open (?:shared|workspace) file/u })).toBeNull();
+    expect(onOpenSharedFile).not.toHaveBeenCalled();
+    expect(onOpenWorkspaceFile).not.toHaveBeenCalled();
+  });
+
   it("turns filenames listed after a Shared directory into preview references", async () => {
     const onOpenSharedFile = vi.fn();
     const onOpenWorkspaceFile = vi.fn();


### PR DESCRIPTION
## Summary
- normalize escaped Markdown delimiters only for local file targets
- preserve Windows paths and route Shared files through the existing handler
- render clean local-file labels and leave escaped web links unchanged

## Tests
- `bunx vitest run src/renderer/src/components/conversation/MessageRendering.test.tsx --reporter=dot`
- `bun run typecheck:renderer`
- `bun run dev` startup smoke check