### PR TITLE
fix: ensure OpenPanel identities and hosted site tracking

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -18,11 +18,11 @@ Every event has these low-cardinality properties:
 
 - `surface`: `desktop`, `desktop_host`, or `landing`;
 - `environment`: currently `production` only;
-- `event_schema_version`: the integer schema generation, currently `3`;
+- `event_schema_version`: the integer schema generation, currently `4`;
 - `app_version` and `platform` on desktop surfaces;
 - `acquisition_source` on landing surfaces: `direct`, `search`, `social`, `github`, or `other`.
 
-Reports must filter to `event_schema_version = 3`. Historical events remain available but must not
+Reports must filter to `event_schema_version = 4`. Historical events remain available but must not
 be mixed into current conversion or reliability metrics.
 
 ## Identity
@@ -33,8 +33,12 @@ be mixed into current conversion or reliability metrics.
 - Landing, invitation, and pre-authentication events are anonymous.
 - OpenPanel receives the central account ID as `profileId` and the normalized account email as the
   profile email. Email is not copied into individual event properties.
-- Existing profiles receive their email the next time the production app identifies them. There is
-  no historical backfill.
+- Existing profiles are repaired by the controlled identity backfill when their `profileId` matches
+  a current account. The backfill updates profile traits only; it does not rewrite events or merge
+  unknown profiles.
+- The backfill is dry-run by default: `bun run analytics:backfill -- --auth-users users.json
+  --openpanel-profiles profiles.json`; pass `--apply` only after reviewing the counters. Credentials
+  come from `OPENPANEL_CLIENT_ID` and `OPENPANEL_CLIENT_SECRET`, and logs contain counts only.
 - Local IDs for agents, servers, members, messages, threads, turns, files, or deliveries are never
   analytics properties.
 
@@ -75,6 +79,7 @@ lifecycle. A malformed preference fails closed; a missing preference uses the do
 | `voice_transcription` | Is local voice input reliable and fast? | Transcription returned text without sending it to analytics |
 | `reaction_action` | Are reactions used? | Reaction operation completed |
 | `maintenance_action` | Can accounts export data and diagnostics? | Export reported a saved artifact |
+| `hosted_site_action` | Can accounts publish, replace, and delete Hosted Sites? | A terminal Hosted Site operation result; site metadata is never sent |
 | `screen_view` | Which public website routes are viewed in a session? | One safe view for `/` or `/join`, without a query or hash |
 | `landing_viewed` | How much qualified landing traffic arrives? | Non-automation production page view |
 | `landing_download_clicked` | Which safe channel/placement drives downloads? | Allowlisted download link clicked |
@@ -104,7 +109,7 @@ automatic interaction capture remain disabled.
    segment only by coarse acquisition source, placement, and platform.
 5. Reliability: failed outcomes, safe failure codes, P90/P99 durations, and update/provider health.
 
-Every dashboard must filter by the intended `surface` and `event_schema_version = 3`. Website bounce
+Every dashboard must filter by the intended `surface` and `event_schema_version = 4`. Website bounce
 uses OpenPanel's standard single-`screen_view` definition. Do not emit synthetic screen views to
 change it; use the engaged-session report for meaningful landing activity.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -14,7 +14,7 @@ The production website records anonymous page views using only the fixed paths `
 also records download clicks, clicks on allowlisted public links, invitation validity, and open-app
 actions on invitation pages. The production desktop app records application, sign-in, onboarding,
 agent, message, turn, prompt, approval, queue, routine, team, browser, search, Remote Desktop, update,
-marketplace, memory, provider, voice transcription, reaction, maintenance, and confirmed
+marketplace, memory, provider, voice transcription, reaction, maintenance, Hosted Site, and confirmed
 application-version-change actions. Event properties are limited to metadata such as counts, result
 states, timing, provider, model, reasoning effort, application version, operating system, and coarse
 failure codes.
@@ -38,6 +38,11 @@ Analytics is enabled in production by default. Desktop users can disable it unde
 General → Privacy → Share product analytics**. The preference is stored locally and disables both UI
 analytics and lifecycle analytics emitted by the local host. Website analytics does not use the
 desktop preference.
+
+Hosted Site analytics records only the operation, entry point, result, and bounded failure code. It
+does not contain the site's URL, hostname, title, source path, site ID, or content. A one-time
+backfill may update the email trait of an existing OpenPanel profile matched to a current account; it
+does not create profiles for accounts without existing analytics activity.
 
 OpenPanel event and profile data has no automatic retention limit. It remains stored until it is
 removed manually or the analytics project is deleted. OpenPanel analytics does not change where

--- a/apps/auth-api/src/lib/analytics.ts
+++ b/apps/auth-api/src/lib/analytics.ts
@@ -4,7 +4,7 @@ import { OPENBOT_DOWNLOAD_LINKS, OPENBOT_LINKS } from "./landing-links";
 
 export const OPENPANEL_API_URL = "https://analytics.openbot.run/api";
 const OPENPANEL_CLIENT_ID = "6c989975-87ef-4f0c-857e-ab449a65b5c2";
-const ANALYTICS_SCHEMA_VERSION = 3;
+const ANALYTICS_SCHEMA_VERSION = 4;
 
 export type LandingAcquisitionSource = "direct" | "search" | "social" | "github" | "other";
 

--- a/apps/auth-api/test/analytics.test.ts
+++ b/apps/auth-api/test/analytics.test.ts
@@ -48,7 +48,7 @@ describe("landing analytics", () => {
       __referrer: "",
       surface: "landing",
       environment: "production",
-      event_schema_version: 3,
+      event_schema_version: 4,
     });
     expect(client.trackScreenView).toHaveBeenCalledOnce();
     expect(client.trackScreenView).toHaveBeenCalledWith("/");

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "all": "bun run dev:all",
     "dev:seed": "tsx scripts/seed-dev-state.ts",
     "dev:reset": "tsx scripts/reset-dev-state.ts",
+    "analytics:backfill": "bun scripts/backfill-openpanel-identities.ts",
     "build": "electron-vite build",
     "voice:prepare": "bun scripts/prepare-whisper.ts",
     "voice:prepare-runtime": "bun scripts/prepare-whisper.ts --runtime-only",

--- a/scripts/backfill-openpanel-identities.test.ts
+++ b/scripts/backfill-openpanel-identities.test.ts
@@ -24,6 +24,24 @@ describe("OpenPanel identity backfill", () => {
     ]);
   });
 
+  it("counts profiles using the same normalized ids as the update join", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "openbot-openpanel-backfill-test-"));
+    try {
+      await writeFile(join(directory, "users.json"), JSON.stringify([{ id: " account-1 ", email: "one@example.com" }]));
+      await writeFile(join(directory, "profiles.json"), JSON.stringify([{ profileId: " account-1 ", email: null }]));
+
+      await expect(
+        runBackfill({
+          authUsersPath: join(directory, "users.json"),
+          openPanelProfilesPath: join(directory, "profiles.json"),
+          apply: false,
+        }),
+      ).resolves.toEqual({ authUsers: 1, openPanelProfiles: 1, matchedProfiles: 1, updates: 1, applied: 0 });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("rejects duplicate ids and malformed auth emails, while repairing malformed profiles", () => {
     expect(() =>
       buildBackfillUpdates(
@@ -98,6 +116,20 @@ describe("OpenPanel identity backfill", () => {
       payload: { profileId: "account-1", email: "person@example.com" },
     });
     expect(JSON.stringify(requests[0])).not.toContain("track");
+  });
+
+  it("rejects non-loopback HTTP before sending the client secret", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(
+      applyBackfill([{ profileId: "account-1", email: "person@example.com" }], {
+        apiUrl: "http://analytics.example.com/api",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        fetcher,
+      }),
+    ).rejects.toThrow("requires an HTTPS API URL");
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("stops immediately on an authorization failure", async () => {

--- a/scripts/backfill-openpanel-identities.test.ts
+++ b/scripts/backfill-openpanel-identities.test.ts
@@ -24,7 +24,7 @@ describe("OpenPanel identity backfill", () => {
     ]);
   });
 
-  it("rejects duplicate profile ids and malformed emails", () => {
+  it("rejects duplicate ids and malformed auth emails, while repairing malformed profiles", () => {
     expect(() =>
       buildBackfillUpdates(
         [{ id: "account-1", email: "person@example.com" }],
@@ -37,12 +37,15 @@ describe("OpenPanel identity backfill", () => {
     expect(() =>
       buildBackfillUpdates([{ id: "account-1", email: "invalid" }], [{ profileId: "account-1", email: null }]),
     ).toThrow("Invalid auth user email");
-    expect(() =>
+    expect(
       buildBackfillUpdates(
         [{ id: "account-1", email: "person@example.com" }],
-        [{ profileId: "unmatched-account", email: "invalid" }],
+        [
+          { profileId: "account-1", email: "invalid" },
+          { profileId: "unmatched-account", email: "also-invalid" },
+        ],
       ),
-    ).toThrow("Invalid OpenPanel profile email");
+    ).toEqual([{ profileId: "account-1", email: "person@example.com" }]);
   });
 
   it("keeps dry runs read-only", async () => {

--- a/scripts/backfill-openpanel-identities.test.ts
+++ b/scripts/backfill-openpanel-identities.test.ts
@@ -111,6 +111,7 @@ describe("OpenPanel identity backfill", () => {
     ).toBe(1);
     expect(fetcher).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls[0]?.[1]?.redirect).toBe("error");
     expect(requests[0]).toEqual({
       type: "identify",
       payload: { profileId: "account-1", email: "person@example.com" },

--- a/scripts/backfill-openpanel-identities.test.ts
+++ b/scripts/backfill-openpanel-identities.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { applyBackfill, buildBackfillUpdates, runBackfill } from "./backfill-openpanel-identities";
+
+describe("OpenPanel identity backfill", () => {
+  it("updates only existing profiles with missing or stale email", () => {
+    expect(
+      buildBackfillUpdates(
+        [
+          { id: "account-1", email: " Person@EXAMPLE.COM " },
+          { id: "account-2", email: "two@example.com" },
+        ],
+        [
+          { profileId: "account-1", email: null },
+          { profileId: "account-2", email: "old@example.com" },
+          { profileId: "account-3", email: null },
+        ],
+      ),
+    ).toEqual([
+      { profileId: "account-1", email: "person@example.com" },
+      { profileId: "account-2", email: "two@example.com" },
+    ]);
+  });
+
+  it("rejects duplicate profile ids and malformed emails", () => {
+    expect(() =>
+      buildBackfillUpdates(
+        [{ id: "account-1", email: "person@example.com" }],
+        [
+          { profileId: "account-1", email: null },
+          { profileId: "account-1", email: null },
+        ],
+      ),
+    ).toThrow("Duplicate OpenPanel profile id");
+    expect(() =>
+      buildBackfillUpdates([{ id: "account-1", email: "invalid" }], [{ profileId: "account-1", email: null }]),
+    ).toThrow("Invalid auth user email");
+    expect(() =>
+      buildBackfillUpdates(
+        [{ id: "account-1", email: "person@example.com" }],
+        [{ profileId: "unmatched-account", email: "invalid" }],
+      ),
+    ).toThrow("Invalid OpenPanel profile email");
+  });
+
+  it("keeps dry runs read-only", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "openbot-openpanel-backfill-test-"));
+    try {
+      await writeFile(
+        join(directory, "users.json"),
+        JSON.stringify([{ id: "account-1", email: "person@example.com" }]),
+      );
+      await writeFile(join(directory, "profiles.json"), JSON.stringify([{ profileId: "account-1", email: null }]));
+      const fetcher = vi.fn<typeof fetch>();
+
+      const summary = await runBackfill({
+        authUsersPath: join(directory, "users.json"),
+        openPanelProfilesPath: join(directory, "profiles.json"),
+        apply: false,
+        fetcher,
+      });
+
+      expect(summary).toEqual({ authUsers: 1, openPanelProfiles: 1, matchedProfiles: 1, updates: 1, applied: 0 });
+      expect(fetcher).not.toHaveBeenCalled();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("retries transient failures and sends identify payloads without event data", async () => {
+    let attempts = 0;
+    const requests: unknown[] = [];
+    const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
+      attempts += 1;
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: attempts < 3 ? 503 : 202 });
+    });
+    const sleep = vi.fn(async () => undefined);
+
+    expect(
+      await applyBackfill([{ profileId: "account-1", email: "person@example.com" }], {
+        apiUrl: "https://analytics.openbot.run/api",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        fetcher,
+        sleep,
+      }),
+    ).toBe(1);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(requests[0]).toEqual({
+      type: "identify",
+      payload: { profileId: "account-1", email: "person@example.com" },
+    });
+    expect(JSON.stringify(requests[0])).not.toContain("track");
+  });
+
+  it("stops immediately on an authorization failure", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => new Response(null, { status: 401 }));
+    const sleep = vi.fn(async () => undefined);
+
+    await expect(
+      applyBackfill([{ profileId: "account-1", email: "person@example.com" }], {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        fetcher,
+        sleep,
+      }),
+    ).rejects.toThrow("HTTP 401");
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/backfill-openpanel-identities.test.ts
+++ b/scripts/backfill-openpanel-identities.test.ts
@@ -115,4 +115,49 @@ describe("OpenPanel identity backfill", () => {
     expect(fetcher).toHaveBeenCalledOnce();
     expect(sleep).not.toHaveBeenCalled();
   });
+
+  it("retries rejected requests and passes a bounded abort signal", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("network reset"))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const sleep = vi.fn(async () => undefined);
+
+    await expect(
+      applyBackfill([{ profileId: "account-1", email: "person@example.com" }], {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        requestTimeoutMs: 50,
+        fetcher,
+        sleep,
+      }),
+    ).resolves.toBe(1);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(sleep).toHaveBeenCalledOnce();
+  });
+
+  it("retries timed out requests and stops after the retry limit", async () => {
+    const fetcher = vi.fn<typeof fetch>(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+            once: true,
+          });
+        }),
+    );
+    const sleep = vi.fn(async () => undefined);
+
+    await expect(
+      applyBackfill([{ profileId: "account-1", email: "person@example.com" }], {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        requestTimeoutMs: 1,
+        fetcher,
+        sleep,
+      }),
+    ).rejects.toThrow("after retries");
+    expect(fetcher).toHaveBeenCalledTimes(4);
+    expect(sleep).toHaveBeenCalledTimes(3);
+  });
 });

--- a/scripts/backfill-openpanel-identities.ts
+++ b/scripts/backfill-openpanel-identities.ts
@@ -1,0 +1,265 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { isDynamicRecord, isString } from "@openbot/contracts/runtime-values";
+import { normalizeEmailAddress } from "@openbot/contracts/validation";
+
+const DEFAULT_OPENPANEL_API_URL = "https://analytics.openbot.run/api";
+const MAX_RETRIES = 3;
+const INITIAL_RETRY_DELAY_MS = 250;
+
+export interface BackfillAuthUser {
+  id: string;
+  email: string;
+}
+
+export interface BackfillOpenPanelProfile {
+  profileId: string;
+  email: string | null;
+}
+
+export interface BackfillIdentity {
+  profileId: string;
+  email: string;
+}
+
+export interface BackfillOptions {
+  authUsersPath: string;
+  openPanelProfilesPath: string;
+  apply: boolean;
+  apiUrl?: string;
+  clientId?: string;
+  clientSecret?: string;
+  fetcher?: typeof fetch;
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+export interface BackfillSummary {
+  authUsers: number;
+  openPanelProfiles: number;
+  matchedProfiles: number;
+  updates: number;
+  applied: number;
+}
+
+export async function runBackfill(options: BackfillOptions): Promise<BackfillSummary> {
+  const [authUsers, profiles] = await Promise.all([
+    readRecords(options.authUsersPath, "auth users"),
+    readRecords(options.openPanelProfilesPath, "OpenPanel profiles"),
+  ]);
+  const updates = buildBackfillUpdates(authUsers, profiles);
+  const authIds = new Set(authUsers.map((user) => parseAuthUser(user).id));
+  let applied = 0;
+  if (options.apply) {
+    applied = await applyBackfill(updates, options);
+  }
+  return {
+    authUsers: authUsers.length,
+    openPanelProfiles: profiles.length,
+    matchedProfiles: profiles.filter((profile) => authIds.has(parseOpenPanelProfile(profile).profileId)).length,
+    updates: updates.length,
+    applied,
+  };
+}
+
+export function buildBackfillUpdates(authUsers: readonly unknown[], profiles: readonly unknown[]): BackfillIdentity[] {
+  const usersById = new Map<string, string>();
+  for (const user of authUsers) {
+    const parsed = parseAuthUser(user);
+    const id = requiredIdentifier(parsed.id, "auth user id");
+    const email = requiredEmail(parsed.email, "auth user email");
+    if (usersById.has(id)) throw new Error("Duplicate auth user id in the input.");
+    usersById.set(id, email);
+  }
+
+  const profileIds = new Set<string>();
+  const updates: BackfillIdentity[] = [];
+  for (const profile of profiles) {
+    const parsed = parseOpenPanelProfile(profile);
+    const profileId = requiredIdentifier(parsed.profileId, "OpenPanel profile id");
+    if (profileIds.has(profileId)) throw new Error("Duplicate OpenPanel profile id in the input.");
+    profileIds.add(profileId);
+    const existingEmail = parsed.email?.trim() ? requiredEmail(parsed.email, "OpenPanel profile email") : null;
+    const email = usersById.get(profileId);
+    if (!email) continue;
+    if (existingEmail === email) continue;
+    updates.push({ profileId, email });
+  }
+  return updates.sort((left, right) => left.profileId.localeCompare(right.profileId));
+}
+
+export async function applyBackfill(
+  updates: readonly BackfillIdentity[],
+  options: Pick<BackfillOptions, "apiUrl" | "clientId" | "clientSecret" | "fetcher" | "sleep">,
+) {
+  const clientId = requiredSecret(options.clientId, "OPENPANEL_CLIENT_ID");
+  const clientSecret = requiredSecret(options.clientSecret, "OPENPANEL_CLIENT_SECRET");
+  const endpoint = trackEndpoint(options.apiUrl ?? DEFAULT_OPENPANEL_API_URL);
+  const fetcher = options.fetcher ?? fetch;
+  const sleep = options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+
+  let applied = 0;
+  for (const identity of updates) {
+    await identifyProfile(endpoint, identity, clientId, clientSecret, fetcher, sleep);
+    applied += 1;
+  }
+  return applied;
+}
+
+async function identifyProfile(
+  endpoint: string,
+  identity: BackfillIdentity,
+  clientId: string,
+  clientSecret: string,
+  fetcher: typeof fetch,
+  sleep: (milliseconds: number) => Promise<void>,
+): Promise<void> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt += 1) {
+    const response = await fetcher(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "openpanel-client-id": clientId,
+        "openpanel-client-secret": clientSecret,
+        "openpanel-sdk-name": "openbot-backfill",
+      },
+      body: JSON.stringify({ type: "identify", payload: identity }),
+    });
+    if (response.status >= 200 && response.status < 300) return;
+    if ((response.status !== 429 && (response.status < 500 || response.status >= 600)) || attempt === MAX_RETRIES) {
+      throw new Error(`OpenPanel backfill failed with HTTP ${response.status}.`);
+    }
+    await sleep(INITIAL_RETRY_DELAY_MS * 2 ** attempt);
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  const summary = await runBackfill(options);
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+  if (!options.apply && summary.updates > 0) {
+    process.stdout.write("Dry run only. Re-run with --apply to update the listed profile count.\n");
+  }
+}
+
+function parseOptions(args: string[]): BackfillOptions {
+  let authUsersPath = "";
+  let openPanelProfilesPath = "";
+  let apply = false;
+  let apiUrl: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--apply") {
+      apply = true;
+      continue;
+    }
+    if (argument === "--auth-users") {
+      authUsersPath = nextArgument(args, ++index, "--auth-users");
+      continue;
+    }
+    if (argument === "--openpanel-profiles") {
+      openPanelProfilesPath = nextArgument(args, ++index, "--openpanel-profiles");
+      continue;
+    }
+    if (argument === "--api-url") {
+      apiUrl = nextArgument(args, ++index, "--api-url");
+      continue;
+    }
+    if (argument === "--help") {
+      process.stdout.write(
+        "Usage: bun scripts/backfill-openpanel-identities.ts --auth-users FILE --openpanel-profiles FILE [--apply]\n",
+      );
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+  if (!authUsersPath || !openPanelProfilesPath) {
+    throw new Error("Both --auth-users and --openpanel-profiles are required.");
+  }
+  return {
+    authUsersPath,
+    openPanelProfilesPath,
+    apply,
+    apiUrl: apiUrl ?? process.env.OPENPANEL_API_URL ?? DEFAULT_OPENPANEL_API_URL,
+    clientId: process.env.OPENPANEL_CLIENT_ID,
+    clientSecret: process.env.OPENPANEL_CLIENT_SECRET,
+  };
+}
+
+async function readRecords(path: string, label: string): Promise<unknown[]> {
+  const raw = path === "-" ? await readStdin() : await readFile(path, "utf8");
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // Fall through to newline-delimited JSON.
+  }
+  try {
+    return raw
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch {
+    throw new Error(`Unable to parse ${label} input.`);
+  }
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function trackEndpoint(apiUrl: string): string {
+  try {
+    const base = new URL(apiUrl);
+    return new URL("track", `${base.toString().replace(/\/+$/u, "")}/`).toString();
+  } catch {
+    throw new Error("OPENPANEL_API_URL is invalid.");
+  }
+}
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 256) throw new Error(`Invalid ${label}.`);
+  return normalized;
+}
+
+function parseAuthUser(value: unknown): BackfillAuthUser {
+  if (!isDynamicRecord(value) || !isString(value.id) || !isString(value.email)) {
+    throw new Error("Invalid auth user record.");
+  }
+  return { id: value.id, email: value.email };
+}
+
+function parseOpenPanelProfile(value: unknown): BackfillOpenPanelProfile {
+  if (!isDynamicRecord(value) || !isString(value.profileId) || (value.email !== null && !isString(value.email))) {
+    throw new Error("Invalid OpenPanel profile record.");
+  }
+  return { profileId: value.profileId, email: value.email };
+}
+
+function requiredEmail(value: string, label: string): string {
+  const normalized = normalizeEmailAddress(value);
+  if (!normalized) throw new Error(`Invalid ${label}.`);
+  return normalized;
+}
+
+function requiredSecret(value: string | undefined, label: string): string {
+  if (!value?.trim()) throw new Error(`${label} is required for --apply.`);
+  return value;
+}
+
+function nextArgument(args: readonly string[], index: number, flag: string): string {
+  const value = args[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value.`);
+  return value;
+}
+
+const scriptPath = process.argv[1] ? fileURLToPath(import.meta.url) : "";
+if (scriptPath && process.argv[1] === scriptPath) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : "OpenPanel backfill failed.");
+    process.exitCode = 1;
+  });
+}

