### PR TITLE
Fix incomplete Markdown markers while streaming

### DIFF
--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -329,9 +329,10 @@ function MarkdownInline(props: {
   const renderedTokens = createMemo(() => {
     const values = tokens();
     const lastTokenIndex = lastRenderableTokenIndex(values);
+    const markerTokenIndex = props.streaming === true ? incompleteStrongMarkerTokenIndex(values) : -1;
     return values.map((token, index) => ({
       token,
-      streaming: props.streaming === true && index === lastTokenIndex,
+      streaming: index === markerTokenIndex,
       streamingTail: props.streamingTail === true && index === lastTokenIndex,
     }));
   });
@@ -484,6 +485,32 @@ function RichText(props: {
 
 function hideIncompleteStrongMarker(body: string): string {
   const characters = [...body];
+  const markerIndex = incompleteStrongMarkerIndex(characters);
+  if (markerIndex === undefined) return body;
+  characters.splice(markerIndex, 2);
+  return characters.join("");
+}
+
+function incompleteStrongMarkerTokenIndex(tokens: Token[]): number {
+  const characters: string[] = [];
+  const owners: number[] = [];
+  for (const [tokenIndex, token] of tokens.entries()) {
+    for (const character of [...token.raw]) {
+      characters.push(character);
+      owners.push(token.type === "text" ? tokenIndex : -1);
+    }
+  }
+  const markerIndex = incompleteStrongMarkerIndex(
+    characters,
+    (start, end) => owners[start] !== -1 && owners[start] === owners[end - 1],
+  );
+  return markerIndex === undefined ? -1 : (owners[markerIndex] ?? -1);
+}
+
+function incompleteStrongMarkerIndex(
+  characters: string[],
+  eligible: (start: number, end: number) => boolean = () => true,
+): number | undefined {
   let markerIndex: number | undefined;
   for (let index = 0; index < characters.length; ) {
     const delimiter = characters[index];
@@ -495,20 +522,26 @@ function hideIncompleteStrongMarker(body: string): string {
     while (characters[runEnd] === delimiter) runEnd += 1;
     const previous = characters[index - 1];
     const next = characters[runEnd];
-    if (
-      runEnd - index === 2 &&
-      isLeftFlankingMarkdownDelimiter(previous, next) &&
-      (delimiter === "*" ||
-        !isRightFlankingMarkdownDelimiter(previous, next) ||
-        (previous !== undefined && isMarkdownPunctuation(previous)))
-    ) {
+    if (runEnd - index === 2 && eligible(index, runEnd) && canOpenStrongDelimiter(delimiter, previous, next)) {
       markerIndex = index;
     }
     index = runEnd;
   }
-  if (markerIndex === undefined) return body;
-  characters.splice(markerIndex, 2);
-  return characters.join("");
+  return markerIndex;
+}
+
+function canOpenStrongDelimiter(delimiter: "*" | "_", previous: string | undefined, next: string | undefined) {
+  if (next === undefined) {
+    return (
+      delimiter === "*" || previous === undefined || isMarkdownWhitespace(previous) || isMarkdownPunctuation(previous)
+    );
+  }
+  return (
+    isLeftFlankingMarkdownDelimiter(previous, next) &&
+    (delimiter === "*" ||
+      !isRightFlankingMarkdownDelimiter(previous, next) ||
+      (previous !== undefined && isMarkdownPunctuation(previous)))
+  );
 }
 
 function isLeftFlankingMarkdownDelimiter(previous: string | undefined, next: string | undefined): boolean {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -353,10 +353,11 @@ function MarkdownInline(props: {
   const renderedTokens = createMemo(() => {
     const values = tokens();
     const lastTokenIndex = lastRenderableTokenIndex(values);
-    const markerTokenIndex = props.streaming === true ? incompleteEmphasisMarkerTokenIndex(values) : -1;
+    const markerTokenIndexes =
+      props.streaming === true ? incompleteEmphasisMarkerTokenIndexes(values) : new Set<number>();
     return values.map((token, index) => ({
       token,
-      streaming: index === markerTokenIndex,
+      streaming: markerTokenIndexes.has(index),
       streamingTail: props.streamingTail === true && index === lastTokenIndex,
     }));
   });
@@ -509,13 +510,12 @@ function RichText(props: {
 
 function hideIncompleteEmphasisMarker(body: string): string {
   const characters = [...body];
-  const marker = incompleteEmphasisMarker(characters);
-  if (!marker) return body;
-  characters.splice(marker.index, marker.length);
+  const markers = incompleteEmphasisMarkers(characters);
+  for (const marker of markers.toReversed()) characters.splice(marker.index, marker.length);
   return characters.join("");
 }
 
-function incompleteEmphasisMarkerTokenIndex(tokens: Token[]): number {
+function incompleteEmphasisMarkerTokenIndexes(tokens: Token[]): Set<number> {
   const characters: string[] = [];
   const owners: number[] = [];
   for (const [tokenIndex, token] of tokens.entries()) {
@@ -524,18 +524,18 @@ function incompleteEmphasisMarkerTokenIndex(tokens: Token[]): number {
       owners.push(token.type === "text" ? tokenIndex : -1);
     }
   }
-  const marker = incompleteEmphasisMarker(
+  const markers = incompleteEmphasisMarkers(
     characters,
     (start, end) => owners[start] !== -1 && owners[start] === owners[end - 1],
   );
-  return marker ? (owners[marker.index] ?? -1) : -1;
+  return new Set(markers.map((marker) => owners[marker.index]).filter((owner) => owner !== undefined && owner !== -1));
 }
 
-function incompleteEmphasisMarker(
+function incompleteEmphasisMarkers(
   characters: string[],
   eligible: (start: number, end: number) => boolean = () => true,
-): { index: number; length: number } | undefined {
-  let marker: { index: number; length: number } | undefined;
+): Array<{ index: number; length: number }> {
+  const markers: Array<{ index: number; length: number }> = [];
   for (let index = 0; index < characters.length; ) {
     const delimiter = characters[index];
     if (delimiter !== "*" && delimiter !== "_") {
@@ -547,11 +547,11 @@ function incompleteEmphasisMarker(
     const previous = characters[index - 1];
     const next = characters[runEnd];
     if (eligible(index, runEnd) && canOpenEmphasisDelimiter(delimiter, previous, next)) {
-      marker = { index, length: runEnd - index };
+      markers.push({ index, length: runEnd - index });
     }
     index = runEnd;
   }
-  return marker;
+  return markers;
 }
 
 function canOpenEmphasisDelimiter(delimiter: "*" | "_", previous: string | undefined, next: string | undefined) {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -201,7 +201,7 @@ function MarkdownBlock(props: {
     }
     case "table": {
       if (!tokenIs(token, "table")) return token.raw;
-      return <MarkdownTable token={token} content={props.content} />;
+      return <MarkdownTable token={token} content={props.content} streaming={props.streaming} />;
     }
     case "hr":
       return <hr />;
@@ -282,7 +282,7 @@ function MarkdownList(props: {
   );
 }
 
-function MarkdownTable(props: { token: Tokens.Table; content: MarkdownContentProps }) {
+function MarkdownTable(props: { token: Tokens.Table; content: MarkdownContentProps; streaming?: boolean }) {
   const headers = createMemo(() => props.token.header);
   const rows = createMemo(() => props.token.rows);
   return (
@@ -291,9 +291,13 @@ function MarkdownTable(props: { token: Tokens.Table; content: MarkdownContentPro
         <thead>
           <tr>
             <For each={headers()}>
-              {(cell) => (
+              {(cell, index) => (
                 <th scope="col" data-align={cell.align ?? "left"}>
-                  <MarkdownInline tokens={cell.tokens} content={props.content} />
+                  <MarkdownInline
+                    tokens={cell.tokens}
+                    content={props.content}
+                    streaming={props.streaming === true && rows().length === 0 && index() === headers().length - 1}
+                  />
                 </th>
               )}
             </For>
@@ -301,12 +305,18 @@ function MarkdownTable(props: { token: Tokens.Table; content: MarkdownContentPro
         </thead>
         <tbody>
           <For each={rows()}>
-            {(row) => (
+            {(row, rowIndex) => (
               <tr>
                 <For each={row}>
-                  {(cell) => (
+                  {(cell, cellIndex) => (
                     <td data-align={cell.align ?? "left"}>
-                      <MarkdownInline tokens={cell.tokens} content={props.content} />
+                      <MarkdownInline
+                        tokens={cell.tokens}
+                        content={props.content}
+                        streaming={
+                          props.streaming === true && rowIndex() === rows().length - 1 && cellIndex() === row.length - 1
+                        }
+                      />
                     </td>
                   )}
                 </For>

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -513,7 +513,8 @@ function hideIncompleteStrongMarker(body: string): string {
   const characters = [...body];
   const markerIndex = incompleteStrongMarkerIndex(characters);
   if (markerIndex === undefined) return body;
-  characters.splice(markerIndex, 2);
+  const markerLength = characters[markerIndex + 2] === characters[markerIndex] ? 3 : 2;
+  characters.splice(markerIndex, markerLength);
   return characters.join("");
 }
 
@@ -548,7 +549,12 @@ function incompleteStrongMarkerIndex(
     while (characters[runEnd] === delimiter) runEnd += 1;
     const previous = characters[index - 1];
     const next = characters[runEnd];
-    if (runEnd - index === 2 && eligible(index, runEnd) && canOpenStrongDelimiter(delimiter, previous, next)) {
+    const runLength = runEnd - index;
+    if (
+      (runLength === 2 || runLength === 3) &&
+      eligible(index, runEnd) &&
+      canOpenStrongDelimiter(delimiter, previous, next)
+    ) {
       markerIndex = index;
     }
     index = runEnd;

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -307,13 +307,9 @@ function MarkdownTable(props: { token: Tokens.Table; content: MarkdownContentPro
         <thead>
           <tr>
             <For each={headers()}>
-              {(cell, index) => (
+              {(cell) => (
                 <th scope="col" data-align={cell.align ?? "left"}>
-                  <MarkdownInline
-                    tokens={cell.tokens}
-                    content={props.content}
-                    streaming={props.streaming === true && rows().length === 0 && index() === headers().length - 1}
-                  />
+                  <MarkdownInline tokens={cell.tokens} content={props.content} />
                 </th>
               )}
             </For>
@@ -355,7 +351,7 @@ function MarkdownInline(props: {
   const renderedTokens = createMemo(() => {
     const values = tokens();
     const lastTokenIndex = lastRenderableTokenIndex(values);
-    const markerTokenIndex = props.streaming === true ? incompleteStrongMarkerTokenIndex(values) : -1;
+    const markerTokenIndex = props.streaming === true ? incompleteEmphasisMarkerTokenIndex(values) : -1;
     return values.map((token, index) => ({
       token,
       streaming: index === markerTokenIndex,
@@ -502,23 +498,22 @@ function RichText(props: {
   return (
     <RichMessageText
       {...props.content}
-      body={props.streaming ? hideIncompleteStrongMarker(props.body) : props.body}
+      body={props.streaming ? hideIncompleteEmphasisMarker(props.body) : props.body}
       showCitationFooter={false}
       streamingTail={props.streamingTail}
     />
   );
 }
 
-function hideIncompleteStrongMarker(body: string): string {
+function hideIncompleteEmphasisMarker(body: string): string {
   const characters = [...body];
-  const markerIndex = incompleteStrongMarkerIndex(characters);
-  if (markerIndex === undefined) return body;
-  const markerLength = characters[markerIndex + 2] === characters[markerIndex] ? 3 : 2;
-  characters.splice(markerIndex, markerLength);
+  const marker = incompleteEmphasisMarker(characters);
+  if (!marker) return body;
+  characters.splice(marker.index, marker.length);
   return characters.join("");
 }
 
-function incompleteStrongMarkerTokenIndex(tokens: Token[]): number {
+function incompleteEmphasisMarkerTokenIndex(tokens: Token[]): number {
   const characters: string[] = [];
   const owners: number[] = [];
   for (const [tokenIndex, token] of tokens.entries()) {
@@ -527,18 +522,18 @@ function incompleteStrongMarkerTokenIndex(tokens: Token[]): number {
       owners.push(token.type === "text" ? tokenIndex : -1);
     }
   }
-  const markerIndex = incompleteStrongMarkerIndex(
+  const marker = incompleteEmphasisMarker(
     characters,
     (start, end) => owners[start] !== -1 && owners[start] === owners[end - 1],
   );
-  return markerIndex === undefined ? -1 : (owners[markerIndex] ?? -1);
+  return marker ? (owners[marker.index] ?? -1) : -1;
 }
 
-function incompleteStrongMarkerIndex(
+function incompleteEmphasisMarker(
   characters: string[],
   eligible: (start: number, end: number) => boolean = () => true,
-): number | undefined {
-  let markerIndex: number | undefined;
+): { index: number; length: number } | undefined {
+  let marker: { index: number; length: number } | undefined;
   for (let index = 0; index < characters.length; ) {
     const delimiter = characters[index];
     if (delimiter !== "*" && delimiter !== "_") {
@@ -549,24 +544,17 @@ function incompleteStrongMarkerIndex(
     while (characters[runEnd] === delimiter) runEnd += 1;
     const previous = characters[index - 1];
     const next = characters[runEnd];
-    const runLength = runEnd - index;
-    if (
-      (runLength === 2 || runLength === 3) &&
-      eligible(index, runEnd) &&
-      canOpenStrongDelimiter(delimiter, previous, next)
-    ) {
-      markerIndex = index;
+    if (eligible(index, runEnd) && canOpenEmphasisDelimiter(delimiter, previous, next)) {
+      marker = { index, length: runEnd - index };
     }
     index = runEnd;
   }
-  return markerIndex;
+  return marker;
 }
 
-function canOpenStrongDelimiter(delimiter: "*" | "_", previous: string | undefined, next: string | undefined) {
+function canOpenEmphasisDelimiter(delimiter: "*" | "_", previous: string | undefined, next: string | undefined) {
   if (next === undefined) {
-    return (
-      delimiter === "*" || previous === undefined || isMarkdownWhitespace(previous) || isMarkdownPunctuation(previous)
-    );
+    return previous === undefined || isMarkdownWhitespace(previous) || isMarkdownPunctuation(previous);
   }
   return (
     isLeftFlankingMarkdownDelimiter(previous, next) &&

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -114,6 +114,7 @@ function MarkdownBlocks(props: {
     const lastTokenIndex = lastRenderableTokenIndex(values);
     return values.map((token, index) => ({
       token,
+      streaming: props.streaming === true && index === lastTokenIndex,
       streamingTail: props.streamingTail === true && index === lastTokenIndex,
     }));
   });
@@ -123,7 +124,7 @@ function MarkdownBlocks(props: {
         <MarkdownBlock
           token={item.token}
           content={props.content}
-          streaming={props.streaming}
+          streaming={item.streaming}
           streamingTail={item.streamingTail}
         />
       )}
@@ -147,7 +148,12 @@ function MarkdownBlock(props: {
       const level = headingLevel(token.depth);
       return (
         <Dynamic component={`h${level}`} class="message-markdown-heading" data-level={level}>
-          <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={props.streamingTail} />
+          <MarkdownInline
+            tokens={token.tokens}
+            content={props.content}
+            streaming={props.streaming}
+            streamingTail={props.streamingTail}
+          />
         </Dynamic>
       );
     }
@@ -155,7 +161,12 @@ function MarkdownBlock(props: {
       if (!tokenIs(token, "paragraph")) return token.raw;
       return (
         <p>
-          <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={props.streamingTail} />
+          <MarkdownInline
+            tokens={token.tokens}
+            content={props.content}
+            streaming={props.streaming}
+            streamingTail={props.streamingTail}
+          />
         </p>
       );
     }
@@ -199,13 +210,30 @@ function MarkdownBlock(props: {
     case "text": {
       if (!tokenIs(token, "text")) return token.raw;
       return token.tokens ? (
-        <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={props.streamingTail} />
+        <MarkdownInline
+          tokens={token.tokens}
+          content={props.content}
+          streaming={props.streaming}
+          streamingTail={props.streamingTail}
+        />
       ) : (
-        <RichText body={token.text} content={props.content} streamingTail={props.streamingTail} />
+        <RichText
+          body={token.text}
+          content={props.content}
+          streaming={props.streaming}
+          streamingTail={props.streamingTail}
+        />
       );
     }
     default:
-      return <RichText body={token.raw} content={props.content} streamingTail={props.streamingTail} />;
+      return (
+        <RichText
+          body={token.raw}
+          content={props.content}
+          streaming={props.streaming}
+          streamingTail={props.streamingTail}
+        />
+      );
   }
 }
 
@@ -220,6 +248,7 @@ function MarkdownList(props: {
     const values = items();
     return values.map((item, index) => ({
       item,
+      streaming: props.streaming === true && index === values.length - 1,
       streamingTail: props.streamingTail === true && index === values.length - 1,
     }));
   });
@@ -238,7 +267,7 @@ function MarkdownList(props: {
           <MarkdownBlocks
             tokens={renderedItem.item.tokens.filter((child) => child.type !== "checkbox")}
             content={props.content}
-            streaming={props.streaming}
+            streaming={renderedItem.streaming}
             streamingTail={renderedItem.streamingTail}
           />
         </li>
@@ -290,13 +319,19 @@ function MarkdownTable(props: { token: Tokens.Table; content: MarkdownContentPro
   );
 }
 
-function MarkdownInline(props: { tokens: Token[]; content: MarkdownContentProps; streamingTail?: boolean }) {
+function MarkdownInline(props: {
+  tokens: Token[];
+  content: MarkdownContentProps;
+  streaming?: boolean;
+  streamingTail?: boolean;
+}) {
   const tokens = createMemo(() => props.tokens);
   const renderedTokens = createMemo(() => {
     const values = tokens();
     const lastTokenIndex = lastRenderableTokenIndex(values);
     return values.map((token, index) => ({
       token,
+      streaming: props.streaming === true && index === lastTokenIndex,
       streamingTail: props.streamingTail === true && index === lastTokenIndex,
     }));
   });
@@ -309,21 +344,36 @@ function MarkdownInline(props: { tokens: Token[]; content: MarkdownContentProps;
             if (!tokenIs(token, "strong")) return token.raw;
             return (
               <strong>
-                <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={item.streamingTail} />
+                <MarkdownInline
+                  tokens={token.tokens}
+                  content={props.content}
+                  streaming={item.streaming}
+                  streamingTail={item.streamingTail}
+                />
               </strong>
             );
           case "em":
             if (!tokenIs(token, "em")) return token.raw;
             return (
               <em>
-                <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={item.streamingTail} />
+                <MarkdownInline
+                  tokens={token.tokens}
+                  content={props.content}
+                  streaming={item.streaming}
+                  streamingTail={item.streamingTail}
+                />
               </em>
             );
           case "del":
             if (!tokenIs(token, "del")) return token.raw;
             return (
               <del>
-                <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={item.streamingTail} />
+                <MarkdownInline
+                  tokens={token.tokens}
+                  content={props.content}
+                  streaming={item.streaming}
+                  streamingTail={item.streamingTail}
+                />
               </del>
             );
           case "codespan": {
@@ -359,7 +409,12 @@ function MarkdownInline(props: { tokens: Token[]; content: MarkdownContentProps;
                 {token.text === token.href ? (
                   token.text
                 ) : (
-                  <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={item.streamingTail} />
+                  <MarkdownInline
+                    tokens={token.tokens}
+                    content={props.content}
+                    streaming={item.streaming}
+                    streamingTail={item.streamingTail}
+                  />
                 )}
               </MessageLink>
             ) : sharedPath && props.content.onOpenSharedFile ? (
@@ -377,7 +432,12 @@ function MarkdownInline(props: { tokens: Token[]; content: MarkdownContentProps;
                 onOpen={props.content.onOpenWorkspaceFile}
               />
             ) : (
-              <RichText body={token.text} content={props.content} streamingTail={item.streamingTail} />
+              <RichText
+                body={token.text}
+                content={props.content}
+                streaming={item.streaming}
+                streamingTail={item.streamingTail}
+              />
             );
           }
           case "image": {
@@ -394,42 +454,84 @@ function MarkdownInline(props: { tokens: Token[]; content: MarkdownContentProps;
                 referrerpolicy="no-referrer"
               />
             ) : (
-              <RichText body={token.text || token.raw} content={props.content} streamingTail={item.streamingTail} />
+              <RichText
+                body={token.text || token.raw}
+                content={props.content}
+                streaming={item.streaming}
+                streamingTail={item.streamingTail}
+              />
             );
           }
           case "html":
             return token.raw;
           case "escape": {
             if (!tokenIs(token, "escape")) return token.raw;
-            return <RichText body={token.text} content={props.content} streamingTail={item.streamingTail} />;
+            return (
+              <RichText
+                body={token.text}
+                content={props.content}
+                streaming={item.streaming}
+                streamingTail={item.streamingTail}
+              />
+            );
           }
           case "text": {
             if (!tokenIs(token, "text")) return token.raw;
             return token.tokens ? (
-              <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={item.streamingTail} />
+              <MarkdownInline
+                tokens={token.tokens}
+                content={props.content}
+                streaming={item.streaming}
+                streamingTail={item.streamingTail}
+              />
             ) : (
-              <RichText body={token.text} content={props.content} streamingTail={item.streamingTail} />
+              <RichText
+                body={token.text}
+                content={props.content}
+                streaming={item.streaming}
+                streamingTail={item.streamingTail}
+              />
             );
           }
           case "checkbox":
             return null;
           default:
-            return <RichText body={token.raw} content={props.content} streamingTail={item.streamingTail} />;
+            return (
+              <RichText
+                body={token.raw}
+                content={props.content}
+                streaming={item.streaming}
+                streamingTail={item.streamingTail}
+              />
+            );
         }
       }}
     </For>
   );
 }
 
-function RichText(props: { body: string; content: MarkdownContentProps; streamingTail?: boolean }) {
+function RichText(props: {
+  body: string;
+  content: MarkdownContentProps;
+  streaming?: boolean;
+  streamingTail?: boolean;
+}) {
   return (
     <RichMessageText
       {...props.content}
-      body={props.body}
+      body={props.streaming ? hideIncompleteStrongMarker(props.body) : props.body}
       showCitationFooter={false}
       streamingTail={props.streamingTail}
     />
   );
+}
+
+function hideIncompleteStrongMarker(body: string): string {
+  const matches = [...body.matchAll(/(^|\s)\*\*(?=\S)/gu)];
+  const match = matches.at(-1);
+  if (!match || match.index === undefined) return body;
+  const markerIndex = match.index + (match[1]?.length ?? 0);
+  return `${body.slice(0, markerIndex)}${body.slice(markerIndex + 2)}`;
 }
 
 function lastRenderableTokenIndex(tokens: Token[]): number {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -344,36 +344,21 @@ function MarkdownInline(props: {
             if (!tokenIs(token, "strong")) return token.raw;
             return (
               <strong>
-                <MarkdownInline
-                  tokens={token.tokens}
-                  content={props.content}
-                  streaming={item.streaming}
-                  streamingTail={item.streamingTail}
-                />
+                <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={item.streamingTail} />
               </strong>
             );
           case "em":
             if (!tokenIs(token, "em")) return token.raw;
             return (
               <em>
-                <MarkdownInline
-                  tokens={token.tokens}
-                  content={props.content}
-                  streaming={item.streaming}
-                  streamingTail={item.streamingTail}
-                />
+                <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={item.streamingTail} />
               </em>
             );
           case "del":
             if (!tokenIs(token, "del")) return token.raw;
             return (
               <del>
-                <MarkdownInline
-                  tokens={token.tokens}
-                  content={props.content}
-                  streaming={item.streaming}
-                  streamingTail={item.streamingTail}
-                />
+                <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={item.streamingTail} />
               </del>
             );
           case "codespan": {
@@ -409,12 +394,7 @@ function MarkdownInline(props: {
                 {token.text === token.href ? (
                   token.text
                 ) : (
-                  <MarkdownInline
-                    tokens={token.tokens}
-                    content={props.content}
-                    streaming={item.streaming}
-                    streamingTail={item.streamingTail}
-                  />
+                  <MarkdownInline tokens={token.tokens} content={props.content} streamingTail={item.streamingTail} />
                 )}
               </MessageLink>
             ) : sharedPath && props.content.onOpenSharedFile ? (
@@ -432,12 +412,7 @@ function MarkdownInline(props: {
                 onOpen={props.content.onOpenWorkspaceFile}
               />
             ) : (
-              <RichText
-                body={token.text}
-                content={props.content}
-                streaming={item.streaming}
-                streamingTail={item.streamingTail}
-              />
+              <RichText body={token.text} content={props.content} streamingTail={item.streamingTail} />
             );
           }
           case "image": {
@@ -454,26 +429,14 @@ function MarkdownInline(props: {
                 referrerpolicy="no-referrer"
               />
             ) : (
-              <RichText
-                body={token.text || token.raw}
-                content={props.content}
-                streaming={item.streaming}
-                streamingTail={item.streamingTail}
-              />
+              <RichText body={token.text || token.raw} content={props.content} streamingTail={item.streamingTail} />
             );
           }
           case "html":
             return token.raw;
           case "escape": {
             if (!tokenIs(token, "escape")) return token.raw;
-            return (
-              <RichText
-                body={token.text}
-                content={props.content}
-                streaming={item.streaming}
-                streamingTail={item.streamingTail}
-              />
-            );
+            return <RichText body={token.text} content={props.content} streamingTail={item.streamingTail} />;
           }
           case "text": {
             if (!tokenIs(token, "text")) return token.raw;
@@ -496,14 +459,7 @@ function MarkdownInline(props: {
           case "checkbox":
             return null;
           default:
-            return (
-              <RichText
-                body={token.raw}
-                content={props.content}
-                streaming={item.streaming}
-                streamingTail={item.streamingTail}
-              />
-            );
+            return <RichText body={token.raw} content={props.content} streamingTail={item.streamingTail} />;
         }
       }}
     </For>
@@ -530,22 +486,21 @@ function hideIncompleteStrongMarker(body: string): string {
   const characters = [...body];
   let markerIndex: number | undefined;
   for (let index = 0; index < characters.length; ) {
-    if (characters[index] !== "*") {
+    const delimiter = characters[index];
+    if (delimiter !== "*" && delimiter !== "_") {
       index += 1;
       continue;
     }
     let runEnd = index + 1;
-    while (characters[runEnd] === "*") runEnd += 1;
+    while (characters[runEnd] === delimiter) runEnd += 1;
     const previous = characters[index - 1];
     const next = characters[runEnd];
     if (
       runEnd - index === 2 &&
-      next !== undefined &&
-      !isMarkdownWhitespace(next) &&
-      (!isMarkdownPunctuation(next) ||
-        previous === undefined ||
-        isMarkdownWhitespace(previous) ||
-        isMarkdownPunctuation(previous))
+      isLeftFlankingMarkdownDelimiter(previous, next) &&
+      (delimiter === "*" ||
+        !isRightFlankingMarkdownDelimiter(previous, next) ||
+        (previous !== undefined && isMarkdownPunctuation(previous)))
     ) {
       markerIndex = index;
     }
@@ -554,6 +509,28 @@ function hideIncompleteStrongMarker(body: string): string {
   if (markerIndex === undefined) return body;
   characters.splice(markerIndex, 2);
   return characters.join("");
+}
+
+function isLeftFlankingMarkdownDelimiter(previous: string | undefined, next: string | undefined): boolean {
+  return (
+    next !== undefined &&
+    !isMarkdownWhitespace(next) &&
+    (!isMarkdownPunctuation(next) ||
+      previous === undefined ||
+      isMarkdownWhitespace(previous) ||
+      isMarkdownPunctuation(previous))
+  );
+}
+
+function isRightFlankingMarkdownDelimiter(previous: string | undefined, next: string | undefined): boolean {
+  return (
+    previous !== undefined &&
+    !isMarkdownWhitespace(previous) &&
+    (!isMarkdownPunctuation(previous) ||
+      next === undefined ||
+      isMarkdownWhitespace(next) ||
+      isMarkdownPunctuation(next))
+  );
 }
 
 function isMarkdownWhitespace(value: string): boolean {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -194,7 +194,7 @@ function MarkdownBlock(props: {
           <MarkdownBlocks
             tokens={token.tokens}
             content={props.content}
-            streaming={props.streaming === true && !parentClosesFinalNestedTable(token)}
+            streaming={props.streaming === true && !containerClosesFinalNestedTable(token)}
             streamingTail={props.streamingTail}
           />
         </blockquote>
@@ -206,7 +206,7 @@ function MarkdownBlock(props: {
         <MarkdownList
           token={token}
           content={props.content}
-          streaming={props.streaming}
+          streaming={props.streaming === true && !containerClosesFinalNestedTable(token)}
           streamingTail={props.streamingTail}
         />
       );
@@ -633,11 +633,26 @@ function activeStreamingTableCellIndex(token: Tokens.Table): number {
   return cellIndex < row.length ? cellIndex : -1;
 }
 
-function parentClosesFinalNestedTable(token: Tokens.Blockquote): boolean {
+function containerClosesFinalNestedTable(token: Tokens.Blockquote | Tokens.List): boolean {
   if (!/\n[\t ]*$/u.test(token.raw)) return false;
-  const index = lastRenderableTokenIndex(token.tokens);
-  const finalToken = token.tokens[index];
-  return finalToken !== undefined && tokenIs(finalToken, "table");
+  return finalNestedBlockToken(token) === "table";
+}
+
+function finalNestedBlockToken(token: Tokens.Blockquote | Tokens.List): Token["type"] | undefined {
+  if (tokenIs(token, "list")) {
+    const item = token.items.at(-1);
+    if (!item) return token.type;
+    return finalNestedTokenType(item.tokens);
+  }
+  return finalNestedTokenType(token.tokens);
+}
+
+function finalNestedTokenType(tokens: Token[]): Token["type"] | undefined {
+  const index = lastRenderableTokenIndex(tokens);
+  const token = tokens[index];
+  if (!token) return undefined;
+  if (tokenIs(token, "blockquote") || tokenIs(token, "list")) return finalNestedBlockToken(token);
+  return token.type;
 }
 
 function isEscapedMarkdownCharacter(value: string, index: number): boolean {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -194,7 +194,7 @@ function MarkdownBlock(props: {
           <MarkdownBlocks
             tokens={token.tokens}
             content={props.content}
-            streaming={props.streaming}
+            streaming={props.streaming === true && !parentClosesFinalNestedTable(token)}
             streamingTail={props.streamingTail}
           />
         </blockquote>
@@ -302,6 +302,9 @@ function MarkdownList(props: {
 function MarkdownTable(props: { token: Tokens.Table; content: MarkdownContentProps; streaming?: boolean }) {
   const headers = createMemo(() => props.token.header);
   const rows = createMemo(() => props.token.rows);
+  const streamingCellIndex = createMemo(() =>
+    props.streaming === true ? activeStreamingTableCellIndex(props.token) : -1,
+  );
   return (
     <section class="message-markdown-table-scroll" aria-label="Data table" tabindex="0">
       <table class="message-markdown-table">
@@ -326,9 +329,7 @@ function MarkdownTable(props: { token: Tokens.Table; content: MarkdownContentPro
                       <MarkdownInline
                         tokens={cell.tokens}
                         content={props.content}
-                        streaming={
-                          props.streaming === true && rowIndex() === rows().length - 1 && cellIndex() === row.length - 1
-                        }
+                        streaming={rowIndex() === rows().length - 1 && cellIndex() === streamingCellIndex()}
                       />
                     </td>
                   )}
@@ -608,6 +609,43 @@ function activeStreamingBlockTokenIndex(tokens: Token[]): number {
   const token = tokens[index];
   if (tokenIs(token, "heading") && token.raw.includes("\n")) return -1;
   return index;
+}
+
+function activeStreamingTableCellIndex(token: Tokens.Table): number {
+  const row = token.rows.at(-1);
+  if (!row || /\n[\t ]*$/u.test(token.raw)) return -1;
+  const sourceRow = token.raw.split("\n").at(-1)?.trimEnd();
+  if (!sourceRow) return -1;
+
+  const finalCharacterIndex = sourceRow.length - 1;
+  if (sourceRow[finalCharacterIndex] === "|" && !isEscapedMarkdownCharacter(sourceRow, finalCharacterIndex)) {
+    return -1;
+  }
+
+  let sourceIndex = sourceRow.search(/\S/u);
+  if (sourceIndex === -1) return -1;
+  if (sourceRow[sourceIndex] === "|") sourceIndex += 1;
+
+  let cellIndex = 0;
+  for (; sourceIndex < sourceRow.length; sourceIndex += 1) {
+    if (sourceRow[sourceIndex] === "|" && !isEscapedMarkdownCharacter(sourceRow, sourceIndex)) cellIndex += 1;
+  }
+  return cellIndex < row.length ? cellIndex : -1;
+}
+
+function parentClosesFinalNestedTable(token: Tokens.Blockquote): boolean {
+  if (!/\n[\t ]*$/u.test(token.raw)) return false;
+  const index = lastRenderableTokenIndex(token.tokens);
+  const finalToken = token.tokens[index];
+  return finalToken !== undefined && tokenIs(finalToken, "table");
+}
+
+function isEscapedMarkdownCharacter(value: string, index: number): boolean {
+  let slashCount = 0;
+  for (let slashIndex = index - 1; slashIndex >= 0 && value[slashIndex] === "\\"; slashIndex -= 1) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
 }
 
 function markdownInlinePlainText(tokens: Token[]): string {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -128,9 +128,10 @@ function MarkdownBlocks(props: {
   const renderedTokens = createMemo(() => {
     const values = tokens();
     const lastTokenIndex = lastRenderableTokenIndex(values);
+    const streamingTokenIndex = activeStreamingBlockTokenIndex(values);
     return values.map((token, index) => ({
       token,
-      streaming: props.streaming === true && index === lastTokenIndex,
+      streaming: props.streaming === true && index === streamingTokenIndex,
       streamingTail: props.streamingTail === true && index === lastTokenIndex,
     }));
   });
@@ -599,6 +600,14 @@ function lastRenderableTokenIndex(tokens: Token[]): number {
     if (tokens[index]?.type !== "space" && tokens[index]?.type !== "def") return index;
   }
   return -1;
+}
+
+function activeStreamingBlockTokenIndex(tokens: Token[]): number {
+  const index = lastRenderableTokenIndex(tokens);
+  if (index === -1 || index !== tokens.length - 1) return -1;
+  const token = tokens[index];
+  if (tokenIs(token, "heading") && token.raw.includes("\n")) return -1;
+  return index;
 }
 
 function markdownInlinePlainText(tokens: Token[]): string {

--- a/src/renderer/src/components/conversation/MarkdownMessageText.tsx
+++ b/src/renderer/src/components/conversation/MarkdownMessageText.tsx
@@ -527,11 +527,41 @@ function RichText(props: {
 }
 
 function hideIncompleteStrongMarker(body: string): string {
-  const matches = [...body.matchAll(/(^|\s)\*\*(?=\S)/gu)];
-  const match = matches.at(-1);
-  if (!match || match.index === undefined) return body;
-  const markerIndex = match.index + (match[1]?.length ?? 0);
-  return `${body.slice(0, markerIndex)}${body.slice(markerIndex + 2)}`;
+  const characters = [...body];
+  let markerIndex: number | undefined;
+  for (let index = 0; index < characters.length; ) {
+    if (characters[index] !== "*") {
+      index += 1;
+      continue;
+    }
+    let runEnd = index + 1;
+    while (characters[runEnd] === "*") runEnd += 1;
+    const previous = characters[index - 1];
+    const next = characters[runEnd];
+    if (
+      runEnd - index === 2 &&
+      next !== undefined &&
+      !isMarkdownWhitespace(next) &&
+      (!isMarkdownPunctuation(next) ||
+        previous === undefined ||
+        isMarkdownWhitespace(previous) ||
+        isMarkdownPunctuation(previous))
+    ) {
+      markerIndex = index;
+    }
+    index = runEnd;
+  }
+  if (markerIndex === undefined) return body;
+  characters.splice(markerIndex, 2);
+  return characters.join("");
+}
+
+function isMarkdownWhitespace(value: string): boolean {
+  return /\s/u.test(value);
+}
+
+function isMarkdownPunctuation(value: string): boolean {
+  return /[\p{P}\p{S}]/u.test(value);
 }
 
 function lastRenderableTokenIndex(tokens: Token[]): number {

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -526,6 +526,59 @@ describe("MessageBody", () => {
     expect(container.querySelector(".message-content-blocks")).toBe(messageContent);
   });
 
+  it("hides a punctuation-adjacent strong marker while streaming", async () => {
+    const [body, setBody] = createSignal("Use (**Kobal");
+    const [streaming, setStreaming] = createSignal(true);
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-punctuation",
+          author: "bot",
+          body: body(),
+          time: "10:00",
+          streaming: streaming(),
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(screen.getByText("Use (Kobal")).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("**");
+
+    setBody("Use (**Kobalte**).");
+    setStreaming(false);
+
+    await waitFor(() => expect(screen.getByText("Kobalte").tagName).toBe("STRONG"));
+    expect(container).toHaveTextContent("Use (Kobalte).");
+    expect(container).not.toHaveTextContent("**");
+  });
+
+  it("keeps earlier text unchanged while a structured block streams", () => {
+    render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-code",
+          author: "bot",
+          body: "Earlier **literal\n\n```js\nconst answer = 4",
+          time: "10:00",
+          streaming: true,
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(screen.getByText("Earlier **literal")).toBeInTheDocument();
+    expect(screen.getByText("const answer = 4")).toBeInTheDocument();
+  });
+
   it("keeps Markdown tables in user messages as plain text", () => {
     render(() => (
       <MessageBody

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -774,6 +774,38 @@ describe("MessageBody", () => {
     expect(container).not.toHaveTextContent(marker);
   });
 
+  it("hides every incomplete nested emphasis opener while streaming", async () => {
+    const [body, setBody] = createSignal("Use **bold [link](https://example.com) and _italic");
+    const [streaming, setStreaming] = createSignal(true);
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-nested-emphasis",
+          author: "bot",
+          body: body(),
+          time: "10:00",
+          streaming: streaming(),
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(container).toHaveTextContent("Use bold link and italic");
+    expect(container).not.toHaveTextContent("**");
+    expect(container).not.toHaveTextContent("_italic");
+    expect(screen.getByRole("link", { name: "link" })).toBeInTheDocument();
+
+    setBody("Use **bold [link](https://example.com) and _italic_**");
+    setStreaming(false);
+
+    await waitFor(() => expect(container.querySelector("strong em")).toHaveTextContent("italic"));
+    expect(container.querySelector("strong a")).toHaveTextContent("link");
+  });
+
   it("cleans an opener before a completed inline token without changing its contents", () => {
     const { container } = render(() => (
       <MessageBody

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -655,6 +655,36 @@ describe("MessageBody", () => {
     expect(screen.getByText("const answer = 4")).toBeInTheDocument();
   });
 
+  it("hides an incomplete marker in the final cell of a nested streaming table", async () => {
+    const [body, setBody] = createSignal("> | A | B |\n> | --- | --- |\n> | x | **bold");
+    const [streaming, setStreaming] = createSignal(true);
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-nested-table",
+          author: "bot",
+          body: body(),
+          time: "10:00",
+          streaming: streaming(),
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(container).toHaveTextContent("bold");
+    expect(container).not.toHaveTextContent("**");
+
+    setBody("> | A | B |\n> | --- | --- |\n> | x | **bold**");
+    setStreaming(false);
+
+    await waitFor(() => expect(screen.getByText("bold").tagName).toBe("STRONG"));
+  });
+
   it("keeps Markdown tables in user messages as plain text", () => {
     render(() => (
       <MessageBody

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -847,6 +847,30 @@ describe("MessageBody", () => {
     },
   );
 
+  it.each([
+    ["closed paragraph", "Earlier **literal\n\n"],
+    ["closed heading", "# Heading **literal\n"],
+  ])("preserves markers in a %s while another block can stream", (name, body) => {
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: `message-streaming-${name.replaceAll(" ", "-")}`,
+          author: "bot",
+          body,
+          time: "10:00",
+          streaming: true,
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(container).toHaveTextContent("**literal");
+  });
+
   it("keeps earlier text unchanged while a structured block streams", () => {
     render(() => (
       <MessageBody

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -738,9 +738,13 @@ describe("MessageBody", () => {
   });
 
   it.each([
-    ["***", "asterisk"],
-    ["___", "underscore"],
-  ])("hides an incomplete combined %s emphasis marker while streaming", async (marker, name) => {
+    ["*", "asterisk italic", "em"],
+    ["_", "underscore italic", "em"],
+    ["***", "asterisk bold italic", "em strong, strong em"],
+    ["___", "underscore bold italic", "em strong, strong em"],
+    ["****", "nested asterisk bold", "strong strong"],
+    ["____", "nested underscore bold", "strong strong"],
+  ])("hides an incomplete %s marker while streaming", async (marker, name, selector) => {
     const [body, setBody] = createSignal(`Use ${marker}Kobal`);
     const [streaming, setStreaming] = createSignal(true);
     const { container } = render(() => (
@@ -766,7 +770,7 @@ describe("MessageBody", () => {
     setBody(`Use ${marker}Kobalte${marker}`);
     setStreaming(false);
 
-    await waitFor(() => expect(screen.getByText("Kobalte").closest("strong, em")).not.toBeNull());
+    await waitFor(() => expect(container.querySelector(selector)).toHaveTextContent("Kobalte"));
     expect(container).not.toHaveTextContent(marker);
   });
 
@@ -794,7 +798,7 @@ describe("MessageBody", () => {
     expect(screen.getByRole("link", { name: "label **literal" })).toBeInTheDocument();
   });
 
-  it.each(["Use **", "Use __", "Use ***", "Use ___"])(
+  it.each(["Use *", "Use _", "Use **", "Use __", "Use ***", "Use ___", "Use ****", "Use ____"])(
     "hides an emphasis marker at the end of a streaming chunk",
     (body) => {
       const { container } = render(() => (
@@ -816,6 +820,30 @@ describe("MessageBody", () => {
 
       expect(container).toHaveTextContent("Use");
       expect(container).not.toHaveTextContent(body.trim().slice(4));
+    },
+  );
+
+  it.each(["value*", "value_", "value**", "value__", "value***", "value___"])(
+    "preserves a literal trailing delimiter while streaming",
+    (body) => {
+      const { container } = render(() => (
+        <MessageBody
+          message={{
+            id: `message-streaming-literal-${body.at(-1)}`,
+            author: "bot",
+            body,
+            time: "10:00",
+            streaming: true,
+          }}
+          bots={bots}
+          onSelectAgent={vi.fn()}
+          onOpenLink={vi.fn()}
+          onPreview={vi.fn()}
+          onAttachmentAction={vi.fn()}
+        />
+      ));
+
+      expect(container).toHaveTextContent(body);
     },
   );
 
@@ -869,6 +897,28 @@ describe("MessageBody", () => {
     setStreaming(false);
 
     await waitFor(() => expect(screen.getByText("bold").tagName).toBe("STRONG"));
+  });
+
+  it("preserves literal markers in a completed streaming table header", () => {
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-table-header",
+          author: "bot",
+          body: "| A | **literal |\n| --- | --- |",
+          time: "10:00",
+          streaming: true,
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(container).toHaveTextContent("**literal");
   });
 
   it("keeps Markdown tables in user messages as plain text", () => {

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -737,6 +737,39 @@ describe("MessageBody", () => {
     expect(container).toHaveTextContent("Use Kobalte, but keep a__literal");
   });
 
+  it.each([
+    ["***", "asterisk"],
+    ["___", "underscore"],
+  ])("hides an incomplete combined %s emphasis marker while streaming", async (marker, name) => {
+    const [body, setBody] = createSignal(`Use ${marker}Kobal`);
+    const [streaming, setStreaming] = createSignal(true);
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: `message-streaming-combined-${name}`,
+          author: "bot",
+          body: body(),
+          time: "10:00",
+          streaming: streaming(),
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(container).toHaveTextContent("Use Kobal");
+    expect(container).not.toHaveTextContent(marker);
+
+    setBody(`Use ${marker}Kobalte${marker}`);
+    setStreaming(false);
+
+    await waitFor(() => expect(screen.getByText("Kobalte").closest("strong, em")).not.toBeNull());
+    expect(container).not.toHaveTextContent(marker);
+  });
+
   it("cleans an opener before a completed inline token without changing its contents", () => {
     const { container } = render(() => (
       <MessageBody
@@ -761,27 +794,30 @@ describe("MessageBody", () => {
     expect(screen.getByRole("link", { name: "label **literal" })).toBeInTheDocument();
   });
 
-  it.each(["Use **", "Use __"])("hides a strong marker at the end of a streaming chunk", (body) => {
-    const { container } = render(() => (
-      <MessageBody
-        message={{
-          id: `message-streaming-marker-${body.at(-1)}`,
-          author: "bot",
-          body,
-          time: "10:00",
-          streaming: true,
-        }}
-        bots={bots}
-        onSelectAgent={vi.fn()}
-        onOpenLink={vi.fn()}
-        onPreview={vi.fn()}
-        onAttachmentAction={vi.fn()}
-      />
-    ));
+  it.each(["Use **", "Use __", "Use ***", "Use ___"])(
+    "hides an emphasis marker at the end of a streaming chunk",
+    (body) => {
+      const { container } = render(() => (
+        <MessageBody
+          message={{
+            id: `message-streaming-marker-${body.at(-1)}`,
+            author: "bot",
+            body,
+            time: "10:00",
+            streaming: true,
+          }}
+          bots={bots}
+          onSelectAgent={vi.fn()}
+          onOpenLink={vi.fn()}
+          onPreview={vi.fn()}
+          onAttachmentAction={vi.fn()}
+        />
+      ));
 
-    expect(container).toHaveTextContent("Use");
-    expect(container).not.toHaveTextContent(body.slice(-2));
-  });
+      expect(container).toHaveTextContent("Use");
+      expect(container).not.toHaveTextContent(body.trim().slice(4));
+    },
+  );
 
   it("keeps earlier text unchanged while a structured block streams", () => {
     render(() => (

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -587,13 +587,13 @@ describe("MessageBody", () => {
     expect(container).toHaveTextContent("Use Kobalte, but keep a__literal");
   });
 
-  it("does not clean text inside a completed inline container", () => {
-    render(() => (
+  it("cleans an opener before a completed inline token without changing its contents", () => {
+    const { container } = render(() => (
       <MessageBody
         message={{
           id: "message-streaming-link",
           author: "bot",
-          body: "[label **literal](https://example.com)",
+          body: "Use **[Kobal](https://example.com), keep [label **literal](https://example.com/label)",
           time: "10:00",
           streaming: true,
         }}
@@ -605,7 +605,32 @@ describe("MessageBody", () => {
       />
     ));
 
+    expect(container).toHaveTextContent("Use Kobal, keep label **literal");
+    expect(container).not.toHaveTextContent("Use **");
+    expect(screen.getByRole("link", { name: "Kobal" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "label **literal" })).toBeInTheDocument();
+  });
+
+  it.each(["Use **", "Use __"])("hides a strong marker at the end of a streaming chunk", (body) => {
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: `message-streaming-marker-${body.at(-1)}`,
+          author: "bot",
+          body,
+          time: "10:00",
+          streaming: true,
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(container).toHaveTextContent("Use");
+    expect(container).not.toHaveTextContent(body.slice(-2));
   });
 
   it("keeps earlier text unchanged while a structured block streams", () => {

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -976,6 +976,30 @@ describe("MessageBody", () => {
     expect(container).toHaveTextContent("**literal");
   });
 
+  it.each([
+    ["list", "- | A | B |\n  | --- | --- |\n  | x | **literal\n"],
+    ["list in a blockquote", "> - | A | B |\n>   | --- | --- |\n>   | x | **literal\n"],
+  ])("preserves markers in a closed table nested through a %s", (_containerName, body) => {
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-closed-nested-table",
+          author: "bot",
+          body,
+          time: "10:00",
+          streaming: true,
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(container).toHaveTextContent("**literal");
+  });
+
   it("preserves literal markers in a completed streaming table header", () => {
     const { container } = render(() => (
       <MessageBody

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -923,6 +923,59 @@ describe("MessageBody", () => {
     await waitFor(() => expect(screen.getByText("bold").tagName).toBe("STRONG"));
   });
 
+  it("hides an incomplete marker in an unpadded source cell", async () => {
+    const [body, setBody] = createSignal("> | A | B |\n> | --- | --- |\n> | **bold");
+    const [streaming, setStreaming] = createSignal(true);
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-short-table-row",
+          author: "bot",
+          body: body(),
+          time: "10:00",
+          streaming: streaming(),
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(container).toHaveTextContent("bold");
+    expect(container).not.toHaveTextContent("**");
+
+    setBody("> | A | B |\n> | --- | --- |\n> | **bold**");
+    setStreaming(false);
+
+    await waitFor(() => expect(screen.getByText("bold").tagName).toBe("STRONG"));
+  });
+
+  it.each([
+    ["closing pipe", "> | A | B |\n> | --- | --- |\n> | x | **literal |"],
+    ["newline", "> | A | B |\n> | --- | --- |\n> | x | **literal\n"],
+  ])("preserves markers in a table cell closed by a %s", (_boundary, body) => {
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-closed-table-cell",
+          author: "bot",
+          body,
+          time: "10:00",
+          streaming: true,
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(container).toHaveTextContent("**literal");
+  });
+
   it("preserves literal markers in a completed streaming table header", () => {
     const { container } = render(() => (
       <MessageBody

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -557,6 +557,57 @@ describe("MessageBody", () => {
     expect(container).not.toHaveTextContent("**");
   });
 
+  it("hides a valid underscore strong marker but preserves an intraword delimiter", async () => {
+    const [body, setBody] = createSignal("Use __Kobal, but keep a__literal");
+    const [streaming, setStreaming] = createSignal(true);
+    const { container } = render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-underscore",
+          author: "bot",
+          body: body(),
+          time: "10:00",
+          streaming: streaming(),
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(container).toHaveTextContent("Use Kobal, but keep a__literal");
+    expect(container).not.toHaveTextContent("Use __Kobal");
+
+    setBody("Use __Kobalte__, but keep a__literal");
+    setStreaming(false);
+
+    await waitFor(() => expect(screen.getByText("Kobalte").tagName).toBe("STRONG"));
+    expect(container).toHaveTextContent("Use Kobalte, but keep a__literal");
+  });
+
+  it("does not clean text inside a completed inline container", () => {
+    render(() => (
+      <MessageBody
+        message={{
+          id: "message-streaming-link",
+          author: "bot",
+          body: "[label **literal](https://example.com)",
+          time: "10:00",
+          streaming: true,
+        }}
+        bots={bots}
+        onSelectAgent={vi.fn()}
+        onOpenLink={vi.fn()}
+        onPreview={vi.fn()}
+        onAttachmentAction={vi.fn()}
+      />
+    ));
+
+    expect(screen.getByRole("link", { name: "label **literal" })).toBeInTheDocument();
+  });
+
   it("keeps earlier text unchanged while a structured block streams", () => {
     render(() => (
       <MessageBody

--- a/src/renderer/src/components/conversation/MessageRendering.test.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.test.tsx
@@ -493,10 +493,11 @@ describe("MessageBody", () => {
     ));
 
     expect(screen.getByRole("heading", { level: 2, name: "Plan" })).toBeInTheDocument();
-    expect(screen.getByText("Use **Kobal")).toBeInTheDocument();
+    expect(screen.getByText("Use Kobal")).toBeInTheDocument();
     const messageContent = container.querySelector<HTMLElement>(".message-content-blocks");
     const messageResize = container.querySelector<HTMLElement>(".message-content-resize");
     if (!messageContent || !messageResize) throw new Error("Streaming resize elements are missing.");
+    expect(messageContent).not.toHaveTextContent("**");
     let contentHeight = 40;
     vi.spyOn(messageContent, "getBoundingClientRect").mockImplementation(() =>
       DOMRect.fromRect({ height: contentHeight, width: 640, x: 0, y: 0 }),
@@ -521,7 +522,7 @@ describe("MessageBody", () => {
     expect(messageContent).not.toHaveTextContent("Resize the row");
     await waitFor(() => expect(messageContent).toHaveTextContent("Resize the row"));
     expect(screen.getByText("Parse Markdown")).toBeInTheDocument();
-    expect(screen.queryByText("Use **Kobal")).toBeNull();
+    expect(screen.queryByText("Use Kobal")).toBeNull();
     expect(container.querySelector(".message-content-blocks")).toBe(messageContent);
   });
 

--- a/src/renderer/src/components/conversation/MessageRendering.tsx
+++ b/src/renderer/src/components/conversation/MessageRendering.tsx
@@ -390,7 +390,7 @@ export function MessageBody(props: {
                         onOpenSharedFile={props.onOpenSharedFile}
                         onOpenWorkspaceFile={props.onOpenWorkspaceFile}
                         showCitationFooter={index() === lastTextBlockIndex()}
-                        streaming={props.message.streaming === true}
+                        streaming={props.message.streaming === true && index() === contentBlocks().length - 1}
                         streamingTail={streamingBody.animateTail() && index() === lastTextBlockIndex()}
                       />
                     </div>


### PR DESCRIPTION
## Summary

- hide an unmatched strong-emphasis opener in the active streaming Markdown token
- keep completed Markdown and earlier message tokens unchanged
- update the streaming regression test to reject visible raw syntax and confirm final semantic bold text

## Verification

- `bun run test src/renderer/src/components/conversation/MessageRendering.test.tsx src/renderer/src/app-message-projection.test.ts`
- `bun run typecheck:renderer`
- `bunx biome check src/renderer/src/components/conversation/MarkdownMessageText.tsx src/renderer/src/components/conversation/MessageRendering.test.tsx`
- integrated UI check with `bun run dev`