### PR TITLE
Add deterministic gradient logos for servers

### DIFF
--- a/src/renderer/src/components/ServerRail.tsx
+++ b/src/renderer/src/components/ServerRail.tsx
@@ -1,7 +1,7 @@
 import type { ServerSummary } from "@openbot/contracts/ipc";
 import { createEffect, createSignal, For, onCleanup, onSettled, Show } from "solid-js";
 import { createVerticalDragPreview } from "./createVerticalDragPreview";
-import { buttonVariants, ContextMenu, Tooltip } from "./ui";
+import { buttonVariants, ContextMenu, ServerGradientLogo, Tooltip } from "./ui";
 
 const SERVER_RAIL_TOOLTIP_OPEN_DELAY = 150;
 
@@ -381,27 +381,8 @@ function ServerMark(props: { server: ServerSummary }) {
     },
   );
   return (
-    <Show
-      when={!failed() ? props.server.logoUrl : null}
-      fallback={
-        <span class={props.server.kind === "local" ? "server-rail-local" : "server-rail-monogram"}>
-          {initials(props.server.name)}
-        </span>
-      }
-    >
+    <Show when={!failed() ? props.server.logoUrl : null} fallback={<ServerGradientLogo seed={props.server.id} />}>
       {(url) => <img class="server-rail-logo" src={url()} alt="" draggable={false} onError={() => setFailed(true)} />}
     </Show>
-  );
-}
-
-function initials(name: string): string {
-  return (
-    name
-      .split(/\s+/)
-      .filter(Boolean)
-      .slice(0, 2)
-      .map((part) => part[0])
-      .join("")
-      .toUpperCase() || "O"
   );
 }

--- a/src/renderer/src/components/ui/index.ts
+++ b/src/renderer/src/components/ui/index.ts
@@ -17,6 +17,7 @@ export * from "./qr-code";
 export * from "./questionnaire";
 export * from "./radial-progress";
 export * from "./select";
+export * from "./server-gradient-logo";
 export * from "./settings";
 export * from "./sliding-tabs";
 export * from "./surface";

