### PR TITLE
Fix embedded browser panel control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to OpenBot will be documented here. The project follows
 
 ### Fixed
 
+- Keep the embedded browser panel closed until requested and prevent repeated toggles from opening duplicate tabs.
 - Restore embedded X sign-in with persistent cookie consent, a compatible browser identity, and current login routing.
 - Flush the embedded browser profile before restarts, system shutdowns, and application updates so authenticated sessions persist.
 

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -4511,6 +4511,43 @@ describe("OpenBot connected desktop shell", () => {
     expect(window.openbot.browser.open).toHaveBeenCalledTimes(1);
   });
 
+  it("allows a replacement when a loading browser tab is closed before its open request settles", async () => {
+    const loadingTab: BrowserTab = {
+      id: "tab-loading",
+      title: "Loading…",
+      url: "https://www.google.com/",
+      loading: true,
+      ownerThreadId: "thread-chief",
+      ownerBotId: "chief",
+    };
+    let resolveFirstOpen: ((tab: BrowserTab) => void) | undefined;
+    vi.mocked(window.openbot.browser.open).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstOpen = resolve;
+        }),
+    );
+
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Open computer" }));
+    expect(window.openbot.browser.open).toHaveBeenCalledTimes(1);
+
+    emitAgentEvent?.({ type: "browser-changed", tabs: [loadingTab], activeTabId: loadingTab.id });
+    const tab = await screen.findByRole("tab", { name: "Loading…" });
+    await fireEvent.keyDown(tab, { key: "Delete" });
+    expect(window.openbot.browser.close).toHaveBeenCalledWith(loadingTab.id);
+
+    emitAgentEvent?.({ type: "browser-changed", tabs: [], activeTabId: null });
+    await waitFor(() => expect(screen.queryByRole("complementary", { name: "Browser" })).not.toBeInTheDocument());
+
+    await fireEvent.click(screen.getByRole("button", { name: "Open computer" }));
+    expect(window.openbot.browser.open).toHaveBeenCalledTimes(2);
+
+    resolveFirstOpen?.(loadingTab);
+  });
+
   it("reveals the requested browser tab and resumes the agent from the takeover card", async () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -4410,6 +4410,12 @@ describe("OpenBot connected desktop shell", () => {
       },
     });
 
+    expect(screen.queryByRole("complementary", { name: "Browser" })).not.toBeInTheDocument();
+    const browserControl = screen.getByRole("button", { name: "Chief is controlling the browser" });
+    expect(browserControl).toHaveAttribute("aria-expanded", "false");
+    expect(window.openbot.browser.open).not.toHaveBeenCalled();
+
+    await fireEvent.click(browserControl);
     const controlledTab = await screen.findByRole("tab", {
       name: "Local smoke page, controlled by Chief",
     });
@@ -4417,7 +4423,6 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.getAllByRole("tab")).toHaveLength(3);
     await fireEvent.keyDown(screen.getByRole("tab", { name: "Third page" }), { key: "Delete" });
     expect(window.openbot.browser.close).toHaveBeenCalledWith("tab-3");
