### PR TITLE
Add account update island

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -2481,7 +2481,7 @@ describe("OpenBot connected desktop shell", () => {
     });
     render(() => <App />);
 
-    expect(await screen.findByText("OpenBot update available")).toBeInTheDocument();
+    expect(await screen.findByText("New update available")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open account actions" }));
     fireEvent.click(await screen.findByRole("button", { name: /Download update/ }));
     await waitFor(() => expect(window.openbot.update.download).toHaveBeenCalledOnce());

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -2536,6 +2536,25 @@ describe("OpenBot connected desktop shell", () => {
         failure_code: "download_failed",
       }),
     );
+    expect(await screen.findByRole("button", { name: /Retry update.*Could not check for updates/ })).toBeEnabled();
+  });
+
+  it("keeps the update retry visible when downloading rejects", async () => {
+    vi.mocked(window.openbot.update.getStatus).mockResolvedValueOnce({
+      phase: "available",
+      currentVersion: "0.1.0",
+      availableVersion: "0.2.0",
+      progress: null,
+      checkedAt: null,
+      message: null,
+      errorCode: null,
+    });
+    vi.mocked(window.openbot.update.download).mockRejectedValueOnce(new Error("Could not download update. Try again."));
+    render(() => <App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Download update/ }));
+
+    expect(await screen.findByRole("button", { name: /Retry update.*Could not download update/ })).toBeEnabled();
   });
 
   it("confirms an installed app version on the next launch", async () => {

--- a/src/renderer/src/components/AccountDock.tsx
+++ b/src/renderer/src/components/AccountDock.tsx
@@ -55,6 +55,7 @@ export function AccountDock(props: AccountDockProps) {
   const [usageRefreshAcknowledging, setUsageRefreshAcknowledging] = createSignal(false);
   const [usageError, setUsageError] = createSignal<string | null>(null);
   const [menuError, setMenuError] = createSignal<string | null>(null);
+  const [updateError, setUpdateError] = createSignal<string | null>(null);
   const [loggingOut, setLoggingOut] = createSignal(false);
   let initialUsageRequested = false;
   let usageRefreshTimer: number | undefined;
@@ -112,7 +113,7 @@ export function AccountDock(props: AccountDockProps) {
   });
   const updatePresentation = createMemo(() => presentUpdateStatus(props.updateStatus));
   const accountMenuError = createMemo(
-    () => menuError() ?? (props.updateStatus.phase === "error" ? props.updateStatus.message : null),
+    () => menuError() ?? updateError() ?? (props.updateStatus.phase === "error" ? props.updateStatus.message : null),
   );
 
   onCleanup(() => {
@@ -125,6 +126,13 @@ export function AccountDock(props: AccountDockProps) {
       if (!hybrid || agentPhase !== "ready" || accountUsage || initialUsageRequested) return;
       initialUsageRequested = true;
       void refreshUsage();
+    },
+  );
+
+  createEffect(
+    () => props.updateStatus.phase,
+    () => {
+      setUpdateError(null);
     },
   );
 
@@ -172,10 +180,11 @@ export function AccountDock(props: AccountDockProps) {
 
   async function runUpdateAction(): Promise<void> {
     setMenuError(null);
+    setUpdateError(null);
     try {
       await props.onUpdateAction();
     } catch (cause) {
-      setMenuError(cause instanceof Error ? cause.message : "Could not update OpenBot.");
+      setUpdateError(cause instanceof Error ? cause.message : "Could not update OpenBot.");
     }
   }
 
@@ -550,7 +559,11 @@ export function AccountDock(props: AccountDockProps) {
       ]}
     >
       <Show when={hybridLayout()} fallback={legacyDock()}>
-        <AccountUpdateIsland updateStatus={props.updateStatus} onUpdateAction={runUpdateAction} />
+        <AccountUpdateIsland
+          updateStatus={props.updateStatus}
+          errorMessage={updateError()}
+          onUpdateAction={runUpdateAction}
+        />
         {hybridDock()}
       </Show>
     </div>

--- a/src/renderer/src/components/AccountDock.tsx
+++ b/src/renderer/src/components/AccountDock.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-js";
 import { presentUpdateStatus } from "../update-status";
+import { AccountUpdateIsland } from "./AccountUpdateIsland";
 import {
   Badge,
   Button,
@@ -169,11 +170,13 @@ export function AccountDock(props: AccountDockProps) {
       .catch((cause) => setMenuError(cause instanceof Error ? cause.message : "Could not open the link."));
   }
 
-  function runUpdateAction() {
+  async function runUpdateAction(): Promise<void> {
     setMenuError(null);
-    void props
-      .onUpdateAction()
-      .catch((cause) => setMenuError(cause instanceof Error ? cause.message : "Could not update OpenBot."));
+    try {
+      await props.onUpdateAction();
+    } catch (cause) {
+      setMenuError(cause instanceof Error ? cause.message : "Could not update OpenBot.");
+    }
   }
 
   async function logout() {
@@ -225,12 +228,14 @@ export function AccountDock(props: AccountDockProps) {
           <div class="account-menu-separator" />
         </Show>
         <section class="account-menu-group" aria-label="OpenBot">
-          <Show when={props.updateStatus.phase !== "unsupported"}>
+          <Show
+            when={props.updateStatus.phase !== "unsupported" && (!hybridLayout() || !updatePresentation().available)}
+          >
             <Button
               variant="ghost"
               type="button"
               class="account-menu-row"
-              onClick={runUpdateAction}
+              onClick={() => void runUpdateAction()}
               disabled={updatePresentation().busy}
             >
               <CircleArrowDown
@@ -392,9 +397,6 @@ export function AccountDock(props: AccountDockProps) {
                   </span>
                 )}
               </Show>
-              <Show when={updatePresentation().available}>
-                <span class="sr-only">OpenBot update available</span>
-              </Show>
             </span>
           </Popover.Trigger>
           <Popover.Portal>
@@ -548,6 +550,7 @@ export function AccountDock(props: AccountDockProps) {
       ]}
     >
       <Show when={hybridLayout()} fallback={legacyDock()}>
+        <AccountUpdateIsland updateStatus={props.updateStatus} onUpdateAction={runUpdateAction} />
         {hybridDock()}
       </Show>
     </div>

--- a/src/renderer/src/components/AccountUpdateIsland.tsx
+++ b/src/renderer/src/components/AccountUpdateIsland.tsx
@@ -4,6 +4,7 @@ import { Button, Download, RefreshCw, Spinner } from "./ui";
 
 interface AccountUpdateIslandProps {
   updateStatus: UpdateStatus;
+  errorMessage?: string | null;
   onUpdateAction: () => Promise<void>;
 }
 
@@ -61,25 +62,33 @@ function UpdateProgressValue(props: UpdateProgressValueProps) {
 export function AccountUpdateIsland(props: AccountUpdateIslandProps) {
   const [actionPending, setActionPending] = createSignal(false);
   const phase = () => props.updateStatus.phase;
-  const open = createMemo(() => VISIBLE_UPDATE_PHASES.has(phase()));
+  const errorMessage = createMemo(() => {
+    const message = props.errorMessage?.trim() || props.updateStatus.message?.trim();
+    return message || "Update failed. Try again.";
+  });
+  const failed = createMemo(() => Boolean(props.errorMessage) || phase() === "error");
+  const open = createMemo(() => failed() || VISIBLE_UPDATE_PHASES.has(phase()));
   const downloading = createMemo(() => phase() === "downloading");
   const busy = createMemo(() => actionPending() || ["downloading", "preparing", "installing"].includes(phase()));
-  const ready = createMemo(() => phase() === "ready" || phase() === "installing");
+  const ready = createMemo(() => !failed() && (phase() === "ready" || phase() === "installing"));
   const progress = createMemo(() => {
     const value = props.updateStatus.progress;
     return value === null ? null : Math.min(100, Math.max(0, Math.round(value)));
   });
-  const actionLabel = createMemo(() => (ready() ? "Restart" : "Download"));
+  const actionLabel = createMemo(() => (failed() ? "Retry" : ready() ? "Restart" : "Download"));
   const busyLabel = createMemo(() => {
+    if (actionPending() && failed()) return "Retrying";
     if (downloading() && progress() !== null) return null;
     if (phase() === "preparing") return "Preparing";
     if (phase() === "installing" || (actionPending() && ready())) return "Restarting";
     return "Starting";
   });
   const accessibleActionLabel = createMemo(() => {
+    if (actionPending() && failed()) return "Retrying update";
     if (downloading() && progress() !== null) return `Downloading update, ${progress()}%`;
     if (phase() === "preparing") return "Preparing update";
     if (phase() === "installing" || (actionPending() && ready())) return "Restarting to update";
+    if (failed()) return `Retry update. ${errorMessage()}`;
     return `${ready() ? "Restart to update" : "Download update"}. ${
       ready() ? "Update ready" : "New update available"
     }.`;
@@ -112,15 +121,18 @@ export function AccountUpdateIsland(props: AccountUpdateIslandProps) {
     >
       <div
         class="account-update-island__copy t-update-text-swap"
-        data-state={ready() ? "ready" : "available"}
+        data-state={failed() ? "error" : ready() ? "ready" : "available"}
         role="status"
         aria-live="polite"
       >
-        <strong data-text="available" aria-hidden={ready() ? "true" : undefined}>
+        <strong data-text="available" aria-hidden={ready() || failed() ? "true" : undefined}>
           New update available
         </strong>
-        <strong data-text="ready" aria-hidden={ready() ? undefined : "true"}>
+        <strong data-text="ready" aria-hidden={ready() && !failed() ? undefined : "true"}>
           Update ready
+        </strong>
+        <strong data-text="error" aria-hidden={failed() ? undefined : "true"} title={errorMessage()}>
+          {errorMessage()}
         </strong>
       </div>
       <div class="account-update-island__action-shell" data-downloading={busy() ? "true" : "false"}>
@@ -136,7 +148,7 @@ export function AccountUpdateIsland(props: AccountUpdateIslandProps) {
           <span class="account-update-island__action-content">
             <span class="account-update-island__icon t-icon-swap" data-state={busy() ? "b" : "a"}>
               <span class="t-icon" data-icon="a" aria-hidden="true">
-                <Show when={ready()} fallback={<Download />}>
+                <Show when={failed() || ready()} fallback={<Download />}>
                   <RefreshCw />
                 </Show>
               </span>

--- a/src/renderer/src/components/AccountUpdateIsland.tsx
+++ b/src/renderer/src/components/AccountUpdateIsland.tsx
@@ -1,0 +1,177 @@
+import type { UpdateStatus } from "@openbot/contracts/ipc";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { Button, Download, RefreshCw, Spinner } from "./ui";
+
+interface AccountUpdateIslandProps {
+  updateStatus: UpdateStatus;
+  onUpdateAction: () => Promise<void>;
+}
+
+interface UpdateProgressValueProps {
+  active: boolean;
+  value: number;
+}
+
+const VISIBLE_UPDATE_PHASES = new Set<UpdateStatus["phase"]>([
+  "available",
+  "downloading",
+  "preparing",
+  "ready",
+  "installing",
+]);
+
+function UpdateProgressValue(props: UpdateProgressValueProps) {
+  let digitGroup: HTMLSpanElement | undefined;
+  const characters = () => `${props.value}`.split("");
+
+  createEffect(
+    () => ({ active: props.active, value: props.value }),
+    ({ active }) => {
+      if (!active || !digitGroup) return;
+
+      digitGroup.classList.remove("is-animating");
+      void digitGroup.offsetHeight;
+      digitGroup.classList.add("is-animating");
+    },
+  );
+
+  return (
+    <span class="account-update-island__progress-value">
+      <span ref={digitGroup} class="account-update-island__progress-digits t-digit-group">
+        <For each={characters()}>
+          {(character, index) => {
+            const stagger = () => {
+              if (index() === characters().length - 2) return "1";
+              if (index() === characters().length - 1) return "2";
+              return undefined;
+            };
+            return (
+              <span class="t-digit" data-stagger={stagger()}>
+                {character}
+              </span>
+            );
+          }}
+        </For>
+      </span>
+      <span class="account-update-island__progress-suffix">%</span>
+    </span>
+  );
+}
+
+export function AccountUpdateIsland(props: AccountUpdateIslandProps) {
+  const [actionPending, setActionPending] = createSignal(false);
+  const phase = () => props.updateStatus.phase;
+  const open = createMemo(() => VISIBLE_UPDATE_PHASES.has(phase()));
+  const downloading = createMemo(() => phase() === "downloading");
+  const busy = createMemo(() => actionPending() || ["downloading", "preparing", "installing"].includes(phase()));
+  const ready = createMemo(() => phase() === "ready" || phase() === "installing");
+  const progress = createMemo(() => {
+    const value = props.updateStatus.progress;
+    return value === null ? null : Math.min(100, Math.max(0, Math.round(value)));
+  });
+  const actionLabel = createMemo(() => (ready() ? "Restart" : "Download"));
+  const busyLabel = createMemo(() => {
+    if (downloading() && progress() !== null) return null;
+    if (phase() === "preparing") return "Preparing";
+    if (phase() === "installing" || (actionPending() && ready())) return "Restarting";
+    return "Starting";
+  });
+  const accessibleActionLabel = createMemo(() => {
+    if (downloading() && progress() !== null) return `Downloading update, ${progress()}%`;
+    if (phase() === "preparing") return "Preparing update";
+    if (phase() === "installing" || (actionPending() && ready())) return "Restarting to update";
+    return `${ready() ? "Restart to update" : "Download update"}. ${
+      ready() ? "Update ready" : "New update available"
+    }.`;
+  });
+
+  createEffect(
+    () => phase(),
+    () => {
+      setActionPending(false);
+    },
+  );
+
+  async function runUpdateAction(): Promise<void> {
+    if (!open() || busy()) return;
+    setActionPending(true);
+    try {
+      await props.onUpdateAction();
+    } finally {
+      setActionPending(false);
+    }
+  }
+
+  return (
+    <div
+      class="account-update-island t-panel-slide"
+      data-open={open() ? "true" : "false"}
+      data-phase={phase()}
+      aria-hidden={open() ? undefined : "true"}
+      inert={open() ? undefined : true}
+    >
+      <div
+        class="account-update-island__copy t-update-text-swap"
+        data-state={ready() ? "ready" : "available"}
+        role="status"
+        aria-live="polite"
+      >
+        <strong data-text="available" aria-hidden={ready() ? "true" : undefined}>
+          New update available
+        </strong>
+        <strong data-text="ready" aria-hidden={ready() ? undefined : "true"}>
+          Update ready
+        </strong>
+      </div>
+      <div class="account-update-island__action-shell" data-downloading={busy() ? "true" : "false"}>
+        <Button
+          type="button"
+          size="xs"
+          class="account-update-island__action"
+          aria-label={accessibleActionLabel()}
+          aria-busy={busy() ? "true" : undefined}
+          disabled={!open() || busy()}
+          onClick={() => void runUpdateAction()}
+        >
+          <span class="account-update-island__action-content">
+            <span class="account-update-island__icon t-icon-swap" data-state={busy() ? "b" : "a"}>
+              <span class="t-icon" data-icon="a" aria-hidden="true">
+                <Show when={ready()} fallback={<Download />}>
+                  <RefreshCw />
+                </Show>
+              </span>
+              <span class="t-icon" data-icon="b" aria-hidden="true">
+                <Spinner size="sm" />
+              </span>
+            </span>
+            <span
+              class="account-update-island__action-label t-update-text-swap"
+              data-state={busy() ? "progress" : "action"}
+              aria-hidden="true"
+            >
+              <span data-text="action">{actionLabel()}</span>
+              <span data-text="progress">
+                <Show
+                  when={downloading() && progress() !== null}
+                  fallback={<span class="account-update-island__busy-label">{busyLabel()}</span>}
+                >
+                  <UpdateProgressValue active={busy()} value={progress() ?? 0} />
+                </Show>
+              </span>
+            </span>
+          </span>
+        </Button>
+        <Show when={downloading() && progress() !== null}>
+          <span
+            class="sr-only"
+            role="progressbar"
+            aria-valuenow={progress() ?? 0}
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-label="Update download progress"
+          />
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/components/ui/icons.ts
+++ b/src/renderer/src/components/ui/icons.ts
@@ -17,6 +17,7 @@ export { default as CircleQuestionMark } from "lucide-solid/icons/circle-questio
 export { default as Clock3 } from "lucide-solid/icons/clock-3";
 export { default as Copy } from "lucide-solid/icons/copy";
 export { default as CornerDownLeft } from "lucide-solid/icons/corner-down-left";
+export { default as Download } from "lucide-solid/icons/download";
 export { default as Ellipsis } from "lucide-solid/icons/ellipsis";
 export { default as ExternalLink } from "lucide-solid/icons/external-link";
 export { default as File } from "lucide-solid/icons/file";

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -13,6 +13,7 @@
 @import "./styles/onboarding.css";
 @import "./styles/first-bot-setup.css";
 @import "./styles/app-shell.css";
+@import "./styles/account-update-island.css";
 @import "./styles/join-server-dialog.css";
 @import "./styles/conversation.css";
 @import "./styles/settings-modal.css";

--- a/src/renderer/src/styles/account-update-island.css
+++ b/src/renderer/src/styles/account-update-island.css
@@ -94,7 +94,7 @@
 
 .account-update-island
   .t-update-text-swap:is([data-state="available"], [data-state="action"])
-  > [data-text]:is([data-text="ready"], [data-text="progress"]) {
+  > [data-text]:is([data-text="ready"], [data-text="progress"], [data-text="error"]) {
   transform: translateY(var(--text-swap-translate-y));
   opacity: 0;
   filter: blur(var(--text-swap-blur));
@@ -102,7 +102,13 @@
 
 .account-update-island
   .t-update-text-swap:is([data-state="ready"], [data-state="progress"])
-  > [data-text]:is([data-text="available"], [data-text="action"]) {
+  > [data-text]:is([data-text="available"], [data-text="action"], [data-text="error"]) {
+  transform: translateY(calc(var(--text-swap-translate-y) * -1));
+  opacity: 0;
+  filter: blur(var(--text-swap-blur));
+}
+
+.account-update-island .t-update-text-swap[data-state="error"] > [data-text]:not([data-text="error"]) {
   transform: translateY(calc(var(--text-swap-translate-y) * -1));
   opacity: 0;
   filter: blur(var(--text-swap-blur));

--- a/src/renderer/src/styles/account-update-island.css
+++ b/src/renderer/src/styles/account-update-island.css
@@ -1,0 +1,303 @@
+.account-update-island {
+  --panel-open-dur: calc(var(--openbot-duration-slow) + var(--openbot-duration-slow));
+  --panel-close-dur: calc(var(--openbot-duration-slow) + var(--openbot-duration-normal));
+  --panel-translate-y: calc(100% - var(--openbot-space-3));
+  --panel-blur: var(--openbot-space-0-5);
+  --panel-ease: var(--openbot-ease-out);
+  --text-swap-dur: var(--openbot-duration-normal);
+  --text-swap-translate-y: var(--openbot-space-1);
+  --text-swap-blur: var(--openbot-space-0-5);
+  --text-swap-ease: var(--openbot-ease-in-out);
+  --digit-dur: var(--openbot-duration-slow);
+  --digit-distance: var(--openbot-space-1);
+  --digit-stagger: calc(var(--openbot-duration-fast) - var(--openbot-duration-dialog));
+  --digit-blur: var(--openbot-space-0-5);
+  --digit-ease: var(--openbot-ease-out);
+  --digit-dir-x: 0;
+  --digit-dir-y: 1;
+
+  position: absolute;
+  z-index: 0;
+  right: var(--openbot-space-4);
+  bottom: var(--openbot-control-xl);
+  left: var(--openbot-space-4);
+  display: grid;
+  min-height: calc(var(--openbot-control-xl) + var(--openbot-radius-dialog));
+  align-items: center;
+  border: 0;
+  border-radius: var(--openbot-radius-lg) var(--openbot-radius-lg) var(--openbot-radius-md) var(--openbot-radius-md);
+  background: var(--openbot-settings-accent-strong);
+  box-shadow: 0 0 0 1px var(--openbot-settings-accent-soft);
+  -webkit-backdrop-filter: blur(var(--openbot-space-3));
+  backdrop-filter: blur(var(--openbot-space-3));
+  padding: calc(var(--openbot-space-1) + 1px) var(--openbot-space-1-5)
+    calc(var(--openbot-space-4) + var(--openbot-space-1) - 1px);
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--openbot-space-2);
+  color: var(--openbot-settings-accent-text);
+  -webkit-font-smoothing: antialiased;
+}
+
+.account-update-island.t-panel-slide {
+  transform: translateY(var(--panel-translate-y));
+  opacity: 0;
+  filter: blur(var(--panel-blur));
+  pointer-events: none;
+  transition:
+    transform var(--panel-close-dur) var(--panel-ease),
+    opacity var(--panel-close-dur) var(--panel-ease),
+    filter var(--panel-close-dur) var(--panel-ease);
+  will-change: transform, opacity, filter;
+}
+
+.account-update-island.t-panel-slide[data-open="true"] {
+  transform: translateY(0);
+  opacity: 1;
+  filter: blur(0);
+  pointer-events: auto;
+  transition:
+    transform var(--panel-open-dur) var(--panel-ease),
+    opacity var(--panel-open-dur) var(--panel-ease),
+    filter var(--panel-open-dur) var(--panel-ease);
+}
+
+.account-update-island__copy {
+  min-width: 0;
+}
+
+.account-update-island__copy strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--openbot-settings-accent-text);
+  font-size: var(--openbot-text-sm);
+  font-weight: var(--openbot-weight-semibold);
+  line-height: var(--openbot-leading-sm);
+  white-space: nowrap;
+}
+
+.account-update-island .t-update-text-swap {
+  display: inline-grid;
+}
+
+.account-update-island .t-update-text-swap > [data-text] {
+  grid-area: 1 / 1;
+  transform: translateY(0);
+  opacity: 1;
+  filter: blur(0);
+  transition:
+    transform var(--text-swap-dur) var(--text-swap-ease),
+    filter var(--text-swap-dur) var(--text-swap-ease),
+    opacity var(--text-swap-dur) var(--text-swap-ease);
+  will-change: transform, filter, opacity;
+}
+
+.account-update-island
+  .t-update-text-swap:is([data-state="available"], [data-state="action"])
+  > [data-text]:is([data-text="ready"], [data-text="progress"]) {
+  transform: translateY(var(--text-swap-translate-y));
+  opacity: 0;
+  filter: blur(var(--text-swap-blur));
+}
+
+.account-update-island
+  .t-update-text-swap:is([data-state="ready"], [data-state="progress"])
+  > [data-text]:is([data-text="available"], [data-text="action"]) {
+  transform: translateY(calc(var(--text-swap-translate-y) * -1));
+  opacity: 0;
+  filter: blur(var(--text-swap-blur));
+}
+
+.account-update-island__action-shell {
+  position: relative;
+  display: grid;
+  width: calc(var(--openbot-control-xl) + var(--openbot-control-xl) + var(--openbot-space-6) + var(--openbot-space-1));
+  min-width: calc(var(--openbot-control-xl) + var(--openbot-control-xl) + var(--openbot-space-3));
+  flex-shrink: 0;
+}
+
+.account-update-island__action.ui-button {
+  width: 100%;
+  height: var(--openbot-control-sm);
+  min-height: var(--openbot-control-sm);
+  border-radius: var(--openbot-radius-sm);
+  background: var(--openbot-surface-light);
+  box-shadow: 0 1px 2px var(--openbot-shadow-popover-key);
+  padding: 0 var(--openbot-space-3) 0 var(--openbot-space-2);
+  color: var(--openbot-text-on-light);
+  transition:
+    box-shadow var(--openbot-duration-normal) var(--openbot-ease-out),
+    transform var(--openbot-duration-fast) var(--openbot-ease-out);
+}
+
+.account-update-island__action.ui-button::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: calc(100% + var(--openbot-space-4));
+  min-width: var(--openbot-control-xl);
+  height: var(--openbot-control-xl);
+  transform: translate(-50%, -50%);
+  content: "";
+}
+
+.account-update-island__action.ui-button:disabled {
+  cursor: progress;
+  opacity: 1;
+}
+
+.account-update-island__action-content {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--openbot-space-1-5);
+}
+
+.account-update-island__action-label {
+  min-width: calc(var(--openbot-control-xl) + var(--openbot-space-3));
+  color: var(--openbot-text-on-light);
+  font-weight: var(--openbot-weight-semibold);
+  text-align: left;
+}
+
+.account-update-island__progress-value {
+  display: inline-grid;
+  align-items: baseline;
+  grid-template-columns: 3ch max-content;
+  font-size: var(--openbot-text-sm);
+  font-weight: var(--openbot-weight-semibold);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.account-update-island__progress-digits {
+  display: inline-flex;
+  justify-content: flex-end;
+}
+
+.account-update-island__progress-suffix,
+.account-update-island__busy-label {
+  display: inline-block;
+}
+
+@keyframes account-update-digit-pop-in {
+  0% {
+    transform: translate(
+      calc(var(--digit-distance) * var(--digit-dir-x)),
+      calc(var(--digit-distance) * var(--digit-dir-y))
+    );
+    opacity: 0.4;
+    filter: blur(var(--digit-blur));
+  }
+
+  100% {
+    transform: translate(0, 0);
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+.account-update-island__progress-value .t-digit {
+  display: inline-block;
+  will-change: transform, opacity, filter;
+}
+
+.account-update-island__progress-digits.is-animating .t-digit {
+  animation: account-update-digit-pop-in var(--digit-dur) var(--digit-ease) both;
+}
+
+.account-update-island__progress-digits.is-animating .t-digit[data-stagger="1"] {
+  animation-delay: var(--digit-stagger);
+}
+
+.account-update-island__progress-digits.is-animating .t-digit[data-stagger="2"] {
+  animation-delay: calc(var(--digit-stagger) * 2);
+}
+
+.account-update-island__action-shell[data-downloading="true"] .account-update-island__action-label {
+  min-width: var(--openbot-control-md);
+  text-align: center;
+}
+
+.account-update-island__action-shell[data-downloading="true"] .account-update-island__action.ui-button {
+  padding-inline: var(--openbot-space-2);
+}
+
+.account-update-island__icon.t-icon-swap {
+  --icon-swap-dur: var(--openbot-duration-overlay);
+  --icon-swap-blur: var(--openbot-space-0-5);
+  --icon-swap-start-scale: 0.25;
+  --icon-swap-ease: var(--openbot-ease-in-out);
+
+  position: relative;
+  display: inline-grid;
+  width: var(--openbot-icon-sm);
+  height: var(--openbot-icon-sm);
+  flex: 0 0 auto;
+  place-items: center;
+}
+
+.account-update-island__icon.t-icon-swap .t-icon {
+  position: relative;
+  top: 1px;
+  display: grid;
+  grid-area: 1 / 1;
+  place-items: center;
+  transition:
+    opacity var(--icon-swap-dur) var(--icon-swap-ease),
+    filter var(--icon-swap-dur) var(--icon-swap-ease),
+    transform var(--icon-swap-dur) var(--icon-swap-ease);
+  will-change: opacity, filter, transform;
+}
+
+.account-update-island__icon.t-icon-swap svg {
+  width: var(--openbot-icon-sm);
+  height: var(--openbot-icon-sm);
+  stroke-width: 2;
+}
+
+.account-update-island__icon.t-icon-swap .ui-spinner {
+  border-color: var(--openbot-text-dim-on-light);
+  border-top-color: currentColor;
+}
+
+.account-update-island__icon.t-icon-swap[data-state="a"] .t-icon[data-icon="a"],
+.account-update-island__icon.t-icon-swap[data-state="b"] .t-icon[data-icon="b"] {
+  transform: scale(1);
+  opacity: 1;
+  filter: blur(0);
+}
+
+.account-update-island__icon.t-icon-swap[data-state="a"] .t-icon[data-icon="b"],
+.account-update-island__icon.t-icon-swap[data-state="b"] .t-icon[data-icon="a"] {
+  transform: scale(var(--icon-swap-start-scale));
+  opacity: 0;
+  filter: blur(var(--icon-swap-blur));
+}
+
+.account-update-island__action.ui-button:active:not(:disabled):not([data-disabled]) {
+  transform: scale(0.96);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .account-update-island__action.ui-button:hover:not(:disabled):not([data-disabled]) {
+    background: var(--openbot-surface-light);
+    box-shadow:
+      0 0 0 1px var(--openbot-text-dim-on-light),
+      0 1px 2px var(--openbot-shadow-popover-key);
+    color: var(--openbot-text-on-light);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .account-update-island.t-panel-slide,
+  .account-update-island__action.ui-button,
+  .account-update-island__icon.t-icon-swap .t-icon,
+  .account-update-island .t-update-text-swap > [data-text] {
+    transition: none;
+  }
+
+  .account-update-island__progress-value .t-digit {
+    animation: none;
+  }
+}

--- a/src/renderer/stories/AccountDockConcepts.stories.tsx
+++ b/src/renderer/stories/AccountDockConcepts.stories.tsx
@@ -1,10 +1,15 @@
-import type { AccountUsage, BotSummary, ServerSummary } from "@openbot/contracts/ipc";
-import { onCleanup } from "solid-js";
+import type { AccountUsage, BotSummary, ServerSummary, UpdateStatus } from "@openbot/contracts/ipc";
+import { Portal } from "@solidjs/web";
+import { createEffect, createSignal, onCleanup, onSettled, Show } from "solid-js";
+import { fn } from "storybook/test";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import productionLogoUrl from "../src/assets/openbot-logo-production.png";
+import { AccountUpdateIsland } from "../src/components/AccountUpdateIsland";
 import { STORY_BOT_SUMMARIES, STORY_SERVERS, STORY_UPDATE_STATUS, STORY_USAGE } from "../src/preview/fixtures";
 import { OpenBotPlayground } from "../src/preview/OpenBotPlayground";
 import "./AccountDockConcepts.css";
+
+type UpdateIslandState = "none" | "available" | "ready";
 
 const CONCEPT_BOT_NAMES = [
   "Launch planner",
@@ -83,6 +88,102 @@ const CONCEPT_SERVERS: ServerSummary[] = [
 
 interface AccountDockConceptPlaygroundProps {
   remainingPercent: number;
+  updateState: UpdateIslandState;
+  previewMotion: boolean;
+  onUpdateAction: () => void;
+}
+
+const NEUTRAL_UPDATE_STATUS: UpdateStatus = {
+  ...STORY_UPDATE_STATUS,
+  phase: "idle",
+  availableVersion: null,
+};
+
+function updateStatusForState(state: UpdateIslandState): UpdateStatus {
+  if (state === "none") return NEUTRAL_UPDATE_STATUS;
+  return {
+    ...STORY_UPDATE_STATUS,
+    phase: state,
+    progress: state === "ready" ? 100 : null,
+  };
+}
+
+function StoryUpdateIsland(props: Pick<AccountDockConceptPlaygroundProps, "updateState" | "onUpdateAction">) {
+  const [updateStatus, setUpdateStatus] = createSignal(updateStatusForState(props.updateState));
+  let progressTimer: number | undefined;
+  let completeTimer: number | undefined;
+
+  function clearTimers(): void {
+    if (progressTimer !== undefined) window.clearInterval(progressTimer);
+    if (completeTimer !== undefined) window.clearTimeout(completeTimer);
+    progressTimer = undefined;
+    completeTimer = undefined;
+  }
+
+  function resetStatus(): void {
+    clearTimers();
+    setUpdateStatus(updateStatusForState(props.updateState));
+  }
+
+  function startDownload(): void {
+    setUpdateStatus((current) => ({ ...current, phase: "downloading", progress: 0 }));
+    progressTimer = window.setInterval(() => {
+      setUpdateStatus((current) => {
+        const nextProgress = Math.min((current.progress ?? 0) + 5, 100);
+        if (nextProgress === 100) {
+          if (progressTimer !== undefined) window.clearInterval(progressTimer);
+          progressTimer = undefined;
+          completeTimer = window.setTimeout(() => {
+            completeTimer = undefined;
+            setUpdateStatus((complete) => ({ ...complete, phase: "ready", progress: 100 }));
+          }, 500);
+        }
+        return { ...current, progress: nextProgress };
+      });
+    }, 240);
+  }
+
+  async function handleUpdateAction(): Promise<void> {
+    props.onUpdateAction();
+    if (updateStatus().phase === "available") startDownload();
+  }
+
+  createEffect(
+    () => props.updateState,
+    () => resetStatus(),
+  );
+  onCleanup(clearTimers);
+
+  return <AccountUpdateIsland updateStatus={updateStatus()} onUpdateAction={handleUpdateAction} />;
+}
+
+function UpdateIslandPortal(props: Pick<AccountDockConceptPlaygroundProps, "updateState" | "onUpdateAction">) {
+  const [mount, setMount] = createSignal<HTMLElement | null>(null);
+
+  onSettled(() => {
+    const storyRoot = document.querySelector<HTMLElement>(".account-dock-concept");
+    if (!storyRoot) return;
+
+    const syncMount = () => {
+      const nextMount = storyRoot.querySelector<HTMLElement>(".account-dock.account-dock-hybrid");
+      setMount(nextMount);
+    };
+
+    syncMount();
+    const observer = new MutationObserver(syncMount);
+    observer.observe(storyRoot, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  });
+
+  return (
+    <Show when={mount()}>
+      {(mountElement) => (
+        <Portal mount={mountElement()}>
+          <StoryUpdateIsland updateState={props.updateState} onUpdateAction={props.onUpdateAction} />
+        </Portal>
+      )}
+    </Show>
+  );
 }
 
 function usageWithRemaining(remainingPercent: number): AccountUsage {
@@ -96,13 +197,41 @@ function usageWithRemaining(remainingPercent: number): AccountUsage {
 }
 
 function AccountDockConceptPlayground(props: AccountDockConceptPlaygroundProps) {
+  const [previewUpdateState, setPreviewUpdateState] = createSignal<UpdateIslandState>("none");
+  let previewTimer: number | undefined;
+
+  function clearMotionPreview(): void {
+    if (previewTimer !== undefined) window.clearTimeout(previewTimer);
+    previewTimer = undefined;
+  }
+
+  function openMotionPreview(): void {
+    setPreviewUpdateState("available");
+    previewTimer = window.setTimeout(() => {
+      setPreviewUpdateState("none");
+      previewTimer = window.setTimeout(openMotionPreview, 900);
+    }, 1_800);
+  }
+
+  createEffect(
+    () => props.previewMotion,
+    (previewMotion) => {
+      clearMotionPreview();
+      setPreviewUpdateState("none");
+      if (previewMotion) previewTimer = window.setTimeout(openMotionPreview, 700);
+    },
+  );
+
   const storageKey = "openbot:left-panel-collapsed";
   const previous = window.localStorage.getItem(storageKey);
   window.localStorage.setItem(storageKey, "false");
   onCleanup(() => {
+    clearMotionPreview();
     if (previous === null) window.localStorage.removeItem(storageKey);
     else window.localStorage.setItem(storageKey, previous);
   });
+
+  const renderedUpdateState = () => (props.previewMotion ? previewUpdateState() : props.updateState);
 
   return (
     <div class="account-dock-concept">
@@ -120,9 +249,10 @@ function AccountDockConceptPlayground(props: AccountDockConceptPlaygroundProps) 
           bots: CONCEPT_BOTS,
           servers: CONCEPT_SERVERS,
           usage: usageWithRemaining(props.remainingPercent),
-          updateStatus: STORY_UPDATE_STATUS,
+          updateStatus: NEUTRAL_UPDATE_STATUS,
         }}
       />
+      <UpdateIslandPortal updateState={renderedUpdateState()} onUpdateAction={props.onUpdateAction} />
     </div>
   );
 }
@@ -132,11 +262,27 @@ const meta = {
   component: AccountDockConceptPlayground,
   args: {
     remainingPercent: 59,
+    updateState: "none",
+    previewMotion: false,
+    onUpdateAction: fn(),
   },
   argTypes: {
     remainingPercent: {
       control: { type: "range", min: 0, max: 100, step: 1 },
       description: "Weekly usage remaining percentage.",
+    },
+    updateState: {
+      control: "inline-radio",
+      options: ["none", "available", "ready"],
+      description: "Automatic update island state.",
+    },
+    previewMotion: {
+      control: false,
+      table: { disable: true },
+    },
+    onUpdateAction: {
+      control: false,
+      description: "Storybook-only update action.",
     },
   },
   parameters: {
@@ -185,6 +331,34 @@ export const WeeklyUsageCritical: Story = {
     docs: {
       description: {
         story: "Critical state: below 10% remaining, the gauge and percentage use the danger color.",
+      },
+    },
+  },
+};
+
+export const UpdateIsland: Story = {
+  args: {
+    updateState: "available",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The production update island rises from behind the real account dock without moving the sidebar content.",
+      },
+    },
+  },
+};
+
+export const UpdateIslandMotion: Story = {
+  args: {
+    previewMotion: true,
+    updateState: "available",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "The real update island repeatedly opens and closes so both panel-reveal directions can be reviewed.",
       },
     },
   },


### PR DESCRIPTION
## Summary

- add the production update island to the macOS account dock
- show real download progress, preparing, ready, and installing states
- keep the legacy update menu behavior outside the hybrid dock
- reuse the production component in the Storybook concept and motion preview

## Verification

- bun run typecheck:renderer
- bun run typecheck:storybook
- targeted App update tests
- Biome check for changed files
- Storybook visual and interaction check
- bun run dev