--- a/scripts/backfill-openpanel-identities.ts
+++ b/scripts/backfill-openpanel-identities.ts
@@ -49,7 +49,7 @@ export async function runBackfill(options: BackfillOptions): Promise<BackfillSum
     readRecords(options.openPanelProfilesPath, "OpenPanel profiles"),
   ]);
   const updates = buildBackfillUpdates(authUsers, profiles);
-  const authIds = new Set(authUsers.map((user) => parseAuthUser(user).id));
+  const authIds = new Set(authUsers.map((user) => requiredIdentifier(parseAuthUser(user).id, "auth user id")));
   let applied = 0;
   if (options.apply) {
     applied = await applyBackfill(updates, options);
@@ -57,7 +57,9 @@ export async function runBackfill(options: BackfillOptions): Promise<BackfillSum
   return {
     authUsers: authUsers.length,
     openPanelProfiles: profiles.length,
-    matchedProfiles: profiles.filter((profile) => authIds.has(parseOpenPanelProfile(profile).profileId)).length,
+    matchedProfiles: profiles.filter((profile) =>
+      authIds.has(requiredIdentifier(parseOpenPanelProfile(profile).profileId, "OpenPanel profile id")),
+    ).length,
     updates: updates.length,
     applied,
   };
@@ -237,12 +239,17 @@ async function readStdin(): Promise<string> {
 }
 
 function trackEndpoint(apiUrl: string): string {
+  let base: URL;
   try {
-    const base = new URL(apiUrl);
-    return new URL("track", `${base.toString().replace(/\/+$/u, "")}/`).toString();
+    base = new URL(apiUrl);
   } catch {
     throw new Error("OPENPANEL_API_URL is invalid.");
   }
+  const loopbackHttp = base.protocol === "http:" && ["localhost", "127.0.0.1", "[::1]", "::1"].includes(base.hostname);
+  if (base.protocol !== "https:" && !loopbackHttp) {
+    throw new Error("OpenPanel backfill requires an HTTPS API URL (HTTP is allowed only for loopback hosts).");
+  }
+  return new URL("track", `${base.toString().replace(/\/+$/u, "")}/`).toString();
 }
 
 function requiredIdentifier(value: string, label: string): string {

--- a/scripts/backfill-openpanel-identities.ts
+++ b/scripts/backfill-openpanel-identities.ts
@@ -6,6 +6,7 @@ import { normalizeEmailAddress } from "@openbot/contracts/validation";
 const DEFAULT_OPENPANEL_API_URL = "https://analytics.openbot.run/api";
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY_MS = 250;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 
 export interface BackfillAuthUser {
   id: string;
@@ -29,6 +30,7 @@ export interface BackfillOptions {
   apiUrl?: string;
   clientId?: string;
   clientSecret?: string;
+  requestTimeoutMs?: number;
   fetcher?: typeof fetch;
   sleep?: (milliseconds: number) => Promise<void>;
 }
@@ -89,7 +91,7 @@ export function buildBackfillUpdates(authUsers: readonly unknown[], profiles: re
 
 export async function applyBackfill(
   updates: readonly BackfillIdentity[],
-  options: Pick<BackfillOptions, "apiUrl" | "clientId" | "clientSecret" | "fetcher" | "sleep">,
+  options: Pick<BackfillOptions, "apiUrl" | "clientId" | "clientSecret" | "requestTimeoutMs" | "fetcher" | "sleep">,
 ) {
   const clientId = requiredSecret(options.clientId, "OPENPANEL_CLIENT_ID");
   const clientSecret = requiredSecret(options.clientSecret, "OPENPANEL_CLIENT_SECRET");
@@ -99,7 +101,15 @@ export async function applyBackfill(
 
   let applied = 0;
   for (const identity of updates) {
-    await identifyProfile(endpoint, identity, clientId, clientSecret, fetcher, sleep);
+    await identifyProfile(
+      endpoint,
+      identity,
+      clientId,
+      clientSecret,
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      fetcher,
+      sleep,
+    );
     applied += 1;
   }
   return applied;
@@ -110,20 +120,36 @@ async function identifyProfile(
   identity: BackfillIdentity,
   clientId: string,
   clientSecret: string,
+  requestTimeoutMs: number,
   fetcher: typeof fetch,
   sleep: (milliseconds: number) => Promise<void>,
 ): Promise<void> {
+  if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
+    throw new Error("OpenPanel backfill request timeout must be positive.");
+  }
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt += 1) {
-    const response = await fetcher(endpoint, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "openpanel-client-id": clientId,
-        "openpanel-client-secret": clientSecret,
-        "openpanel-sdk-name": "openbot-backfill",
-      },
-      body: JSON.stringify({ type: "identify", payload: identity }),
-    });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+    let response: Response;
+    try {
+      response = await fetcher(endpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "openpanel-client-id": clientId,
+          "openpanel-client-secret": clientSecret,
+          "openpanel-sdk-name": "openbot-backfill",
+        },
+        body: JSON.stringify({ type: "identify", payload: identity }),
+        signal: controller.signal,
+      });
+    } catch {
+      if (attempt === MAX_RETRIES) throw new Error("OpenPanel backfill request failed after retries.");
+      await sleep(INITIAL_RETRY_DELAY_MS * 2 ** attempt);
+      continue;
+    } finally {
+      clearTimeout(timeout);
+    }
     if (response.status >= 200 && response.status < 300) return;
     if ((response.status !== 429 && (response.status < 500 || response.status >= 600)) || attempt === MAX_RETRIES) {
       throw new Error(`OpenPanel backfill failed with HTTP ${response.status}.`);

--- a/scripts/backfill-openpanel-identities.ts
+++ b/scripts/backfill-openpanel-identities.ts
@@ -78,9 +78,9 @@ export function buildBackfillUpdates(authUsers: readonly unknown[], profiles: re
     const profileId = requiredIdentifier(parsed.profileId, "OpenPanel profile id");
     if (profileIds.has(profileId)) throw new Error("Duplicate OpenPanel profile id in the input.");
     profileIds.add(profileId);
-    const existingEmail = parsed.email?.trim() ? requiredEmail(parsed.email, "OpenPanel profile email") : null;
     const email = usersById.get(profileId);
     if (!email) continue;
+    const existingEmail = parsed.email?.trim() ? normalizeEmailAddress(parsed.email) : null;
     if (existingEmail === email) continue;
     updates.push({ profileId, email });
   }

--- a/scripts/backfill-openpanel-identities.ts
+++ b/scripts/backfill-openpanel-identities.ts
@@ -143,6 +143,7 @@ async function identifyProfile(
           "openpanel-sdk-name": "openbot-backfill",
         },
         body: JSON.stringify({ type: "identify", payload: identity }),
+        redirect: "error",
         signal: controller.signal,
       });
     } catch {

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -48,7 +48,7 @@ describe("host analytics", () => {
     );
 
     expect(client.setGlobalProperties).toHaveBeenCalledWith(
-      expect.objectContaining({ event_schema_version: 3, surface: "desktop_host" }),
+      expect.objectContaining({ event_schema_version: 4, surface: "desktop_host" }),
     );
 
     analytics.handleAgentEvent({
@@ -129,6 +129,30 @@ describe("host analytics", () => {
     );
   });
 
+  it("clears pending host events and the identified session on logout", () => {
+    const client = fakeClient();
+    let owner: { id: string; email: string } | null = { id: "owner-account", email: "owner@example.com" };
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => owner,
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "private" });
+    owner = null;
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "pending-after-logout" });
+    analytics.clear();
+    analytics.flushPending();
+
+    expect(client.track).toHaveBeenCalledOnce();
+    expect(client.clear).toHaveBeenCalledOnce();
+  });
+
   it("updates the email for the same owner without clearing its session", () => {
     const client = fakeClient();
     let owner = { id: "owner-account", email: "old@example.com" };
@@ -155,8 +179,14 @@ describe("host analytics", () => {
 
   it("sends the owner email through the real SDK transport", async () => {
     const requests: unknown[] = [];
+    let releaseIdentify!: () => void;
+    const identifyReady = new Promise<void>((resolve) => {
+      releaseIdentify = resolve;
+    });
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      requests.push(JSON.parse(String(init?.body)));
+      const request = JSON.parse(String(init?.body));
+      requests.push(request);
+      if (isDynamicRecord(request) && request.type === "identify") await identifyReady;
       return new Response(null, { status: 200 });
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -173,6 +203,9 @@ describe("host analytics", () => {
       );
       analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "private" });
 
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      expect(isDynamicRecord(requests[0]) ? requests[0].type : undefined).toBe("identify");
+      releaseIdentify();
       await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
       const identifyRequest = requests.find((candidate) => isDynamicRecord(candidate) && candidate.type === "identify");
       const trackRequest = requests.find(
@@ -193,6 +226,24 @@ describe("host analytics", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("normalizes the owner email before identifying", () => {
+    const client = fakeClient();
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => ({ id: "owner-account", email: " Owner@EXAMPLE.COM " }),
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "private" });
+
+    expect(client.identify).toHaveBeenCalledWith({ profileId: "owner-account", email: "owner@example.com" });
   });
 
   it("drops unsafe runtime fields", () => {
@@ -305,5 +356,25 @@ describe("host analytics", () => {
       origin: "user",
     });
     expect(client.track).toHaveBeenCalledOnce();
+  });
+
+  it("clears the host OpenPanel client when tracking is disabled", () => {
+    const client = fakeClient();
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => ({ id: "owner-account", email: "owner@example.com" }),
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "private" });
+    vi.mocked(client.clear).mockClear();
+
+    analytics.setTrackingEnabled(false);
+
+    expect(client.clear).toHaveBeenCalledOnce();
   });
 });

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -160,6 +160,18 @@ describe("host analytics", () => {
         __timestamp: expect.any(String),
       }),
     );
