### PR TITLE
Show account dock in landing demo

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1877,9 +1877,12 @@ describe("OpenBot connected desktop shell", () => {
 
     const accountButton = screen.getByRole("button", { name: "Open account actions" });
     await fireEvent.click(accountButton);
-    expect(screen.getByRole("dialog", { name: "Account actions" })).toBeInTheDocument();
+    const accountDialog = screen.getByRole("dialog", { name: "Account actions" });
+    expect(accountDialog).toBeInTheDocument();
     expect(screen.getByText("Norbert")).toBeInTheDocument();
     expect(screen.getByText("norbertbodziony@gmail.com")).toBeInTheDocument();
+    expect(within(accountDialog).queryByRole("button", { name: "Sign out" })).not.toBeInTheDocument();
+    expect(window.openbot.auth.logout).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: "Open computer" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /remote control/iu })).not.toBeInTheDocument();
     await fireEvent.click(screen.getByRole("button", { name: "Add remote server" }));

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1844,7 +1844,7 @@ describe("OpenBot connected desktop shell", () => {
     expect(window.openbot.servers.join).not.toHaveBeenCalled();
   });
 
-  it("keeps the landing preview account static and omits browser and remote control", async () => {
+  it("shows the interactive account dock in the landing preview and omits browser and remote control", async () => {
     vi.mocked(window.openbot.auth.getState).mockResolvedValueOnce({
       status: "signed_in",
       user: {
@@ -1871,7 +1871,13 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App landingPreview />);
     await screen.findByRole("heading", { name: "Chief" });
 
-    expect(screen.queryByRole("button", { name: "Open account menu" })).not.toBeInTheDocument();
+    const usageButton = await screen.findByRole("button", { name: "Weekly usage, 59% left" });
+    await fireEvent.click(usageButton);
+    expect(screen.getByRole("dialog", { name: "Weekly usage" })).toBeInTheDocument();
+
+    const accountButton = screen.getByRole("button", { name: "Open account actions" });
+    await fireEvent.click(accountButton);
+    expect(screen.getByRole("dialog", { name: "Account actions" })).toBeInTheDocument();
     expect(screen.getByText("Norbert")).toBeInTheDocument();
     expect(screen.getByText("norbertbodziony@gmail.com")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Open computer" })).not.toBeInTheDocument();

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1882,6 +1882,10 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.getByText("Norbert")).toBeInTheDocument();
     expect(screen.getByText("norbertbodziony@gmail.com")).toBeInTheDocument();
     expect(within(accountDialog).queryByRole("button", { name: "Sign out" })).not.toBeInTheDocument();
+    await fireEvent.click(within(accountDialog).getByRole("button", { name: "Providers & permissions" }));
+    const permissionsDialog = await screen.findByRole("dialog", { name: "Providers & permissions" });
+    expect(within(permissionsDialog).queryByRole("button", { name: "Sign out" })).not.toBeInTheDocument();
+    await fireEvent.click(within(permissionsDialog).getByRole("button", { name: "Cancel" }));
     expect(window.openbot.auth.logout).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: "Open computer" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /remote control/iu })).not.toBeInTheDocument();

--- a/src/renderer/src/AppView.tsx
+++ b/src/renderer/src/AppView.tsx
@@ -399,7 +399,7 @@ function WorkspaceShell(props: {
           withServerRail={appInfo()?.platform === "darwin" || appInfo()?.platform === "win32"}
           onRefreshUsage={refreshAccountUsage}
           onUpdateAction={runUpdateAction}
-          onLogout={logoutCentralAccount}
+          onLogout={appProps.landingPreview ? undefined : logoutCentralAccount}
           onOpenExternal={(destination) => window.openbot.openExternal(destination)}
           onOpenPermissions={() => setPermissionsOpen(true)}
           onOpenSettings={openAppSettings}

--- a/src/renderer/src/AppView.tsx
+++ b/src/renderer/src/AppView.tsx
@@ -379,43 +379,33 @@ function WorkspaceShell(props: {
             : undefined
         }
       />
-      <Show
-        when={!appProps.landingPreview}
+      <Loading
         fallback={
           <StaticAccountDock
             account={props.account()}
             compact={leftPanelCompact()}
+            hybrid={appInfo()?.platform === "darwin" && !leftPanelCompact()}
             withServerRail={appInfo()?.platform === "darwin" || appInfo()?.platform === "win32"}
           />
         }
       >
-        <Loading
-          fallback={
-            <StaticAccountDock
-              account={props.account()}
-              compact={leftPanelCompact()}
-              withServerRail={appInfo()?.platform === "darwin" || appInfo()?.platform === "win32"}
-            />
-          }
-        >
-          <AccountDock
-            account={props.account()}
-            appInfo={appInfo()}
-            agentStatus={agentStatus()}
-            accountUsage={accountUsage()}
-            updateStatus={updateStatus()}
-            compact={leftPanelCompact()}
-            withServerRail={appInfo()?.platform === "darwin" || appInfo()?.platform === "win32"}
-            onRefreshUsage={refreshAccountUsage}
-            onUpdateAction={runUpdateAction}
-            onLogout={logoutCentralAccount}
-            onOpenExternal={(destination) => window.openbot.openExternal(destination)}
-            onOpenPermissions={() => setPermissionsOpen(true)}
-            onOpenSettings={openAppSettings}
-            onOpenSkills={() => setSkillsMarketplaceOpen(true)}
-          />
-        </Loading>
-      </Show>
+        <AccountDock
+          account={props.account()}
+          appInfo={appInfo()}
+          agentStatus={agentStatus()}
+          accountUsage={accountUsage()}
+          updateStatus={updateStatus()}
+          compact={leftPanelCompact()}
+          withServerRail={appInfo()?.platform === "darwin" || appInfo()?.platform === "win32"}
+          onRefreshUsage={refreshAccountUsage}
+          onUpdateAction={runUpdateAction}
+          onLogout={logoutCentralAccount}
+          onOpenExternal={(destination) => window.openbot.openExternal(destination)}
+          onOpenPermissions={() => setPermissionsOpen(true)}
+          onOpenSettings={openAppSettings}
+          onOpenSkills={() => setSkillsMarketplaceOpen(true)}
+        />
+      </Loading>
       <PanelResizer
         class="left-panel-resizer"
         label="Resize left sidebar"

--- a/src/renderer/src/AppView.tsx
+++ b/src/renderer/src/AppView.tsx
@@ -705,7 +705,7 @@ function WorkspaceOverlays(props: {
             onSave={saveSetup}
             onPreviewInvite={previewInvite}
             onJoinRemote={joinRemoteDuringSetup}
-            onLogout={logoutCentralAccount}
+            onLogout={appProps.landingPreview ? undefined : logoutCentralAccount}
             onClose={() => setPermissionsOpen(false)}
           />
         </Loading>

--- a/src/renderer/src/components/AccountDock.tsx
+++ b/src/renderer/src/components/AccountDock.tsx
@@ -39,7 +39,7 @@ interface AccountDockProps {
   withServerRail: boolean;
   onRefreshUsage: () => Promise<AccountUsage>;
   onUpdateAction: () => Promise<void>;
-  onLogout: () => Promise<void>;
+  onLogout?: () => Promise<void>;
   onOpenExternal: (destination: ExternalDestination) => Promise<void>;
   onOpenPermissions: () => void;
   onOpenSettings: (trigger: HTMLElement) => void;
@@ -177,11 +177,12 @@ export function AccountDock(props: AccountDockProps) {
   }
 
   async function logout() {
-    if (loggingOut()) return;
+    const onLogout = props.onLogout;
+    if (!onLogout || loggingOut()) return;
     setLoggingOut(true);
     setMenuError(null);
     try {
-      await props.onLogout();
+      await onLogout();
     } catch (cause) {
       setMenuError(cause instanceof Error ? cause.message : "Could not sign out.");
       setLoggingOut(false);
@@ -279,17 +280,19 @@ export function AccountDock(props: AccountDockProps) {
           </Button>
         </section>
 
-        <div class="account-menu-separator" />
-        <Button
-          variant="ghost"
-          type="button"
-          class="account-menu-row account-menu-danger"
-          onClick={() => void logout()}
-          disabled={loggingOut()}
-        >
-          <LogOut class="account-menu-icon" aria-hidden="true" />
-          <span>{loggingOut() ? "Signing out…" : "Sign out"}</span>
-        </Button>
+        <Show when={props.onLogout}>
+          <div class="account-menu-separator" />
+          <Button
+            variant="ghost"
+            type="button"
+            class="account-menu-row account-menu-danger"
+            onClick={() => void logout()}
+            disabled={loggingOut()}
+          >
+            <LogOut class="account-menu-icon" aria-hidden="true" />
+            <span>{loggingOut() ? "Signing out…" : "Sign out"}</span>
+          </Button>
+        </Show>
         <Show when={accountMenuError()}>{(message) => <p class="account-popover-error">{message()}</p>}</Show>
         <Show when={includeDockActions ? usageError() : null}>
           {(message) => <p class="account-popover-error">{message()}</p>}

--- a/src/renderer/src/components/InitialSetup.tsx
+++ b/src/renderer/src/components/InitialSetup.tsx
@@ -25,7 +25,7 @@ interface InitialSetupProps {
   onSave: (provider: AgentProviderId) => Promise<void>;
   onPreviewInvite: (input: JoinServerInput) => Promise<InvitePreview>;
   onJoinRemote: (input: JoinServerInput, provider: AgentProviderId) => Promise<void>;
-  onLogout: () => Promise<void>;
+  onLogout?: () => Promise<void>;
   onClose?: () => void;
 }
 
@@ -253,9 +253,16 @@ export function InitialSetup(props: InitialSetupProps) {
                 <i aria-hidden="true" />
                 {props.accountEmail}
               </span>
-              <Button variant="ghost" type="button" class="initial-setup-signout" onClick={() => void props.onLogout()}>
-                Sign out
-              </Button>
+              <Show when={props.onLogout}>
+                <Button
+                  variant="ghost"
+                  type="button"
+                  class="initial-setup-signout"
+                  onClick={() => void props.onLogout?.()}
+                >
+                  Sign out
+                </Button>
+              </Show>
             </div>
             <p class="initial-setup-eyebrow">OpenBot setup</p>
             <Dialog.Title as="h1" id="initial-setup-title">

--- a/src/renderer/src/components/StaticAccountDock.tsx
+++ b/src/renderer/src/components/StaticAccountDock.tsx
@@ -1,10 +1,11 @@
 import type { CentralAuthUser } from "@openbot/contracts/ipc";
-import { createMemo } from "solid-js";
+import { createMemo, Show } from "solid-js";
 import { UserAvatar } from "./ui";
 
 interface StaticAccountDockProps {
   account: CentralAuthUser;
   compact: boolean;
+  hybrid: boolean;
   withServerRail: boolean;
 }
 
@@ -19,16 +20,40 @@ export function StaticAccountDock(props: StaticAccountDockProps) {
         {
           "account-dock-with-server-rail": props.withServerRail,
           "account-dock-compact": props.compact,
+          "account-dock-hybrid": props.hybrid,
         },
       ]}
     >
-      <div class="account-dock-trigger">
-        <UserAvatar user={props.account} class="account-dock-avatar" decorative />
-        <span class="account-dock-copy">
-          <strong title={accountName()}>{accountName()}</strong>
-          <span title={props.account.email}>{props.account.email}</span>
-        </span>
-      </div>
+      <Show
+        when={props.hybrid}
+        fallback={
+          <div class="account-dock-trigger">
+            <UserAvatar user={props.account} class="account-dock-avatar" decorative />
+            <span class="account-dock-copy">
+              <strong title={accountName()}>{accountName()}</strong>
+              <span title={props.account.email}>{props.account.email}</span>
+            </span>
+          </div>
+        }
+      >
+        <div class="account-dock-hybrid-shelf">
+          <div class="account-dock-hybrid-identity">
+            <span class="account-dock-avatar-frame">
+              <UserAvatar user={props.account} class="account-dock-avatar" decorative />
+            </span>
+            <span class="account-dock-copy">
+              <strong title={accountName()}>{accountName()}</strong>
+              <span title={props.account.email}>{props.account.email}</span>
+            </span>
+          </div>
+          <span class="account-dock-usage-trigger" aria-hidden="true">
+            <span class="account-dock-usage-chip">
+              <strong>—</strong>
+            </span>
+          </span>
+          <span class="account-dock-icon-button" aria-hidden="true" />
+        </div>
+      </Show>
     </div>
   );
 }

--- a/src/renderer/src/components/StaticAccountDock.tsx
+++ b/src/renderer/src/components/StaticAccountDock.tsx
@@ -1,6 +1,6 @@
 import type { CentralAuthUser } from "@openbot/contracts/ipc";
 import { createMemo, Show } from "solid-js";
-import { UserAvatar } from "./ui";
+import { Gauge, UserAvatar } from "./ui";
 
 interface StaticAccountDockProps {
   account: CentralAuthUser;
@@ -48,6 +48,7 @@ export function StaticAccountDock(props: StaticAccountDockProps) {
           </div>
           <span class="account-dock-usage-trigger" aria-hidden="true">
             <span class="account-dock-usage-chip">
+              <Gauge aria-hidden="true" />
               <strong>—</strong>
             </span>
           </span>

--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -3378,11 +3378,13 @@ textarea {
 }
 
 .account-dock-usage-chip > strong {
+  min-width: 4ch;
   color: inherit;
   font-size: var(--openbot-text-xs);
   font-weight: var(--openbot-weight-semibold);
   font-variant-numeric: tabular-nums;
   line-height: 14px;
+  text-align: right;
 }
 
 .account-usage-popover {


### PR DESCRIPTION
## Summary

- render the real lazy-loaded account dock in the landing app preview
- keep a layout-compatible hybrid fallback to avoid a dock loading shift
- preserve the landing preview browser and remote-control restrictions

## Performance

- keep AccountDock as a separate dynamic chunk (4.93 kB gzip)
- keep the critical landing entry free of AccountDock imports
- preserve the delayed iframe and landing controller loading

## Verification

- bun run typecheck:renderer
- targeted landing AccountDock test
- landing iframe tests (4/4)
- bun run --cwd apps/auth-api build
- Biome check for changed files
- desktop and mobile landing preview checks