--- a/src/renderer/src/components/ui/server-gradient-logo.tsx
+++ b/src/renderer/src/components/ui/server-gradient-logo.tsx
@@ -1,0 +1,98 @@
+import type { JSX } from "@solidjs/web";
+import { createMemo } from "solid-js";
+import { cx } from "./utils";
+
+type GradientPalette = readonly [base: string, first: string, second: string, third: string];
+
+export interface ServerGradientLogoProfile {
+  paletteIndex: number;
+  colors: GradientPalette;
+  backgroundImage: string;
+}
+
+export interface ServerGradientLogoProps {
+  seed: string;
+  class?: JSX.HTMLAttributes<HTMLSpanElement>["class"];
+}
+
+const SERVER_GRADIENT_PALETTES = [
+  ["#10195c", "#4361ee", "#4cc9f0", "#b5179e"],
+  ["#4a102a", "#ff4d6d", "#ff9f1c", "#7b2cbf"],
+  ["#073b3a", "#00f5d4", "#80ff72", "#4361ee"],
+  ["#4a2100", "#ff6b35", "#ffd166", "#ef476f"],
+  ["#240046", "#9d4edd", "#ff70a6", "#3a86ff"],
+  ["#003049", "#00b4d8", "#90e0ef", "#2a9d8f"],
+  ["#3c096c", "#ff006e", "#8338ec", "#ffbe0b"],
+  ["#102a43", "#1f7a8c", "#bfdbf7", "#e63946"],
+  ["#3d0c11", "#e63946", "#ffb703", "#fb8500"],
+  ["#132a13", "#38b000", "#ccff33", "#00b4d8"],
+  ["#1b263b", "#3a86ff", "#8338ec", "#06d6a0"],
+  ["#3a0f2d", "#f72585", "#7209b7", "#4cc9f0"],
+] as const satisfies readonly GradientPalette[];
+
+const BLOB_RANGES = [
+  { x: [-12, 36], y: [-12, 42] },
+  { x: [62, 112], y: [-8, 58] },
+  { x: [8, 92], y: [64, 112] },
+] as const;
+
+export function serverGradientLogoProfile(seed: string): ServerGradientLogoProfile {
+  const stableSeed = seed || "server";
+  const paletteIndex = stableHash(`${stableSeed}:palette`) % SERVER_GRADIENT_PALETTES.length;
+  const colors = requiredPalette(paletteIndex);
+  const layers = colors.slice(1).map((color, index) => {
+    const range = BLOB_RANGES[index];
+    if (!range) throw new Error("Server gradient blob ranges are incomplete.");
+    const x = seededRange(`${stableSeed}:blob:${index}:x`, range.x[0], range.x[1]);
+    const y = seededRange(`${stableSeed}:blob:${index}:y`, range.y[0], range.y[1]);
+    const width = seededRange(`${stableSeed}:blob:${index}:width`, 68, 94);
+    const height = seededRange(`${stableSeed}:blob:${index}:height`, 64, 92);
+    const solidStop = seededRange(`${stableSeed}:blob:${index}:solid`, 4, 15);
+    const fadeStop = seededRange(`${stableSeed}:blob:${index}:fade`, 66, 82);
+    return `radial-gradient(ellipse ${width}% ${height}% at ${x}% ${y}%, ${color} 0%, ${color} ${solidStop}%, ${transparentHex(color)} ${fadeStop}%)`;
+  });
+
+  return {
+    paletteIndex,
+    colors,
+    backgroundImage: layers.join(", "),
+  };
+}
+
+export function ServerGradientLogo(props: ServerGradientLogoProps): JSX.Element {
+  const profile = createMemo(() => serverGradientLogoProfile(props.seed));
+
+  return (
+    <span
+      class={cx("ui-server-gradient-logo", props.class)}
+      style={{
+        "--server-gradient-base": profile().colors[0],
+        "--server-gradient-layers": profile().backgroundImage,
+      }}
+      aria-hidden="true"
+    />
+  );
+}
+
+function stableHash(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function seededRange(seed: string, minimum: number, maximum: number): number {
+  return minimum + (stableHash(seed) % (maximum - minimum + 1));
+}
+
+function transparentHex(color: string): string {
+  return `${color}00`;
+}
+
+function requiredPalette(index: number): GradientPalette {
+  const palette = SERVER_GRADIENT_PALETTES[index];
+  if (!palette) throw new Error("Server gradient palettes are empty.");
+  return palette;
+}

--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -440,8 +440,7 @@
   }
 }
 
