### PR TITLE
fix(hosting): use Wrangler lifecycle schema

### DIFF
--- a/apps/site-router/r2-lifecycle.json
+++ b/apps/site-router/r2-lifecycle.json
@@ -1,13 +1,16 @@
 {
-  "Rules": [
+  "rules": [
     {
-      "ID": "delete-orphaned-site-deployments",
-      "Status": "Enabled",
-      "Filter": {
-        "Prefix": "sites/"
+      "id": "delete-orphaned-site-deployments",
+      "enabled": true,
+      "conditions": {
+        "prefix": "sites/"
       },
-      "Expiration": {
-        "Days": 32
+      "deleteObjectsTransition": {
+        "condition": {
+          "type": "Age",
+          "maxAge": 2764800
+        }
       }
     }
   ]


### PR DESCRIPTION
Fix the R2 lifecycle configuration format so `bun run sites:lifecycle` is accepted by Wrangler. Verified against the production `openbot-sites` bucket: objects under `sites/` expire after 32 days.