### PR TITLE
Hide Dynamic Island from Mission Control

### DIFF
--- a/src/main/dynamic-island-window.test.ts
+++ b/src/main/dynamic-island-window.test.ts
@@ -155,6 +155,8 @@ describe("dynamic island window geometry", () => {
     await controller.initialize();
     expect(windows).toHaveLength(2);
     expect(controller.overlayRendererIds).toEqual(new Set([42, 43]));
+    expect(windows[0]?.setHiddenInMissionControl).toHaveBeenCalledWith(true);
+    expect(windows[1]?.setHiddenInMissionControl).toHaveBeenCalledWith(true);
 
     controller.publish({ serverId: "local", mode: "working", working: [] });
     controller.publish({ serverId: "local", mode: "working", working: [] });
@@ -571,6 +573,7 @@ class FakeWindow extends EventEmitter {
   readonly setWindowButtonVisibility = vi.fn();
   readonly setAlwaysOnTop = vi.fn();
   readonly setVisibleOnAllWorkspaces = vi.fn();
+  readonly setHiddenInMissionControl = vi.fn();
   readonly setFocusable = vi.fn();
   readonly setIgnoreMouseEvents = vi.fn();
   readonly isMinimized = vi.fn(() => false);

--- a/src/main/dynamic-island-window.ts
+++ b/src/main/dynamic-island-window.ts
@@ -196,6 +196,7 @@ export class DynamicIslandWindowController {
     window.setWindowButtonVisibility(false);
     window.setAlwaysOnTop(true, "status");
     window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+    window.setHiddenInMissionControl(true);
     window.setFocusable(false);
     window.setIgnoreMouseEvents(true, { forward: true });
     window.once("ready-to-show", () => {


### PR DESCRIPTION
## Summary

- hide Dynamic Island overlay windows from macOS Mission Control
- keep the existing panel and all-workspaces behavior
- add regression coverage for every display overlay

## Verification

- `bunx vitest run src/main/dynamic-island-window.test.ts`
- `bun run typecheck`
- `bunx biome check src/main/dynamic-island-window.ts src/main/dynamic-island-window.test.ts`
- `git diff --check`

## Manual verification

Not run. A shared `bun run dev` stack from another worktree was already using the default profile and ports.