### PR TITLE
Add dynamic routine event markers

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -368,6 +368,18 @@
   color: var(--openbot-text-secondary);
 }
 
+.routine-event-context-grid {
+  width: min(1200px, 100%);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
+  align-items: start;
+  gap: var(--openbot-space-6);
+}
+
+.routine-event-context-grid .chat-primitives-stage {
+  width: 100%;
+}
+
 .question-prompt-story-stage {
   min-height: 100vh;
   display: grid;
@@ -463,6 +475,10 @@
   .chat-primitives-gallery,
   .question-prompt-story-stage {
     padding: var(--openbot-space-4);
+  }
+
+  .routine-event-context-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .question-prompt-story-stage:has(.question-prompt-chat-preview) {

--- a/packages/contracts/src/ipc-conversation.ts
+++ b/packages/contracts/src/ipc-conversation.ts
@@ -630,6 +630,45 @@ export interface ConversationMessage {
   questionPrompt?: ConversationQuestionPrompt;
 }
 
+export const ROUTINE_EVENT_ITEM_TYPE_PREFIX = "routine-event:";
+
+export type RoutineConversationEventAction = "created" | "updated" | "deleted";
+
+export interface RoutineConversationEvent {
+  action: RoutineConversationEventAction;
+  routineId: string;
+  routineName: string;
+}
+
+export function routineConversationEventItemType(action: RoutineConversationEventAction, routineId: string): string {
+  if (!isIdentifier(routineId)) throw new Error("A valid routine id is required.");
+  const itemType = `${ROUTINE_EVENT_ITEM_TYPE_PREFIX}${action}:${routineId}`;
+  if (itemType.length > INPUT_LIMITS.identifier) throw new Error("The routine event item type is too long.");
+  return itemType;
+}
+
+export function parseRoutineConversationEventItemType(
+  itemType: string | undefined,
+): Pick<RoutineConversationEvent, "action" | "routineId"> | null {
+  if (!itemType?.startsWith(ROUTINE_EVENT_ITEM_TYPE_PREFIX)) return null;
+  const separator = itemType.indexOf(":", ROUTINE_EVENT_ITEM_TYPE_PREFIX.length);
+  if (separator < 0) return null;
+  const action = itemType.slice(ROUTINE_EVENT_ITEM_TYPE_PREFIX.length, separator);
+  const routineId = itemType.slice(separator + 1);
+  if ((action !== "created" && action !== "updated" && action !== "deleted") || !isIdentifier(routineId)) {
+    return null;
+  }
+  return { action, routineId };
+}
+
+export function routineConversationEvent(message: ConversationMessage): RoutineConversationEvent | null {
+  if (message.author !== "system" || message.source !== "system" || message.status !== "completed") return null;
+  const event = parseRoutineConversationEventItemType(message.itemType);
+  const routineName = message.text.trim();
+  if (!event || !routineName || routineName.length > INPUT_LIMITS.routineName) return null;
+  return { ...event, routineName };
+}
+
 function isAgentPromptQuestion(value: unknown): value is AgentPromptQuestion {
   if (!isDynamicRecord(value)) return false;
   return (

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -10,6 +10,9 @@ import {
   isConversationMessage,
   isDynamicIslandAction,
   isMessageReaction,
+  parseRoutineConversationEventItemType,
+  routineConversationEvent,
+  routineConversationEventItemType,
 } from "./ipc";
 
 describe("Dynamic Island action validation", () => {
@@ -307,6 +310,38 @@ describe("conversation event validation", () => {
         },
       }),
     ).toBe(true);
+  });
+});
+
+describe("routine conversation events", () => {
+  it("encodes and decodes a valid routine marker", () => {
+    const itemType = routineConversationEventItemType("updated", "routine-1");
+    const message = {
+      id: "event-1",
+      author: "system",
+      source: "system",
+      text: "Morning brief",
+      createdAt: "2026-08-31T12:00:00.000Z",
+      status: "completed",
+      itemType,
+    } as const;
+
+    expect(itemType).toBe("routine-event:updated:routine-1");
+    expect(parseRoutineConversationEventItemType(itemType)).toEqual({ action: "updated", routineId: "routine-1" });
+    expect(routineConversationEvent(message)).toEqual({
+      action: "updated",
+      routineId: "routine-1",
+      routineName: "Morning brief",
+    });
+    expect(isConversationMessage(message)).toBe(true);
+  });
+
+  it("rejects malformed routine marker metadata", () => {
+    expect(parseRoutineConversationEventItemType("routine-event:renamed:routine-1")).toBeNull();
+    expect(parseRoutineConversationEventItemType("routine-event:created:")).toBeNull();
+    expect(() => routineConversationEventItemType("created", "x".repeat(128))).toThrow(
+      "The routine event item type is too long.",
+    );
   });
 });
 

--- a/packages/contracts/src/team-protocol/v1.test.ts
+++ b/packages/contracts/src/team-protocol/v1.test.ts
@@ -197,10 +197,26 @@ describe("Team protocol v1", () => {
             },
           ],
         },
+        {
+          id: "routine-event-1",
+          text: "Morning brief",
+          createdAt: "2026-08-30T12:01:00.000Z",
+          author: "system",
+          source: "system",
+          status: "completed",
+          itemType: "routine-event:created:routine-1",
+        },
       ],
     });
     expect(conversation).toMatchObject({
-      messages: [{ id: "message-1", attachments: [{ id: "attachment-1" }] }],
+      messages: [
+        { id: "message-1", attachments: [{ id: "attachment-1" }] },
+        {
+          id: "routine-event-1",
+          text: "Morning brief",
+          itemType: "routine-event:created:routine-1",
+        },
+      ],
     });
     expect(JSON.stringify(conversation)).not.toContain("future");
 

--- a/packages/contracts/src/team-protocol/v1.ts
+++ b/packages/contracts/src/team-protocol/v1.ts
@@ -3,6 +3,7 @@ import { type DynamicRecord, isBoolean, isDynamicRecord, isNumber, isString } fr
 export const TEAM_PROTOCOL_V1 = 1;
 export const TEAM_PROTOCOL_VERSION_HEADER = "OpenBot-Protocol-Version";
 export const TEAM_APP_VERSION_HEADER = "OpenBot-App-Version";
+export const TEAM_CAPABILITIES_HEADER = "OpenBot-Capabilities";
 export const TEAM_PROTOCOL_V1_WEBSOCKET = "openbot-team-v1";
 
 export const TEAM_PROTOCOL_V1_CAPABILITIES = [
@@ -11,6 +12,7 @@ export const TEAM_PROTOCOL_V1_CAPABILITIES = [
   "conversation-pagination",
   "direct-messages",
   "remote-desktop",
+  "routine-event-markers",
   "sidebar-layout",
 ] as const;
 

--- a/src/backend/agent-service.test.ts
+++ b/src/backend/agent-service.test.ts
@@ -14,6 +14,7 @@ import {
   type BrowserControlState,
   type BrowserTab,
   isAgentEvent,
+  routineConversationEvent,
 } from "@openbot/contracts/ipc";
 import { type DynamicRecord, isDynamicRecord, isString } from "@openbot/contracts/runtime-values";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -2679,6 +2680,83 @@ describe.sequential("AgentService", () => {
     });
     expect(service.listRoutines("chief")).toEqual([]);
     expect(service.listRoutines("design")).toEqual([expect.objectContaining({ id: otherRoutine.id, active: true })]);
+    const ownEvents = (await service.readConversation("chief")).messages.flatMap((message) => {
+      const event = routineConversationEvent(message);
+      return event ? [{ ...event, turnId: message.turnId }] : [];
+    });
+    expect(ownEvents).toEqual([
+      expect.objectContaining({ action: "created", routineId: ownRoutine.id, turnId: expect.any(String) }),
+      expect.objectContaining({ action: "deleted", routineId: ownRoutine.id, turnId: expect.any(String) }),
+    ]);
+    const otherEvents = (await service.readConversation("design")).messages.flatMap((message) => {
+      const event = routineConversationEvent(message);
+      return event ? [{ ...event, turnId: message.turnId }] : [];
+    });
+    expect(otherEvents).toEqual([
+      expect.objectContaining({ action: "created", routineId: otherRoutine.id, turnId: undefined }),
+      expect.objectContaining({ action: "updated", routineId: otherRoutine.id, turnId: undefined }),
+    ]);
+  });
+
+  it("persists routine lifecycle markers without adding unread or search results", async () => {
+    const { store, mailbox } = stores();
+    service = new AgentService(store, mailbox, fakeBrowser());
+    await service.initialize();
+    const bot = await store.getOrCreate("chief");
+
+    const created = service.createRoutine({
+      botId: bot.id,
+      name: "Morning brief",
+      instruction: "Prepare the daily brief.",
+      active: true,
+      timezone: "UTC",
+      schedule: { kind: "daily", time: "09:00" },
+    });
+    const updated = service.updateRoutine({
+      botId: bot.id,
+      routineId: created.id,
+      name: "Updated morning brief",
+    });
+    await service.deleteRoutine({ botId: bot.id, routineId: created.id });
+
+    const conversation = await service.readConversation(bot.id);
+    expect(conversation.messages.flatMap((message) => routineConversationEvent(message) ?? [])).toEqual([
+      { action: "created", routineId: created.id, routineName: "Morning brief" },
+      { action: "updated", routineId: updated.id, routineName: "Updated morning brief" },
+      { action: "deleted", routineId: updated.id, routineName: "Updated morning brief" },
+    ]);
+    expect((await service.readConversationPageFor(bot.id, "member-1")).readState?.unreadCount).toBe(0);
+    expect(service.searchConversationMessages("morning brief", bot.id).total).toBe(0);
+
+    await service.stop();
+    service = new AgentService(store, mailbox, fakeBrowser());
+    await service.initialize();
+    expect(
+      (await service.readConversation(bot.id)).messages.flatMap((message) => routineConversationEvent(message) ?? []),
+    ).toHaveLength(3);
+  });
+
+  it("rolls back a routine mutation when its transcript marker cannot persist", async () => {
+    const { store, mailbox } = stores();
+    service = new AgentService(store, mailbox, fakeBrowser());
+    await service.initialize();
+    const bot = await store.getOrCreate("chief");
+    vi.spyOn(store.database, "persistConversation").mockImplementationOnce(() => {
+      throw new Error("conversation persistence failed");
+    });
+
+    expect(() =>
+      service?.createRoutine({
+        botId: bot.id,
+        name: "Atomic routine",
+        instruction: "Do not persist half of this change.",
+        active: true,
+        timezone: "UTC",
+        schedule: { kind: "daily", time: "09:00" },
+      }),
+    ).toThrow("conversation persistence failed");
+    expect(service.listRoutines(bot.id)).toEqual([]);
+    expect((await service.readConversation(bot.id)).messages).toEqual([]);
   });
 
   it("rejects invalid or cross-agent routine tool mutations", async () => {

--- a/src/backend/agent-service.test.ts
+++ b/src/backend/agent-service.test.ts
@@ -2764,6 +2764,42 @@ describe.sequential("AgentService", () => {
     });
   });
 