-    expect(screen.queryByRole("button", { name: "Hide browser panel" })).not.toBeInTheDocument();
     await fireEvent.click(screen.getByRole("button", { name: "New browser tab" }));
     expect(window.openbot.browser.open).toHaveBeenCalledWith({
       url: "https://www.google.com",
@@ -4455,6 +4460,55 @@ describe("OpenBot connected desktop shell", () => {
       expect(screen.queryByRole("tab", { name: "Local smoke page, controlled by Chief" })).not.toBeInTheDocument(),
     );
     expect(screen.getByRole("tab", { name: "Local smoke page" })).toBe(controlledTab);
+  });
+
+  it("coalesces repeated empty-browser opens and does not reopen the panel after a late response", async () => {
+    const openedTab: BrowserTab = {
+      id: "tab-delayed",
+      title: "Delayed page",
+      url: "https://www.google.com",
+      loading: false,
+      ownerThreadId: "thread-chief",
+      ownerBotId: "chief",
+    };
+    let resolveOpen: ((tab: BrowserTab) => void) | undefined;
+    vi.mocked(window.openbot.browser.open).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOpen = resolve;
+        }),
+    );
+
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Open computer" }));
+    expect(await screen.findByRole("complementary", { name: "Browser" })).toBeInTheDocument();
+    expect(window.openbot.browser.open).toHaveBeenCalledTimes(1);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Hide computer" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Open computer" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Hide computer" }));
+    expect(window.openbot.browser.open).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("complementary", { name: "Browser" })).not.toBeInTheDocument();
+
+    emitAgentEvent?.({ type: "browser-changed", tabs: [openedTab], activeTabId: openedTab.id });
+    resolveOpen?.(openedTab);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(screen.queryByRole("complementary", { name: "Browser" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open computer" })).toHaveAttribute("aria-expanded", "false");
+    expect(window.openbot.browser.open).toHaveBeenCalledTimes(1);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Open computer" }));
+    expect(await screen.findByRole("tab", { name: "Delayed page" })).toHaveAttribute("aria-selected", "true");
+    await fireEvent.click(screen.getByRole("button", { name: "Reload page" }));
+    expect(window.openbot.browser.reload).toHaveBeenCalledWith(openedTab.id);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Hide computer" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Open computer" }));
+    expect(await screen.findByRole("tab", { name: "Delayed page" })).toHaveAttribute("aria-selected", "true");
+    expect(window.openbot.browser.open).toHaveBeenCalledTimes(1);
   });
 
   it("reveals the requested browser tab and resumes the agent from the takeover card", async () => {

--- a/src/renderer/src/components/Conversation.tsx
+++ b/src/renderer/src/components/Conversation.tsx
@@ -25,7 +25,16 @@ function readBrowserPipBounds(): BrowserBounds | null {
 
 interface ConversationResources {
   agentActivityPresentations: Map<string, { activityId: string; presentation: AgentActivityPresentation }>;
-  browserOpenRequests: Map<string, Promise<void>>;
+  browserOpenRequests: Map<
+    string,
+    {
+      promise: Promise<void>;
+      serverId: string;
+      botId: string | null;
+      url: string;
+      existingTabIds: Set<string>;
+    }
+  >;
   importTargetBots: Map<string, { botId: string; serverId: string }>;
   seenMessageIds: Set<string>;
   typingIdleTimer: ReturnType<typeof setTimeout> | undefined;

--- a/src/renderer/src/components/Conversation.tsx
+++ b/src/renderer/src/components/Conversation.tsx
@@ -25,7 +25,7 @@ function readBrowserPipBounds(): BrowserBounds | null {
 
 interface ConversationResources {
   agentActivityPresentations: Map<string, { activityId: string; presentation: AgentActivityPresentation }>;
-  controlledBrowserBotIds: Set<string>;
+  browserOpenRequests: Map<string, Promise<void>>;
   importTargetBots: Map<string, { botId: string; serverId: string }>;
   seenMessageIds: Set<string>;
   typingIdleTimer: ReturnType<typeof setTimeout> | undefined;
@@ -108,7 +108,7 @@ export function createConversationController(props: Pick<ConversationProps, "onT
   const [browserPanelWidth, setBrowserPanelWidth] = createSignal(BROWSER_PANEL_DEFAULT);
   const resources: ConversationResources = {
     agentActivityPresentations: new Map(),
-    controlledBrowserBotIds: new Set<string>(),
+    browserOpenRequests: new Map(),
     importTargetBots: new Map<string, { botId: string; serverId: string }>(),
     seenMessageIds: new Set<string>(),
     typingIdleTimer: undefined,

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -165,6 +165,14 @@ function isCompleteRuntimeSettingsPatch(updates: AgentRuntimeSettingsPatch): upd
   return "provider" in updates && "model" in updates;
 }
 
+function canonicalBrowserUrl(url: string): string {
+  try {
+    return new URL(url).toString();
+  } catch {
+    return url;
+  }
+}
+
 function rendererDuration(property: string, fallback: number): number {
   if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return 0;
   const value = getComputedStyle(document.documentElement).getPropertyValue(property).trim();
@@ -453,6 +461,20 @@ function createConversationViewScope(props: ConversationProps) {
       tab.ownerBotId ? tab.ownerBotId === bot.id : Boolean(bot.threadId && tab.ownerThreadId === bot.threadId),
     );
   });
+  createEffect(
+    () => browserTabs().map((tab) => ({ id: tab.id, url: tab.url })),
+    (tabs) => {
+      const serverId = props.server?.id ?? "local";
+      const botId = props.bot?.id ?? null;
+      for (const [requestKey, request] of resources.browserOpenRequests) {
+        if (request.serverId !== serverId || request.botId !== botId) continue;
+        const tabAppeared = tabs.some(
+          (tab) => canonicalBrowserUrl(tab.url) === request.url && !request.existingTabIds.has(tab.id),
+        );
+        if (tabAppeared) resources.browserOpenRequests.delete(requestKey);
+      }
+    },
+  );
   const activeBrowserTab = createMemo(
     () => browserTabs().find((tab) => tab.id === props.activeBrowserTabId) ?? browserTabs()[0],
   );
@@ -2081,9 +2103,12 @@ function createConversationViewScope(props: ConversationProps) {
     setBrowserAddressEditing(false);
     const analytics = desktopAnalytics.scope();
     const url = /^https?:\/\//i.test(value) ? value : `https://${value}`;
-    const requestKey = JSON.stringify([props.server?.id ?? "local", props.bot?.id ?? null, url]);
+    const serverId = props.server?.id ?? "local";
+    const botId = props.bot?.id ?? null;
+    const canonicalUrl = canonicalBrowserUrl(url);
+    const requestKey = JSON.stringify([serverId, botId, canonicalUrl]);
     const pendingRequest = resources.browserOpenRequests.get(requestKey);
-    if (pendingRequest) return pendingRequest;
+    if (pendingRequest) return pendingRequest.promise;
     const request = (async () => {
       try {
         const tab = await window.openbot.browser.open({
@@ -2103,11 +2128,18 @@ function createConversationViewScope(props: ConversationProps) {
         });
       }
     })();
-    resources.browserOpenRequests.set(requestKey, request);
+    const pendingRequestState = {
+      promise: request,
+      serverId,
+      botId,
+      url: canonicalUrl,
+      existingTabIds: new Set(browserTabs().map((tab) => tab.id)),
+    };
+    resources.browserOpenRequests.set(requestKey, pendingRequestState);
     try {
       await request;
     } finally {
-      if (resources.browserOpenRequests.get(requestKey) === request) {
+      if (resources.browserOpenRequests.get(requestKey) === pendingRequestState) {
         resources.browserOpenRequests.delete(requestKey);
       }
     }
@@ -3737,9 +3769,11 @@ export function ConversationOverlays() {
 export function ConversationView(props: ConversationProps) {
   const scope = createConversationViewScope(props);
   const {
+    activeBrowserControl,
     agentReady,
     browserPanelWidth,
     browserSidebarOpen,
+    browserTabs,
     dropActive,
     filePreviewOpen,
     handleChatSearchShortcut,
@@ -3747,6 +3781,7 @@ export function ConversationView(props: ConversationProps) {
     setConversationPanelElement,
     setDropActive,
     settingsPanelWidth,
+    screenOpen,
     submitting,
   } = scope;
   createEffect(
@@ -3766,6 +3801,7 @@ export function ConversationView(props: ConversationProps) {
           {
             "conversation-drop-active": dropActive(),
             "browser-panel-active": browserSidebarOpen() || filePreviewOpen(),
+            "browser-panel-available": !screenOpen() && (browserTabs().length > 0 || Boolean(activeBrowserControl())),
           },
         ]}
         style={`--settings-panel-width: ${settingsPanelWidth()}px; --browser-panel-width: ${browserPanelWidth()}px`}

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -1595,33 +1595,6 @@ function createConversationViewScope(props: ConversationProps) {
   );
 
   createEffect(
-    () =>
-      new Set(
-        props.browserControlState.sessions
-          .map((session) => props.bots.find((bot) => bot.threadId === session.threadId)?.id)
-          .filter((botId): botId is string => Boolean(botId)),
-      ),
-    (controlledBotIds) => {
-      if (props.browserEnabled === false) return;
-      const newlyControlledBotIds = [...controlledBotIds].filter(
-        (botId) => !resources.controlledBrowserBotIds.has(botId),
-      );
-      resources.controlledBrowserBotIds = controlledBotIds;
-      if (newlyControlledBotIds.length === 0) return;
-      setRightPanels((current) => {
-        const next = { ...current };
-        let changed = false;
-        for (const botId of newlyControlledBotIds) {
-          if (next[botId] === "browser" || next[botId] === "browser-pip") continue;
-          next[botId] = "browser";
-          changed = true;
-        }
-        return changed ? next : current;
-      });
-    },
-  );
-
-  createEffect(
     () => ({
       botId: props.bot?.id,
       visible: browserSidebarOpen() && !props.globalOverlayOpen && !props.remoteDesktopVisible && !mediaPreview(),
@@ -2108,23 +2081,35 @@ function createConversationViewScope(props: ConversationProps) {
     setBrowserAddressEditing(false);
     const analytics = desktopAnalytics.scope();
     const url = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+    const requestKey = JSON.stringify([props.server?.id ?? "local", props.bot?.id ?? null, url]);
+    const pendingRequest = resources.browserOpenRequests.get(requestKey);
+    if (pendingRequest) return pendingRequest;
+    const request = (async () => {
+      try {
+        const tab = await window.openbot.browser.open({
+          url,
+          ownerThreadId: props.bot?.threadId ?? null,
+          ownerBotId: props.bot?.id ?? null,
+          focus: true,
+        });
+        setBrowserAddress(tab.url);
+        analytics.track("browser_action", { action: "open", result: "succeeded" });
+      } catch {
+        setBrowserAddress(url);
+        analytics.track("browser_action", {
+          action: "open",
+          result: "failed",
+          failure_code: "browser_open_failed",
+        });
+      }
+    })();
+    resources.browserOpenRequests.set(requestKey, request);
     try {
-      const tab = await window.openbot.browser.open({
-        url,
-        ownerThreadId: props.bot?.threadId ?? null,
-        ownerBotId: props.bot?.id ?? null,
-        focus: true,
-      });
-      setBrowserAddress(tab.url);
-      if (!screenOpen()) setActiveRightPanel("browser");
-      analytics.track("browser_action", { action: "open", result: "succeeded" });
-    } catch {
-      setBrowserAddress(url);
-      analytics.track("browser_action", {
-        action: "open",
-        result: "failed",
-        failure_code: "browser_open_failed",
-      });
+      await request;
+    } finally {
+      if (resources.browserOpenRequests.get(requestKey) === request) {
+        resources.browserOpenRequests.delete(requestKey);
+      }
     }
   }
 
@@ -2578,6 +2563,7 @@ export function ConversationHeader() {
     activeBrowserControl,
     agentActivity,
     browserControlBot,
+    browserTabs,
     hideBrowserPanel,
     props,
     screenOpen,
@@ -2661,7 +2647,10 @@ export function ConversationHeader() {
             type="button"
             class={[
               "header-panel-toggle computer-button",
-              { "computer-button-agent-active": Boolean(activeBrowserControl()) },
+              {
+                "computer-button-available": !screenOpen() && browserTabs().length > 0,
+                "computer-button-agent-active": Boolean(activeBrowserControl()),
+              },
             ]}
             aria-label={
               activeBrowserControl()

--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -1685,6 +1685,7 @@ textarea {
   transition:
     border-color var(--openbot-duration-hover) ease,
     background-color var(--openbot-duration-hover) ease,
+    box-shadow var(--openbot-duration-hover) ease,
     color var(--openbot-duration-hover) ease,
     transform var(--openbot-duration-fast) cubic-bezier(0.23, 1, 0.32, 1);
 }

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -3002,6 +3002,7 @@
   }
 }
 
+.computer-button-available,
 .computer-button-agent-active {
   border-color: var(--openbot-accent);
   background: var(--openbot-accent-soft);

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -260,7 +260,7 @@
   align-items: center;
   justify-content: space-between;
   border-bottom: 0;
-  padding: 0 8px;
+  padding: 0 12px 0 8px;
   background: transparent;
 }
 
@@ -3006,6 +3006,7 @@
 .computer-button-agent-active {
   border-color: var(--openbot-accent);
   background: var(--openbot-accent-soft);
+  box-shadow: 0 0 10px var(--openbot-accent-strong);
   color: var(--openbot-accent);
 }
 

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -9,6 +9,19 @@
   transition: padding-right var(--panel-resize-duration, var(--openbot-duration-overlay)) cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+.conversation-panel.browser-panel-available::after {
+  position: absolute;
+  z-index: 13;
+  top: 0;
+  right: 1px;
+  bottom: 0;
+  width: 1px;
+  background: var(--openbot-accent);
+  box-shadow: -10px 0 28px var(--openbot-accent-soft);
+  content: "";
+  pointer-events: none;
+}
+
 .direct-conversation {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary

- keep the embedded browser panel closed until the user explicitly opens it
- highlight the closed control when browser content is available and retain the active-control indicator
- coalesce identical in-flight opens so rapid toggles cannot create duplicate tabs
- keep late open responses from reopening a panel the user already closed

## Verification

- bunx vitest run src/renderer/src/App.test.tsx --reporter=dot (191 passed)
- bun run typecheck:renderer
- Biome check for changed renderer files
- bun run test:browser
- git diff --check
- Electron dev app: verified default-closed state, agent-control indicator without auto-open, rapid toggles, stable tabs across refresh and reopen, and last-tab closure

Closes #105