-.server-rail-monogram,
-.server-rail-local {
+.server-rail-monogram {
   display: grid;
   width: 40px;
   height: 40px;
@@ -463,12 +462,6 @@
   object-fit: cover;
   outline: 1px solid var(--openbot-image-outline);
   outline-offset: -1px;
-}
-
-.server-rail-local {
-  background: linear-gradient(145deg, var(--openbot-text-primary), var(--openbot-accent));
-  color: var(--openbot-accent);
-  font-size: var(--openbot-text-2xl);
 }
 
 .server-rail-mark {
@@ -3941,7 +3934,6 @@ textarea {
 }
 
 .server-rail-monogram,
-.server-rail-local,
 .server-rail-action .server-rail-monogram {
   border-color: var(--openbot-border);
   background: var(--openbot-bg-surface);

--- a/src/renderer/src/styles/primitives.css
+++ b/src/renderer/src/styles/primitives.css
@@ -4,6 +4,20 @@
   font-family: var(--openbot-font-sans);
 }
 
+.ui-server-gradient-logo {
+  width: var(--server-gradient-logo-size, 40px);
+  height: var(--server-gradient-logo-size, 40px);
+  display: block;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border-radius: var(--server-gradient-logo-radius, var(--openbot-radius-lg));
+  background-color: var(--server-gradient-base);
+  background-image: var(--server-gradient-layers);
+  background-repeat: no-repeat;
+  outline: 1px solid var(--openbot-image-outline);
+  outline-offset: -1px;
+}
+
 :where(.ui-text)[data-tone="secondary"],
 :where(.ui-heading)[data-tone="secondary"] {
   color: var(--openbot-text-secondary);

--- a/src/renderer/stories/ServerGradientLogo.stories.tsx
+++ b/src/renderer/stories/ServerGradientLogo.stories.tsx
@@ -1,0 +1,71 @@
+import { For } from "solid-js";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { Heading, ServerGradientLogo, serverGradientLogoProfile, Text } from "../src/components/ui";
+
+const GALLERY_SEEDS = [
+  "cobalt-labs",
+  "lagoon-office",
+  "horizon-works",
+  "juniper-lab",
+  "aurora-research",
+  "ocean-labs",
+] as const;
+
+const meta = {
+  title: "Identity/ServerGradientLogo",
+  component: ServerGradientLogo,
+  args: { seed: GALLERY_SEEDS[0] },
+  parameters: { layout: "centered", a11y: { test: "error" } },
+} satisfies Meta<typeof ServerGradientLogo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Single: Story = {};
+
+export const Gallery: Story = {
+  parameters: { layout: "fullscreen" },
+  render: () => (
+    <main
+      class="min-h-screen p-8"
+      style={{ background: "var(--openbot-bg-canvas)", color: "var(--openbot-text-primary)" }}
+    >
+      <div class="mx-auto grid max-w-5xl gap-6">
+        <header class="grid gap-2">
+          <Heading as="h1" size="lg">
+            Server gradient logos
+          </Heading>
+          <Text tone="muted">Six deterministic mesh gradients, shown large and at the 40 px server rail size.</Text>
+        </header>
+
+        <div class="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-4">
+          <For each={GALLERY_SEEDS}>
+            {(seed) => (
+              <article
+                class="grid justify-items-center gap-4 rounded-2xl p-5"
+                style={{
+                  background: "var(--openbot-bg-surface)",
+                  "box-shadow": "0 0 0 1px var(--openbot-border)",
+                }}
+              >
+                <ServerGradientLogo
+                  seed={seed}
+                  class="[--server-gradient-logo-radius:20px] [--server-gradient-logo-size:96px]"
+                />
+                <div class="flex items-center gap-3">
+                  <ServerGradientLogo seed={seed} />
+                  <div class="grid gap-0.5">
+                    <Text variant="label-sm">{seed}</Text>
+                    <Text variant="caption" tone="muted">
+                      Palette {serverGradientLogoProfile(seed).paletteIndex + 1}
+                    </Text>
+                  </div>
+                </div>
+              </article>
+            )}
+          </For>
+        </div>
+      </div>
+    </main>
+  ),
+};

--- a/src/renderer/stories/ServerRail.stories.tsx
+++ b/src/renderer/stories/ServerRail.stories.tsx
@@ -82,7 +82,7 @@ export const Populated: Story = {
     const localMarker = local.querySelector<HTMLElement>(".server-rail-mark");
     const remoteMarker = remote.querySelector<HTMLElement>(".server-rail-mark");
     const list = rail.querySelector<HTMLElement>(".server-rail-list");
-    const localTile = local.querySelector<HTMLElement>(".server-rail-local");
+    const localTile = local.querySelector<HTMLElement>(".ui-server-gradient-logo");
     const dividerStyle = getComputedStyle(rail, "::after");
 
     await expect(getComputedStyle(rail).borderRightWidth).toBe("0px");


### PR DESCRIPTION
## Summary

- add a reusable four-color mesh gradient logo generated from a stable seed
- use the server ID as the fallback when a custom server logo is missing or fails to load
- add Storybook stories for six distinct palettes and an editable seed

## Testing

- `bun run typecheck:renderer`
- `bun run typecheck:storybook`
- targeted `biome check`
- manual Storybook checks at 96 px and 40 px, including stability after reload

## Notes

- `bun run dev` was not started because the shared development profile and default port were already in use by another worktree.