+  it("restores queued routine work when a delete marker cannot persist", async () => {
+    const { store, mailbox } = stores();
+    service = new AgentService(store, mailbox, fakeBrowser());
+    await service.initialize();
+    const bot = await store.getOrCreate("chief");
+    const routine = service.createRoutine({
+      botId: bot.id,
+      name: "Queued routine",
+      instruction: "Keep this queued when deletion fails.",
+      active: true,
+      timezone: "UTC",
+      schedule: { kind: "daily", time: "09:00" },
+    });
+    await service.testRoutine({ botId: bot.id, routineId: routine.id });
+    await service.testRoutine({ botId: bot.id, routineId: routine.id });
+    await waitFor(() => service?.listQueue(bot.id).deliveries.some((delivery) => delivery.status === "queued"));
+    const queuedDelivery = service.listQueue(bot.id).deliveries.find((delivery) => delivery.status === "queued");
+    if (!queuedDelivery) throw new Error("The queued routine delivery is missing.");
+    vi.spyOn(store.database, "persistConversation").mockImplementationOnce(() => {
+      throw new Error("delete marker persistence failed");
+    });
+
+    await expect(service.deleteRoutine({ botId: bot.id, routineId: routine.id })).rejects.toThrow(
+      "delete marker persistence failed",
+    );
+    expect(service.listRoutines(bot.id)).toEqual([expect.objectContaining({ id: routine.id })]);
+    expect(service.listQueue(bot.id).deliveries).toContainEqual(
+      expect.objectContaining({ id: queuedDelivery.id, status: "queued" }),
+    );
+    expect(
+      service
+        .listRoutineRuns({ botId: bot.id, routineId: routine.id, limit: 10 })
+        .filter((run) => run.status === "queued"),
+    ).toHaveLength(2);
+  });
+
   it("rejects invalid or cross-agent routine tool mutations", async () => {
     const clients = new Map<AgentProvider, FakeAgentClient>();
     const { store, mailbox } = stores();
@@ -3889,7 +3925,7 @@ function inputRecords(value: unknown): DynamicRecord[] {
 
 function stores(): { store: BotStore; mailbox: MailboxStore } {
   const store = new BotStore(join(root, "user-data"), join(root, "home"));
-  return { store, mailbox: new MailboxStore(join(root, "user-data"), store.sharedRoot) };
+  return { store, mailbox: new MailboxStore(join(root, "user-data"), store.sharedRoot, store.database) };
 }
 
 function fakeBrowser(tabs: BrowserTab[] = []) {

--- a/src/backend/agent-service.test.ts
+++ b/src/backend/agent-service.test.ts
@@ -2741,6 +2741,7 @@ describe.sequential("AgentService", () => {
     service = new AgentService(store, mailbox, fakeBrowser());
     await service.initialize();
     const bot = await store.getOrCreate("chief");
+    const initialBot = store.list().find((candidate) => candidate.id === bot.id);
     vi.spyOn(store.database, "persistConversation").mockImplementationOnce(() => {
       throw new Error("conversation persistence failed");
     });
@@ -2757,6 +2758,10 @@ describe.sequential("AgentService", () => {
     ).toThrow("conversation persistence failed");
     expect(service.listRoutines(bot.id)).toEqual([]);
     expect((await service.readConversation(bot.id)).messages).toEqual([]);
+    expect(store.list().find((candidate) => candidate.id === bot.id)).toMatchObject({
+      threadId: initialBot?.threadId ?? null,
+      updatedAt: initialBot?.updatedAt ?? null,
+    });
   });
 
   it("rejects invalid or cross-agent routine tool mutations", async () => {

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -598,13 +598,25 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     this.#requireKnownBot(input.botId);
     const routine = this.#routines.get(input.botId, input.routineId);
     if (!routine) throw new Error("This routine no longer exists.");
-    for (const run of this.#routines.activeRuns(input.botId, input.routineId)) {
-      if (run.status !== "queued" || !run.deliveryId) continue;
-      await this.#mailbox.cancel(input.botId, run.deliveryId).catch(() => undefined);
-      this.#routines.updateRunStatus(run.id, "cancelled");
-    }
+    const activeRuns = this.#routines.activeRuns(input.botId, input.routineId);
     if (options.recordConversationEvent === false) {
-      this.#routines.delete(input.botId, input.routineId);
+      const database = this.#store.database;
+      const ownsTransaction = !database.connection.isTransaction;
+      if (ownsTransaction) database.connection.exec("BEGIN IMMEDIATE");
+      try {
+        for (const run of activeRuns) {
+          if (run.status !== "queued" || !run.deliveryId) continue;
+          if (this.#mailbox.getDelivery(run.deliveryId)?.delivery.status !== "queued") continue;
+          this.#mailbox.cancelNow(input.botId, run.deliveryId);
+          this.#routines.updateRunStatus(run.id, "cancelled");
+        }
+        this.#routines.delete(input.botId, input.routineId);
+        if (ownsTransaction) database.connection.exec("COMMIT");
+      } catch (error) {
+        if (ownsTransaction && database.connection.isTransaction) database.connection.exec("ROLLBACK");
+        this.#mailbox.restorePersistedState();
+        throw error;
+      }
     } else {
       this.#mutateRoutineWithConversation(
         input.botId,
@@ -612,6 +624,17 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
         () => this.#routines.delete(input.botId, input.routineId),
         () => routine,
         options.turnId,
+        {
+          beforeMutate: () => {
+            for (const run of activeRuns) {
+              if (run.status !== "queued" || !run.deliveryId) continue;
+              if (this.#mailbox.getDelivery(run.deliveryId)?.delivery.status !== "queued") continue;
+              this.#mailbox.cancelNow(input.botId, run.deliveryId);
+              this.#routines.updateRunStatus(run.id, "cancelled");
+            }
+          },
+          onRollback: () => this.#mailbox.restorePersistedState(),
+        },
       );
     }
     this.#emitQueue(input.botId);
@@ -1024,10 +1047,11 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     memberId: string,
     anchor: ConversationPageAnchor = { type: "latest" },
     limit = 50,
+    options: { excludeRoutineEvents?: boolean } = {},
   ): Promise<ConversationPage> {
     const bot = await this.#store.getOrCreate(botId);
     this.#reconcilePersistedMailboxMessages(bot);
-    const page = this.#store.database.readConversationPage(botId, bot.threadId, anchor, limit);
+    const page = this.#store.database.readConversationPage(botId, bot.threadId, anchor, limit, options);
     return {
       ...page,
       readState: this.#conversationReads.readStateForThread(memberId, bot.threadId),
@@ -4308,6 +4332,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     mutate: () => T,
     eventRoutine: (result: T) => Pick<Routine, "id" | "name">,
     turnId?: string,
+    transactionHooks?: { beforeMutate?: () => void; onRollback?: () => void },
   ): T {
     const previousBot = this.#requireKnownBot(botId);
     const previousSnapshot = this.#snapshots.get(botId);
@@ -4321,6 +4346,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       const threadId = this.#store.ensureThreadIdNow(botId);
       const nextSnapshot = structuredClone(this.#ensureSnapshot(botId, threadId));
       nextSnapshot.threadId = threadId;
+      transactionHooks?.beforeMutate?.();
       result = mutate();
       const routine = eventRoutine(result);
       const createdAt = new Date().toISOString();
@@ -4345,6 +4371,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       if (ownsTransaction) database.connection.exec("COMMIT");
     } catch (error) {
       if (ownsTransaction && database.connection.isTransaction) database.connection.exec("ROLLBACK");
+      transactionHooks?.onRollback?.();
       if (previousBot.threadId === null) {
         this.#store.restoreThreadIdentity(botId, previousBot.threadId, previousBot.updatedAt);
       }

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -4309,15 +4309,18 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     eventRoutine: (result: T) => Pick<Routine, "id" | "name">,
     turnId?: string,
   ): T {
-    const threadId = this.#store.ensureThreadIdNow(botId);
-    const nextSnapshot = structuredClone(this.#ensureSnapshot(botId, threadId));
-    nextSnapshot.threadId = threadId;
+    const previousBot = this.#requireKnownBot(botId);
+    const previousSnapshot = this.#snapshots.get(botId);
+    const previousSnapshotState = previousSnapshot ? structuredClone(previousSnapshot) : undefined;
     const database = this.#store.database;
     const ownsTransaction = !database.connection.isTransaction;
     if (ownsTransaction) database.connection.exec("BEGIN IMMEDIATE");
     let result: T;
     let persisted: ConversationSnapshot;
     try {
+      const threadId = this.#store.ensureThreadIdNow(botId);
+      const nextSnapshot = structuredClone(this.#ensureSnapshot(botId, threadId));
+      nextSnapshot.threadId = threadId;
       result = mutate();
       const routine = eventRoutine(result);
       const createdAt = new Date().toISOString();
@@ -4342,6 +4345,11 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       if (ownsTransaction) database.connection.exec("COMMIT");
     } catch (error) {
       if (ownsTransaction && database.connection.isTransaction) database.connection.exec("ROLLBACK");
+      if (previousBot.threadId === null) {
+        this.#store.restoreThreadIdentity(botId, previousBot.threadId, previousBot.updatedAt);
+      }
+      if (previousSnapshotState) this.#snapshots.set(botId, previousSnapshotState);
+      else this.#snapshots.delete(botId);
       throw error;
     }
     this.#snapshots.set(botId, persisted);

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -51,6 +51,7 @@ import type {
   RespondToBrowserTakeoverInput,
   RespondToPromptInput,
   Routine,
+  RoutineConversationEventAction,
   RoutineRun,
   RoutineSchedule,
   SendMessageInput,
@@ -73,6 +74,7 @@ import {
   isMessageReaction,
   isReasoningEffort,
   isRoutineSchedule,
+  routineConversationEventItemType,
 } from "@openbot/contracts/ipc";
 import { type DynamicRecord, isBoolean, isNumber, isString } from "@openbot/contracts/runtime-values";
 import type { AgentClient, AgentProvider } from "./agent-client";
@@ -207,6 +209,11 @@ interface ImageGenerationOperation {
 interface OpenBotToolResponse {
   success: boolean;
   contentItems: Array<{ type: "inputText"; text: string }>;
+}
+
+export interface RoutineMutationOptions {
+  recordConversationEvent?: boolean;
+  turnId?: string;
 }
 
 const MCP_ELICITATION_DECISION_ID = "mcp-elicitation-decision";
@@ -553,23 +560,41 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     return this.#routines.list(botId);
   }
 
-  createRoutine(input: CreateRoutineInput): Routine {
+  createRoutine(input: CreateRoutineInput, options: RoutineMutationOptions = {}): Routine {
     this.#requireKnownBot(input.botId);
-    const routine = this.#routines.create(input);
+    const routine =
+      options.recordConversationEvent === false
+        ? this.#routines.create(input)
+        : this.#mutateRoutineWithConversation(
+            input.botId,
+            "created",
+            () => this.#routines.create(input),
+            (created) => created,
+            options.turnId,
+          );
     this.#routineStateChanged(input.botId);
     this.#armRoutineTimer();
     return routine;
   }
 
-  updateRoutine(input: UpdateRoutineInput): Routine {
+  updateRoutine(input: UpdateRoutineInput, options: RoutineMutationOptions = {}): Routine {
     this.#requireKnownBot(input.botId);
-    const routine = this.#routines.update(input);
+    const routine =
+      options.recordConversationEvent === false
+        ? this.#routines.update(input)
+        : this.#mutateRoutineWithConversation(
+            input.botId,
+            "updated",
+            () => this.#routines.update(input),
+            (updated) => updated,
+            options.turnId,
+          );
     this.#routineStateChanged(input.botId);
     this.#armRoutineTimer();
     return routine;
   }
 
-  async deleteRoutine(input: DeleteRoutineInput): Promise<void> {
+  async deleteRoutine(input: DeleteRoutineInput, options: RoutineMutationOptions = {}): Promise<void> {
     this.#requireKnownBot(input.botId);
     const routine = this.#routines.get(input.botId, input.routineId);
     if (!routine) throw new Error("This routine no longer exists.");
@@ -578,7 +603,17 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       await this.#mailbox.cancel(input.botId, run.deliveryId).catch(() => undefined);
       this.#routines.updateRunStatus(run.id, "cancelled");
     }
-    this.#routines.delete(input.botId, input.routineId);
+    if (options.recordConversationEvent === false) {
+      this.#routines.delete(input.botId, input.routineId);
+    } else {
+      this.#mutateRoutineWithConversation(
+        input.botId,
+        "deleted",
+        () => this.#routines.delete(input.botId, input.routineId),
+        () => routine,
+        options.turnId,
+      );
+    }
     this.#emitQueue(input.botId);
     this.#routineStateChanged(input.botId);
     this.#armRoutineTimer();
@@ -2269,19 +2304,22 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
         args.timezone === undefined
           ? localTimezone()
           : routineToolString(args.timezone, "timezone", 128, "A routine timezone is required.");
-      const routine = this.createRoutine({
-        botId,
-        name: routineToolString(args.name, "name", INPUT_LIMITS.routineName, "A routine name is required."),
-        instruction: routineToolString(
-          args.instruction,
-          "instruction",
-          INPUT_LIMITS.routineInstruction,
-          "A routine instruction is required.",
-        ),
-        active,
-        timezone,
-        schedule: routineToolSchedule(args.schedule),
-      });
+      const routine = this.createRoutine(
+        {
+          botId,
+          name: routineToolString(args.name, "name", INPUT_LIMITS.routineName, "A routine name is required."),
+          instruction: routineToolString(
+            args.instruction,
+            "instruction",
+            INPUT_LIMITS.routineInstruction,
+            "A routine instruction is required.",
+          ),
+          active,
+          timezone,
+          schedule: routineToolSchedule(args.schedule),
+        },
+        { turnId: botId === senderBotId ? params.turnId : undefined },
+      );
       return openBotToolResult(routine);
     }
 
@@ -2322,7 +2360,9 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
         hasUpdate = true;
       }
       if (!hasUpdate) throw new Error("At least one routine update is required.");
-      return openBotToolResult(this.updateRoutine(input));
+      return openBotToolResult(
+        this.updateRoutine(input, { turnId: input.botId === senderBotId ? params.turnId : undefined }),
+      );
     }
 
     if (params.tool === "delete_routine") {
@@ -2334,7 +2374,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
         INPUT_LIMITS.identifier,
         "routineId is required.",
       );
-      await this.deleteRoutine({ botId, routineId });
+      await this.deleteRoutine({ botId, routineId }, { turnId: botId === senderBotId ? params.turnId : undefined });
       return openBotToolResult({ deleted: true, botId, routineId });
     }
 
@@ -4262,6 +4302,53 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     this.#emit({ type: "routines-changed", botId });
   }
 
+  #mutateRoutineWithConversation<T>(
+    botId: string,
+    action: RoutineConversationEventAction,
+    mutate: () => T,
+    eventRoutine: (result: T) => Pick<Routine, "id" | "name">,
+    turnId?: string,
+  ): T {
+    const threadId = this.#store.ensureThreadIdNow(botId);
+    const nextSnapshot = structuredClone(this.#ensureSnapshot(botId, threadId));
+    nextSnapshot.threadId = threadId;
+    const database = this.#store.database;
+    const ownsTransaction = !database.connection.isTransaction;
+    if (ownsTransaction) database.connection.exec("BEGIN IMMEDIATE");
+    let result: T;
+    let persisted: ConversationSnapshot;
+    try {
+      result = mutate();
+      const routine = eventRoutine(result);
+      const createdAt = new Date().toISOString();
+      const message: ConversationMessage = {
+        id: randomUUID(),
+        ...(turnId ? { turnId } : {}),
+        author: "system",
+        source: "system",
+        text: routine.name,
+        createdAt,
+        status: "completed",
+        itemType: routineConversationEventItemType(action, routine.id),
+      };
+      nextSnapshot.messages.push(message);
+      sortConversationMessages(nextSnapshot.messages);
+      persisted = database.persistConversation(nextSnapshot, `routine.${action}`, {
+        action,
+        routineId: routine.id,
+        routineName: routine.name,
+        messageId: message.id,
+      });
+      if (ownsTransaction) database.connection.exec("COMMIT");
+    } catch (error) {
+      if (ownsTransaction && database.connection.isTransaction) database.connection.exec("ROLLBACK");
+      throw error;
+    }
+    this.#snapshots.set(botId, persisted);
+    this.#publishConversation(persisted);
+    return result;
+  }
+
   #requireReadyClient(provider: AgentProvider): AgentClient {
     const client = this.#clients.get(provider);
     if (!client || this.#status.phase !== "ready") {
@@ -4301,7 +4388,11 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       const persisted = this.#store.database.persistConversation(snapshot, eventType, detail);
       snapshot.revision = persisted.revision;
     }
-    this.#lastConversationSignatures.set(snapshot.botId, signature);
+    this.#publishConversation(snapshot);
+  }
+
+  #publishConversation(snapshot: ConversationSnapshot): void {
+    this.#lastConversationSignatures.set(snapshot.botId, conversationContentSignature(snapshot));
     this.#emit({ type: "conversation", snapshot: structuredClone(snapshot) });
   }
 

--- a/src/backend/bot-store.ts
+++ b/src/backend/bot-store.ts
@@ -288,6 +288,10 @@ export class BotStore {
   }
 
   async ensureThreadId(id: string): Promise<string> {
+    return this.ensureThreadIdNow(id);
+  }
+
+  ensureThreadIdNow(id: string): string {
     const bot = this.#requireBot(id);
     if (bot.threadId) return bot.threadId;
     bot.threadId = `openbot-thread-${randomUUID()}`;

--- a/src/backend/bot-store.ts
+++ b/src/backend/bot-store.ts
@@ -300,6 +300,12 @@ export class BotStore {
     return bot.threadId;
   }
 
+  restoreThreadIdentity(id: string, threadId: string | null, updatedAt: string | null): void {
+    const bot = this.#requireBot(id);
+    bot.threadId = threadId;
+    bot.updatedAt = updatedAt;
+  }
+
   activeProviderSession(id: string): ProviderSession | null {
     const bot = this.#requireBot(id);
     if (!bot.threadId) return null;

--- a/src/backend/conversation-read-store.ts
+++ b/src/backend/conversation-read-store.ts
@@ -1,4 +1,5 @@
 import type { BotSummary, ConversationReadState, ConversationSnapshot } from "@openbot/contracts/ipc";
+import { parseRoutineConversationEventItemType, ROUTINE_EVENT_ITEM_TYPE_PREFIX } from "@openbot/contracts/ipc";
 import { isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
 import type { OpenBotDatabase } from "./openbot-database";
 
@@ -144,7 +145,8 @@ export class ConversationReadStore {
     const parameters = boundary ? [threadId, boundary.created_at, boundary.ordinal, throughMessageId] : [threadId];
     const unreadFilter = `author != 'user'
       AND COALESCE(item_type, '') != 'commentary'
-      AND COALESCE(item_type, '') != 'agent_attachment'`;
+      AND COALESCE(item_type, '') != 'agent_attachment'
+      AND COALESCE(item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'`;
     const countRow = this.database.connection
       .prepare(
         `SELECT COUNT(*) AS unread_count FROM projection_thread_messages
@@ -240,7 +242,10 @@ function stateFromSnapshot(snapshot: ConversationSnapshot, throughMessageId: str
     .slice(throughIndex + 1)
     .filter(
       (message) =>
-        message.author !== "user" && message.itemType !== "commentary" && message.itemType !== "agent_attachment",
+        message.author !== "user" &&
+        message.itemType !== "commentary" &&
+        message.itemType !== "agent_attachment" &&
+        parseRoutineConversationEventItemType(message.itemType) === null,
     );
   return {
     unreadCount: unread.length,

--- a/src/backend/mailbox-store.ts
+++ b/src/backend/mailbox-store.ts
@@ -779,13 +779,28 @@ export class MailboxStore {
   }
 
   async cancel(botId: string, deliveryId: string): Promise<void> {
+    this.cancelNow(botId, deliveryId);
+  }
+
+  cancelNow(botId: string, deliveryId: string): void {
     const delivery = this.#state.deliveries.find(
       (candidate) => candidate.id === deliveryId && candidate.recipientBotId === botId,
     );
     if (!delivery) throw new Error("Queued message was not found.");
     if (delivery.status !== "queued") throw new Error("Only queued messages can be cancelled.");
     delivery.status = "cancelled";
-    await this.#persist("delivery.cancelled");
+    try {
+      this.#persist("delivery.cancelled");
+    } catch (error) {
+      delivery.status = "queued";
+      throw error;
+    }
+  }
+
+  restorePersistedState(): void {
+    const persisted = this.#database.readMailboxState();
+    if (!isStoredState(persisted)) throw new Error("Stored mailbox projection is invalid.");
+    this.#state = normalizeStoredState(persisted);
   }
 
   async updateQueuedMessage(
@@ -1305,12 +1320,12 @@ export class MailboxStore {
     }
   }
 
-  async #persist(
+  #persist(
     eventType = "mailbox.updated",
     commandId = `mailbox:${eventType}:${randomUUID()}`,
     fileDeletions: string[] = [],
     rebaseHistory = false,
-  ): Promise<void> {
+  ): void {
     this.#database.replaceMailboxState(commandId, this.#state, eventType, fileDeletions, rebaseHistory);
   }
 

--- a/src/backend/openbot-database.test.ts
+++ b/src/backend/openbot-database.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { BotSummary, ConversationSnapshot } from "@openbot/contracts/ipc";
+import { routineConversationEventItemType } from "@openbot/contracts/ipc";
 import { isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
 import { afterEach, describe, expect, it } from "vitest";
 import { OpenBotDatabase } from "./openbot-database";
@@ -289,6 +290,67 @@ describe("OpenBotDatabase", () => {
     const search = database.searchConversationMessages("pagination needle", bot.id, undefined, 100);
     expect(search.total).toBe(1);
     expect(search.results[0]?.message.id).toBe("message-00234");
+    database.close();
+  });
+
+  it("fills legacy pages after excluding routine event markers", async () => {
+    const database = await createDatabase();
+    const bot = testBot();
+    database.replaceAgents("agents-routine-history", [bot], "agents.imported");
+    const routineEvent = (id: string, createdAt: string) => ({
+      id,
+      author: "system" as const,
+      source: "system" as const,
+      text: "Morning brief",
+      createdAt,
+      status: "completed" as const,
+      itemType: routineConversationEventItemType("updated", "routine-1"),
+    });
+    database.persistConversation(
+      {
+        botId: bot.id,
+        threadId: bot.threadId,
+        activeTurnId: null,
+        revision: 0,
+        messages: [
+          {
+            id: "reply-old",
+            author: "assistant",
+            text: "Older reply",
+            createdAt: "2026-08-29T10:00:00.000Z",
+            status: "completed",
+          },
+          routineEvent("routine-event-1", "2026-08-29T10:01:00.000Z"),
+          {
+            id: "reply-new",
+            author: "assistant",
+            text: "Newer reply",
+            createdAt: "2026-08-29T10:02:00.000Z",
+            status: "completed",
+          },
+          routineEvent("routine-event-2", "2026-08-29T10:03:00.000Z"),
+          routineEvent("routine-event-3", "2026-08-29T10:04:00.000Z"),
+        ],
+      },
+      "conversation.routine-history",
+    );
+
+    const latest = database.readConversationPage(bot.id, bot.threadId, { type: "latest" }, 1, {
+      excludeRoutineEvents: true,
+    });
+    expect(latest.messages.map((message) => message.id)).toEqual(["reply-new"]);
+    expect(latest.pageInfo.hasOlder).toBe(true);
+    if (!latest.pageInfo.olderCursor) throw new Error("The older page cursor is missing.");
+
+    const older = database.readConversationPage(
+      bot.id,
+      bot.threadId,
+      { type: "before", cursor: latest.pageInfo.olderCursor },
+      1,
+      { excludeRoutineEvents: true },
+    );
+    expect(older.messages.map((message) => message.id)).toEqual(["reply-old"]);
+    expect(older.pageInfo.hasOlder).toBe(false);
     database.close();
   });
 

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -11,7 +11,12 @@ import type {
   ConversationSearchPage,
   ConversationSnapshot,
 } from "@openbot/contracts/ipc";
-import { isAgentProvider, isConversationMessage, providerForLegacyModel } from "@openbot/contracts/ipc";
+import {
+  isAgentProvider,
+  isConversationMessage,
+  providerForLegacyModel,
+  ROUTINE_EVENT_ITEM_TYPE_PREFIX,
+} from "@openbot/contracts/ipc";
 import { type DynamicRecord, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
 import { migrateOpenBotDatabase } from "./openbot-database-schema";
 
@@ -485,6 +490,7 @@ export class OpenBotDatabase {
            JOIN projection_threads thread ON thread.thread_id = message.thread_id
            WHERE LOWER(json_extract(message.message_json, '$.text')) LIKE ? ESCAPE '\\'
              AND COALESCE(json_extract(message.message_json, '$.delivery.status'), '') NOT IN ('queued', 'cancelled')
+             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'
              ${filter}`,
         )
         .get(...parameters),
@@ -498,6 +504,7 @@ export class OpenBotDatabase {
            JOIN projection_threads thread ON thread.thread_id = message.thread_id
            WHERE LOWER(json_extract(message.message_json, '$.text')) LIKE ? ESCAPE '\\'
              AND COALESCE(json_extract(message.message_json, '$.delivery.status'), '') NOT IN ('queued', 'cancelled')
+             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'
              ${filter}
            ORDER BY message.created_at DESC, message.ordinal DESC, message.message_id DESC
            LIMIT ? OFFSET ?`,

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -406,6 +406,7 @@ export class OpenBotDatabase {
     threadId: string | null,
     anchor: ConversationPageAnchor = { type: "latest" },
     requestedLimit = 50,
+    options: { excludeRoutineEvents?: boolean } = {},
   ): ConversationPage {
     if (!threadId) {
       return {
@@ -427,7 +428,7 @@ export class OpenBotDatabase {
         )
         .get(threadId, botId),
     );
-    const rows = this.#conversationPageRows(threadId, anchor, limit);
+    const rows = this.#conversationPageRows(threadId, anchor, limit, options.excludeRoutineEvents === true);
     const messages = rows.map((row) => decodeConversationMessageJson(requiredStringColumn(row, "message_json")));
     const messageIds = new Set(messages.map((message) => message.id));
     const referenceIdSet = new Set<string>();
@@ -443,7 +444,8 @@ export class OpenBotDatabase {
         this.connection
           .prepare(
             `SELECT message_id, message_json FROM projection_thread_messages
-             WHERE thread_id = ? AND message_id IN (${placeholders})`,
+             WHERE thread_id = ? AND message_id IN (${placeholders})
+             ${options.excludeRoutineEvents ? `AND COALESCE(item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'` : ""}`,
           )
           .all(threadId, ...referenceIds),
       );
@@ -454,7 +456,9 @@ export class OpenBotDatabase {
       }
     }
     const first = rows[0];
-    const hasOlder = first ? this.#hasConversationRowsBefore(threadId, conversationRowCursor(first)) : false;
+    const hasOlder = first
+      ? this.#hasConversationRowsBefore(threadId, conversationRowCursor(first), options.excludeRoutineEvents === true)
+      : false;
     return {
       botId,
       threadId,
@@ -523,14 +527,23 @@ export class OpenBotDatabase {
     };
   }
 
-  #conversationPageRows(threadId: string, anchor: ConversationPageAnchor, limit: number): DynamicRecord[] {
+  #conversationPageRows(
+    threadId: string,
+    anchor: ConversationPageAnchor,
+    limit: number,
+    excludeRoutineEvents: boolean,
+  ): DynamicRecord[] {
     const columns = "created_at, ordinal, message_id, message_json";
+    const routineFilter = excludeRoutineEvents
+      ? `AND COALESCE(item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'`
+      : "";
     if (anchor.type === "latest") {
       return databaseRows(
         this.connection
           .prepare(
             `SELECT ${columns} FROM projection_thread_messages
              WHERE thread_id = ?
+             ${routineFilter}
              ORDER BY created_at DESC, ordinal DESC, message_id DESC LIMIT ?`,
           )
           .all(threadId, limit),
@@ -547,6 +560,7 @@ export class OpenBotDatabase {
                (created_at = ? AND ordinal < ?) OR
                (created_at = ? AND ordinal = ? AND message_id < ?)
              )
+             ${routineFilter}
              ORDER BY created_at DESC, ordinal DESC, message_id DESC LIMIT ?`,
           )
           .all(
@@ -565,7 +579,8 @@ export class OpenBotDatabase {
       this.connection
         .prepare(
           `SELECT created_at, ordinal, message_id FROM projection_thread_messages
-           WHERE thread_id = ? AND message_id = ?`,
+           WHERE thread_id = ? AND message_id = ?
+           ${routineFilter}`,
         )
         .get(threadId, anchor.messageId),
     );
@@ -581,6 +596,7 @@ export class OpenBotDatabase {
              (created_at = ? AND ordinal < ?) OR
              (created_at = ? AND ordinal = ? AND message_id <= ?)
            )
+           ${routineFilter}
            ORDER BY created_at DESC, ordinal DESC, message_id DESC LIMIT ?`,
         )
         .all(
@@ -603,6 +619,7 @@ export class OpenBotDatabase {
              (created_at = ? AND ordinal > ?) OR
              (created_at = ? AND ordinal = ? AND message_id > ?)
            )
+           ${routineFilter}
            ORDER BY created_at, ordinal, message_id LIMIT ?`,
         )
         .all(
@@ -619,7 +636,10 @@ export class OpenBotDatabase {
     return [...older, ...newer];
   }
 
-  #hasConversationRowsBefore(threadId: string, cursor: ConversationPageCursor): boolean {
+  #hasConversationRowsBefore(threadId: string, cursor: ConversationPageCursor, excludeRoutineEvents: boolean): boolean {
+    const routineFilter = excludeRoutineEvents
+      ? `AND COALESCE(item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'`
+      : "";
     return Boolean(
       this.connection
         .prepare(
@@ -628,7 +648,9 @@ export class OpenBotDatabase {
              created_at < ? OR
              (created_at = ? AND ordinal < ?) OR
              (created_at = ? AND ordinal = ? AND message_id < ?)
-           ) LIMIT 1`,
+           )
+           ${routineFilter}
+           LIMIT 1`,
         )
         .get(
           threadId,

--- a/src/main/agent-marketplace-service.test.ts
+++ b/src/main/agent-marketplace-service.test.ts
@@ -147,6 +147,7 @@ describe("AgentMarketplaceService", () => {
         timezone: "America/New_York",
         schedule: expect.objectContaining({ kind: "interval", anchorAt: expect.not.stringContaining("2026-01-01") }),
       }),
+      { recordConversationEvent: false },
     );
   });
 
@@ -182,7 +183,10 @@ describe("AgentMarketplaceService", () => {
 
     expect(agents.createBotProfile).not.toHaveBeenCalled();
     expect(agents.updateBot).toHaveBeenCalledWith(expect.objectContaining({ botId: bot.id, name: detail.name }));
-    expect(agents.deleteRoutine).toHaveBeenCalledWith({ botId: bot.id, routineId: "routine-old-id" });
+    expect(agents.deleteRoutine).toHaveBeenCalledWith(
+      { botId: bot.id, routineId: "routine-old-id" },
+      { recordConversationEvent: false },
+    );
     expect(skills.uninstall).toHaveBeenCalledWith({ botId: bot.id, skillId: "retired-skill" });
     expect(agents.setMarketplaceSource).toHaveBeenCalledWith(
       bot.id,

--- a/src/main/agent-marketplace-service.ts
+++ b/src/main/agent-marketplace-service.ts
@@ -50,15 +50,21 @@ interface AgentMarketplaceAgents {
     avatarHue: MarketplaceAgentDetail["avatarHue"];
   }): Promise<BotSummary>;
   setAvatar(botId: string, image: AvatarImageInput | null): Promise<BotSummary>;
-  createRoutine(input: {
-    botId: string;
-    name: string;
-    instruction: string;
-    active: boolean;
-    timezone: string;
-    schedule: RoutineSchedule;
-  }): { id: string };
-  deleteRoutine(input: { botId: string; routineId: string }): Promise<void>;
+  createRoutine(
+    input: {
+      botId: string;
+      name: string;
+      instruction: string;
+      active: boolean;
+      timezone: string;
+      schedule: RoutineSchedule;
+    },
+    options?: { recordConversationEvent?: boolean },
+  ): { id: string };
+  deleteRoutine(
+    input: { botId: string; routineId: string },
+    options?: { recordConversationEvent?: boolean },
+  ): Promise<void>;
   setMarketplaceSource(botId: string, source: NonNullable<BotSummary["marketplaceSource"]>): BotSummary;
   deleteBot(botId: string): Promise<void>;
 }
@@ -183,14 +189,17 @@ export class AgentMarketplaceService {
         await this.skills.installVersion({ botId: bot.id, skillId: skill.skillId, versionId: skill.versionId });
       }
       for (const routine of detail.routines) {
-        const created = this.agents.createRoutine({
-          botId: bot.id,
-          name: routine.name,
-          instruction: routine.instruction,
-          active: routine.active,
-          timezone: input.timezone,
-          schedule: localSchedule(routine.schedule),
-        });
+        const created = this.agents.createRoutine(
+          {
+            botId: bot.id,
+            name: routine.name,
+            instruction: routine.instruction,
+            active: routine.active,
+            timezone: input.timezone,
+            schedule: localSchedule(routine.schedule),
+          },
+          { recordConversationEvent: false },
+        );
         createdRoutineIds.push(created.id);
       }
       if (existing) {
@@ -216,13 +225,17 @@ export class AgentMarketplaceService {
         routineIds: createdRoutineIds,
       });
       for (const routineId of existing?.marketplaceSource?.routineIds ?? []) {
-        await this.agents.deleteRoutine({ botId: bot.id, routineId }).catch(() => undefined);
+        await this.agents
+          .deleteRoutine({ botId: bot.id, routineId }, { recordConversationEvent: false })
+          .catch(() => undefined);
       }
     } catch (error) {
       if (existing) {
         await Promise.all(
           createdRoutineIds.map((routineId) =>
-            this.agents.deleteRoutine({ botId: bot.id, routineId }).catch(() => undefined),
+            this.agents
+              .deleteRoutine({ botId: bot.id, routineId }, { recordConversationEvent: false })
+              .catch(() => undefined),
           ),
         );
       } else {

--- a/src/main/remote-server-manager.test.ts
+++ b/src/main/remote-server-manager.test.ts
@@ -5,6 +5,7 @@ import { mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseInviteUrl } from "@openbot/contracts/invite-links";
+import { TEAM_CAPABILITIES_HEADER } from "@openbot/contracts/team-protocol/v1";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   decodeBrowserPreview,
@@ -997,6 +998,7 @@ describe("Team API compatibility negotiation", () => {
       const headers = new Headers(init?.headers);
       expect(headers.get("OpenBot-Protocol-Version")).toBe("1");
       expect(headers.get("OpenBot-App-Version")).toBe("0.4.0");
+      expect(headers.get(TEAM_CAPABILITIES_HEADER)).toContain("routine-event-markers");
       return Response.json({
         phase: "ready",
         cliVersion: "1.0.0",

--- a/src/main/remote-server-manager.ts
+++ b/src/main/remote-server-manager.ts
@@ -81,6 +81,7 @@ import {
   encodeTeamProtocolV1ClientEvent,
   highestCommonTeamProtocol,
   TEAM_APP_VERSION_HEADER,
+  TEAM_CAPABILITIES_HEADER,
   TEAM_PROTOCOL_V1,
   TEAM_PROTOCOL_V1_CAPABILITIES,
   TEAM_PROTOCOL_V1_WEBSOCKET,
@@ -853,10 +854,15 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     };
   }
 
-  #requestProtocol(compatibility: ServerCompatibility): { protocol?: number; appVersion?: string } {
+  #requestProtocol(compatibility: ServerCompatibility): {
+    protocol?: number;
+    appVersion?: string;
+    capabilities?: readonly TeamProtocolV1Capability[];
+  } {
     return {
       protocol: compatibility.negotiatedProtocol ?? undefined,
       appVersion: this.#appVersion ?? undefined,
+      capabilities: this.#appVersion ? TEAM_PROTOCOL_V1_CAPABILITIES : undefined,
     };
   }
 
@@ -866,7 +872,10 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
       const headers = new Headers(init.headers);
       headers.set("Authorization", `Bearer ${this.#token(server)}`);
       headers.set(TEAM_PROTOCOL_VERSION_HEADER, String(compatibility.negotiatedProtocol));
-      if (this.#appVersion) headers.set(TEAM_APP_VERSION_HEADER, this.#appVersion);
+      if (this.#appVersion) {
+        headers.set(TEAM_APP_VERSION_HEADER, this.#appVersion);
+        headers.set(TEAM_CAPABILITIES_HEADER, TEAM_PROTOCOL_V1_CAPABILITIES.join(","));
+      }
       const response = await remoteFetch(input, { ...init, headers });
       if (!response.ok) {
         const method = init.method ?? "GET";
@@ -1528,7 +1537,14 @@ async function requestJson<T>(
   apiUrl: string,
   path: string,
   decoder: ResponseDecoder<T>,
-  options: { method?: string; body?: unknown; token?: string; protocol?: number; appVersion?: string } = {},
+  options: {
+    method?: string;
+    body?: unknown;
+    token?: string;
+    protocol?: number;
+    appVersion?: string;
+    capabilities?: readonly TeamProtocolV1Capability[];
+  } = {},
 ): Promise<T> {
   const method = options.method ?? (options.body === undefined ? "GET" : "POST");
   const response = await remoteFetch(new URL(path, apiUrl), {
@@ -1539,6 +1555,7 @@ async function requestJson<T>(
       ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
       ...(options.protocol ? { [TEAM_PROTOCOL_VERSION_HEADER]: String(options.protocol) } : {}),
       ...(options.appVersion ? { [TEAM_APP_VERSION_HEADER]: options.appVersion } : {}),
+      ...(options.capabilities ? { [TEAM_CAPABILITIES_HEADER]: options.capabilities.join(",") } : {}),
     },
     body: options.body === undefined ? undefined : encodeTeamProtocolV1CurrentHttpRequest(method, path, options.body),
   });

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -14,9 +14,13 @@ import type {
   RoutineRun,
   TeamPresenceSnapshot,
 } from "@openbot/contracts/ipc";
-import { AGENT_RUNTIME_SNAPSHOT_BYTES_LIMIT } from "@openbot/contracts/ipc";
+import { AGENT_RUNTIME_SNAPSHOT_BYTES_LIMIT, routineConversationEventItemType } from "@openbot/contracts/ipc";
 import { isBoolean, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
-import { TEAM_APP_VERSION_HEADER, TEAM_PROTOCOL_VERSION_HEADER } from "@openbot/contracts/team-protocol/v1";
+import {
+  TEAM_APP_VERSION_HEADER,
+  TEAM_CAPABILITIES_HEADER,
+  TEAM_PROTOCOL_VERSION_HEADER,
+} from "@openbot/contracts/team-protocol/v1";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { OpenBotDatabase } from "../backend/openbot-database";
 import { SidebarLayoutStore } from "../backend/sidebar-layout-store";
@@ -420,6 +424,39 @@ describe("TeamApiServer administration", () => {
       agentEvents.emit("event", { type: "runtime-snapshot", snapshot: createAgents().getRuntimeSnapshot() });
       agentEvents.emit("event", { type: "bots-changed", bots: [] });
       await expect(supportedEvent).resolves.toMatchObject({ type: "bots-changed" });
+
+      const conversationEvent = nextJsonEvent(socket);
+      agentEvents.emit("event", {
+        type: "conversation",
+        snapshot: {
+          botId: "chief",
+          threadId: "thread-chief",
+          activeTurnId: null,
+          revision: 2,
+          messages: [
+            {
+              id: "reply-1",
+              author: "assistant",
+              text: "Done",
+              createdAt: "2026-08-29T10:00:00.000Z",
+              status: "completed",
+            },
+            {
+              id: "routine-event-1",
+              author: "system",
+              source: "system",
+              text: "Morning brief",
+              createdAt: "2026-08-29T10:01:00.000Z",
+              status: "completed",
+              itemType: routineConversationEventItemType("created", "routine-1"),
+            },
+          ],
+        },
+      });
+      await expect(conversationEvent).resolves.toMatchObject({
+        type: "conversation",
+        snapshot: { messages: [expect.objectContaining({ id: "reply-1" })] },
+      });
     } finally {
       socket.close();
       await api.stop();
@@ -1204,6 +1241,15 @@ describe("TeamApiServer administration", () => {
           createdAt: "2026-08-19T10:00:00.000Z",
           status: "completed",
         },
+        {
+          id: "routine-event-1",
+          author: "system",
+          source: "system",
+          text: "Morning brief",
+          createdAt: "2026-08-19T10:01:00.000Z",
+          status: "completed",
+          itemType: routineConversationEventItemType("created", "routine-1"),
+        },
       ],
     };
     const createBot = vi.fn(
@@ -1265,6 +1311,16 @@ describe("TeamApiServer administration", () => {
       expect(createBot).toHaveBeenCalledWith(createInput);
       await expect(jsonRequest(base, "/v1/agents", { token: login.sessionToken })).resolves.toEqual(localBots);
       await expect(jsonRequest(base, "/v1/agents/chief/conversation", { token: login.sessionToken })).resolves.toEqual({
+        ...localConversation,
+        messages: [localConversation.messages[0]],
+        readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: "message-1" },
+      });
+      await expect(
+        jsonRequest(base, "/v1/agents/chief/conversation", {
+          token: login.sessionToken,
+          capabilities: ["routine-event-markers"],
+        }),
+      ).resolves.toEqual({
         ...localConversation,
         readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: "message-1" },
       });
@@ -1579,13 +1635,14 @@ function nextJsonEvents(websocket: WebSocket, count: number): Promise<TestRealti
 async function jsonRequest<T>(
   base: string,
   path: string,
-  options: { method?: string; token?: string; body?: unknown } = {},
+  options: { method?: string; token?: string; body?: unknown; capabilities?: string[] } = {},
 ): Promise<T> {
   const response = await fetch(`${base}${path}`, {
     method: options.method ?? (options.body === undefined ? "GET" : "POST"),
     headers: {
       ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
       ...(options.body === undefined ? {} : { "Content-Type": "application/json" }),
+      ...(options.capabilities ? { [TEAM_CAPABILITIES_HEADER]: options.capabilities.join(",") } : {}),
     },
     body: options.body === undefined ? undefined : JSON.stringify(options.body),
   });

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -19,6 +19,7 @@ import { isBoolean, isDynamicRecord, isNumber, isString } from "@openbot/contrac
 import {
   TEAM_APP_VERSION_HEADER,
   TEAM_CAPABILITIES_HEADER,
+  TEAM_PROTOCOL_V1_CAPABILITIES,
   TEAM_PROTOCOL_VERSION_HEADER,
 } from "@openbot/contracts/team-protocol/v1";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -1318,7 +1319,7 @@ describe("TeamApiServer administration", () => {
       await expect(
         jsonRequest(base, "/v1/agents/chief/conversation", {
           token: login.sessionToken,
-          capabilities: ["routine-event-markers"],
+          capabilities: [...TEAM_PROTOCOL_V1_CAPABILITIES],
         }),
       ).resolves.toEqual({
         ...localConversation,

--- a/src/main/team-api-server.ts
+++ b/src/main/team-api-server.ts
@@ -8,7 +8,10 @@ import {
   AGENT_RUNTIME_SNAPSHOT_BYTES_LIMIT,
   type AgentEvent,
   type CentralAuthUser,
+  type ConversationPage,
   type ConversationPageAnchor,
+  type ConversationSnapshot,
+  type ConversationWithReadState,
   type CreateBotInput,
   type CreateTeamInviteInput,
   type DirectConversationPage,
@@ -24,6 +27,7 @@ import {
   isAvatarSeed,
   isMessageReaction,
   isReasoningEffort,
+  parseRoutineConversationEventItemType,
   type ReorderQueueInput,
   type RespondToApprovalInput,
   type RespondToBrowserTakeoverInput,
@@ -40,6 +44,7 @@ import {
   decodeTeamProtocolV1ClientEvent,
   isTeamProtocolV1Capability,
   TEAM_APP_VERSION_HEADER,
+  TEAM_CAPABILITIES_HEADER,
   TEAM_PROTOCOL_V1,
   TEAM_PROTOCOL_V1_CAPABILITIES,
   TEAM_PROTOCOL_V1_WEBSOCKET,
@@ -448,6 +453,7 @@ export class TeamApiServer {
       response.setHeader("X-Content-Type-Options", "nosniff");
       const url = new URL(request.url ?? "/", "http://127.0.0.1");
       const method = request.method ?? "GET";
+      const clientCapabilities = requestCapabilities(request);
       this.#responseRoutes.set(response, { method, path: url.pathname });
 
       if (method === "GET" && url.pathname === "/v1/compatibility") {
@@ -1040,13 +1046,26 @@ export class TeamApiServer {
           }
         }
         if (method === "GET" && action === "conversation") {
-          return this.#json(response, 200, await this.#options.agents.readConversationFor(botId, member.id));
-        }
-        if (method === "GET" && action === "conversation-page") {
+          const conversation = await this.#options.agents.readConversationFor(botId, member.id);
           return this.#json(
             response,
             200,
-            await this.#options.agents.readConversationPageFor(botId, member.id, pageAnchor(url), pageLimit(url)),
+            clientCapabilities.has("routine-event-markers")
+              ? conversation
+              : conversationWithoutRoutineEvents(conversation),
+          );
+        }
+        if (method === "GET" && action === "conversation-page") {
+          const page = await this.#options.agents.readConversationPageFor(
+            botId,
+            member.id,
+            pageAnchor(url),
+            pageLimit(url),
+          );
+          return this.#json(
+            response,
+            200,
+            clientCapabilities.has("routine-event-markers") ? page : conversationPageWithoutRoutineEvents(page),
           );
         }
         if (method === "POST" && action === "conversation/read") {
@@ -1195,6 +1214,7 @@ export class TeamApiServer {
 
   #broadcastAgentEvent(event: AgentEvent): void {
     let payload: string | undefined;
+    let routineEventFilteredPayload: string | undefined;
     let conversationInvalidation: string | undefined;
     let queueInvalidation: string | undefined;
     let completionSnapshot: string | undefined;
@@ -1221,6 +1241,14 @@ export class TeamApiServer {
           encodeTeamProtocolV1CurrentEvent({ type: "queue-invalidated", botId: event.snapshot.botId }) ?? undefined;
         if (!queueInvalidation) continue;
         outgoing = queueInvalidation;
+      } else if (event.type === "conversation" && !connection.capabilities.has("routine-event-markers")) {
+        routineEventFilteredPayload ??=
+          encodeTeamProtocolV1CurrentEvent({
+            ...event,
+            snapshot: conversationSnapshotWithoutRoutineEvents(event.snapshot),
+          }) ?? undefined;
+        if (!routineEventFilteredPayload) continue;
+        outgoing = routineEventFilteredPayload;
       } else {
         payload ??= encodeTeamProtocolV1CurrentEvent(event) ?? undefined;
         if (!payload) continue;
@@ -1258,7 +1286,9 @@ export class TeamApiServer {
         acceptsCapabilityDeclaration
           ? []
           : TEAM_PROTOCOL_V1_CAPABILITIES.filter(
-              (capability) => supportsSnapshotTransport || capability !== "agent-runtime-snapshots",
+              (capability) =>
+                capability !== "routine-event-markers" &&
+                (supportsSnapshotTransport || capability !== "agent-runtime-snapshots"),
             ),
       ),
       includeConversationEvents: !supportsSnapshotTransport,
@@ -1580,6 +1610,42 @@ function unavailableSidebarLayout(): TeamApiSidebarLayout {
     }),
     on: () => undefined,
     off: () => undefined,
+  };
+}
+
+function requestCapabilities(request: import("node:http").IncomingMessage): Set<string> {
+  const value = firstHeaderValue(request.headers[TEAM_CAPABILITIES_HEADER.toLowerCase()]);
+  if (!value || value.length > 4_096) return new Set();
+  const capabilities = value.split(",").map((capability) => capability.trim());
+  if (capabilities.length > 64) return new Set();
+  return new Set(capabilities.filter(isTeamProtocolV1Capability));
+}
+
+function conversationSnapshotWithoutRoutineEvents(snapshot: ConversationSnapshot): ConversationSnapshot {
+  return {
+    ...snapshot,
+    messages: snapshot.messages.filter((message) => parseRoutineConversationEventItemType(message.itemType) === null),
+  };
+}
+
+function conversationWithoutRoutineEvents(conversation: ConversationWithReadState): ConversationWithReadState {
+  return {
+    ...conversation,
+    messages: conversation.messages.filter(
+      (message) => parseRoutineConversationEventItemType(message.itemType) === null,
+    ),
+  };
+}
+
+function conversationPageWithoutRoutineEvents(page: ConversationPage): ConversationPage {
+  return {
+    ...page,
+    messages: page.messages.filter((message) => parseRoutineConversationEventItemType(message.itemType) === null),
+    references: Object.fromEntries(
+      Object.entries(page.references).filter(
+        ([, message]) => parseRoutineConversationEventItemType(message.itemType) === null,
+      ),
+    ),
   };
 }
 

--- a/src/main/team-api-server.ts
+++ b/src/main/team-api-server.ts
@@ -8,7 +8,6 @@ import {
   AGENT_RUNTIME_SNAPSHOT_BYTES_LIMIT,
   type AgentEvent,
   type CentralAuthUser,
-  type ConversationPage,
   type ConversationPageAnchor,
   type ConversationSnapshot,
   type ConversationWithReadState,
@@ -1061,12 +1060,9 @@ export class TeamApiServer {
             member.id,
             pageAnchor(url),
             pageLimit(url),
+            { excludeRoutineEvents: !clientCapabilities.has("routine-event-markers") },
           );
-          return this.#json(
-            response,
-            200,
-            clientCapabilities.has("routine-event-markers") ? page : conversationPageWithoutRoutineEvents(page),
-          );
+          return this.#json(response, 200, page);
         }
         if (method === "POST" && action === "conversation/read") {
           const body = await readJson(request);
@@ -1614,7 +1610,8 @@ function unavailableSidebarLayout(): TeamApiSidebarLayout {
 }
 
 function requestCapabilities(request: import("node:http").IncomingMessage): Set<string> {
-  const value = firstHeaderValue(request.headers[TEAM_CAPABILITIES_HEADER.toLowerCase()]);
+  const header = request.headers[TEAM_CAPABILITIES_HEADER.toLowerCase()];
+  const value = Array.isArray(header) ? header.join(",") : header;
   if (!value || value.length > 4_096) return new Set();
   const capabilities = value.split(",").map((capability) => capability.trim());
   if (capabilities.length > 64) return new Set();
@@ -1633,18 +1630,6 @@ function conversationWithoutRoutineEvents(conversation: ConversationWithReadStat
     ...conversation,
     messages: conversation.messages.filter(
       (message) => parseRoutineConversationEventItemType(message.itemType) === null,
-    ),
-  };
-}
-
-function conversationPageWithoutRoutineEvents(page: ConversationPage): ConversationPage {
-  return {
-    ...page,
-    messages: page.messages.filter((message) => parseRoutineConversationEventItemType(message.itemType) === null),
-    references: Object.fromEntries(
-      Object.entries(page.references).filter(
-        ([, message]) => parseRoutineConversationEventItemType(message.itemType) === null,
-      ),
     ),
   };
 }

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -19,6 +19,7 @@ import type {
   UpdateStatus,
   VoiceModelStatus,
 } from "@openbot/contracts/ipc";
+import { routineConversationEventItemType } from "@openbot/contracts/ipc";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { createSignal, Show } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -468,6 +469,7 @@ describe("OpenBot connected desktop shell", () => {
           listBots: vi.fn().mockResolvedValue(BOTS),
           listMemories: vi.fn().mockResolvedValue([]),
           listRoutines: vi.fn().mockResolvedValue([]),
+          listRoutineRuns: vi.fn().mockResolvedValue([]),
           createMemory: vi.fn().mockImplementation(async (input) => ({
             id: "memory-new",
             botId: input.botId,
@@ -862,6 +864,52 @@ describe("OpenBot connected desktop shell", () => {
     expect(window.openbot.agent.onEvent).toHaveBeenCalledTimes(agentSubscriptionCount);
     expect(window.openbot.auth.onEvent).toHaveBeenCalledTimes(authSubscriptionCount);
     expect(window.openbot.servers.onPresence).toHaveBeenCalledTimes(presenceSubscriptionCount);
+  });
+
+  it("opens routine settings from a persisted routine event marker", async () => {
+    const routine = {
+      id: "routine-1",
+      botId: "chief",
+      name: "Morning brief",
+      instruction: "Prepare the daily brief.",
+      active: true,
+      timezone: "UTC",
+      trigger: {
+        id: "trigger-1",
+        routineId: "routine-1",
+        schedule: { kind: "daily", time: "09:00" } as const,
+        nextRunAt: "2026-09-01T09:00:00.000Z",
+        createdAt: "2026-08-31T09:00:00.000Z",
+        updatedAt: "2026-08-31T09:00:00.000Z",
+      },
+      createdAt: "2026-08-31T09:00:00.000Z",
+      updatedAt: "2026-08-31T09:00:00.000Z",
+    };
+    vi.mocked(window.openbot.agent.listRoutines).mockResolvedValue([routine]);
+    vi.mocked(window.openbot.agent.readConversation).mockResolvedValue(
+      testConversationPage("chief", [
+        {
+          id: "routine-event-1",
+          author: "system",
+          source: "system",
+          text: routine.name,
+          createdAt: "2026-08-31T10:00:00.000Z",
+          status: "completed",
+          itemType: routineConversationEventItemType("created", routine.id),
+        },
+      ]),
+    );
+
+    render(() => <App />);
+
+    const marker = await screen.findByRole("button", { name: "Open routine Morning brief" });
+    await fireEvent.click(marker);
+    expect(await screen.findByRole("textbox", { name: "Name" })).toHaveValue("Morning brief");
+    expect(window.openbot.agent.listRoutineRuns).toHaveBeenCalledWith({
+      botId: "chief",
+      routineId: routine.id,
+      limit: 10,
+    });
   });
 
   it("restores the active server before loading its workspace data", async () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,6 +39,7 @@ import type {
   UpdateStatus,
   UpdateTeamMemberInput,
 } from "@openbot/contracts/ipc";
+import { parseRoutineConversationEventItemType } from "@openbot/contracts/ipc";
 import type { TeamProtocolV1Capability } from "@openbot/contracts/team-protocol/v1";
 import {
   createContext,
@@ -161,6 +162,10 @@ function serverSupportsCapability(server: ServerSummary | undefined, capability:
 type PromptEvent = Extract<AgentEvent, { type: "prompt" }>;
 type BrowserTakeoverEvent = Extract<AgentEvent, { type: "browser-takeover-requested" }>;
 
+function isRoutineEventItem(message: { itemType?: string }): boolean {
+  return parseRoutineConversationEventItemType(message.itemType) !== null;
+}
+
 function preserveKnownAgentUnread(
   state: ConversationReadState,
   boundary: string | null,
@@ -176,6 +181,7 @@ function preserveKnownAgentUnread(
         message.author !== "you" &&
         message.itemType !== "commentary" &&
         message.itemType !== "agent_attachment" &&
+        !isRoutineEventItem(message) &&
         !message.id.startsWith("thinking:") &&
         !message.id.startsWith("ui-"),
     );
@@ -999,7 +1005,8 @@ export function createAppController(props: AppProps = {}) {
                 (message) =>
                   message.author !== "user" &&
                   message.itemType !== "commentary" &&
-                  message.itemType !== "agent_attachment",
+                  message.itemType !== "agent_attachment" &&
+                  !isRoutineEventItem(message),
               );
             if (latestIncomingMessage) autoMarkAgentMessageRead(botId, latestIncomingMessage.id);
           }
@@ -1071,7 +1078,8 @@ export function createAppController(props: AppProps = {}) {
                   (message) =>
                     message.author !== "user" &&
                     message.itemType !== "commentary" &&
-                    message.itemType !== "agent_attachment",
+                    message.itemType !== "agent_attachment" &&
+                    !isRoutineEventItem(message),
                 )
             : undefined;
           if (pageApplied && latestIncomingMessage) {
@@ -1344,6 +1352,7 @@ export function createAppController(props: AppProps = {}) {
             message.author !== "you" &&
             message.itemType !== "commentary" &&
             message.itemType !== "agent_attachment" &&
+            !isRoutineEventItem(message) &&
             !message.id.startsWith("thinking:") &&
             !message.id.startsWith("ui-"),
         )
@@ -1564,7 +1573,10 @@ export function createAppController(props: AppProps = {}) {
           .reverse()
           .find(
             (message) =>
-              message.author !== "user" && message.itemType !== "commentary" && message.itemType !== "agent_attachment",
+              message.author !== "user" &&
+              message.itemType !== "commentary" &&
+              message.itemType !== "agent_attachment" &&
+              !isRoutineEventItem(message),
           )
       : undefined;
     if (latestIncomingMessage) {
@@ -1628,7 +1640,10 @@ export function createAppController(props: AppProps = {}) {
         .reverse()
         .find(
           (message) =>
-            message.author !== "user" && message.itemType !== "commentary" && message.itemType !== "agent_attachment",
+            message.author !== "user" &&
+            message.itemType !== "commentary" &&
+            message.itemType !== "agent_attachment" &&
+            !isRoutineEventItem(message),
         );
       let retainedState: ConversationReadState | null = null;
       if (trackedAutoRead && trackedAutoRead.messageId === latestIncomingMessage?.id) {

--- a/src/renderer/src/app-message-projection.test.ts
+++ b/src/renderer/src/app-message-projection.test.ts
@@ -1,4 +1,5 @@
 import type { BotSummary, ConversationMessage } from "@openbot/contracts/ipc";
+import { routineConversationEventItemType } from "@openbot/contracts/ipc";
 import { describe, expect, it } from "vitest";
 import { botProfilesEqual, readStateForMessages, toBotMessage, toBotProfile } from "./app-message-projection";
 
@@ -66,6 +67,24 @@ describe("readStateForMessages", () => {
       readStateForMessages({ unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null }, messages),
     ).toMatchObject({ unreadCount: 1, firstUnreadMessageId: "answer" });
   });
+
+  it("does not count routine event markers as unread replies", () => {
+    const messages: ConversationMessage[] = [
+      {
+        id: "routine-event",
+        author: "system",
+        source: "system",
+        text: "Morning brief",
+        createdAt: "2026-08-30T11:00:00.000Z",
+        status: "completed",
+        itemType: routineConversationEventItemType("created", "routine-1"),
+      },
+    ];
+
+    expect(
+      readStateForMessages({ unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null }, messages),
+    ).toMatchObject({ unreadCount: 0, firstUnreadMessageId: null });
+  });
 });
 
 describe("toBotMessage", () => {
@@ -82,6 +101,23 @@ describe("toBotMessage", () => {
     expect(
       toBotMessage({ ...message, text: "Storms are likely. \u{e200}cite\u{e202}turn0fore", status: "streaming" }).body,
     ).toBe("Storms are likely. ");
+  });
+
+  it("projects routine event metadata for the conversation timeline", () => {
+    const message = {
+      id: "routine-event",
+      author: "system",
+      source: "system",
+      text: "Morning brief",
+      createdAt: "2026-08-31T10:00:00.000Z",
+      status: "completed",
+      itemType: routineConversationEventItemType("created", "routine-1"),
+    } satisfies ConversationMessage;
+
+    expect(toBotMessage(message)).toMatchObject({
+      kind: "routine-event",
+      routineEvent: { action: "created", routineId: "routine-1", routineName: "Morning brief" },
+    });
   });
 });
 

--- a/src/renderer/src/app-message-projection.ts
+++ b/src/renderer/src/app-message-projection.ts
@@ -1,4 +1,5 @@
 import type { BotSummary, ConversationMessage, ConversationReadState } from "@openbot/contracts/ipc";
+import { parseRoutineConversationEventItemType, routineConversationEvent } from "@openbot/contracts/ipc";
 import { cleanAgentMessageText } from "./agent-message-text";
 import type { BotMessage, BotProfile } from "./data";
 
@@ -25,6 +26,7 @@ export function toBotProfile(stored: BotSummary): BotProfile {
 
 export function toBotMessage(message: ConversationMessage): BotMessage {
   const exchangeSenderId = message.senderBotId ?? message.exchange?.senderBotId;
+  const routineEvent = routineConversationEvent(message);
   return {
     id: message.id,
     turnId: message.turnId,
@@ -34,7 +36,7 @@ export function toBotMessage(message: ConversationMessage): BotMessage {
     createdAt: message.createdAt,
     streaming: message.status === "streaming",
     itemType: message.itemType,
-    kind: message.questionPrompt ? "question" : message.exchange ? "exchange" : "text",
+    kind: message.questionPrompt ? "question" : message.exchange ? "exchange" : routineEvent ? "routine-event" : "text",
     senderBotId: exchangeSenderId,
     replyToMessageId: message.replyToMessageId,
     attachments: message.attachments,
@@ -45,6 +47,7 @@ export function toBotMessage(message: ConversationMessage): BotMessage {
     reactions:
       message.reactions ?? (message.reaction ? [{ emoji: message.reaction, actor: { kind: "user" as const } }] : []),
     routine: message.routine,
+    routineEvent: routineEvent ?? undefined,
     status: message.exchange
       ? undefined
       : message.delivery?.status === "queued"
@@ -108,7 +111,10 @@ export function readStateForMessages(
     .slice(throughIndex + 1)
     .filter(
       (message) =>
-        message.author !== "user" && message.itemType !== "commentary" && message.itemType !== "agent_attachment",
+        message.author !== "user" &&
+        message.itemType !== "commentary" &&
+        message.itemType !== "agent_attachment" &&
+        parseRoutineConversationEventItemType(message.itemType) === null,
     );
   return {
     ...state,
@@ -176,6 +182,7 @@ export function botMessagesEqual(left: BotMessage, right: BotMessage): boolean {
     JSON.stringify(left.questionPrompt) === JSON.stringify(right.questionPrompt) &&
     JSON.stringify(left.exchange) === JSON.stringify(right.exchange) &&
     JSON.stringify(left.routine) === JSON.stringify(right.routine) &&
+    JSON.stringify(left.routineEvent) === JSON.stringify(right.routineEvent) &&
     JSON.stringify(left.items) === JSON.stringify(right.items)
   );
 }

--- a/src/renderer/src/components/AccountDock.tsx
+++ b/src/renderer/src/components/AccountDock.tsx
@@ -507,7 +507,7 @@ export function AccountDock(props: AccountDockProps) {
             </Popover.Root>
           </Tooltip.Trigger>
           <Tooltip.Portal>
-            <Tooltip.Content class="account-dock-tooltip">Weekly usage</Tooltip.Content>
+            <Tooltip.Content class="ui-tooltip">Weekly usage</Tooltip.Content>
           </Tooltip.Portal>
         </Tooltip.Root>
 
@@ -529,7 +529,7 @@ export function AccountDock(props: AccountDockProps) {
             </Button>
           </Tooltip.Trigger>
           <Tooltip.Portal>
-            <Tooltip.Content class="account-dock-tooltip">Settings</Tooltip.Content>
+            <Tooltip.Content class="ui-tooltip">Settings</Tooltip.Content>
           </Tooltip.Portal>
         </Tooltip.Root>
       </div>

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -76,6 +76,7 @@ import { calculateChatScrollMargin, createChatVirtualizer } from "./conversation
 import { messageContentBlocks } from "./conversation/DataTable";
 import { ScrollToLatestButton, scrollToLatestMessage } from "./conversation/MessageNavigation";
 import { ExchangeSystemRow, MessageActions, MessageBody } from "./conversation/MessageRendering";
+import { RoutineEventMarker } from "./conversation/RoutineEventMarker";
 import { MessageSelectionActions } from "./conversation/SelectionActions";
 import {
   scrollToUnreadBoundary,
@@ -2854,6 +2855,43 @@ export function ConversationTimeline() {
                 const message = createMemo(() => props.messages[virtualRow.index]);
                 const initialMessage = untrack(message);
                 if (!initialMessage) return null;
+                const routineEvent = initialMessage.routineEvent;
+                if (initialMessage.kind === "routine-event" && routineEvent) {
+                  return (
+                    <div
+                      data-index={virtualRow.index}
+                      ref={messageVirtualizer.measureElement}
+                      class="virtual-chat-row"
+                      style={{
+                        transform: messageVirtualizer.isVirtualized()
+                          ? `translateY(${virtualRow.start - messageVirtualizer.scrollMargin()}px)`
+                          : "none",
+                      }}
+                    >
+                      <article aria-label={`${routineEvent.routineName}, ${routineEvent.action}`}>
+                        <Show
+                          when={routineEvent.action === "deleted"}
+                          fallback={
+                            <RoutineEventMarker
+                              action={routineEvent.action === "created" ? "created" : "updated"}
+                              routineId={routineEvent.routineId}
+                              routineName={routineEvent.routineName}
+                              onOpenRoutine={(routineId) =>
+                                openRoutineSettings({ routineId, name: routineEvent.routineName })
+                              }
+                            />
+                          }
+                        >
+                          <RoutineEventMarker
+                            action="deleted"
+                            routineId={routineEvent.routineId}
+                            routineName={routineEvent.routineName}
+                          />
+                        </Show>
+                      </article>
+                    </div>
+                  );
+                }
                 const displayedReactions = createMemo(() => {
                   const currentMessage = message();
                   if (currentMessage?.reactions?.length) return currentMessage.reactions;

--- a/src/renderer/src/components/conversation/RoutineEventMarker.tsx
+++ b/src/renderer/src/components/conversation/RoutineEventMarker.tsx
@@ -1,0 +1,80 @@
+import { Show } from "solid-js";
+import { Button, Clock3, Marker, MarkerContent, MarkerIcon, Tooltip } from "../ui";
+
+export type RoutineEventAction = "created" | "updated" | "deleted";
+
+interface RoutineEventBaseProps {
+  routineId: string;
+  routineName: string;
+}
+
+interface ActiveRoutineEventMarkerProps extends RoutineEventBaseProps {
+  action: Exclude<RoutineEventAction, "deleted">;
+  onOpenRoutine: (routineId: string) => void;
+}
+
+interface DeletedRoutineEventMarkerProps extends RoutineEventBaseProps {
+  action: "deleted";
+  onOpenRoutine?: never;
+}
+
+export type RoutineEventMarkerProps = ActiveRoutineEventMarkerProps | DeletedRoutineEventMarkerProps;
+
+const ROUTINE_EVENT_LABELS: Record<RoutineEventAction, string> = {
+  created: "Created routine",
+  updated: "Updated routine",
+  deleted: "Deleted routine",
+};
+
+export function RoutineEventMarker(props: RoutineEventMarkerProps) {
+  const actionLabel = () => ROUTINE_EVENT_LABELS[props.action];
+
+  return (
+    <Marker class="routine-event-marker">
+      <MarkerContent class="routine-event-content">
+        <span class="routine-event-label">{actionLabel()}</span>
+        <Show
+          when={props.action === "deleted"}
+          fallback={
+            <Button
+              type="button"
+              variant="ghost"
+              class="routine-event-pill routine-event-pill-interactive"
+              aria-label={`Open routine ${props.routineName}`}
+              onClick={() => {
+                if (props.action !== "deleted") props.onOpenRoutine(props.routineId);
+              }}
+            >
+              <RoutineEventPillContent routineName={props.routineName} />
+            </Button>
+          }
+        >
+          <Tooltip.Root openDelay={100} closeDelay={75} placement="top" gutter={6}>
+            <Tooltip.Trigger
+              as="span"
+              class="routine-event-pill routine-event-pill-deleted"
+              aria-label={`${props.routineName}, deleted`}
+              tabindex={0}
+            >
+              <RoutineEventPillContent routineName={props.routineName} />
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content class="ui-tooltip routine-event-tooltip">Deleted</Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Show>
+      </MarkerContent>
+    </Marker>
+  );
+}
+
+function RoutineEventPillContent(props: { routineName: string }) {
+  return (
+    <>
+      <MarkerIcon>
+        <Clock3 aria-hidden="true" />
+      </MarkerIcon>
+      <span class="routine-event-pill-name">{props.routineName}</span>
+    </>
+  );
+}

--- a/src/renderer/src/components/ui/index.ts
+++ b/src/renderer/src/components/ui/index.ts
@@ -10,6 +10,7 @@ export * from "./form";
 export * from "./icons";
 export * from "./image-remove-button";
 export * from "./item";
+export * from "./marker";
 export * from "./message";
 export * from "./progress";
 export * from "./questionnaire";

--- a/src/renderer/src/components/ui/marker.tsx
+++ b/src/renderer/src/components/ui/marker.tsx
@@ -1,0 +1,28 @@
+import { Dynamic, type JSX } from "@solidjs/web";
+import { omit } from "solid-js";
+import { cx } from "./utils";
+
+type MarkerElement = "div" | "li" | "section";
+
+export interface MarkerProps extends JSX.HTMLAttributes<HTMLElement> {
+  as?: MarkerElement;
+}
+
+export function Marker(props: MarkerProps): JSX.Element {
+  const others = omit(props, "as", "class");
+  return <Dynamic component={props.as ?? "div"} data-slot="marker" class={cx("ui-marker", props.class)} {...others} />;
+}
+
+export interface MarkerIconProps extends JSX.HTMLAttributes<HTMLSpanElement> {}
+
+export function MarkerIcon(props: MarkerIconProps): JSX.Element {
+  const others = omit(props, "class");
+  return <span data-slot="marker-icon" class={cx("ui-marker-icon", props.class)} {...others} />;
+}
+
+export interface MarkerContentProps extends JSX.HTMLAttributes<HTMLSpanElement> {}
+
+export function MarkerContent(props: MarkerContentProps): JSX.Element {
+  const others = omit(props, "class");
+  return <span data-slot="marker-content" class={cx("ui-marker-content", props.class)} {...others} />;
+}

--- a/src/renderer/src/data.ts
+++ b/src/renderer/src/data.ts
@@ -10,9 +10,10 @@ import type {
   ConversationReaction,
   ImageGenerationInfo,
   MessageReaction,
+  RoutineConversationEvent,
 } from "@openbot/contracts/ipc";
 
-export type MessageKind = "text" | "thinking" | "exchange" | "question";
+export type MessageKind = "text" | "thinking" | "exchange" | "question" | "routine-event";
 
 export interface MessageCitation {
   number: number;
@@ -54,6 +55,7 @@ export interface BotMessage {
     name: string;
     scheduledFor: string;
   };
+  routineEvent?: RoutineConversationEvent;
   items?: string[];
 }
 

--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -3385,46 +3385,6 @@ textarea {
   line-height: 14px;
 }
 
-.account-dock-tooltip {
-  position: relative;
-  z-index: 80;
-  border: 0;
-  border-radius: var(--openbot-radius-sm);
-  background: var(--openbot-bg-canvas);
-  box-shadow:
-    0 0 0 1px var(--openbot-border-strong),
-    var(--openbot-shadow-raised);
-  padding: var(--openbot-space-1-5) var(--openbot-space-2);
-  color: var(--openbot-text-primary);
-  font-size: var(--openbot-text-sm);
-  font-weight: var(--openbot-weight-semibold);
-  line-height: var(--openbot-leading-sm);
-  opacity: 1;
-  pointer-events: none;
-  transform: translateY(0) scale(1);
-  transform-origin: bottom center;
-  transition:
-    opacity var(--openbot-duration-fast) ease,
-    transform var(--openbot-duration-fast) var(--openbot-ease-out);
-
-  @starting-style {
-    opacity: 0;
-    transform: translateY(2px) scale(0.96);
-  }
-}
-
-.account-dock-tooltip::after {
-  position: absolute;
-  bottom: -4px;
-  left: 50%;
-  width: 8px;
-  height: 8px;
-  background: var(--openbot-bg-canvas);
-  box-shadow: 1px 1px 0 var(--openbot-border-strong);
-  content: "";
-  transform: translateX(-50%) rotate(45deg);
-}
-
 .account-usage-popover {
   position: relative;
   z-index: 80;

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -3689,6 +3689,121 @@
   animation: image-generation-shine 2.25s cubic-bezier(0.25, 0.1, 0.25, 1) infinite;
 }
 
+.routine-event-marker {
+  width: min(88%, 640px);
+  min-height: 40px;
+  justify-content: center;
+  margin: 0 auto;
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-sm);
+  line-height: var(--openbot-leading-sm);
+  text-align: center;
+}
+
+.routine-event-content {
+  max-width: 100%;
+  gap: var(--openbot-space-1);
+}
+
+.routine-event-label {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.routine-event-pill {
+  position: relative;
+  box-sizing: border-box;
+  display: inline-flex;
+  min-width: 0;
+  max-width: min(320px, 100%);
+  height: 24px;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: var(--openbot-space-1);
+  border: 0;
+  border-radius: var(--openbot-radius-pill);
+  background: transparent;
+  box-shadow: none;
+  padding: 0 var(--openbot-space-2) 0 var(--openbot-space-1-5);
+  color: var(--openbot-text-secondary);
+  font: inherit;
+  line-height: inherit;
+  outline: none;
+  white-space: nowrap;
+  transition:
+    background-color var(--openbot-duration-normal) var(--openbot-ease-out),
+    box-shadow var(--openbot-duration-normal) var(--openbot-ease-out),
+    color var(--openbot-duration-normal) var(--openbot-ease-out),
+    scale var(--openbot-duration-fast) var(--openbot-ease-out);
+}
+
+.routine-event-pill .ui-marker-icon,
+.routine-event-pill .ui-marker-icon svg {
+  width: var(--openbot-icon-xs);
+  height: var(--openbot-icon-xs);
+}
+
+.routine-event-pill-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transform: translateY(-0.5px);
+  white-space: nowrap;
+}
+
+.routine-event-pill-interactive {
+  cursor: pointer;
+}
+
+.routine-event-pill-interactive::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  min-width: 100%;
+  height: 40px;
+  content: "";
+  translate: -50% -50%;
+}
+
+.routine-event-pill-interactive:hover {
+  background: var(--openbot-bg-control-hover);
+  box-shadow: 0 0 0 1px var(--openbot-border-strong);
+  color: var(--openbot-text-primary);
+}
+
+.routine-event-pill-interactive:focus-visible {
+  background: var(--openbot-bg-control-hover);
+  box-shadow: var(--openbot-focus-ring);
+  color: var(--openbot-text-primary);
+}
+
+.routine-event-pill-interactive:active {
+  background: var(--openbot-bg-control-active);
+  scale: 0.96;
+}
+
+.routine-event-pill-deleted {
+  cursor: default;
+}
+
+.routine-event-pill-deleted:hover,
+.routine-event-pill-deleted:focus-visible {
+  background: var(--openbot-danger-soft);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--openbot-danger) 42%, transparent);
+  color: var(--openbot-danger);
+}
+
+.routine-event-pill-deleted:focus-visible {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--openbot-danger) 55%, transparent),
+    0 0 0 3px var(--openbot-danger-soft);
+}
+
+.routine-event-tooltip::after {
+  content: none;
+}
+
 .exchange-system-row {
   position: relative;
   display: flex;

--- a/src/renderer/src/styles/primitives.css
+++ b/src/renderer/src/styles/primitives.css
@@ -1589,10 +1589,51 @@
   line-height: 1;
 }
 
+.ui-tooltip {
+  position: relative;
+  z-index: 80;
+  border: 0;
+  border-radius: var(--openbot-radius-sm);
+  background: var(--openbot-bg-canvas);
+  box-shadow:
+    0 0 0 1px var(--openbot-border-strong),
+    var(--openbot-shadow-raised);
+  padding: var(--openbot-space-1-5) var(--openbot-space-2);
+  color: var(--openbot-text-primary);
+  font-size: var(--openbot-text-sm);
+  font-weight: var(--openbot-weight-semibold);
+  line-height: var(--openbot-leading-sm);
+  opacity: 1;
+  pointer-events: none;
+  transform: translateY(0) scale(1);
+  transform-origin: bottom center;
+  transition:
+    opacity var(--openbot-duration-fast) ease,
+    transform var(--openbot-duration-fast) var(--openbot-ease-out);
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(2px) scale(0.96);
+  }
+}
+
+.ui-tooltip::after {
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  background: var(--openbot-bg-canvas);
+  box-shadow: 1px 1px 0 var(--openbot-border-strong);
+  content: "";
+  transform: translateX(-50%) rotate(45deg);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .ui-button,
   .ui-switch,
-  .ui-switch-thumb {
+  .ui-switch-thumb,
+  .ui-tooltip {
     transition-property: background-color, border-color, color, opacity;
   }
 
@@ -1790,6 +1831,26 @@ button.ui-bubble-content {
 .ui-bubble-reaction-overflow {
   color: var(--openbot-text-primary);
   font: inherit;
+}
+
+.ui-marker {
+  position: relative;
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+}
+
+.ui-marker-content {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+}
+
+.ui-marker-icon {
+  display: inline-grid;
+  flex: 0 0 auto;
+  place-items: center;
 }
 
 .ui-message-group {

--- a/src/renderer/stories/RoutineEventMarker.stories.tsx
+++ b/src/renderer/stories/RoutineEventMarker.stories.tsx
@@ -1,0 +1,192 @@
+import { Match, Switch } from "solid-js";
+import { expect, fn, waitFor, within } from "storybook/test";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { type RoutineEventAction, RoutineEventMarker } from "../src/components/conversation/RoutineEventMarker";
+import { Bubble, BubbleContent, Heading, Message, MessageContent, MessageFooter, Text } from "../src/components/ui";
+
+interface RoutineEventStoryArgs {
+  action: RoutineEventAction;
+  routineId: string;
+  routineName: string;
+  onOpenRoutine: (routineId: string) => void;
+}
+
+const onPlaygroundOpenRoutine = fn();
+const onCreatedRoutine = fn();
+const onUpdatedRoutine = fn();
+const onContextOpenRoutine = fn();
+
+function StoryRoutineEventMarker(props: RoutineEventStoryArgs) {
+  return (
+    <Switch
+      fallback={
+        <RoutineEventMarker
+          action="created"
+          routineId={props.routineId}
+          routineName={props.routineName}
+          onOpenRoutine={props.onOpenRoutine}
+        />
+      }
+    >
+      <Match when={props.action === "updated"}>
+        <RoutineEventMarker
+          action="updated"
+          routineId={props.routineId}
+          routineName={props.routineName}
+          onOpenRoutine={props.onOpenRoutine}
+        />
+      </Match>
+      <Match when={props.action === "deleted"}>
+        <RoutineEventMarker action="deleted" routineId={props.routineId} routineName={props.routineName} />
+      </Match>
+    </Switch>
+  );
+}
+
+function StoryMessage(props: { author: "assistant" | "user"; children: string; time: string }) {
+  const own = () => props.author === "user";
+  return (
+    <Message align={own() ? "end" : "start"} class="chat-prototype-message message-entry">
+      <MessageContent>
+        <Bubble align={own() ? "end" : "start"} variant={own() ? "secondary" : "muted"}>
+          <BubbleContent>{props.children}</BubbleContent>
+        </Bubble>
+        <MessageFooter>{props.time}</MessageFooter>
+      </MessageContent>
+    </Message>
+  );
+}
+
+function ConversationPreview(props: { narrow?: boolean }) {
+  return (
+    <section
+      class={props.narrow ? "chat-primitives-stage chat-primitives-stage-narrow" : "chat-primitives-stage"}
+      aria-label={props.narrow ? "Narrow routine event conversation" : "Routine event conversation"}
+    >
+      <header class="chat-primitives-stage-header">
+        <div>
+          <Text variant="label">Chief</Text>
+          <Text variant="caption" tone="muted">
+            Product workspace · online
+          </Text>
+        </div>
+        <span class="chat-primitives-live-dot" aria-hidden="true" />
+      </header>
+      <div class="chat-primitives-thread">
+        <StoryMessage author="user" time="10:02">
+          Please prepare a Kraków weather update every morning.
+        </StoryMessage>
+        <RoutineEventMarker
+          action={props.narrow ? "updated" : "created"}
+          routineId="routine-weather-krakow"
+          routineName={props.narrow ? "Pogoda Kraków with a detailed morning forecast" : "Pogoda Kraków"}
+          onOpenRoutine={onContextOpenRoutine}
+        />
+        <StoryMessage author="assistant" time="10:03">
+          Done. I will include temperature, rain, wind, and alerts.
+        </StoryMessage>
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: "Conversation/Routine Event Marker",
+  component: StoryRoutineEventMarker,
+  args: {
+    action: "created",
+    routineId: "routine-weather-krakow",
+    routineName: "Pogoda Kraków",
+    onOpenRoutine: onPlaygroundOpenRoutine,
+  },
+  argTypes: {
+    action: { control: "select", options: ["created", "updated", "deleted"] },
+    routineId: { control: false },
+    onOpenRoutine: { control: false },
+  },
+  parameters: { layout: "fullscreen", a11y: { test: "error" } },
+} satisfies Meta<typeof StoryRoutineEventMarker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: (args) => (
+    <main class="foundation-story">
+      <Heading as="h1" size="lg">
+        Routine event marker
+      </Heading>
+      <Text tone="secondary">Use the controls to compare routine event states and names.</Text>
+      <section class="chat-primitives-gallery" aria-label="Routine event marker playground">
+        <StoryRoutineEventMarker {...args} />
+      </section>
+    </main>
+  ),
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <main class="foundation-story">
+      <Heading as="h1" size="lg">
+        Routine event states
+      </Heading>
+      <Text tone="secondary">
+        Created and updated routines open their settings. Deleted routines remain as history.
+      </Text>
+      <section class="chat-primitives-gallery" aria-label="Routine event marker states">
+        <RoutineEventMarker
+          action="created"
+          routineId="routine-weather-krakow"
+          routineName="Pogoda Kraków"
+          onOpenRoutine={onCreatedRoutine}
+        />
+        <RoutineEventMarker
+          action="updated"
+          routineId="routine-morning-brief"
+          routineName="Morning brief"
+          onOpenRoutine={onUpdatedRoutine}
+        />
+        <RoutineEventMarker action="deleted" routineId="routine-old-sync" routineName="Old portfolio sync" />
+      </section>
+    </main>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    onCreatedRoutine.mockClear();
+    onUpdatedRoutine.mockClear();
+
+    await userEvent.click(canvas.getByRole("button", { name: "Open routine Pogoda Kraków" }));
+    await expect(onCreatedRoutine).toHaveBeenCalledWith("routine-weather-krakow");
+
+    await userEvent.click(canvas.getByRole("button", { name: "Open routine Morning brief" }));
+    await expect(onUpdatedRoutine).toHaveBeenCalledWith("routine-morning-brief");
+
+    await expect(canvas.queryByRole("button", { name: /Old portfolio sync/ })).not.toBeInTheDocument();
+    const deletedPill = canvas.getByLabelText("Old portfolio sync, deleted");
+    const body = within(document.body);
+
+    await userEvent.hover(deletedPill);
+    await expect(await body.findByRole("tooltip")).toHaveTextContent("Deleted");
+    await userEvent.unhover(deletedPill);
+    await waitFor(() => expect(body.queryByRole("tooltip")).not.toBeInTheDocument());
+
+    deletedPill.focus();
+    await expect(deletedPill).toHaveFocus();
+    await expect(await body.findByRole("tooltip")).toHaveTextContent("Deleted");
+    await userEvent.keyboard("{Escape}");
+    await expect(body.queryByRole("tooltip")).not.toBeInTheDocument();
+  },
+};
+
+export const InConversation: Story = {
+  render: () => (
+    <main class="foundation-story">
+      <Heading as="h1" size="lg">
+        Routine events in a conversation
+      </Heading>
+      <div class="routine-event-context-grid">
+        <ConversationPreview />
+        <ConversationPreview narrow />
+      </div>
+    </main>
+  ),
+};


### PR DESCRIPTION
## Summary

- add shared routine event message encoding and persist create, update, and delete events with routine mutations
- render routine markers in the real conversation timeline and open active routines from their markers
- exclude routine events from unread counts and conversation search
- keep marketplace install, upgrade, and rollback operations silent
- add Storybook states and interaction coverage for the marker UI

## Verification

- `bun run lint`
- `bun run check:ui`
- `bun run typecheck:node`
- `bun run typecheck:contracts`
- `bun run typecheck:renderer`
- `bun run typecheck:storybook`
- `bunx vitest run packages/contracts/src/ipc.test.ts packages/contracts/src/team-protocol/v1.test.ts`
- `bunx vitest run src/backend/agent-service.test.ts src/main/agent-marketplace-service.test.ts`
- `bunx vitest run src/renderer/src/app-message-projection.test.ts src/renderer/src/App.test.tsx`
- `git diff --check`
- Electron dev app: created a routine, opened it from the marker, renamed it, and verified both markers after reload