+    analytics.handleAgentEvent({
+      type: "turn-completed",
+      botId: BOT.id,
+      threadId: BOT.threadId ?? "",
+      turnId: "turn-1",
+      origin: "unknown",
+      status: "completed",
+    });
+    expect(client.track).toHaveBeenLastCalledWith(
+      "system_turn_completed",
+      expect.objectContaining({ profileId: "owner-account" }),
+    );
   });
 
   it("clears pending host events and the identified session on logout", () => {

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 
-import type { BotSummary } from "@openbot/contracts/ipc";
+import {
+  type BotSummary,
+  type ConversationMessage,
+  hostedSiteConversationEventItemType,
+  hostedSiteConversationEventText,
+} from "@openbot/contracts/ipc";
 import { isDynamicRecord } from "@openbot/contracts/runtime-values";
 import { OpenPanelBase } from "@openpanel/web";
 import { describe, expect, it, vi } from "vitest";
@@ -30,6 +35,34 @@ function fakeClient(): HostOpenPanelClient {
     track: vi.fn(),
     identify: vi.fn(),
     clear: vi.fn(),
+  };
+}
+
+function hostedSiteMessage(
+  id: string,
+  action: "publish" | "replace" | "delete",
+  status: "running" | "succeeded" | "failed" | "interrupted" | "cancelled",
+  operationId: string,
+): ConversationMessage {
+  const terminalSite = {
+    siteId: "site-1",
+    title: "Hosted site",
+    hostname: "hosted-site-23456789ab.openbot.site",
+    url: "https://hosted-site-23456789ab.openbot.site",
+  };
+  const details =
+    action === "publish" && status !== "succeeded"
+      ? { siteId: null, title: "Hosted site", hostname: null, url: null }
+      : terminalSite;
+  return {
+    id,
+    turnId: "turn-hosted-site",
+    author: "system",
+    source: "system",
+    text: hostedSiteConversationEventText(details),
+    createdAt: "2026-08-31T10:00:00.000Z",
+    status: "completed",
+    itemType: hostedSiteConversationEventItemType(action, status, operationId),
   };
 }
 
@@ -226,6 +259,182 @@ describe("host analytics", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("tracks terminal hosted-site markers once for the operation owner", () => {
+    const client = fakeClient();
+    let owner = { id: "owner-1", email: "one@example.com" };
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => owner,
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+    const running = hostedSiteMessage("hosted-running", "publish", "running", "operation-success");
+    const runningFailed = hostedSiteMessage("hosted-running-failed", "replace", "running", "operation-failed");
+    const runningCancelled = hostedSiteMessage("hosted-running-cancelled", "delete", "running", "operation-cancelled");
+    const runningInterrupted = hostedSiteMessage(
+      "hosted-running-interrupted",
+      "replace",
+      "running",
+      "operation-interrupted",
+    );
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: {
+        botId: BOT.id,
+        threadId: BOT.threadId,
+        activeTurnId: null,
+        revision: 1,
+        messages: [running, runningFailed, runningCancelled, runningInterrupted],
+      },
+    });
+
+    owner = { id: "owner-2", email: "two@example.com" };
+    const succeeded = hostedSiteMessage("hosted-succeeded", "publish", "succeeded", "operation-success");
+    const failed = hostedSiteMessage("hosted-failed", "replace", "failed", "operation-failed");
+    const cancelled = hostedSiteMessage("hosted-cancelled", "delete", "cancelled", "operation-cancelled");
+    const interrupted = hostedSiteMessage("hosted-interrupted", "replace", "interrupted", "operation-interrupted");
+    const messages = [
+      running,
+      runningFailed,
+      runningCancelled,
+      runningInterrupted,
+      succeeded,
+      failed,
+      cancelled,
+      interrupted,
+    ];
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: { botId: BOT.id, threadId: BOT.threadId, activeTurnId: null, revision: 2, messages },
+    });
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: { botId: BOT.id, threadId: BOT.threadId, activeTurnId: null, revision: 3, messages },
+    });
+
+    expect(client.track).toHaveBeenCalledTimes(4);
+    expect(client.track).toHaveBeenNthCalledWith(1, "hosted_site_action", {
+      action: "publish",
+      entry_point: "agent",
+      result: "succeeded",
+      profileId: "owner-1",
+    });
+    expect(client.track).toHaveBeenNthCalledWith(2, "hosted_site_action", {
+      action: "replace",
+      entry_point: "agent",
+      result: "failed",
+      failure_code: "hosted_site_failed",
+      profileId: "owner-1",
+    });
+    expect(client.track).toHaveBeenNthCalledWith(3, "hosted_site_action", {
+      action: "delete",
+      entry_point: "agent",
+      result: "failed",
+      failure_code: "cancelled",
+      profileId: "owner-1",
+    });
+    expect(client.track).toHaveBeenNthCalledWith(4, "hosted_site_action", {
+      action: "replace",
+      entry_point: "agent",
+      result: "failed",
+      failure_code: "interrupted",
+      profileId: "owner-1",
+    });
+    expect(JSON.stringify(vi.mocked(client.track).mock.calls)).not.toContain("hosted-site-23456789ab.openbot.site");
+  });
+
+  it("ignores terminal hosted-site history without a live running marker", () => {
+    const client = fakeClient();
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => ({ id: "owner-account", email: "owner@example.com" }),
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: {
+        botId: BOT.id,
+        threadId: BOT.threadId,
+        activeTurnId: null,
+        revision: 1,
+        messages: [hostedSiteMessage("hosted-history", "publish", "succeeded", "operation-history")],
+      },
+    });
+
+    expect(client.track).not.toHaveBeenCalled();
+  });
+
+  it("keeps a hosted-site operation owner across account clearing", () => {
+    const client = fakeClient();
+    let owner: { id: string; email: string } | null = { id: "owner-1", email: "one@example.com" };
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => owner,
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+    const running = hostedSiteMessage("hosted-running", "publish", "running", "operation-owner");
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: { botId: BOT.id, threadId: BOT.threadId, activeTurnId: null, revision: 1, messages: [running] },
+    });
+
+    analytics.clear();
+    owner = { id: "owner-2", email: "two@example.com" };
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: {
+        botId: BOT.id,
+        threadId: BOT.threadId,
+        activeTurnId: null,
+        revision: 2,
+        messages: [running, hostedSiteMessage("hosted-succeeded", "publish", "succeeded", "operation-owner")],
+      },
+    });
+
+    expect(client.track).toHaveBeenCalledWith("hosted_site_action", expect.objectContaining({ profileId: "owner-1" }));
+  });
+
+  it("bounds events behind a stalled identify request", async () => {
+    const client = fakeClient();
+    let releaseIdentify!: () => void;
+    const identifyReady = new Promise<void>((resolve) => {
+      releaseIdentify = resolve;
+    });
+    vi.mocked(client.identify).mockImplementation(async () => identifyReady);
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => ({ id: "owner-account", email: "owner@example.com" }),
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+
+    for (let index = 0; index < 150; index += 1) {
+      analytics.handleAgentEvent({ type: "error", code: `agent_${index}`, message: "private" });
+    }
+    releaseIdentify();
+
+    await vi.waitFor(() => expect(client.track).toHaveBeenCalledTimes(100));
   });
 
   it("normalizes the owner email before identifying", () => {

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -420,6 +420,51 @@ describe("host analytics", () => {
     expect(client.clear).toHaveBeenCalledTimes(2);
   });
 
+  it("does not flush ownerless events with a captured hosted-site owner", () => {
+    const client = fakeClient();
+    let owner: { id: string; email: string } | null = { id: "owner-1", email: "one@example.com" };
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => owner,
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+    const running = hostedSiteMessage("hosted-running", "publish", "running", "operation-pending");
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: { botId: BOT.id, threadId: BOT.threadId, activeTurnId: null, revision: 1, messages: [running] },
+    });
+
+    owner = null;
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "private" });
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: {
+        botId: BOT.id,
+        threadId: BOT.threadId,
+        activeTurnId: null,
+        revision: 2,
+        messages: [running, hostedSiteMessage("hosted-succeeded", "publish", "succeeded", "operation-pending")],
+      },
+    });
+
+    expect(client.track).toHaveBeenCalledOnce();
+    expect(client.track).toHaveBeenCalledWith("hosted_site_action", expect.objectContaining({ profileId: "owner-1" }));
+
+    owner = { id: "owner-2", email: "two@example.com" };
+    analytics.flushPending();
+
+    expect(client.track).toHaveBeenCalledTimes(2);
+    expect(client.track).toHaveBeenLastCalledWith(
+      "system_operation_failed",
+      expect.objectContaining({ profileId: "owner-2" }),
+    );
+  });
+
   it("preserves identity transitions when the queue overflows", async () => {
     const client = fakeClient();
     let releaseIdentify!: () => void;

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -349,7 +349,7 @@ describe("host analytics", () => {
     expect(JSON.stringify(vi.mocked(client.track).mock.calls)).not.toContain("hosted-site-23456789ab.openbot.site");
   });
 
-  it("ignores terminal hosted-site history without a live running marker", () => {
+  it("ignores hosted-site history even when it contains running and terminal markers", () => {
     const client = fakeClient();
     const analytics = new HostAnalytics(
       {
@@ -362,6 +362,10 @@ describe("host analytics", () => {
       () => client,
     );
 
+    const messages = [
+      hostedSiteMessage("hosted-history-running", "publish", "running", "operation-history"),
+      hostedSiteMessage("hosted-history-terminal", "publish", "succeeded", "operation-history"),
+    ];
     analytics.handleAgentEvent({
       type: "conversation",
       snapshot: {
@@ -369,8 +373,12 @@ describe("host analytics", () => {
         threadId: BOT.threadId,
         activeTurnId: null,
         revision: 1,
-        messages: [hostedSiteMessage("hosted-history", "publish", "succeeded", "operation-history")],
+        messages,
       },
+    });
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: { botId: BOT.id, threadId: BOT.threadId, activeTurnId: null, revision: 2, messages },
     });
 
     expect(client.track).not.toHaveBeenCalled();
@@ -396,7 +404,7 @@ describe("host analytics", () => {
     });
 
     analytics.clear();
-    owner = { id: "owner-2", email: "two@example.com" };
+    owner = null;
     analytics.handleAgentEvent({
       type: "conversation",
       snapshot: {
@@ -409,32 +417,38 @@ describe("host analytics", () => {
     });
 
     expect(client.track).toHaveBeenCalledWith("hosted_site_action", expect.objectContaining({ profileId: "owner-1" }));
+    expect(client.clear).toHaveBeenCalledTimes(2);
   });
 
-  it("bounds events behind a stalled identify request", async () => {
+  it("preserves identity transitions when the queue overflows", async () => {
     const client = fakeClient();
     let releaseIdentify!: () => void;
     const identifyReady = new Promise<void>((resolve) => {
       releaseIdentify = resolve;
     });
     vi.mocked(client.identify).mockImplementation(async () => identifyReady);
+    let owner = { id: "owner-1", email: "one@example.com" };
     const analytics = new HostAnalytics(
       {
         enabled: true,
         appVersion: "1.2.3",
         platform: "darwin",
-        resolveOwner: () => ({ id: "owner-account", email: "owner@example.com" }),
+        resolveOwner: () => owner,
         resolveBot: () => BOT,
       },
       () => client,
     );
 
+    analytics.handleAgentEvent({ type: "error", code: "agent_initial", message: "private" });
+    owner = { id: "owner-2", email: "two@example.com" };
     for (let index = 0; index < 150; index += 1) {
       analytics.handleAgentEvent({ type: "error", code: `agent_${index}`, message: "private" });
     }
     releaseIdentify();
 
     await vi.waitFor(() => expect(client.track).toHaveBeenCalledTimes(100));
+    expect(client.identify).toHaveBeenCalledWith({ profileId: "owner-2", email: "two@example.com" });
+    expect(client.clear).toHaveBeenCalled();
   });
 
   it("normalizes the owner email before identifying", () => {

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -594,6 +594,52 @@ describe("host analytics", () => {
     );
   });
 
+  it("keeps an active turn with the account that started it", () => {
+    const client = fakeClient();
+    let owner = { id: "owner-1", email: "one@example.com" };
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => owner,
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+
+    analytics.handleAgentEvent({
+      type: "turn-started",
+      botId: BOT.id,
+      threadId: BOT.threadId ?? "",
+      turnId: "turn-account-bound",
+      origin: "user",
+    });
+    analytics.clear();
+    owner = { id: "owner-2", email: "two@example.com" };
+    analytics.handleAgentEvent({
+      type: "prompt",
+      requestId: "request-1",
+      botId: BOT.id,
+      threadId: BOT.threadId ?? "",
+      turnId: "turn-account-bound",
+      questions: [],
+    });
+    analytics.handleAgentEvent({
+      type: "turn-completed",
+      botId: BOT.id,
+      threadId: BOT.threadId ?? "",
+      turnId: "turn-account-bound",
+      origin: "unknown",
+      status: "completed",
+    });
+
+    expect(client.track).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(client.track).mock.calls.every(([, properties]) => properties?.profileId === "owner-1")).toBe(
+      true,
+    );
+  });
+
   it("adds safe bot context to host failures", () => {
     const client = fakeClient();
     const analytics = new HostAnalytics(

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -615,7 +615,22 @@ describe("host analytics", () => {
     expect(client.identify).not.toHaveBeenCalled();
     expect(client.track).not.toHaveBeenCalled();
 
+    const running = hostedSiteMessage("hosted-running", "publish", "running", "operation-opted-out");
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: { botId: BOT.id, threadId: BOT.threadId, activeTurnId: null, revision: 1, messages: [running] },
+    });
     analytics.setTrackingEnabled(true);
+    analytics.handleAgentEvent({
+      type: "conversation",
+      snapshot: {
+        botId: BOT.id,
+        threadId: BOT.threadId,
+        activeTurnId: null,
+        revision: 2,
+        messages: [running, hostedSiteMessage("hosted-succeeded", "publish", "succeeded", "operation-opted-out")],
+      },
+    });
     analytics.handleAgentEvent({
       type: "turn-started",
       botId: BOT.id,
@@ -624,6 +639,7 @@ describe("host analytics", () => {
       origin: "user",
     });
     expect(client.track).toHaveBeenCalledOnce();
+    expect(client.track).toHaveBeenCalledWith("system_turn_started", expect.anything());
   });
 
   it("clears the host OpenPanel client when tracking is disabled", () => {

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -640,6 +640,41 @@ describe("host analytics", () => {
     );
   });
 
+  it("clears a captured host identity after a turn continues past logout", () => {
+    const client = fakeClient();
+    let owner: { id: string; email: string } | null = { id: "owner-1", email: "one@example.com" };
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => owner,
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+
+    analytics.handleAgentEvent({
+      type: "turn-started",
+      botId: BOT.id,
+      threadId: BOT.threadId ?? "",
+      turnId: "turn-after-logout",
+      origin: "user",
+    });
+    analytics.clear();
+    owner = null;
+    analytics.handleAgentEvent({
+      type: "turn-completed",
+      botId: BOT.id,
+      threadId: BOT.threadId ?? "",
+      turnId: "turn-after-logout",
+      origin: "unknown",
+      status: "completed",
+    });
+
+    expect(client.clear).toHaveBeenCalledTimes(2);
+  });
+
   it("adds safe bot context to host failures", () => {
     const client = fakeClient();
     const analytics = new HostAnalytics(

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -673,6 +673,43 @@ describe("host analytics", () => {
     });
 
     expect(client.clear).toHaveBeenCalledTimes(2);
+
+    owner = { id: "owner-1", email: "one@example.com" };
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "private-after-relogin" });
+
+    expect(client.identify).toHaveBeenCalledTimes(3);
+  });
+
+  it("drops ownerless events after logout until a signed-in owner is flushed", () => {
+    const client = fakeClient();
+    let owner: { id: string; email: string } | null = { id: "owner-1", email: "one@example.com" };
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => owner,
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "before-logout" });
+    owner = null;
+    analytics.clear();
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "after-logout" });
+    owner = { id: "owner-2", email: "two@example.com" };
+    analytics.flushPending();
+
+    expect(client.track).toHaveBeenCalledOnce();
+    owner = { id: "owner-2", email: "two@example.com" };
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "after-relogin" });
+
+    expect(client.track).toHaveBeenCalledTimes(2);
+    expect(client.track).toHaveBeenLastCalledWith(
+      "system_operation_failed",
+      expect.objectContaining({ profileId: "owner-2" }),
+    );
   });
 
   it("adds safe bot context to host failures", () => {

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -496,6 +496,32 @@ describe("host analytics", () => {
     expect(client.clear).toHaveBeenCalled();
   });
 
+  it("preserves host events queued before logout", async () => {
+    const client = fakeClient();
+    let releaseIdentify!: () => void;
+    const identifyReady = new Promise<void>((resolve) => {
+      releaseIdentify = resolve;
+    });
+    vi.mocked(client.identify).mockImplementation(async () => identifyReady);
+    const analytics = new HostAnalytics(
+      {
+        enabled: true,
+        appVersion: "1.2.3",
+        platform: "darwin",
+        resolveOwner: () => ({ id: "owner-account", email: "owner@example.com" }),
+        resolveBot: () => BOT,
+      },
+      () => client,
+    );
+
+    analytics.handleAgentEvent({ type: "error", code: "provider_error", message: "private" });
+    analytics.clear();
+    releaseIdentify();
+
+    await vi.waitFor(() => expect(client.track).toHaveBeenCalledOnce());
+    expect(client.clear).toHaveBeenCalledOnce();
+  });
+
   it("normalizes the owner email before identifying", () => {
     const client = fakeClient();
     const analytics = new HostAnalytics(

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -62,7 +62,7 @@ const HOST_ALLOWLIST = {
 type HostPropertyName = (typeof HOST_ALLOWLIST)[HostEventName][number];
 type HostProperties = Partial<Record<HostPropertyName, string | number | boolean>>;
 type HostPendingEvent = { name: HostEventName; properties: HostProperties; timestamp: string };
-type ActiveTurn = { startedAt: number; origin: string };
+type ActiveTurn = { startedAt: number; origin: string; owner: AnalyticsIdentity | null };
 
 export class HostAnalytics {
   readonly #resolveOwner: HostAnalyticsOptions["resolveOwner"];
@@ -115,11 +115,16 @@ export class HostAnalytics {
         this.#pruneActiveTurns(now);
         if (this.#activeTurns.has(event.turnId)) return;
         this.#makeTurnCapacity();
-        this.#activeTurns.set(event.turnId, { startedAt: now, origin: event.origin ?? "unknown" });
-        this.#track("system_turn_started", {
-          ...this.#botProperties(event.botId),
-          origin: event.origin ?? "unknown",
-        });
+        const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
+        this.#activeTurns.set(event.turnId, { startedAt: now, origin: event.origin ?? "unknown", owner });
+        this.#track(
+          "system_turn_started",
+          {
+            ...this.#botProperties(event.botId),
+            origin: event.origin ?? "unknown",
+          },
+          owner,
+        );
         return;
       }
       case "turn-completed": {
@@ -127,32 +132,44 @@ export class HostAnalytics {
         this.#activeTurns.delete(event.turnId);
         const origin =
           event.origin && event.origin !== "unknown" ? event.origin : (activeTurn?.origin ?? event.origin ?? "unknown");
-        this.#track("system_turn_completed", {
-          ...this.#botProperties(event.botId),
-          origin,
-          status: normalizedTurnStatus(event.status),
-          ...(activeTurn === undefined
-            ? {}
-            : { duration_ms: Math.max(0, Math.round(performance.now() - activeTurn.startedAt)) }),
-        });
+        this.#track(
+          "system_turn_completed",
+          {
+            ...this.#botProperties(event.botId),
+            origin,
+            status: normalizedTurnStatus(event.status),
+            ...(activeTurn === undefined
+              ? {}
+              : { duration_ms: Math.max(0, Math.round(performance.now() - activeTurn.startedAt)) }),
+          },
+          activeTurn?.owner,
+        );
         return;
       }
       case "prompt":
-        this.#track("system_agent_input_requested", {
-          ...this.#botProperties(event.botId),
-          origin: this.#activeTurns.get(event.turnId)?.origin ?? "unknown",
-          kind: "prompt",
-          prompt_count: event.questions.length,
-          has_secret_prompt: event.questions.some((question) => question.isSecret),
-        });
+        this.#track(
+          "system_agent_input_requested",
+          {
+            ...this.#botProperties(event.botId),
+            origin: this.#activeTurns.get(event.turnId)?.origin ?? "unknown",
+            kind: "prompt",
+            prompt_count: event.questions.length,
+            has_secret_prompt: event.questions.some((question) => question.isSecret),
+          },
+          this.#activeTurns.get(event.turnId)?.owner,
+        );
         return;
       case "approval":
-        this.#track("system_agent_input_requested", {
-          ...this.#botProperties(event.approval.botId),
-          origin: this.#activeTurns.get(event.approval.turnId)?.origin ?? "unknown",
-          kind: "approval",
-          approval_kind: event.approval.kind,
-        });
+        this.#track(
+          "system_agent_input_requested",
+          {
+            ...this.#botProperties(event.approval.botId),
+            origin: this.#activeTurns.get(event.approval.turnId)?.origin ?? "unknown",
+            kind: "approval",
+            approval_kind: event.approval.kind,
+          },
+          this.#activeTurns.get(event.approval.turnId)?.owner,
+        );
         return;
       case "error":
         this.#track("system_operation_failed", {
@@ -175,7 +192,6 @@ export class HostAnalytics {
 
   clear(): void {
     this.#pending = [];
-    this.#activeTurns.clear();
     this.#identifiedOwner = null;
     if (this.#trackingEnabled) this.#enqueue("clear", () => this.#client?.clear());
   }
@@ -185,6 +201,7 @@ export class HostAnalytics {
     this.#trackingEnabled = enabled;
     if (!enabled) {
       this.#hostedSiteOwners.clear();
+      this.#activeTurns.clear();
       this.clear();
       this.#operationQueue.operations = [];
       this.#enqueue("clear", () => this.#client?.clear());
@@ -263,16 +280,16 @@ export class HostAnalytics {
     for (const event of pending) this.#send(event.name, event.properties, owner.id, event.timestamp);
   }
 
-  #track(name: HostEventName, properties: HostProperties): void {
+  #track(name: HostEventName, properties: HostProperties, ownerOverride?: AnalyticsIdentity | null): void {
     if (!this.#trackingEnabled) return;
     const sanitized = sanitizeHostEvent(name, properties);
-    const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
+    const owner = ownerOverride === undefined ? normalizeAnalyticsIdentity(this.#resolveOwner()) : ownerOverride;
     if (!owner) {
       this.#pending.push({ name, properties: sanitized, timestamp: new Date().toISOString() });
       if (this.#pending.length > MAX_PENDING_EVENTS) this.#pending.shift();
       return;
     }
-    this.#trackForOwner(name, sanitized, owner);
+    this.#trackForOwner(name, sanitized, owner, ownerOverride === undefined);
   }
 
   #identify(owner: AnalyticsIdentity): void {

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -21,7 +21,8 @@ const ACTIVE_TURN_TTL_MS = 24 * 60 * 60 * 1_000;
 const ANALYTICS_SCHEMA_VERSION = 4;
 
 type AnalyticsIdentity = Pick<CentralAuthUser, "id" | "email">;
-type AnalyticsOperation = () => unknown;
+type AnalyticsOperationKind = "clear" | "identify" | "track";
+type AnalyticsOperation = { kind: AnalyticsOperationKind; run: () => unknown };
 type AnalyticsOperationQueue = { active: boolean; operations: AnalyticsOperation[] };
 type HostEventName =
   | "system_turn_started"
@@ -175,7 +176,7 @@ export class HostAnalytics {
     this.#activeTurns.clear();
     this.#identifiedOwner = null;
     this.#operationQueue.operations = [];
-    if (this.#trackingEnabled) this.#enqueue(() => this.#client?.clear());
+    if (this.#trackingEnabled) this.#enqueue("clear", () => this.#client?.clear());
   }
 
   setTrackingEnabled(enabled: boolean): void {
@@ -183,18 +184,24 @@ export class HostAnalytics {
     this.#trackingEnabled = enabled;
     if (!enabled) {
       this.clear();
-      this.#enqueue(() => this.#client?.clear());
+      this.#enqueue("clear", () => this.#client?.clear());
       return;
     }
     this.flushPending();
   }
 
   #handleHostedSiteConversation(messages: readonly ConversationMessage[]): void {
-    const observedRunningOperations = new Set(this.#hostedSiteOwners.keys());
-    for (const message of messages) {
+    const events = messages.flatMap((message) => {
       const event = hostedSiteConversationEvent(message);
-      if (!event) continue;
+      return event ? [event] : [];
+    });
+    const terminalOperations = new Set(
+      events.filter((event) => event.status !== "running").map((event) => event.operationId),
+    );
+    const observedRunningOperations = new Set(this.#hostedSiteOwners.keys());
+    for (const event of events) {
       if (event.status === "running") {
+        if (terminalOperations.has(event.operationId)) continue;
         const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
         if (!this.#hostedSiteOwners.has(event.operationId)) this.#hostedSiteOwners.set(event.operationId, owner);
         continue;
@@ -236,6 +243,12 @@ export class HostAnalytics {
     const sanitized = sanitizeHostEvent(name, properties);
     this.#flushPendingForOwner(owner);
     this.#send(name, sanitized, owner.id);
+    if (name === "hosted_site_action") {
+      const currentOwner = normalizeAnalyticsIdentity(this.#resolveOwner());
+      if (currentOwner?.id !== owner.id || currentOwner.email !== owner.email) {
+        this.#enqueue("clear", () => this.#client?.clear());
+      }
+    }
   }
 
   #flushPendingForOwner(owner: AnalyticsIdentity): void {
@@ -261,13 +274,13 @@ export class HostAnalytics {
     if (!this.#client) return;
     const previous = this.#identifiedOwner;
     if (previous?.id === owner.id && previous.email === owner.email) return;
-    if (previous && previous.id !== owner.id) this.#enqueue(() => this.#client?.clear());
+    if (previous && previous.id !== owner.id) this.#enqueue("clear", () => this.#client?.clear());
     this.#identifiedOwner = { ...owner };
-    this.#enqueue(() => this.#client?.identify({ profileId: owner.id, email: owner.email }));
+    this.#enqueue("identify", () => this.#client?.identify({ profileId: owner.id, email: owner.email }));
   }
 
   #send(name: HostEventName, properties: HostProperties, profileId: string, timestamp?: string): void {
-    this.#enqueue(() =>
+    this.#enqueue("track", () =>
       this.#client?.track(name, {
         ...properties,
         ...(timestamp ? { __timestamp: timestamp } : {}),
@@ -296,9 +309,22 @@ export class HostAnalytics {
     }
   }
 
-  #enqueue(operation: AnalyticsOperation): void {
-    if (this.#operationQueue.operations.length >= MAX_PENDING_EVENTS) this.#operationQueue.operations.shift();
-    this.#operationQueue.operations.push(operation);
+  #enqueue(kind: AnalyticsOperationKind, run: () => unknown): void {
+    if (kind === "clear") {
+      this.#operationQueue.operations = this.#operationQueue.operations.filter(
+        (operation) => operation.kind === "track",
+      );
+    } else if (kind === "identify") {
+      this.#operationQueue.operations = this.#operationQueue.operations.filter(
+        (operation) => operation.kind !== "identify",
+      );
+    } else if (
+      this.#operationQueue.operations.filter((operation) => operation.kind === "track").length >= MAX_PENDING_EVENTS
+    ) {
+      const oldestTrack = this.#operationQueue.operations.findIndex((operation) => operation.kind === "track");
+      if (oldestTrack >= 0) this.#operationQueue.operations.splice(oldestTrack, 1);
+    }
+    this.#operationQueue.operations.push({ kind, run });
     if (this.#operationQueue.active) return;
     this.#operationQueue.active = true;
     void this.#drainQueue();
@@ -309,7 +335,7 @@ export class HostAnalytics {
       const operation = this.#operationQueue.operations.shift();
       if (!operation) continue;
       try {
-        const result = operation();
+        const result = operation.run();
         if (isPromiseLike(result)) await result;
       } catch {
         // Analytics must never change host behavior or stop later events.

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -225,6 +225,7 @@ export class HostAnalytics {
               : {}),
         },
         owner,
+        false,
       );
     }
     while (this.#hostedSiteOwners.size > MAX_HOSTED_SITE_OPERATIONS) {
@@ -239,9 +240,10 @@ export class HostAnalytics {
     }
   }
 
-  #trackForOwner(name: HostEventName, properties: HostProperties, owner: AnalyticsIdentity): void {
+  #trackForOwner(name: HostEventName, properties: HostProperties, owner: AnalyticsIdentity, flushPending = true): void {
     const sanitized = sanitizeHostEvent(name, properties);
-    this.#flushPendingForOwner(owner);
+    if (flushPending) this.#flushPendingForOwner(owner);
+    else this.#identify(owner);
     this.#send(name, sanitized, owner.id);
     if (name === "hosted_site_action") {
       const currentOwner = normalizeAnalyticsIdentity(this.#resolveOwner());
@@ -274,6 +276,7 @@ export class HostAnalytics {
     if (!this.#client) return;
     const previous = this.#identifiedOwner;
     if (previous?.id === owner.id && previous.email === owner.email) return;
+    if (previous) this.#operationQueue.operations = [];
     if (previous && previous.id !== owner.id) this.#enqueue("clear", () => this.#client?.clear());
     this.#identifiedOwner = { ...owner };
     this.#enqueue("identify", () => this.#client?.identify({ profileId: owner.id, email: owner.email }));

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -103,7 +103,9 @@ export class HostAnalytics {
   }
 
   handleAgentEvent(event: AgentEvent): void {
-    if (event.type === "conversation" && this.#client) this.#handleHostedSiteConversation(event.snapshot.messages);
+    if (event.type === "conversation" && this.#client && this.#trackingEnabled) {
+      this.#handleHostedSiteConversation(event.snapshot.messages);
+    }
     if (!this.#client || !this.#trackingEnabled) return;
     switch (event.type) {
       case "conversation":
@@ -183,6 +185,7 @@ export class HostAnalytics {
     if (this.#trackingEnabled === enabled) return;
     this.#trackingEnabled = enabled;
     if (!enabled) {
+      this.#hostedSiteOwners.clear();
       this.clear();
       this.#enqueue("clear", () => this.#client?.clear());
       return;
@@ -276,7 +279,6 @@ export class HostAnalytics {
     if (!this.#client) return;
     const previous = this.#identifiedOwner;
     if (previous?.id === owner.id && previous.email === owner.email) return;
-    if (previous) this.#operationQueue.operations = [];
     if (previous && previous.id !== owner.id) this.#enqueue("clear", () => this.#client?.clear());
     this.#identifiedOwner = { ...owner };
     this.#enqueue("identify", () => this.#client?.identify({ profileId: owner.id, email: owner.email }));
@@ -313,11 +315,10 @@ export class HostAnalytics {
   }
 
   #enqueue(kind: AnalyticsOperationKind, run: () => unknown): void {
-    if (kind === "clear") {
-      this.#operationQueue.operations = this.#operationQueue.operations.filter(
-        (operation) => operation.kind === "track",
-      );
-    } else if (kind === "identify") {
+    const hasPendingTrack = this.#operationQueue.operations.some((operation) => operation.kind === "track");
+    if (kind === "clear" && !hasPendingTrack) {
+      this.#operationQueue.operations = [];
+    } else if (kind === "identify" && !hasPendingTrack) {
       this.#operationQueue.operations = this.#operationQueue.operations.filter(
         (operation) => operation.kind !== "identify",
       );

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -177,7 +177,6 @@ export class HostAnalytics {
     this.#pending = [];
     this.#activeTurns.clear();
     this.#identifiedOwner = null;
-    this.#operationQueue.operations = [];
     if (this.#trackingEnabled) this.#enqueue("clear", () => this.#client?.clear());
   }
 
@@ -187,6 +186,7 @@ export class HostAnalytics {
     if (!enabled) {
       this.#hostedSiteOwners.clear();
       this.clear();
+      this.#operationQueue.operations = [];
       this.#enqueue("clear", () => this.#client?.clear());
       return;
     }

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -70,6 +70,7 @@ export class HostAnalytics {
   readonly #client: HostOpenPanelClient | null;
   #identifiedOwner: AnalyticsIdentity | null = null;
   #trackingEnabled: boolean;
+  #bufferOwnerlessEvents = true;
   #pending: HostPendingEvent[] = [];
   readonly #activeTurns = new Map<string, ActiveTurn>();
   readonly #hostedSiteOwners = new Map<string, AnalyticsIdentity | null>();
@@ -187,11 +188,13 @@ export class HostAnalytics {
     if (!this.#client || !this.#trackingEnabled) return;
     const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
     if (!owner) return;
+    this.#bufferOwnerlessEvents = true;
     this.#flushPendingForOwner(owner);
   }
 
   clear(): void {
     this.#pending = [];
+    this.#bufferOwnerlessEvents = false;
     this.#identifiedOwner = null;
     if (this.#trackingEnabled) this.#enqueue("clear", () => this.#client?.clear());
   }
@@ -267,6 +270,7 @@ export class HostAnalytics {
     this.#send(name, sanitized, owner.id);
     const currentOwner = normalizeAnalyticsIdentity(this.#resolveOwner());
     if (currentOwner?.id !== owner.id || currentOwner.email !== owner.email) {
+      this.#identifiedOwner = null;
       this.#enqueue("clear", () => this.#client?.clear());
     }
   }
@@ -283,6 +287,7 @@ export class HostAnalytics {
     const sanitized = sanitizeHostEvent(name, properties);
     const owner = ownerOverride === undefined ? normalizeAnalyticsIdentity(this.#resolveOwner()) : ownerOverride;
     if (!owner) {
+      if (!this.#bufferOwnerlessEvents) return;
       this.#pending.push({ name, properties: sanitized, timestamp: new Date().toISOString() });
       if (this.#pending.length > MAX_PENDING_EVENTS) this.#pending.shift();
       return;

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -6,7 +6,8 @@ import {
   type CentralAuthUser,
   isAgentModel,
 } from "@openbot/contracts/ipc";
-import { isBoolean, isNumber, isOneOf, isString } from "@openbot/contracts/runtime-values";
+import { isBoolean, isDynamicRecord, isFunction, isNumber, isOneOf, isString } from "@openbot/contracts/runtime-values";
+import { normalizeEmailAddress } from "@openbot/contracts/validation";
 import { OpenPanelBase, type OpenPanelOptions } from "@openpanel/web";
 
 export const OPENPANEL_API_URL = "https://analytics.openbot.run/api";
@@ -14,9 +15,11 @@ export const OPENPANEL_CLIENT_ID = "6c989975-87ef-4f0c-857e-ab449a65b5c2";
 const MAX_PENDING_EVENTS = 100;
 const MAX_ACTIVE_TURNS = 1_000;
 const ACTIVE_TURN_TTL_MS = 24 * 60 * 60 * 1_000;
-const ANALYTICS_SCHEMA_VERSION = 3;
+const ANALYTICS_SCHEMA_VERSION = 4;
 
 type AnalyticsIdentity = Pick<CentralAuthUser, "id" | "email">;
+type AnalyticsOperation = () => unknown;
+type AnalyticsOperationQueue = { active: boolean; operations: AnalyticsOperation[] };
 type HostEventName =
   | "system_turn_started"
   | "system_turn_completed"
@@ -63,6 +66,7 @@ export class HostAnalytics {
   #trackingEnabled: boolean;
   #pending: HostPendingEvent[] = [];
   readonly #activeTurns = new Map<string, ActiveTurn>();
+  readonly #operationQueue: AnalyticsOperationQueue = { active: false, operations: [] };
 
   constructor(
     options: HostAnalyticsOptions,
@@ -151,7 +155,7 @@ export class HostAnalytics {
 
   flushPending(): void {
     if (!this.#client || !this.#trackingEnabled) return;
-    const owner = this.#resolveOwner();
+    const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
     if (!owner) return;
     this.#identify(owner);
     const pending = this.#pending;
@@ -159,14 +163,20 @@ export class HostAnalytics {
     for (const event of pending) this.#send(event.name, event.properties, owner.id, event.timestamp);
   }
 
+  clear(): void {
+    this.#pending = [];
+    this.#activeTurns.clear();
+    this.#identifiedOwner = null;
+    this.#operationQueue.operations = [];
+    if (this.#trackingEnabled) this.#enqueue(() => this.#client?.clear());
+  }
+
   setTrackingEnabled(enabled: boolean): void {
     if (this.#trackingEnabled === enabled) return;
     this.#trackingEnabled = enabled;
     if (!enabled) {
-      this.#pending = [];
-      this.#activeTurns.clear();
-      this.#identifiedOwner = null;
-      this.#run(() => this.#client?.clear());
+      this.clear();
+      this.#enqueue(() => this.#client?.clear());
       return;
     }
     this.flushPending();
@@ -175,7 +185,7 @@ export class HostAnalytics {
   #track(name: HostEventName, properties: HostProperties): void {
     if (!this.#trackingEnabled) return;
     const sanitized = sanitizeHostEvent(name, properties);
-    const owner = this.#resolveOwner();
+    const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
     if (!owner) {
       this.#pending.push({ name, properties: sanitized, timestamp: new Date().toISOString() });
       if (this.#pending.length > MAX_PENDING_EVENTS) this.#pending.shift();
@@ -190,13 +200,13 @@ export class HostAnalytics {
     if (!this.#client) return;
     const previous = this.#identifiedOwner;
     if (previous?.id === owner.id && previous.email === owner.email) return;
-    if (previous && previous.id !== owner.id) this.#run(() => this.#client?.clear());
+    if (previous && previous.id !== owner.id) this.#enqueue(() => this.#client?.clear());
     this.#identifiedOwner = { ...owner };
-    this.#run(() => this.#client?.identify({ profileId: owner.id, email: owner.email }));
+    this.#enqueue(() => this.#client?.identify({ profileId: owner.id, email: owner.email }));
   }
 
   #send(name: HostEventName, properties: HostProperties, profileId: string, timestamp?: string): void {
-    this.#run(() =>
+    this.#enqueue(() =>
       this.#client?.track(name, {
         ...properties,
         ...(timestamp ? { __timestamp: timestamp } : {}),
@@ -225,14 +235,37 @@ export class HostAnalytics {
     }
   }
 
-  #run(operation: () => unknown): void {
-    try {
-      const result = operation();
-      if (result instanceof Promise) void result.catch(() => undefined);
-    } catch {
-      // Analytics must never change host behavior.
-    }
+  #enqueue(operation: AnalyticsOperation): void {
+    this.#operationQueue.operations.push(operation);
+    if (this.#operationQueue.active) return;
+    this.#operationQueue.active = true;
+    void this.#drainQueue();
   }
+
+  async #drainQueue(): Promise<void> {
+    while (this.#operationQueue.operations.length > 0) {
+      const operation = this.#operationQueue.operations.shift();
+      if (!operation) continue;
+      try {
+        const result = operation();
+        if (isPromiseLike(result)) await result;
+      } catch {
+        // Analytics must never change host behavior or stop later events.
+      }
+    }
+    this.#operationQueue.active = false;
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return isDynamicRecord(value) && isFunction(value.then);
+}
+
+function normalizeAnalyticsIdentity(user: AnalyticsIdentity | null): AnalyticsIdentity | null {
+  if (!user) return null;
+  const id = user.id.trim();
+  const email = normalizeEmailAddress(user.email);
+  return id && email ? { id, email } : null;
 }
 
 export function sanitizeHostEvent(name: HostEventName, properties: HostProperties): HostProperties {

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -62,7 +62,12 @@ const HOST_ALLOWLIST = {
 type HostPropertyName = (typeof HOST_ALLOWLIST)[HostEventName][number];
 type HostProperties = Partial<Record<HostPropertyName, string | number | boolean>>;
 type HostPendingEvent = { name: HostEventName; properties: HostProperties; timestamp: string };
-type ActiveTurn = { startedAt: number; origin: string; owner: AnalyticsIdentity | null };
+type ActiveTurn = {
+  startedAt: number;
+  origin: string;
+  owner: AnalyticsIdentity | null;
+  ownerResolutionPending: boolean;
+};
 
 export class HostAnalytics {
   readonly #resolveOwner: HostAnalyticsOptions["resolveOwner"];
@@ -117,7 +122,12 @@ export class HostAnalytics {
         if (this.#activeTurns.has(event.turnId)) return;
         this.#makeTurnCapacity();
         const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
-        this.#activeTurns.set(event.turnId, { startedAt: now, origin: event.origin ?? "unknown", owner });
+        this.#activeTurns.set(event.turnId, {
+          startedAt: now,
+          origin: event.origin ?? "unknown",
+          owner,
+          ownerResolutionPending: owner === null && this.#bufferOwnerlessEvents,
+        });
         this.#track(
           "system_turn_started",
           {
@@ -189,12 +199,20 @@ export class HostAnalytics {
     const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
     if (!owner) return;
     this.#bufferOwnerlessEvents = true;
+    for (const activeTurn of this.#activeTurns.values()) {
+      if (!activeTurn.ownerResolutionPending) continue;
+      activeTurn.owner = owner;
+      activeTurn.ownerResolutionPending = false;
+    }
     this.#flushPendingForOwner(owner);
   }
 
   clear(): void {
     this.#pending = [];
     this.#bufferOwnerlessEvents = false;
+    for (const activeTurn of this.#activeTurns.values()) {
+      if (activeTurn.owner === null) activeTurn.ownerResolutionPending = false;
+    }
     this.#identifiedOwner = null;
     if (this.#trackingEnabled) this.#enqueue("clear", () => this.#client?.clear());
   }

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -265,11 +265,9 @@ export class HostAnalytics {
     if (flushPending) this.#flushPendingForOwner(owner);
     else this.#identify(owner);
     this.#send(name, sanitized, owner.id);
-    if (name === "hosted_site_action") {
-      const currentOwner = normalizeAnalyticsIdentity(this.#resolveOwner());
-      if (currentOwner?.id !== owner.id || currentOwner.email !== owner.email) {
-        this.#enqueue("clear", () => this.#client?.clear());
-      }
+    const currentOwner = normalizeAnalyticsIdentity(this.#resolveOwner());
+    if (currentOwner?.id !== owner.id || currentOwner.email !== owner.email) {
+      this.#enqueue("clear", () => this.#client?.clear());
     }
   }
 

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -4,6 +4,8 @@ import {
   type AgentEvent,
   type BotSummary,
   type CentralAuthUser,
+  type ConversationMessage,
+  hostedSiteConversationEvent,
   isAgentModel,
 } from "@openbot/contracts/ipc";
 import { isBoolean, isDynamicRecord, isFunction, isNumber, isOneOf, isString } from "@openbot/contracts/runtime-values";
@@ -14,6 +16,7 @@ export const OPENPANEL_API_URL = "https://analytics.openbot.run/api";
 export const OPENPANEL_CLIENT_ID = "6c989975-87ef-4f0c-857e-ab449a65b5c2";
 const MAX_PENDING_EVENTS = 100;
 const MAX_ACTIVE_TURNS = 1_000;
+const MAX_HOSTED_SITE_OPERATIONS = 10_000;
 const ACTIVE_TURN_TTL_MS = 24 * 60 * 60 * 1_000;
 const ANALYTICS_SCHEMA_VERSION = 4;
 
@@ -24,7 +27,8 @@ type HostEventName =
   | "system_turn_started"
   | "system_turn_completed"
   | "system_agent_input_requested"
-  | "system_operation_failed";
+  | "system_operation_failed"
+  | "hosted_site_action";
 export type HostOpenPanelClient = Pick<OpenPanelBase, "setGlobalProperties" | "track" | "identify" | "clear">;
 type ClientFactory = (options: OpenPanelOptions) => HostOpenPanelClient;
 
@@ -51,6 +55,7 @@ const HOST_ALLOWLIST = {
     "approval_kind",
   ],
   system_operation_failed: ["provider", "model", "reasoning_effort", "area", "failure_code"],
+  hosted_site_action: ["action", "entry_point", "result", "failure_code"],
 } as const satisfies Record<HostEventName, readonly string[]>;
 
 type HostPropertyName = (typeof HOST_ALLOWLIST)[HostEventName][number];
@@ -66,6 +71,8 @@ export class HostAnalytics {
   #trackingEnabled: boolean;
   #pending: HostPendingEvent[] = [];
   readonly #activeTurns = new Map<string, ActiveTurn>();
+  readonly #hostedSiteOwners = new Map<string, AnalyticsIdentity | null>();
+  readonly #hostedSiteTerminalOperations = new Set<string>();
   readonly #operationQueue: AnalyticsOperationQueue = { active: false, operations: [] };
 
   constructor(
@@ -95,8 +102,11 @@ export class HostAnalytics {
   }
 
   handleAgentEvent(event: AgentEvent): void {
+    if (event.type === "conversation" && this.#client) this.#handleHostedSiteConversation(event.snapshot.messages);
     if (!this.#client || !this.#trackingEnabled) return;
     switch (event.type) {
+      case "conversation":
+        return;
       case "turn-started": {
         const now = performance.now();
         this.#pruneActiveTurns(now);
@@ -157,10 +167,7 @@ export class HostAnalytics {
     if (!this.#client || !this.#trackingEnabled) return;
     const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
     if (!owner) return;
-    this.#identify(owner);
-    const pending = this.#pending;
-    this.#pending = [];
-    for (const event of pending) this.#send(event.name, event.properties, owner.id, event.timestamp);
+    this.#flushPendingForOwner(owner);
   }
 
   clear(): void {
@@ -182,6 +189,62 @@ export class HostAnalytics {
     this.flushPending();
   }
 
+  #handleHostedSiteConversation(messages: readonly ConversationMessage[]): void {
+    const observedRunningOperations = new Set(this.#hostedSiteOwners.keys());
+    for (const message of messages) {
+      const event = hostedSiteConversationEvent(message);
+      if (!event) continue;
+      if (event.status === "running") {
+        const owner = normalizeAnalyticsIdentity(this.#resolveOwner());
+        if (!this.#hostedSiteOwners.has(event.operationId)) this.#hostedSiteOwners.set(event.operationId, owner);
+        continue;
+      }
+      if (!observedRunningOperations.has(event.operationId)) continue;
+      if (this.#hostedSiteTerminalOperations.has(event.operationId)) continue;
+      this.#hostedSiteTerminalOperations.add(event.operationId);
+      const owner = this.#hostedSiteOwners.get(event.operationId) ?? null;
+      this.#hostedSiteOwners.delete(event.operationId);
+      if (!owner || !this.#trackingEnabled) continue;
+      this.#trackForOwner(
+        "hosted_site_action",
+        {
+          action: event.action,
+          entry_point: "agent",
+          result: event.status === "succeeded" ? "succeeded" : "failed",
+          ...(event.status === "failed"
+            ? { failure_code: "hosted_site_failed" }
+            : event.status === "cancelled" || event.status === "interrupted"
+              ? { failure_code: event.status }
+              : {}),
+        },
+        owner,
+      );
+    }
+    while (this.#hostedSiteOwners.size > MAX_HOSTED_SITE_OPERATIONS) {
+      const oldest = this.#hostedSiteOwners.keys().next();
+      if (oldest.done) break;
+      this.#hostedSiteOwners.delete(oldest.value);
+    }
+    while (this.#hostedSiteTerminalOperations.size > MAX_HOSTED_SITE_OPERATIONS) {
+      const oldest = this.#hostedSiteTerminalOperations.values().next();
+      if (oldest.done) break;
+      this.#hostedSiteTerminalOperations.delete(oldest.value);
+    }
+  }
+
+  #trackForOwner(name: HostEventName, properties: HostProperties, owner: AnalyticsIdentity): void {
+    const sanitized = sanitizeHostEvent(name, properties);
+    this.#flushPendingForOwner(owner);
+    this.#send(name, sanitized, owner.id);
+  }
+
+  #flushPendingForOwner(owner: AnalyticsIdentity): void {
+    this.#identify(owner);
+    const pending = this.#pending;
+    this.#pending = [];
+    for (const event of pending) this.#send(event.name, event.properties, owner.id, event.timestamp);
+  }
+
   #track(name: HostEventName, properties: HostProperties): void {
     if (!this.#trackingEnabled) return;
     const sanitized = sanitizeHostEvent(name, properties);
@@ -191,9 +254,7 @@ export class HostAnalytics {
       if (this.#pending.length > MAX_PENDING_EVENTS) this.#pending.shift();
       return;
     }
-    this.#identify(owner);
-    this.flushPending();
-    this.#send(name, sanitized, owner.id);
+    this.#trackForOwner(name, sanitized, owner);
   }
 
   #identify(owner: AnalyticsIdentity): void {
@@ -236,6 +297,7 @@ export class HostAnalytics {
   }
 
   #enqueue(operation: AnalyticsOperation): void {
+    if (this.#operationQueue.operations.length >= MAX_PENDING_EVENTS) this.#operationQueue.operations.shift();
     this.#operationQueue.operations.push(operation);
     if (this.#operationQueue.active) return;
     this.#operationQueue.active = true;
@@ -273,14 +335,25 @@ export function sanitizeHostEvent(name: HostEventName, properties: HostPropertie
   return Object.fromEntries(
     Object.entries(properties).flatMap(([key, value]) => {
       if (value === undefined || !allowed.some((item) => item === key)) return [];
-      const safeValue = sanitizeHostProperty(key, value);
+      const safeValue = sanitizeHostProperty(name, key, value);
       return safeValue === undefined ? [] : [[key, safeValue]];
     }),
   );
 }
 
-function sanitizeHostProperty(key: string, value: unknown): string | number | boolean | undefined {
-  if (key === "failure_code") return isString(value) ? systemFailureCode(value) : "unknown";
+function sanitizeHostProperty(name: HostEventName, key: string, value: unknown): string | number | boolean | undefined {
+  if (key === "failure_code") {
+    return isString(value)
+      ? name === "hosted_site_action"
+        ? hostedSiteFailureCode(value)
+        : systemFailureCode(value)
+      : "unknown";
+  }
+  if (name === "hosted_site_action") {
+    if (key === "action") return isOneOf(["publish", "replace", "delete"] as const, value) ? value : undefined;
+    if (key === "entry_point") return value === "agent" ? value : undefined;
+    if (key === "result") return isOneOf(["succeeded", "failed"] as const, value) ? value : undefined;
+  }
   if (key === "provider") return isOneOf(AGENT_PROVIDERS, value) ? value : undefined;
   if (key === "reasoning_effort") {
     return isOneOf(AGENT_REASONING_EFFORTS, value) ? value : undefined;
@@ -303,6 +376,10 @@ function sanitizeHostProperty(key: string, value: unknown): string | number | bo
   }
   if (key === "has_secret_prompt") return isBoolean(value) ? value : undefined;
   return undefined;
+}
+
+function hostedSiteFailureCode(value: string): string {
+  return value === "hosted_site_failed" || value === "cancelled" || value === "interrupted" ? value : "unknown";
 }
 
 function normalizedTurnStatus(value: string): string {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1926,10 +1926,10 @@ if (!hasSingleInstanceLock) {
         appVersion: app.getVersion(),
         platform: analyticsPlatform,
         resolveOwner: () => {
-          const storedOwner = teamStore.getOwnerAnalyticsIdentity();
-          if (storedOwner) return storedOwner;
           const state = centralAuthManager?.getState();
           if (state?.status !== "signed_in") return null;
+          const storedOwner = teamStore.getOwnerAnalyticsIdentity();
+          if (storedOwner) return storedOwner;
           const ownerEmail = teamStore.getOwnerEmail();
           return !teamStore.configured || ownerEmail?.trim().toLowerCase() === state.user.email.trim().toLowerCase()
             ? state.user

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1929,7 +1929,7 @@ if (!hasSingleInstanceLock) {
           const state = centralAuthManager?.getState();
           if (state?.status !== "signed_in") return null;
           const storedOwner = teamStore.getOwnerAnalyticsIdentity();
-          if (storedOwner) return storedOwner;
+          if (storedOwner) return storedOwner.id === state.user.id ? storedOwner : null;
           const ownerEmail = teamStore.getOwnerEmail();
           return !teamStore.configured || ownerEmail?.trim().toLowerCase() === state.user.email.trim().toLowerCase()
             ? state.user

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -265,6 +265,7 @@ let remoteDesktopManager: RemoteDesktopManager | null = null;
 let remoteServerManager: RemoteServerManager | null = null;
 let centralAuthManager: CentralAuthManager | null = null;
 let activeRemotePrincipalId: string | null = null;
+let activeAnalyticsPrincipalId: string | null = null;
 let remoteAccountSync = Promise.resolve();
 let hostAnalytics: HostAnalytics | null = null;
 let teamWebRtcBridge: TeamWebRtcBridge | null = null;
@@ -1574,6 +1575,13 @@ function forwardDirectTyping(
 }
 
 function forwardCentralAuth(state: CentralAuthState): void {
+  if (state.status === "signed_in") {
+    if (activeAnalyticsPrincipalId && activeAnalyticsPrincipalId !== state.user.id) hostAnalytics?.clear();
+    activeAnalyticsPrincipalId = state.user.id;
+  } else if (state.status === "signed_out") {
+    if (activeAnalyticsPrincipalId) hostAnalytics?.clear();
+    activeAnalyticsPrincipalId = null;
+  }
   remoteAccountSync = remoteAccountSync
     .then(async () => {
       const nextPrincipalId = state.status === "signed_in" ? state.user.id : null;

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -19,7 +19,7 @@ import type {
   UpdateStatus,
   VoiceModelStatus,
 } from "@openbot/contracts/ipc";
-import { routineConversationEventItemType } from "@openbot/contracts/ipc";
+import { hostedSiteConversationEventItemType, routineConversationEventItemType } from "@openbot/contracts/ipc";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { createSignal, Show } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -120,6 +120,34 @@ function testConversationPage(
     readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null },
     pageInfo: { hasOlder: false, olderCursor: null },
     ...overrides,
+  };
+}
+
+function hostedSiteMessage(
+  id: string,
+  action: "publish" | "replace" | "delete",
+  status: "running" | "succeeded" | "failed" | "interrupted" | "cancelled",
+  operationId: string,
+): ConversationPage["messages"][number] {
+  const terminalSite = {
+    siteId: "site-1",
+    title: "Hosted site",
+    hostname: "hosted-site-23456789ab.openbot.site",
+    url: "https://hosted-site-23456789ab.openbot.site",
+  };
+  const details =
+    action === "publish" && status !== "succeeded"
+      ? { siteId: null, title: "Hosted site", hostname: null, url: null }
+      : terminalSite;
+  return {
+    id,
+    turnId: "turn-hosted-site",
+    author: "system",
+    source: "system",
+    text: JSON.stringify(details),
+    createdAt: "2026-08-31T10:00:00.000Z",
+    status: "completed",
+    itemType: hostedSiteConversationEventItemType(action, status, operationId),
   };
 }
 
@@ -962,6 +990,81 @@ describe("OpenBot connected desktop shell", () => {
     expect(await screen.findByText("Archived brief")).toBeInTheDocument();
     await waitFor(() => expect(window.openbot.agent.listRoutines).toHaveBeenCalledWith("chief"));
     expect(screen.queryByRole("button", { name: "Open routine Archived brief" })).not.toBeInTheDocument();
+  });
+
+  it("tracks only new terminal hosted-site markers once", async () => {
+    const historical = hostedSiteMessage("hosted-history", "publish", "succeeded", "operation-history");
+    vi.mocked(window.openbot.agent.readConversation).mockResolvedValueOnce(testConversationPage("chief", [historical]));
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    await waitFor(() => expect(window.openbot.agent.readConversation).toHaveBeenCalled());
+    trackAnalytics.mockClear();
+
+    const running = hostedSiteMessage("hosted-running", "publish", "running", "operation-live");
+    const succeeded = hostedSiteMessage("hosted-succeeded", "publish", "succeeded", "operation-live");
+    emitAgentEvent?.({
+      type: "conversation",
+      snapshot: {
+        botId: "chief",
+        threadId: "thread-1",
+        activeTurnId: null,
+        revision: 2,
+        messages: [historical, running, succeeded],
+      },
+    });
+    await waitFor(() =>
+      expect(trackAnalytics).toHaveBeenCalledWith("hosted_site_action", {
+        action: "publish",
+        entry_point: "agent",
+        result: "succeeded",
+      }),
+    );
+    expect(trackAnalytics).toHaveBeenCalledTimes(1);
+
+    emitAgentEvent?.({
+      type: "conversation-page",
+      page: testConversationPage("chief", [historical, running, succeeded], { revision: 3 }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(trackAnalytics).toHaveBeenCalledTimes(1);
+
+    const failedReplace = hostedSiteMessage("hosted-failed", "replace", "failed", "operation-failed");
+    const cancelledDelete = hostedSiteMessage("hosted-cancelled", "delete", "cancelled", "operation-cancelled");
+    const interruptedReplace = hostedSiteMessage(
+      "hosted-interrupted",
+      "replace",
+      "interrupted",
+      "operation-interrupted",
+    );
+    emitAgentEvent?.({
+      type: "conversation",
+      snapshot: {
+        botId: "chief",
+        threadId: "thread-1",
+        activeTurnId: null,
+        revision: 4,
+        messages: [historical, running, succeeded, failedReplace, cancelledDelete, interruptedReplace],
+      },
+    });
+    await waitFor(() => expect(trackAnalytics).toHaveBeenCalledTimes(4));
+    expect(trackAnalytics).toHaveBeenCalledWith("hosted_site_action", {
+      action: "replace",
+      entry_point: "agent",
+      result: "failed",
+      failure_code: "hosted_site_failed",
+    });
+    expect(trackAnalytics).toHaveBeenCalledWith("hosted_site_action", {
+      action: "delete",
+      entry_point: "agent",
+      result: "failed",
+      failure_code: "cancelled",
+    });
+    expect(trackAnalytics).toHaveBeenCalledWith("hosted_site_action", {
+      action: "replace",
+      entry_point: "agent",
+      result: "failed",
+      failure_code: "interrupted",
+    });
   });
 
   it("restores the active server before loading its workspace data", async () => {
@@ -1958,6 +2061,18 @@ describe("OpenBot connected desktop shell", () => {
     expect(window.openbot.browser.setVisible).not.toHaveBeenCalled();
     expect(window.openbot.remoteDesktop.list).not.toHaveBeenCalled();
     expect(window.openbot.remoteDesktop.onEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not configure desktop analytics in the landing preview", async () => {
+    const configure = vi.spyOn(desktopAnalytics, "configure");
+    try {
+      render(() => <App landingPreview />);
+
+      await screen.findByRole("heading", { name: "Chief" });
+      expect(configure).not.toHaveBeenCalled();
+    } finally {
+      configure.mockRestore();
+    }
   });
 
   it("opens, hides, resumes, and disconnects Remote Control from the header", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -19,7 +19,7 @@ import type {
   UpdateStatus,
   VoiceModelStatus,
 } from "@openbot/contracts/ipc";
-import { hostedSiteConversationEventItemType, routineConversationEventItemType } from "@openbot/contracts/ipc";
+import { routineConversationEventItemType } from "@openbot/contracts/ipc";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { createSignal, Show } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -120,34 +120,6 @@ function testConversationPage(
     readState: { unreadCount: 0, firstUnreadMessageId: null, throughMessageId: null },
     pageInfo: { hasOlder: false, olderCursor: null },
     ...overrides,
-  };
-}
-
-function hostedSiteMessage(
-  id: string,
-  action: "publish" | "replace" | "delete",
-  status: "running" | "succeeded" | "failed" | "interrupted" | "cancelled",
-  operationId: string,
-): ConversationPage["messages"][number] {
-  const terminalSite = {
-    siteId: "site-1",
-    title: "Hosted site",
-    hostname: "hosted-site-23456789ab.openbot.site",
-    url: "https://hosted-site-23456789ab.openbot.site",
-  };
-  const details =
-    action === "publish" && status !== "succeeded"
-      ? { siteId: null, title: "Hosted site", hostname: null, url: null }
-      : terminalSite;
-  return {
-    id,
-    turnId: "turn-hosted-site",
-    author: "system",
-    source: "system",
-    text: JSON.stringify(details),
-    createdAt: "2026-08-31T10:00:00.000Z",
-    status: "completed",
-    itemType: hostedSiteConversationEventItemType(action, status, operationId),
   };
 }
 
@@ -990,81 +962,6 @@ describe("OpenBot connected desktop shell", () => {
     expect(await screen.findByText("Archived brief")).toBeInTheDocument();
     await waitFor(() => expect(window.openbot.agent.listRoutines).toHaveBeenCalledWith("chief"));
     expect(screen.queryByRole("button", { name: "Open routine Archived brief" })).not.toBeInTheDocument();
-  });
-
-  it("tracks only new terminal hosted-site markers once", async () => {
-    const historical = hostedSiteMessage("hosted-history", "publish", "succeeded", "operation-history");
-    vi.mocked(window.openbot.agent.readConversation).mockResolvedValueOnce(testConversationPage("chief", [historical]));
-    render(() => <App />);
-    await screen.findByRole("heading", { name: "Chief" });
-    await waitFor(() => expect(window.openbot.agent.readConversation).toHaveBeenCalled());
-    trackAnalytics.mockClear();
-
-    const running = hostedSiteMessage("hosted-running", "publish", "running", "operation-live");
-    const succeeded = hostedSiteMessage("hosted-succeeded", "publish", "succeeded", "operation-live");
-    emitAgentEvent?.({
-      type: "conversation",
-      snapshot: {
-        botId: "chief",
-        threadId: "thread-1",
-        activeTurnId: null,
-        revision: 2,
-        messages: [historical, running, succeeded],
-      },
-    });
-    await waitFor(() =>
-      expect(trackAnalytics).toHaveBeenCalledWith("hosted_site_action", {
-        action: "publish",
-        entry_point: "agent",
-        result: "succeeded",
-      }),
-    );
-    expect(trackAnalytics).toHaveBeenCalledTimes(1);
-
-    emitAgentEvent?.({
-      type: "conversation-page",
-      page: testConversationPage("chief", [historical, running, succeeded], { revision: 3 }),
-    });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(trackAnalytics).toHaveBeenCalledTimes(1);
-
-    const failedReplace = hostedSiteMessage("hosted-failed", "replace", "failed", "operation-failed");
-    const cancelledDelete = hostedSiteMessage("hosted-cancelled", "delete", "cancelled", "operation-cancelled");
-    const interruptedReplace = hostedSiteMessage(
-      "hosted-interrupted",
-      "replace",
-      "interrupted",
-      "operation-interrupted",
-    );
-    emitAgentEvent?.({
-      type: "conversation",
-      snapshot: {
-        botId: "chief",
-        threadId: "thread-1",
-        activeTurnId: null,
-        revision: 4,
-        messages: [historical, running, succeeded, failedReplace, cancelledDelete, interruptedReplace],
-      },
-    });
-    await waitFor(() => expect(trackAnalytics).toHaveBeenCalledTimes(4));
-    expect(trackAnalytics).toHaveBeenCalledWith("hosted_site_action", {
-      action: "replace",
-      entry_point: "agent",
-      result: "failed",
-      failure_code: "hosted_site_failed",
-    });
-    expect(trackAnalytics).toHaveBeenCalledWith("hosted_site_action", {
-      action: "delete",
-      entry_point: "agent",
-      result: "failed",
-      failure_code: "cancelled",
-    });
-    expect(trackAnalytics).toHaveBeenCalledWith("hosted_site_action", {
-      action: "replace",
-      entry_point: "agent",
-      result: "failed",
-      failure_code: "interrupted",
-    });
   });
 
   it("restores the active server before loading its workspace data", async () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,7 +39,11 @@ import type {
   UpdateStatus,
   UpdateTeamMemberInput,
 } from "@openbot/contracts/ipc";
-import { ROUTINE_EVENT_ITEM_TYPE_PREFIX, ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX } from "@openbot/contracts/ipc";
+import {
+  HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX,
+  ROUTINE_EVENT_ITEM_TYPE_PREFIX,
+  ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX,
+} from "@openbot/contracts/ipc";
 import type { TeamProtocolV3Capability } from "@openbot/contracts/team-protocol/v3";
 import {
   createContext,
@@ -168,7 +172,8 @@ type BrowserTakeoverEvent = Extract<AgentEvent, { type: "browser-takeover-reques
 function isRoutineEventItem(message: { itemType?: string }): boolean {
   return (
     message.itemType?.startsWith(ROUTINE_EVENT_ITEM_TYPE_PREFIX) === true ||
-    message.itemType?.startsWith(ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX) === true
+    message.itemType?.startsWith(ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX) === true ||
+    message.itemType?.startsWith(HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX) === true
   );
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -41,6 +41,7 @@ import type {
 } from "@openbot/contracts/ipc";
 import {
   HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX,
+  hostedSiteConversationEvent,
   ROUTINE_EVENT_ITEM_TYPE_PREFIX,
   ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX,
 } from "@openbot/contracts/ipc";
@@ -458,6 +459,8 @@ export function createAppController(props: AppProps = {}) {
   const routineSnapshotRequests = new Map<string, number>();
   const completedTurnByBot = new Map<string, string>();
   const pendingProviderConnections = new Map<AgentProviderId, ReturnType<typeof desktopAnalytics.scope>>();
+  const observedHostedSiteMessageIds = new Set<string>();
+  const trackedHostedSiteOperations = new Set<string>();
   const dynamicIslandCoordinator = new DynamicIslandCoordinator();
   const dynamicIslandConnectedServers = new Set(["local"]);
   let conversationFrame: number | undefined;
@@ -544,6 +547,7 @@ export function createAppController(props: AppProps = {}) {
     }),
     ({ info, setup, auth, analyticsEnabled }) => {
       if (analyticsEnabled === null) return;
+      if (props.landingPreview) return;
       desktopAnalytics.setTrackingEnabled(analyticsEnabled);
       desktopAnalytics.setUser(auth.status === "signed_in" ? auth.user : null);
       if (!appInfoLoadedFromHost || !info || !setup || auth.status === "loading") return;
@@ -828,6 +832,8 @@ export function createAppController(props: AppProps = {}) {
       if (conversationFrame !== undefined) cancelAnimationFrame(conversationFrame);
       completedTurnByBot.clear();
       pendingProviderConnections.clear();
+      observedHostedSiteMessageIds.clear();
+      trackedHostedSiteOperations.clear();
       if (authSuccessTimer !== undefined) clearTimeout(authSuccessTimer);
     };
     void window.openbot.update
@@ -1110,7 +1116,7 @@ export function createAppController(props: AppProps = {}) {
             (existingUnreadCount === 0 ||
               explicitlyOpenedAgentChatId === event.page.botId ||
               agentChatsToRetryRead.has(trackingKey));
-          const pageApplied = applyConversationPage(event.page, "latest", "latest");
+          const pageApplied = applyConversationPage(event.page, "latest", "latest", true);
           const latestIncomingMessage = markNewMessagesRead
             ? [...event.page.messages]
                 .reverse()
@@ -1539,7 +1545,8 @@ export function createAppController(props: AppProps = {}) {
   function applyConversation(snapshot: ConversationSnapshot, markNewMessagesRead = false) {
     const botId = snapshot.botId;
     if (snapshot.revision < (conversationRevisions()[botId] ?? -1)) return;
-    const initialLoad = conversationLoaded()[botId] !== true || (liveMessages()[botId]?.length ?? 0) === 0;
+    const initialLoad = conversationLoaded()[botId] !== true;
+    observeHostedSiteAnalytics(snapshot.messages, initialLoad);
     setConversationRevisions((current) => ({
       ...current,
       [botId]: snapshot.revision,
@@ -1629,12 +1636,54 @@ export function createAppController(props: AppProps = {}) {
     }
   }
 
+  function observeHostedSiteAnalytics(messages: ConversationSnapshot["messages"], initialLoad: boolean): void {
+    for (const message of messages) {
+      const event = hostedSiteConversationEvent(message);
+      if (!event) continue;
+      const previouslyObserved = observedHostedSiteMessageIds.has(message.id);
+      const terminal = event.status !== "running";
+      if (initialLoad && terminal) {
+        trackedHostedSiteOperations.add(event.operationId);
+      } else if (!initialLoad && !previouslyObserved && !trackedHostedSiteOperations.has(event.operationId)) {
+        if (event.status === "succeeded") {
+          desktopAnalytics.track("hosted_site_action", {
+            action: event.action,
+            entry_point: "agent",
+            result: "succeeded",
+          });
+          trackedHostedSiteOperations.add(event.operationId);
+        } else if (event.status === "failed" || event.status === "cancelled" || event.status === "interrupted") {
+          desktopAnalytics.track("hosted_site_action", {
+            action: event.action,
+            entry_point: "agent",
+            result: "failed",
+            failure_code: event.status === "failed" ? "hosted_site_failed" : event.status,
+          });
+          trackedHostedSiteOperations.add(event.operationId);
+        }
+      }
+      observedHostedSiteMessageIds.add(message.id);
+    }
+    while (observedHostedSiteMessageIds.size > 10_000) {
+      const oldest = observedHostedSiteMessageIds.values().next();
+      if (oldest.done) break;
+      observedHostedSiteMessageIds.delete(oldest.value);
+    }
+    while (trackedHostedSiteOperations.size > 10_000) {
+      const oldest = trackedHostedSiteOperations.values().next();
+      if (oldest.done) break;
+      trackedHostedSiteOperations.delete(oldest.value);
+    }
+  }
+
   function applyConversationPage(
     page: ConversationPage,
     merge: "replace" | "older" | "latest",
     windowMode?: "latest" | "around",
+    trackHostedSiteAnalytics = false,
   ): boolean {
     if (page.revision < (conversationRevisions()[page.botId] ?? -1)) return false;
+    observeHostedSiteAnalytics(page.messages, !trackHostedSiteAnalytics || conversationLoaded()[page.botId] !== true);
     for (const message of page.messages) {
       const key = agentMessageKey(page.botId, message.id);
       if (message.author !== "user" && message.status === "streaming") rawAgentMessageBodies.set(key, message.text);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,12 +39,7 @@ import type {
   UpdateStatus,
   UpdateTeamMemberInput,
 } from "@openbot/contracts/ipc";
-import {
-  HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX,
-  hostedSiteConversationEvent,
-  ROUTINE_EVENT_ITEM_TYPE_PREFIX,
-  ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX,
-} from "@openbot/contracts/ipc";
+import { ROUTINE_EVENT_ITEM_TYPE_PREFIX, ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX } from "@openbot/contracts/ipc";
 import type { TeamProtocolV3Capability } from "@openbot/contracts/team-protocol/v3";
 import {
   createContext,
@@ -173,8 +168,7 @@ type BrowserTakeoverEvent = Extract<AgentEvent, { type: "browser-takeover-reques
 function isRoutineEventItem(message: { itemType?: string }): boolean {
   return (
     message.itemType?.startsWith(ROUTINE_EVENT_ITEM_TYPE_PREFIX) === true ||
-    message.itemType?.startsWith(ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX) === true ||
-    message.itemType?.startsWith(HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX) === true
+    message.itemType?.startsWith(ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX) === true
   );
 }
 
@@ -459,8 +453,6 @@ export function createAppController(props: AppProps = {}) {
   const routineSnapshotRequests = new Map<string, number>();
   const completedTurnByBot = new Map<string, string>();
   const pendingProviderConnections = new Map<AgentProviderId, ReturnType<typeof desktopAnalytics.scope>>();
-  const observedHostedSiteMessageIds = new Set<string>();
-  const trackedHostedSiteOperations = new Set<string>();
   const dynamicIslandCoordinator = new DynamicIslandCoordinator();
   const dynamicIslandConnectedServers = new Set(["local"]);
   let conversationFrame: number | undefined;
@@ -832,8 +824,6 @@ export function createAppController(props: AppProps = {}) {
       if (conversationFrame !== undefined) cancelAnimationFrame(conversationFrame);
       completedTurnByBot.clear();
       pendingProviderConnections.clear();
-      observedHostedSiteMessageIds.clear();
-      trackedHostedSiteOperations.clear();
       if (authSuccessTimer !== undefined) clearTimeout(authSuccessTimer);
     };
     void window.openbot.update
@@ -1116,7 +1106,7 @@ export function createAppController(props: AppProps = {}) {
             (existingUnreadCount === 0 ||
               explicitlyOpenedAgentChatId === event.page.botId ||
               agentChatsToRetryRead.has(trackingKey));
-          const pageApplied = applyConversationPage(event.page, "latest", "latest", true);
+          const pageApplied = applyConversationPage(event.page, "latest", "latest");
           const latestIncomingMessage = markNewMessagesRead
             ? [...event.page.messages]
                 .reverse()
@@ -1546,7 +1536,6 @@ export function createAppController(props: AppProps = {}) {
     const botId = snapshot.botId;
     if (snapshot.revision < (conversationRevisions()[botId] ?? -1)) return;
     const initialLoad = conversationLoaded()[botId] !== true;
-    observeHostedSiteAnalytics(snapshot.messages, initialLoad);
     setConversationRevisions((current) => ({
       ...current,
       [botId]: snapshot.revision,
@@ -1636,54 +1625,12 @@ export function createAppController(props: AppProps = {}) {
     }
   }
 
-  function observeHostedSiteAnalytics(messages: ConversationSnapshot["messages"], initialLoad: boolean): void {
-    for (const message of messages) {
-      const event = hostedSiteConversationEvent(message);
-      if (!event) continue;
-      const previouslyObserved = observedHostedSiteMessageIds.has(message.id);
-      const terminal = event.status !== "running";
-      if (initialLoad && terminal) {
-        trackedHostedSiteOperations.add(event.operationId);
-      } else if (!initialLoad && !previouslyObserved && !trackedHostedSiteOperations.has(event.operationId)) {
-        if (event.status === "succeeded") {
-          desktopAnalytics.track("hosted_site_action", {
-            action: event.action,
-            entry_point: "agent",
-            result: "succeeded",
-          });
-          trackedHostedSiteOperations.add(event.operationId);
-        } else if (event.status === "failed" || event.status === "cancelled" || event.status === "interrupted") {
-          desktopAnalytics.track("hosted_site_action", {
-            action: event.action,
-            entry_point: "agent",
-            result: "failed",
-            failure_code: event.status === "failed" ? "hosted_site_failed" : event.status,
-          });
-          trackedHostedSiteOperations.add(event.operationId);
-        }
-      }
-      observedHostedSiteMessageIds.add(message.id);
-    }
-    while (observedHostedSiteMessageIds.size > 10_000) {
-      const oldest = observedHostedSiteMessageIds.values().next();
-      if (oldest.done) break;
-      observedHostedSiteMessageIds.delete(oldest.value);
-    }
-    while (trackedHostedSiteOperations.size > 10_000) {
-      const oldest = trackedHostedSiteOperations.values().next();
-      if (oldest.done) break;
-      trackedHostedSiteOperations.delete(oldest.value);
-    }
-  }
-
   function applyConversationPage(
     page: ConversationPage,
     merge: "replace" | "older" | "latest",
     windowMode?: "latest" | "around",
-    trackHostedSiteAnalytics = false,
   ): boolean {
     if (page.revision < (conversationRevisions()[page.botId] ?? -1)) return false;
-    observeHostedSiteAnalytics(page.messages, !trackHostedSiteAnalytics || conversationLoaded()[page.botId] !== true);
     for (const message of page.messages) {
       const key = agentMessageKey(page.botId, message.id);
       if (message.author !== "user" && message.status === "streaming") rawAgentMessageBodies.set(key, message.text);

--- a/src/renderer/src/analytics.test.ts
+++ b/src/renderer/src/analytics.test.ts
@@ -49,7 +49,7 @@ describe("desktop analytics", () => {
       __referrer: "",
       surface: "desktop",
       environment: "production",
-      event_schema_version: 3,
+      event_schema_version: 4,
       app_version: "1.2.3",
       platform: "darwin",
     });
@@ -72,7 +72,7 @@ describe("desktop analytics", () => {
     });
   });
 
-  it("clears before identifying a different account", () => {
+  it("clears before identifying a different account", async () => {
     const client = fakeClient();
     const order: string[] = [];
     vi.mocked(client.clear).mockImplementation(async () => {
@@ -88,7 +88,7 @@ describe("desktop analytics", () => {
 
     analytics.setUser({ id: "account-2", email: "two@example.com" });
 
-    expect(order).toEqual(["clear", "identify"]);
+    await vi.waitFor(() => expect(order).toEqual(["clear", "identify"]));
     expect(client.identify).toHaveBeenLastCalledWith({ profileId: "account-2", email: "two@example.com" });
   });
 
@@ -166,8 +166,14 @@ describe("desktop analytics", () => {
 
   it("sends the account email through the real SDK transport", async () => {
     const requests: unknown[] = [];
+    let releaseIdentify!: () => void;
+    const identifyReady = new Promise<void>((resolve) => {
+      releaseIdentify = resolve;
+    });
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      requests.push(JSON.parse(String(init?.body)));
+      const request = JSON.parse(String(init?.body));
+      requests.push(request);
+      if (isDynamicRecord(request) && request.type === "identify") await identifyReady;
       return new Response(null, { status: 200 });
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -177,6 +183,9 @@ describe("desktop analytics", () => {
       analytics.setUser({ id: "account-1", email: "person@example.com" });
       analytics.track("agent_action", { action: "delete", result: "succeeded" });
 
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      expect(isDynamicRecord(requests[0]) ? requests[0].type : undefined).toBe("identify");
+      releaseIdentify();
       await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
       const identifyRequest = requests.find((candidate) => isDynamicRecord(candidate) && candidate.type === "identify");
       const trackRequest = requests.find(
@@ -195,6 +204,34 @@ describe("desktop analytics", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("normalizes the identity email before identifying", () => {
+    const client = fakeClient();
+    const analytics = new DesktopAnalytics(() => client, true);
+    analytics.configure(PRODUCTION_APP);
+
+    analytics.setUser({ id: "account-1", email: " Person@EXAMPLE.COM " });
+
+    expect(client.identify).toHaveBeenCalledWith({ profileId: "account-1", email: "person@example.com" });
+  });
+
+  it("rejects an invalid identity email and keeps the event anonymous", () => {
+    const identifiedClient = fakeClient();
+    const anonymousClient = fakeClient();
+    const createClient = vi.fn().mockReturnValueOnce(identifiedClient).mockReturnValueOnce(anonymousClient);
+    const analytics = new DesktopAnalytics(createClient, true);
+    analytics.configure(PRODUCTION_APP);
+
+    analytics.setUser({ id: "account-1", email: "not-an-email" });
+    analytics.track("agent_action", { action: "delete", result: "succeeded" });
+
+    expect(identifiedClient.identify).not.toHaveBeenCalled();
+    expect(identifiedClient.track).not.toHaveBeenCalled();
+    expect(anonymousClient.track).toHaveBeenCalledWith("agent_action", {
+      action: "delete",
+      result: "succeeded",
+    });
   });
 
   it("sanitizes runtime payloads independently of TypeScript types", () => {
@@ -222,6 +259,15 @@ describe("desktop analytics", () => {
         ),
       ),
     ).toEqual({ action: "test", trigger_type: "hourly", result: "failed", failure_code: "test_failed" });
+    expect(
+      sanitizeDesktopAnalyticsEvent(
+        "hosted_site_action",
+        Object.assign(
+          { action: "publish" as const, entry_point: "agent" as const, result: "succeeded" as const },
+          { url: "https://private.example", hostname: "private.example", title: "private", site_id: "site-1" },
+        ),
+      ),
+    ).toEqual({ action: "publish", entry_point: "agent", result: "succeeded" });
   });
 
   it("keeps only the newest 100 events buffered before configuration", () => {
@@ -279,5 +325,21 @@ describe("desktop analytics", () => {
       email: "person@example.com",
     });
     expect(identifiedClient.track).toHaveBeenCalledOnce();
+  });
+
+  it("clears both OpenPanel clients when tracking is disabled", () => {
+    const identifiedClient = fakeClient();
+    const anonymousClient = fakeClient();
+    const createClient = vi.fn().mockReturnValueOnce(identifiedClient).mockReturnValueOnce(anonymousClient);
+    const analytics = new DesktopAnalytics(createClient, true);
+    analytics.configure(PRODUCTION_APP);
+    analytics.setUser({ id: "account-1", email: "person@example.com" });
+    vi.mocked(identifiedClient.clear).mockClear();
+    vi.mocked(anonymousClient.clear).mockClear();
+
+    analytics.setTrackingEnabled(false);
+
+    expect(identifiedClient.clear).toHaveBeenCalledOnce();
+    expect(anonymousClient.clear).toHaveBeenCalledOnce();
   });
 });

--- a/src/renderer/src/analytics.test.ts
+++ b/src/renderer/src/analytics.test.ts
@@ -287,6 +287,26 @@ describe("desktop analytics", () => {
     );
   });
 
+  it("bounds events behind a stalled identify request", async () => {
+    const client = fakeClient();
+    let releaseIdentify!: () => void;
+    const identifyReady = new Promise<void>((resolve) => {
+      releaseIdentify = resolve;
+    });
+    vi.mocked(client.identify).mockImplementation(async () => identifyReady);
+    const createClient = vi.fn().mockReturnValue(client);
+    const analytics = new DesktopAnalytics(createClient, true);
+    analytics.configure(PRODUCTION_APP);
+    analytics.setUser({ id: "account-1", email: "person@example.com" });
+
+    for (let index = 0; index < 150; index += 1) {
+      analytics.track("search_action", { scope: "global", result: "succeeded", result_count: index });
+    }
+    releaseIdentify();
+
+    await vi.waitFor(() => expect(client.track).toHaveBeenCalledTimes(100));
+  });
+
   it("does not let SDK failures escape", () => {
     const client = fakeClient();
     vi.mocked(client.track).mockImplementation(() => {

--- a/src/renderer/src/analytics.test.ts
+++ b/src/renderer/src/analytics.test.ts
@@ -298,6 +298,7 @@ describe("desktop analytics", () => {
     const analytics = new DesktopAnalytics(createClient, true);
     analytics.configure(PRODUCTION_APP);
     analytics.setUser({ id: "account-1", email: "person@example.com" });
+    analytics.setUser({ id: "account-2", email: "second@example.com" });
 
     for (let index = 0; index < 150; index += 1) {
       analytics.track("search_action", { scope: "global", result: "succeeded", result_count: index });
@@ -305,6 +306,8 @@ describe("desktop analytics", () => {
     releaseIdentify();
 
     await vi.waitFor(() => expect(client.track).toHaveBeenCalledTimes(100));
+    expect(client.identify).toHaveBeenCalledWith({ profileId: "account-2", email: "second@example.com" });
+    expect(client.clear).toHaveBeenCalled();
   });
 
   it("does not let SDK failures escape", () => {

--- a/src/renderer/src/analytics.ts
+++ b/src/renderer/src/analytics.ts
@@ -591,6 +591,7 @@ export class DesktopAnalytics {
   }
 
   #enqueue(queue: AnalyticsOperationQueue, operation: AnalyticsOperation): void {
+    if (queue.operations.length >= MAX_PENDING_EVENTS) queue.operations.shift();
     queue.operations.push(operation);
     if (queue.active) return;
     queue.active = true;

--- a/src/renderer/src/analytics.ts
+++ b/src/renderer/src/analytics.ts
@@ -169,7 +169,8 @@ export type OpenPanelClient = Pick<OpenPanelBase, "setGlobalProperties" | "track
 
 type ClientFactory = (options: OpenPanelOptions) => OpenPanelClient;
 type AnalyticsIdentity = Pick<CentralAuthUser, "id" | "email">;
-type AnalyticsOperation = () => unknown;
+type AnalyticsOperationKind = "clear" | "identify" | "track";
+type AnalyticsOperation = { kind: AnalyticsOperationKind; run: () => unknown };
 type AnalyticsOperationQueue = { active: boolean; operations: AnalyticsOperation[] };
 export interface DesktopAnalyticsScope {
   track<Name extends AnalyticsEventName>(name: Name, properties: DesktopAnalyticsEvents[Name]): void;
@@ -500,7 +501,7 @@ export class DesktopAnalytics {
     this.#identity = normalized;
     if (!this.#client || !this.#trackingEnabled) return;
     if (previous && (!normalized || previous.id !== normalized.id))
-      this.#enqueue(this.#clientQueue, () => this.#client?.clear());
+      this.#enqueue(this.#clientQueue, "clear", () => this.#client?.clear());
     if (normalized) this.#identifyClient(normalized);
   }
 
@@ -519,8 +520,8 @@ export class DesktopAnalytics {
       this.#pending = [];
       this.#clientQueue.operations = [];
       this.#anonymousQueue.operations = [];
-      this.#enqueue(this.#clientQueue, () => this.#client?.clear());
-      this.#enqueue(this.#anonymousQueue, () => this.#anonymousClient?.clear());
+      this.#enqueue(this.#clientQueue, "clear", () => this.#client?.clear());
+      this.#enqueue(this.#anonymousQueue, "clear", () => this.#anonymousClient?.clear());
       return;
     }
     if (this.#identity) this.#identifyClient(this.#identity);
@@ -569,7 +570,7 @@ export class DesktopAnalytics {
     timestamp?: string,
   ): void {
     const client = profileId ? this.#client : this.#anonymousClient;
-    this.#enqueue(profileId ? this.#clientQueue : this.#anonymousQueue, () =>
+    this.#enqueue(profileId ? this.#clientQueue : this.#anonymousQueue, "track", () =>
       client?.track(name, {
         ...properties,
         ...(timestamp ? { __timestamp: timestamp } : {}),
@@ -587,12 +588,21 @@ export class DesktopAnalytics {
   }
 
   #identifyClient(user: AnalyticsIdentity): void {
-    this.#enqueue(this.#clientQueue, () => this.#client?.identify({ profileId: user.id, email: user.email }));
+    this.#enqueue(this.#clientQueue, "identify", () =>
+      this.#client?.identify({ profileId: user.id, email: user.email }),
+    );
   }
 
-  #enqueue(queue: AnalyticsOperationQueue, operation: AnalyticsOperation): void {
-    if (queue.operations.length >= MAX_PENDING_EVENTS) queue.operations.shift();
-    queue.operations.push(operation);
+  #enqueue(queue: AnalyticsOperationQueue, kind: AnalyticsOperationKind, run: () => unknown): void {
+    if (kind === "clear") {
+      queue.operations = queue.operations.filter((operation) => operation.kind === "track");
+    } else if (kind === "identify") {
+      queue.operations = queue.operations.filter((operation) => operation.kind !== "identify");
+    } else if (queue.operations.filter((operation) => operation.kind === "track").length >= MAX_PENDING_EVENTS) {
+      const oldestTrack = queue.operations.findIndex((operation) => operation.kind === "track");
+      if (oldestTrack >= 0) queue.operations.splice(oldestTrack, 1);
+    }
+    queue.operations.push({ kind, run });
     if (queue.active) return;
     queue.active = true;
     void this.#drain(queue);
@@ -603,7 +613,7 @@ export class DesktopAnalytics {
       const operation = queue.operations.shift();
       if (!operation) continue;
       try {
-        const result = operation();
+        const result = operation.run();
         if (isPromiseLike(result)) await result;
       } catch {
         // Analytics must never change application behavior or stop later events.

--- a/src/renderer/src/analytics.ts
+++ b/src/renderer/src/analytics.ts
@@ -500,8 +500,12 @@ export class DesktopAnalytics {
     if (previous?.id === normalized?.id && previous?.email === normalized?.email) return;
     this.#identity = normalized;
     if (!this.#client || !this.#trackingEnabled) return;
-    if (previous && (!normalized || previous.id !== normalized.id))
-      this.#enqueue(this.#clientQueue, "clear", () => this.#client?.clear());
+    if (previous && (!normalized || previous.id !== normalized.id || previous.email !== normalized.email)) {
+      this.#clientQueue.operations = [];
+      if (!normalized || previous.id !== normalized.id) {
+        this.#enqueue(this.#clientQueue, "clear", () => this.#client?.clear());
+      }
+    }
     if (normalized) this.#identifyClient(normalized);
   }
 

--- a/src/renderer/src/analytics.ts
+++ b/src/renderer/src/analytics.ts
@@ -8,13 +8,14 @@ import {
   type CentralAuthUser,
   isAgentModel,
 } from "@openbot/contracts/ipc";
-import { isBoolean, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { isBoolean, isDynamicRecord, isFunction, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { normalizeEmailAddress } from "@openbot/contracts/validation";
 import { OpenPanelBase, type OpenPanelOptions } from "@openpanel/web";
 
 export const OPENPANEL_API_URL = "https://analytics.openbot.run/api";
 export const OPENPANEL_CLIENT_ID = "6c989975-87ef-4f0c-857e-ab449a65b5c2";
 const MAX_PENDING_EVENTS = 100;
-export const ANALYTICS_SCHEMA_VERSION = 3;
+export const ANALYTICS_SCHEMA_VERSION = 4;
 
 export type ServerKind = "local" | "remote" | "unknown";
 export type AnalyticsResult = "succeeded" | "failed";
@@ -155,6 +156,12 @@ export interface DesktopAnalyticsEvents {
     result: AnalyticsResult;
     failure_code?: string;
   };
+  hosted_site_action: {
+    action: "publish" | "replace" | "delete";
+    entry_point: "agent" | "settings";
+    result: AnalyticsResult;
+    failure_code?: string;
+  };
 }
 
 export type AnalyticsEventName = keyof DesktopAnalyticsEvents;
@@ -162,6 +169,8 @@ export type OpenPanelClient = Pick<OpenPanelBase, "setGlobalProperties" | "track
 
 type ClientFactory = (options: OpenPanelOptions) => OpenPanelClient;
 type AnalyticsIdentity = Pick<CentralAuthUser, "id" | "email">;
+type AnalyticsOperation = () => unknown;
+type AnalyticsOperationQueue = { active: boolean; operations: AnalyticsOperation[] };
 export interface DesktopAnalyticsScope {
   track<Name extends AnalyticsEventName>(name: Name, properties: DesktopAnalyticsEvents[Name]): void;
 }
@@ -209,6 +218,7 @@ const EVENT_PROPERTY_ALLOWLIST = {
   voice_transcription: ["result", "audio_duration_seconds", "duration_ms", "failure_code"],
   reaction_action: ["action", "result", "failure_code"],
   maintenance_action: ["action", "result", "failure_code"],
+  hosted_site_action: ["action", "entry_point", "result", "failure_code"],
 } as const satisfies Record<AnalyticsEventName, readonly string[]>;
 
 type AnalyticsPropertyName = (typeof EVENT_PROPERTY_ALLOWLIST)[AnalyticsEventName][number];
@@ -278,6 +288,9 @@ const SAFE_FAILURE_CODES = new Set([
   "unpublish_failed",
   "update_failed",
   "verification_failed",
+  "hosted_site_failed",
+  "cancelled",
+  "interrupted",
 ]);
 
 const EVENT_ACTIONS: Partial<Record<AnalyticsEventName, readonly string[]>> = {
@@ -311,6 +324,7 @@ const EVENT_ACTIONS: Partial<Record<AnalyticsEventName, readonly string[]>> = {
   ],
   reaction_action: ["add", "remove"],
   maintenance_action: ["export_data", "export_diagnostics"],
+  hosted_site_action: ["publish", "replace", "delete"],
 };
 
 const CHANGED_FIELDS = new Map<string, string>([
@@ -397,11 +411,13 @@ function sanitizeDesktopProperty(
   if (["setup_completed", "signed_in", "is_reply", "email_bound"].includes(key)) {
     return isBoolean(value) ? value : undefined;
   }
+  if (key === "entry_point") {
+    return safeEnum(value, name === "hosted_site_action" ? ["agent", "settings"] : ["in_app", "invite_deep_link"]);
+  }
   const enumValues: Record<string, readonly string[] | undefined> = {
     channel: ["agent", "direct"],
     decision: ["answered", "accept", "decline"],
     entity: ["skill", "agent"],
-    entry_point: ["in_app", "invite_deep_link"],
     kind: ["prompt", "approval"],
     role: ["admin", "member"],
     scope: ["global", "agent"],
@@ -432,6 +448,8 @@ export class DesktopAnalytics {
   #trackingEnabled = true;
   #identity: AnalyticsIdentity | null = null;
   #pending: PendingEvent[] = [];
+  readonly #clientQueue: AnalyticsOperationQueue = { active: false, operations: [] };
+  readonly #anonymousQueue: AnalyticsOperationQueue = { active: false, operations: [] };
 
   constructor(
     createClient: ClientFactory = (options) => new OpenPanelBase(options),
@@ -477,11 +495,13 @@ export class DesktopAnalytics {
 
   setUser(user: AnalyticsIdentity | null): void {
     const previous = this.#identity;
-    if (previous?.id === user?.id && previous?.email === user?.email) return;
-    this.#identity = user ? { ...user } : null;
+    const normalized = user ? normalizeAnalyticsIdentity(user) : null;
+    if (previous?.id === normalized?.id && previous?.email === normalized?.email) return;
+    this.#identity = normalized;
     if (!this.#client || !this.#trackingEnabled) return;
-    if (previous && previous.id !== user?.id) this.#run(() => this.#client?.clear());
-    if (user) this.#identifyClient(user);
+    if (previous && (!normalized || previous.id !== normalized.id))
+      this.#enqueue(this.#clientQueue, () => this.#client?.clear());
+    if (normalized) this.#identifyClient(normalized);
   }
 
   identify(user: AnalyticsIdentity): void {
@@ -497,7 +517,10 @@ export class DesktopAnalytics {
     this.#trackingEnabled = enabled;
     if (!enabled) {
       this.#pending = [];
-      this.#run(() => this.#client?.clear());
+      this.#clientQueue.operations = [];
+      this.#anonymousQueue.operations = [];
+      this.#enqueue(this.#clientQueue, () => this.#client?.clear());
+      this.#enqueue(this.#anonymousQueue, () => this.#anonymousClient?.clear());
       return;
     }
     if (this.#identity) this.#identifyClient(this.#identity);
@@ -546,7 +569,7 @@ export class DesktopAnalytics {
     timestamp?: string,
   ): void {
     const client = profileId ? this.#client : this.#anonymousClient;
-    this.#run(() =>
+    this.#enqueue(profileId ? this.#clientQueue : this.#anonymousQueue, () =>
       client?.track(name, {
         ...properties,
         ...(timestamp ? { __timestamp: timestamp } : {}),
@@ -564,17 +587,39 @@ export class DesktopAnalytics {
   }
 
   #identifyClient(user: AnalyticsIdentity): void {
-    this.#run(() => this.#client?.identify({ profileId: user.id, email: user.email }));
+    this.#enqueue(this.#clientQueue, () => this.#client?.identify({ profileId: user.id, email: user.email }));
   }
 
-  #run(operation: () => unknown): void {
-    try {
-      const result = operation();
-      if (result instanceof Promise) void result.catch(() => undefined);
-    } catch {
-      // Analytics must never change application behavior.
-    }
+  #enqueue(queue: AnalyticsOperationQueue, operation: AnalyticsOperation): void {
+    queue.operations.push(operation);
+    if (queue.active) return;
+    queue.active = true;
+    void this.#drain(queue);
   }
+
+  async #drain(queue: AnalyticsOperationQueue): Promise<void> {
+    while (queue.operations.length > 0) {
+      const operation = queue.operations.shift();
+      if (!operation) continue;
+      try {
+        const result = operation();
+        if (isPromiseLike(result)) await result;
+      } catch {
+        // Analytics must never change application behavior or stop later events.
+      }
+    }
+    queue.active = false;
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return isDynamicRecord(value) && isFunction(value.then);
+}
+
+function normalizeAnalyticsIdentity(user: AnalyticsIdentity): AnalyticsIdentity | null {
+  const id = user.id.trim();
+  const email = normalizeEmailAddress(user.email);
+  return id && email ? { id, email } : null;
 }
 
 export const desktopAnalytics = new DesktopAnalytics();

--- a/src/renderer/src/analytics.ts
+++ b/src/renderer/src/analytics.ts
@@ -501,7 +501,6 @@ export class DesktopAnalytics {
     this.#identity = normalized;
     if (!this.#client || !this.#trackingEnabled) return;
     if (previous && (!normalized || previous.id !== normalized.id || previous.email !== normalized.email)) {
-      this.#clientQueue.operations = [];
       if (!normalized || previous.id !== normalized.id) {
         this.#enqueue(this.#clientQueue, "clear", () => this.#client?.clear());
       }
@@ -598,9 +597,10 @@ export class DesktopAnalytics {
   }
 
   #enqueue(queue: AnalyticsOperationQueue, kind: AnalyticsOperationKind, run: () => unknown): void {
-    if (kind === "clear") {
-      queue.operations = queue.operations.filter((operation) => operation.kind === "track");
-    } else if (kind === "identify") {
+    const hasPendingTrack = queue.operations.some((operation) => operation.kind === "track");
+    if (kind === "clear" && !hasPendingTrack) {
+      queue.operations = [];
+    } else if (kind === "identify" && !hasPendingTrack) {
       queue.operations = queue.operations.filter((operation) => operation.kind !== "identify");
     } else if (queue.operations.filter((operation) => operation.kind === "track").length >= MAX_PENDING_EVENTS) {
       const oldestTrack = queue.operations.findIndex((operation) => operation.kind === "track");

--- a/src/renderer/src/components/SettingsModal.test.tsx
+++ b/src/renderer/src/components/SettingsModal.test.tsx
@@ -8,6 +8,7 @@ import type {
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { type DesktopAnalyticsScope, desktopAnalytics } from "../analytics";
 import { DEFAULT_GENERAL_SETTINGS } from "../app-settings";
 import { SettingsModal } from "./SettingsModal";
 
@@ -449,6 +450,9 @@ describe("SettingsModal", () => {
       expiresAt: "2026-09-30T12:00:00.000Z",
       updatedAt: "2026-08-31T12:00:00.000Z",
     };
+    const analyticsTrack = vi.fn<DesktopAnalyticsScope["track"]>();
+    const analyticsScope = { track: analyticsTrack } satisfies DesktopAnalyticsScope;
+    vi.spyOn(desktopAnalytics, "scope").mockReturnValue(analyticsScope);
     const hostedSitesApi: HostedSitesDesktopApi = {
       list: vi.fn().mockResolvedValueOnce([site]).mockResolvedValue([]),
       chooseDirectory: vi.fn(async () => "/tmp/queued-site"),
@@ -483,6 +487,11 @@ describe("SettingsModal", () => {
     await waitFor(() => expect(hostedSitesApi.delete).toHaveBeenCalledWith({ siteId: site.id }));
     await waitFor(() => expect(hostedSitesApi.list).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.queryByText(site.hostname)).not.toBeInTheDocument());
+    expect(analyticsTrack).toHaveBeenCalledWith("hosted_site_action", {
+      action: "delete",
+      entry_point: "settings",
+      result: "succeeded",
+    });
   });
 
   it("shows a blocked hosted site and disables Open", async () => {

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -14,6 +14,7 @@ import type {
 } from "@openbot/contracts/ipc";
 import { normalizeAccountName, validateProfileName } from "@openbot/contracts/validation";
 import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
+import { desktopAnalytics } from "../analytics";
 import type { GeneralSettingsValue } from "../app-settings";
 import { normalizeAvatarFile } from "../avatar-image";
 import { presentUpdateStatus } from "../update-status";
@@ -559,13 +560,30 @@ export function SettingsModal(props: SettingsModalProps) {
   async function deleteSite(site: HostedSiteSummary): Promise<void> {
     if (!props.hostedSitesApi || hostingBusy()) return;
     if (!window.confirm(`Delete ${site.hostname}? This address will immediately return 410 Gone.`)) return;
+    const analytics = desktopAnalytics.scope();
     setHostingBusy(true);
     setHostedSitesError(null);
     try {
-      await props.hostedSitesApi.delete({ siteId: site.id });
+      try {
+        await props.hostedSitesApi.delete({ siteId: site.id });
+      } catch (error) {
+        analytics.track("hosted_site_action", {
+          action: "delete",
+          entry_point: "settings",
+          result: "failed",
+          failure_code: "delete_failed",
+        });
+        setHostedSitesError(error instanceof Error ? error.message : "Could not delete the site.");
+        return;
+      }
+      analytics.track("hosted_site_action", {
+        action: "delete",
+        entry_point: "settings",
+        result: "succeeded",
+      });
       await loadHostedSites();
     } catch (error) {
-      setHostedSitesError(error instanceof Error ? error.message : "Could not delete the site.");
+      setHostedSitesError(error instanceof Error ? error.message : "Could not reload hosted sites.");
     } finally {
       setHostingBusy(false);
     }


### PR DESCRIPTION
## Summary
- serialize OpenPanel clear/identify/track operations and attach normalized account email via identify only
- disable all desktop/host analytics outside production and clear pending/client state when disabled or signed out
- add terminal, deduplicated Hosted Sites action tracking without site metadata
- add schema 4 and a dry-run-by-default, idempotent profile identity backfill script

## Verification
- `bun run typecheck`
- `bunx biome check .`
- targeted analytics, Hosted Sites, SettingsModal, landing, and backfill Vitest suites
- dev Network capture confirmed zero requests to `analytics.openbot.run`

## Notes
- backfill is not run by CI or this PR; it requires exported auth/OpenPanel profiles and explicit `--apply` plus credentials
- existing routine tracking is retained without duplicate events
