### PR TITLE
Establish native-first mobile design guidelines and refresh app screens

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -1,5 +1,15 @@
 This is an Expo/React Native mobile application. Prioritize mobile-first patterns, performance, and cross-platform compatibility.
 
+## Design system and native chrome
+
+Read and follow [`DESIGN.md`](./DESIGN.md) before changing mobile UI.
+
+- Build application content with HeroUI Native. Reuse its installed components and the OpenBot theme aliases in `global.css`; do not introduce a parallel component library, theme, or screen-local design language.
+- Treat system chrome as the deliberate exception to the HeroUI-first rule. Navigation stacks, headers, tab bars, toolbars, search bars, system menus, and route-level sheets must use the native Expo Router or `@expo/ui` APIs whenever they provide the required behavior.
+- Prefer `Stack`, `Stack.Title`, `Stack.Toolbar`, `Stack.SearchBar`, and `NativeTabs` over custom React Native or HeroUI imitations. Native chrome must remain native so iOS can provide Liquid Glass on supported versions and Android can use its platform conventions.
+- Do not fake native chrome with custom blur, gradients, translucent cards, or `GlassView`. Use `expo-glass-effect` only for an intentional custom in-content glass surface, with platform and accessibility fallbacks.
+- If neither an existing OpenBot component nor HeroUI Native fits an application-content need, verify that before creating a reusable component. If native APIs cannot satisfy a system-chrome requirement, document the constraint in the change before using a fallback.
+
 ## Expo has changed — do not trust your training data
 
 Expo ships breaking changes every SDK release. APIs you remember are likely renamed, moved, or removed. Before writing any code that touches an Expo, EAS, or React Native API:

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -1,10 +1,20 @@
 This is an Expo/React Native mobile application. Prioritize mobile-first patterns, performance, and cross-platform compatibility.
 
+## Execution and verification limits
+
+- Never run any build, packaging, signing, submission, or deployment command for the mobile app unless the user gives explicit permission for that specific command.
+- Never start an iOS simulator, Android emulator, device run, or native development client unless the user gives explicit permission for that specific run.
+- Do not run wide or full-repository checks by default. The allowed default checks are lint, Biome, and TypeScript checks limited to files changed by the task.
+- Before creating or executing a PR, wider checks are required. If they have not been run, stop before the PR and request explicit permission for each concrete wider check that must be run.
+- Permission for a wider check authorizes only the one named check or command. It does not authorize other wider checks, builds, simulator/emulator runs, or subsequent commands.
+- If a requested workflow would require a prohibited command, explain the limitation and wait for explicit permission rather than substituting a broader command or running it implicitly.
+
 ## Design system and native chrome
 
 Read and follow [`DESIGN.md`](./DESIGN.md) before changing mobile UI.
 
 - Build application content with HeroUI Native. Reuse its installed components and the OpenBot theme aliases in `global.css`; do not introduce a parallel component library, theme, or screen-local design language.
+- Render product text with HeroUI Native `Typography` and its semantic variants. Do not import React Native `Text` directly in screens or product components unless an integration boundary explicitly requires the native primitive.
 - Treat system chrome as the deliberate exception to the HeroUI-first rule. Navigation stacks, headers, tab bars, toolbars, search bars, system menus, and route-level sheets must use the native Expo Router or `@expo/ui` APIs whenever they provide the required behavior.
 - Prefer `Stack`, `Stack.Title`, `Stack.Toolbar`, `Stack.SearchBar`, and `NativeTabs` over custom React Native or HeroUI imitations. Native chrome must remain native so iOS can provide Liquid Glass on supported versions and Android can use its platform conventions.
 - Do not fake native chrome with custom blur, gradients, translucent cards, or `GlassView`. Use `expo-glass-effect` only for an intentional custom in-content glass surface, with platform and accessibility fallbacks.
@@ -31,7 +41,9 @@ bun run doctor               # diagnose dependency and config issues
 bunx expo install --fix      # fix incompatible package versions
 ```
 
-Run lint and typecheck before declaring any task done.
+The `lint` and `typecheck` examples are permitted only when scoped to files changed by the task; do not run a repository-wide script as-is when it checks unrelated files.
+
+Before declaring any task done, run only targeted lint, Biome, and TypeScript checks covering the files changed by the task.
 
 ## Navigation & Routing
 
@@ -39,13 +51,13 @@ Run lint and typecheck before declaring any task done.
 - Import `Link`, `router`, and `useLocalSearchParams` from `expo-router`.
 - Docs: https://docs.expo.dev/router/introduction.md
 
-## Building with EAS
+## Building with EAS (explicit authorization only)
 
-Use EAS to build, sign, and submit the app in the cloud (`eas build`, `eas submit`) and to ship over-the-air updates (`eas update`) — no local Xcode or Android Studio required. Run EAS CLI as `bunx eas-cli <command>` in Bun projects, or `npx eas-cli@latest <command>` otherwise; substitute that for bare `eas` in docs examples.
+EAS build, signing, submission, and update commands are prohibited unless the user explicitly authorizes that exact command. If authorized, use EAS to perform the requested operation in the cloud (`eas build`, `eas submit`, or `eas update`) — no local Xcode or Android Studio required. Run EAS CLI as `bunx eas-cli <command>` in Bun projects, or `npx eas-cli@latest <command>` otherwise; substitute that for bare `eas` in docs examples.
 Docs: https://docs.expo.dev/eas/index.md
 
 ## Rules
 
 - If `ios/` and `android/` directories do not exist, they are generated (Continuous Native Generation). Never create or edit them by hand — configure native behavior in `app.json` and config plugins.
-- Expo Go only includes its bundled native modules. After adding a library with native code, the app needs a development build: `npx expo run:ios|android` locally, or `eas build --profile development`.
+- Expo Go only includes its bundled native modules. After adding a library with native code, the app needs a development build; do not create or run one without explicit user authorization for the exact build or run command.
 - Prefer recommended Expo modules over third-party libraries, and check your available skills before adding dependencies. Docs: https://docs.expo.dev/versions/latest/index.md

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -14,11 +14,13 @@ This is an Expo/React Native mobile application. Prioritize mobile-first pattern
 Read and follow [`DESIGN.md`](./DESIGN.md) before changing mobile UI.
 
 - Build application content with HeroUI Native. Reuse its installed components and the OpenBot theme aliases in `global.css`; do not introduce a parallel component library, theme, or screen-local design language.
+- HeroUI-first does not mean component-heavy. Prefer the smallest composition that communicates the screen: plain layout plus `Typography` and `Button` is better than decorative `Card`, `Chip`, `Surface`, or `Alert` wrappers when those components add no interaction or hierarchy.
 - Render product text with HeroUI Native `Typography` and its semantic variants. Do not import React Native `Text` directly in screens or product components unless an integration boundary explicitly requires the native primitive.
 - Treat system chrome as the deliberate exception to the HeroUI-first rule. Navigation stacks, headers, tab bars, toolbars, search bars, system menus, and route-level sheets must use the native Expo Router or `@expo/ui` APIs whenever they provide the required behavior.
 - Prefer `Stack`, `Stack.Title`, `Stack.Toolbar`, `Stack.SearchBar`, and `NativeTabs` over custom React Native or HeroUI imitations. Native chrome must remain native so iOS can provide Liquid Glass on supported versions and Android can use its platform conventions.
 - Do not fake native chrome with custom blur, gradients, translucent cards, or `GlassView`. Use `expo-glass-effect` only for an intentional custom in-content glass surface, with platform and accessibility fallbacks.
 - If neither an existing OpenBot component nor HeroUI Native fits an application-content need, verify that before creating a reusable component. If native APIs cannot satisfy a system-chrome requirement, document the constraint in the change before using a fallback.
+- Do not add status badges, warnings, or operational guidance unless the application state and repository behavior support the claim. Verify lifecycle and connectivity copy against the implementation before presenting it to users.
 
 ## Expo has changed — do not trust your training data
 

--- a/apps/mobile/DESIGN.md
+++ b/apps/mobile/DESIGN.md
@@ -1,0 +1,62 @@
+# OpenBot Mobile Design Guidelines
+
+These rules apply to design, implementation, review, and AI-generated mobile UI. They define which layer owns each part of the interface and prevent the app from drifting into multiple visual systems.
+
+## Core rule
+
+HeroUI Native is the foundation for application content. It is already installed, its provider is mounted in `src/app/_layout.tsx`, and its theme aliases are mapped to OpenBot tokens in `global.css`.
+
+Use HeroUI Native for product UI such as buttons, cards, fields, alerts, chips, accordions, and other content rendered inside a screen. Reuse an existing OpenBot component first, then a HeroUI Native component. Do not recreate a component that either layer already provides.
+
+Native system chrome is the intentional exception. Navigation and operating-system-owned controls must remain native even when HeroUI can produce a visually similar element. This lets iOS apply Liquid Glass automatically on supported versions and lets Android retain its native Material behavior.
+
+## Component ownership
+
+| Interface need | Preferred owner | Guidance |
+| --- | --- | --- |
+| Product content and reusable product controls | HeroUI Native | Use installed HeroUI components and variants. Compose them before creating a new primitive. |
+| Screen stacks, titles, back buttons, headers, and route transitions | Expo Router native `Stack` | Configure them in route layouts or screen options instead of drawing custom headers. |
+| Tab navigation | Expo Router `NativeTabs` | Use native tab triggers, labels, badges, and platform icons instead of a custom tab bar. |
+| Search integrated with navigation | `Stack.SearchBar` and native toolbar search slots | Do not place a HeroUI input inside a handmade navigation bar. |
+| Header and bottom toolbar actions or menus | `Stack.Toolbar` native items | Let the platform render placement, materials, menus, and interaction behavior. |
+| Route-level modals and form sheets | Expo Router native presentations | Prefer native modal or form-sheet presentation over a custom full-screen overlay. |
+| Native pickers, switches, sliders, menus, and grouped system forms | `@expo/ui` | Use when the interaction should look and behave like a platform control. Keep every `@expo/ui` tree inside `Host`. |
+| Large or unbounded data lists | React Native `FlatList` or an approved virtualized list | Do not use a non-virtualized component for feeds or large search results. |
+| Custom in-content glass surface | `expo-glass-effect` | Use sparingly, only when glass is part of the product content rather than navigation chrome. Provide non-glass and reduced-transparency behavior. |
+
+Native ownership takes priority over HeroUI for navigation chrome. HeroUI ownership takes priority for application content.
+
+## Liquid Glass and platform behavior
+
+- Obtain Liquid Glass through native navigation components. Do not imitate it with blur views, gradients, translucent HeroUI cards, shadows, or screenshots of glass.
+- Do not replace native headers, tab bars, toolbars, or search bars with `GlassView`. `expo-glass-effect` is for deliberate custom content surfaces, not for rebuilding system chrome.
+- Preserve automatic safe-area and scroll-edge behavior. Screens under native chrome should normally use scroll containers with automatic content inset adjustment instead of manual top or bottom spacers.
+- Avoid forcing opaque colors or bespoke backgrounds onto native chrome unless the product requirement explicitly calls for it. Let the operating system adapt materials to the platform version, appearance, accessibility settings, and scroll state.
+- Treat older iOS versions and Android as first-class fallbacks. The interface must remain complete and readable when Liquid Glass is unavailable or reduced transparency is enabled.
+- Use platform-native icons in native navigation (`sf` on iOS and the corresponding Material icon on Android). Use the existing application icon convention for HeroUI content.
+
+## Theme and visual consistency
+
+- `global.css` is the single source of truth for OpenBot mobile color, typography, radius, shadow, and motion tokens. HeroUI semantic aliases consume those tokens.
+- Use HeroUI semantic variants and existing utility classes. Do not add raw colors, arbitrary radii, or one-off shadows to a screen when a token or component variant can express the intent.
+- Extend OpenBot tokens only for a new semantic role that will be reused. Keep HeroUI aliases mapped to OpenBot tokens rather than creating a second palette.
+- Support light and dark appearance, dynamic type, reduced motion, reduced transparency, and sufficient contrast.
+- Favor composition and shared variants over copying styled JSX between screens.
+
+## Development workflow
+
+Before implementing a mobile UI change:
+
+1. Search `src/components` and current screens for an existing reusable component or pattern.
+2. Check HeroUI Native for the product-content component or composition.
+3. If the element is navigation chrome or a platform control, check the Expo SDK version-matched Expo Router and `@expo/ui` APIs before building anything custom.
+4. Extend the existing component or token layer only when the required state or semantic role is genuinely missing.
+5. Verify behavior and appearance in light and dark mode. For native chrome changes, verify both iOS and Android; include an iOS version that supports Liquid Glass when available.
+
+Any fallback away from this ownership model must be explained in the change: what the preferred layer could not do, which platforms are affected, and how the fallback preserves accessibility and theme behavior.
+
+## AI implementation rules
+
+AI agents must follow the same workflow and must not infer component APIs from memory. Before changing Expo Router, `@expo/ui`, or other Expo UI code, confirm the installed Expo major version and use its versioned documentation. Before using a HeroUI Native component, confirm the installed package API or project usage.
+
+An AI-generated UI change is incomplete when it introduces a custom navigation or search surface that a native API can own, duplicates an available HeroUI component, adds a second theme, or omits platform and accessibility fallbacks.

--- a/apps/mobile/DESIGN.md
+++ b/apps/mobile/DESIGN.md
@@ -8,6 +8,8 @@ HeroUI Native is the foundation for application content. It is already installed
 
 Use HeroUI Native for product UI such as buttons, cards, fields, alerts, chips, accordions, and other content rendered inside a screen. Reuse an existing OpenBot component first, then a HeroUI Native component. Do not recreate a component that either layer already provides.
 
+HeroUI Native is a component source, not a requirement to decorate every screen. Start with the lightest useful composition. A focused screen may need only layout, `Typography`, and one `Button`; add `Card`, `Chip`, `Surface`, or `Alert` only when it expresses real grouping, state, interaction, or actionable information.
+
 Render product text through HeroUI Native `Typography`, including `Typography.Heading` and `Typography.Paragraph` for semantic roles. Screens and product components must not import React Native `Text` directly unless a third-party integration boundary requires the native primitive and the exception is documented.
 
 Native system chrome is the intentional exception. Navigation and operating-system-owned controls must remain native even when HeroUI can produce a visually similar element. This lets iOS apply Liquid Glass automatically on supported versions and lets Android retain its native Material behavior.
@@ -45,6 +47,7 @@ Native ownership takes priority over HeroUI for navigation chrome. HeroUI owners
 - Extend OpenBot tokens only for a new semantic role that will be reused. Keep HeroUI aliases mapped to OpenBot tokens rather than creating a second palette.
 - Support light and dark appearance, dynamic type, reduced motion, reduced transparency, and sufficient contrast.
 - Favor composition and shared variants over copying styled JSX between screens.
+- Keep status and instructional copy evidence-based. Do not introduce badges, alerts, or lifecycle requirements that cannot be derived from the actual session, connectivity, or persistence implementation.
 
 ## Development workflow
 

--- a/apps/mobile/DESIGN.md
+++ b/apps/mobile/DESIGN.md
@@ -8,6 +8,8 @@ HeroUI Native is the foundation for application content. It is already installed
 
 Use HeroUI Native for product UI such as buttons, cards, fields, alerts, chips, accordions, and other content rendered inside a screen. Reuse an existing OpenBot component first, then a HeroUI Native component. Do not recreate a component that either layer already provides.
 
+Render product text through HeroUI Native `Typography`, including `Typography.Heading` and `Typography.Paragraph` for semantic roles. Screens and product components must not import React Native `Text` directly unless a third-party integration boundary requires the native primitive and the exception is documented.
+
 Native system chrome is the intentional exception. Navigation and operating-system-owned controls must remain native even when HeroUI can produce a visually similar element. This lets iOS apply Liquid Glass automatically on supported versions and lets Android retain its native Material behavior.
 
 ## Component ownership
@@ -15,6 +17,7 @@ Native system chrome is the intentional exception. Navigation and operating-syst
 | Interface need | Preferred owner | Guidance |
 | --- | --- | --- |
 | Product content and reusable product controls | HeroUI Native | Use installed HeroUI components and variants. Compose them before creating a new primitive. |
+| Product headings, paragraphs, labels, and inline text | HeroUI Native `Typography` | Use semantic type, color, weight, and alignment props instead of React Native `Text` and screen-local font styling. |
 | Screen stacks, titles, back buttons, headers, and route transitions | Expo Router native `Stack` | Configure them in route layouts or screen options instead of drawing custom headers. |
 | Tab navigation | Expo Router `NativeTabs` | Use native tab triggers, labels, badges, and platform icons instead of a custom tab bar. |
 | Search integrated with navigation | `Stack.SearchBar` and native toolbar search slots | Do not place a HeroUI input inside a handmade navigation bar. |

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -20,6 +20,12 @@ bun run mobile:android
 
 Application routes live in `src/app`. Shared components, hooks, and other application code live in sibling directories under `src`.
 
+## Design development
+
+The mobile design system is documented in [`DESIGN.md`](./DESIGN.md). Read it before implementing or reviewing UI.
+
+In short, use HeroUI Native for application content and reusable product components. Use native Expo Router and `@expo/ui` surfaces for navigation, headers, tabs, toolbars, search, menus, and route-level sheets so each platform owns its chrome and iOS can render Liquid Glass where the operating system supports it.
+
 ## Verification
 
 ```bash

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -10,6 +10,7 @@ import { useColorScheme, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { withUniwind } from "uniwind";
 
+import { isIOS } from "@/lib/platform";
 import { queryClient } from "@/lib/query-client";
 import { MobileSessionProvider, useMobileSession } from "@/providers/mobile-session-provider";
 
@@ -30,7 +31,7 @@ function AppNavigation() {
       screenOptions={{
         headerBackButtonDisplayMode: "minimal",
         headerShadowVisible: false,
-        headerTransparent: process.env.EXPO_OS === "ios",
+        headerTransparent: isIOS,
       }}
     >
       <Stack.Protected guard={!session}>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,10 +1,12 @@
 import "../../global.css";
 
 import { QueryClientProvider } from "@tanstack/react-query";
+import { DarkTheme, DefaultTheme, ThemeProvider } from "expo-router/react-navigation";
 import { Stack } from "expo-router/stack";
 import { StatusBar } from "expo-status-bar";
+import { Spinner } from "heroui-native";
 import { HeroUINativeProvider } from "heroui-native/provider";
-import { ActivityIndicator, View } from "react-native";
+import { useColorScheme, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { withUniwind } from "uniwind";
 
@@ -18,33 +20,43 @@ function AppNavigation() {
   if (loading) {
     return (
       <View className="flex-1 items-center justify-center bg-background">
-        <ActivityIndicator accessibilityLabel="Loading account" />
+        <Spinner color="default" accessibilityLabel="Loading account" />
       </View>
     );
   }
 
   return (
-    <Stack screenOptions={{ headerShown: false }}>
+    <Stack
+      screenOptions={{
+        headerBackButtonDisplayMode: "minimal",
+        headerShadowVisible: false,
+        headerTransparent: process.env.EXPO_OS === "ios",
+      }}
+    >
       <Stack.Protected guard={!session}>
-        <Stack.Screen name="index" />
-        <Stack.Screen name="scan-qr-code" options={{ animation: "slide_from_right" }} />
+        <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen name="scan-qr-code" options={{ animation: "slide_from_right", title: "Scan QR code" }} />
       </Stack.Protected>
       <Stack.Protected guard={Boolean(session)}>
-        <Stack.Screen name="connected" options={{ animation: "fade", gestureEnabled: false }} />
+        <Stack.Screen name="connected" options={{ animation: "fade", gestureEnabled: false, title: "" }} />
       </Stack.Protected>
     </Stack>
   );
 }
 
 export default function RootLayout() {
+  const colorScheme = useColorScheme();
+
   return (
     <UniwindGestureHandlerRootView className="flex-1">
       <QueryClientProvider client={queryClient}>
         <HeroUINativeProvider>
-          <StatusBar style="auto" />
-          <MobileSessionProvider>
-            <AppNavigation />
-          </MobileSessionProvider>
+          <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+            <StatusBar style="auto" />
+            <MobileSessionProvider>
+              <AppNavigation />
+            </MobileSessionProvider>
+          </ThemeProvider>
         </HeroUINativeProvider>
       </QueryClientProvider>
     </UniwindGestureHandlerRootView>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -14,6 +14,10 @@ import { isIOS } from "@/lib/platform";
 import { queryClient } from "@/lib/query-client";
 import { MobileSessionProvider, useMobileSession } from "@/providers/mobile-session-provider";
 
+export const unstable_settings = {
+  initialRouteName: "index",
+};
+
 const UniwindGestureHandlerRootView = withUniwind(GestureHandlerRootView);
 
 function AppNavigation() {

--- a/apps/mobile/src/app/connected.tsx
+++ b/apps/mobile/src/app/connected.tsx
@@ -1,15 +1,13 @@
-import { Button } from "heroui-native/button";
-import { useThemeColor } from "heroui-native/hooks";
-import { LogOut, Smartphone } from "lucide-react-native";
+import { Stack } from "expo-router";
+import { Typography } from "heroui-native";
 import { useState } from "react";
-import { ActivityIndicator, Text, View } from "react-native";
+import { View } from "react-native";
 
 import { AppLogo } from "@/components/app-logo";
 import { useMobileSession } from "@/providers/mobile-session-provider";
 
 export default function Connected() {
   const [signingOut, setSigningOut] = useState(false);
-  const foreground = useThemeColor("foreground");
   const { session, signOut: endSession } = useMobileSession();
 
   async function signOut(): Promise<void> {
@@ -27,32 +25,30 @@ export default function Connected() {
   const displayName = session.user.name?.trim() || session.user.email;
 
   return (
-    <View className="flex-1 items-center justify-center bg-background px-6 pb-safe-offset-8 pt-safe-offset-8">
-      <View className="w-full max-w-90 items-center">
-        <AppLogo size={72} animation="blink" followDeviceOrientation interactive />
-        <View className="mt-8 size-16 items-center justify-center rounded-3xl border border-border bg-control">
-          <Smartphone size={28} color={foreground} strokeWidth={1.5} />
-        </View>
-        <Text
-          accessibilityRole="header"
-          className="mt-5 text-center font-sans text-heading font-semibold text-foreground"
-        >
-          Phone connected
-        </Text>
-        <Text className="mt-2 text-center font-sans text-body text-text-secondary">Signed in as {displayName}</Text>
-        <Text className="mt-1 text-center font-sans text-caption text-muted">{session.user.email}</Text>
+    <>
+      <Stack.Toolbar placement="right">
+        <Stack.Toolbar.Button disabled={signingOut} onPress={() => void signOut()}>
+          {signingOut ? "Signing out…" : "Sign out"}
+        </Stack.Toolbar.Button>
+      </Stack.Toolbar>
 
-        <Button
-          size="md"
-          variant="secondary"
-          className="mt-8 w-full rounded-xl border border-border"
-          isDisabled={signingOut}
-          onPress={() => void signOut()}
-        >
-          {signingOut ? <ActivityIndicator color={foreground} /> : <LogOut size={18} color={foreground} />}
-          <Button.Label className="font-sans">{signingOut ? "Signing out…" : "Sign out"}</Button.Label>
-        </Button>
+      <View className="flex-1 items-center justify-center bg-background px-6 pb-safe-offset-8 pt-8">
+        <View className="w-full max-w-90 items-center">
+          <AppLogo size={72} animation="blink" followDeviceOrientation interactive />
+
+          <Typography.Heading type="h2" align="center" className="mt-5 tracking-openbot-tight">
+            Phone connected
+          </Typography.Heading>
+          <Typography.Paragraph color="muted" align="center" className="mt-2">
+            Signed in as {displayName}
+          </Typography.Paragraph>
+          {displayName !== session.user.email ? (
+            <Typography type="body-xs" color="muted" align="center" selectable className="mt-1">
+              {session.user.email}
+            </Typography>
+          ) : null}
+        </View>
       </View>
-    </View>
+    </>
   );
 }

--- a/apps/mobile/src/app/connected.tsx
+++ b/apps/mobile/src/app/connected.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { View } from "react-native";
 
 import { AppLogo } from "@/components/app-logo";
+import { isAndroid, isIOS } from "@/lib/platform";
 import { useMobileSession } from "@/providers/mobile-session-provider";
 
 export default function Connected() {
@@ -32,18 +33,17 @@ export default function Connected() {
       <Stack.Screen
         options={{
           headerTintColor: foreground,
-          headerRight:
-            process.env.EXPO_OS === "android"
-              ? () => (
-                  <Button size="sm" variant="ghost" isDisabled={signingOut} onPress={signOut}>
-                    <Button.Label>{signOutLabel}</Button.Label>
-                  </Button>
-                )
-              : undefined,
+          headerRight: isAndroid
+            ? () => (
+                <Button size="sm" variant="ghost" isDisabled={signingOut} onPress={signOut}>
+                  <Button.Label>{signOutLabel}</Button.Label>
+                </Button>
+              )
+            : undefined,
         }}
       />
 
-      {process.env.EXPO_OS === "ios" && (
+      {isIOS && (
         <Stack.Toolbar placement="right">
           <Stack.Toolbar.Button disabled={signingOut} onPress={signOut}>
             {signOutLabel}

--- a/apps/mobile/src/app/connected.tsx
+++ b/apps/mobile/src/app/connected.tsx
@@ -1,5 +1,6 @@
 import { Stack } from "expo-router";
-import { Typography } from "heroui-native";
+import { Button, Typography } from "heroui-native";
+import { useThemeColor } from "heroui-native/hooks";
 import { useState } from "react";
 import { View } from "react-native";
 
@@ -8,6 +9,7 @@ import { useMobileSession } from "@/providers/mobile-session-provider";
 
 export default function Connected() {
   const [signingOut, setSigningOut] = useState(false);
+  const [foreground] = useThemeColor(["foreground"]);
   const { session, signOut: endSession } = useMobileSession();
 
   async function signOut(): Promise<void> {
@@ -22,15 +24,32 @@ export default function Connected() {
 
   if (!session) return null;
 
+  const signOutLabel = signingOut ? "Signing out…" : "Sign out";
   const displayName = session.user.name?.trim() || session.user.email;
 
   return (
     <>
-      <Stack.Toolbar placement="right">
-        <Stack.Toolbar.Button disabled={signingOut} onPress={() => void signOut()}>
-          {signingOut ? "Signing out…" : "Sign out"}
-        </Stack.Toolbar.Button>
-      </Stack.Toolbar>
+      <Stack.Screen
+        options={{
+          headerTintColor: foreground,
+          headerRight:
+            process.env.EXPO_OS === "android"
+              ? () => (
+                  <Button size="sm" variant="ghost" isDisabled={signingOut} onPress={signOut}>
+                    <Button.Label>{signOutLabel}</Button.Label>
+                  </Button>
+                )
+              : undefined,
+        }}
+      />
+
+      {process.env.EXPO_OS === "ios" && (
+        <Stack.Toolbar placement="right">
+          <Stack.Toolbar.Button disabled={signingOut} onPress={signOut}>
+            {signOutLabel}
+          </Stack.Toolbar.Button>
+        </Stack.Toolbar>
+      )}
 
       <View className="flex-1 items-center justify-center bg-background px-6 pb-safe-offset-8 pt-8">
         <View className="w-full max-w-90 items-center">

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,7 +1,7 @@
 import { Link } from "expo-router";
 import { useIsFocused } from "expo-router/react-navigation";
-import { Button } from "heroui-native/button";
-import { Text, View } from "react-native";
+import { Button, Typography } from "heroui-native";
+import { View } from "react-native";
 
 import { AppLogo } from "@/components/app-logo";
 
@@ -9,39 +9,33 @@ export default function Index() {
   const isFocused = useIsFocused();
 
   return (
-    <View className="flex-1 bg-background min-h-full grow items-center justify-center px-6">
+    <View className="min-h-full flex-1 grow items-center justify-center bg-background px-6 pb-safe-offset-8 pt-safe-offset-8">
       <View className="w-full max-w-90">
-        <View className="mb-10.5 flex-col items-center justify-center gap-6">
+        <View className="mb-10.5 items-center justify-center gap-6">
           <AppLogo
             size={80}
             animation={isFocused ? "blink" : "none"}
             followDeviceOrientation={isFocused}
             interactive={isFocused}
           />
-          <Text className="font-sans text-display font-semibold tracking-openbot-tight text-foreground">OpenBot</Text>
+          <Typography.Heading type="h1" align="center" className="tracking-openbot-tight">
+            OpenBot
+          </Typography.Heading>
         </View>
 
-        <View className="items-center">
-          <Text
-            accessibilityRole="header"
-            className="font-sans text-heading font-semibold tracking-openbot-tight text-foreground"
-          >
+        <View className="items-center gap-2">
+          <Typography.Heading type="h2" align="center" className="tracking-openbot-tight">
             Sign in to OpenBot
-          </Text>
-          <Text className="mt-2 text-center font-sans text-[14px] leading-5.25 text-text-secondary">
+          </Typography.Heading>
+          <Typography.Paragraph color="muted" align="center">
             Scan the QR code on your OpenBot device to sign in and start controlling it.
-          </Text>
+          </Typography.Paragraph>
         </View>
 
-        <View className="mt-6 gap-3">
-          <Link href="./scan-qr-code" asChild>
-            <Button
-              size="md"
-              variant="secondary"
-              className="w-full rounded-xl border border-border bg-action"
-              accessibilityLabel="Scan QR code"
-            >
-              <Button.Label className="font-sans font-semibold text-action-foreground">Scan QR code</Button.Label>
+        <View className="mt-6">
+          <Link href="/scan-qr-code" asChild>
+            <Button size="md" variant="primary" className="w-full" accessibilityLabel="Scan QR code">
+              <Button.Label className="font-sans font-semibold">Scan QR code</Button.Label>
             </Button>
           </Link>
         </View>

--- a/apps/mobile/src/app/scan-qr-code.tsx
+++ b/apps/mobile/src/app/scan-qr-code.tsx
@@ -155,7 +155,13 @@ export default function ScanQrCode() {
 
   return (
     <>
-      <Stack.Screen options={{ headerTintColor: "#ffffff" }} />
+      <Stack.Screen
+        options={{
+          headerTransparent: process.env.EXPO_OS === "ios",
+          headerStyle: process.env.EXPO_OS === "android" ? { backgroundColor: "#000000" } : undefined,
+          headerTintColor: "#ffffff",
+        }}
+      />
       <StatusBar style="light" />
       <View className="flex-1 bg-black">
         <CameraView

--- a/apps/mobile/src/app/scan-qr-code.tsx
+++ b/apps/mobile/src/app/scan-qr-code.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import { AppState, Linking, ScrollView, StyleSheet, useWindowDimensions, View } from "react-native";
 
 import { redeemMobileConnectUrl } from "@/lib/mobile-auth";
+import { isAndroid, isIOS } from "@/lib/platform";
 import { useMobileSession } from "@/providers/mobile-session-provider";
 
 type ScanState = { status: "idle" } | { status: "connecting" } | { status: "error"; message: string };
@@ -157,8 +158,8 @@ export default function ScanQrCode() {
     <>
       <Stack.Screen
         options={{
-          headerTransparent: process.env.EXPO_OS === "ios",
-          headerStyle: process.env.EXPO_OS === "android" ? { backgroundColor: "#000000" } : undefined,
+          headerTransparent: isIOS,
+          headerStyle: isAndroid ? { backgroundColor: "#000000" } : undefined,
           headerTintColor: "#ffffff",
         }}
       />

--- a/apps/mobile/src/app/scan-qr-code.tsx
+++ b/apps/mobile/src/app/scan-qr-code.tsx
@@ -1,45 +1,68 @@
 import { CameraView, useCameraPermissions } from "expo-camera";
-import { Link } from "expo-router";
-import { Button } from "heroui-native/button";
+import { Stack } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import { Alert, Button, Card, Spinner, Surface } from "heroui-native";
 import { useThemeColor } from "heroui-native/hooks";
-import { ChevronLeft, QrCode } from "lucide-react-native";
+import { Camera, ScanLine } from "lucide-react-native";
 import { useEffect, useState } from "react";
-import {
-  ActivityIndicator,
-  AppState,
-  Linking,
-  ScrollView,
-  StyleSheet,
-  Text,
-  useWindowDimensions,
-  View,
-} from "react-native";
+import { AppState, Linking, ScrollView, StyleSheet, useWindowDimensions, View } from "react-native";
 
 import { redeemMobileConnectUrl } from "@/lib/mobile-auth";
 import { useMobileSession } from "@/providers/mobile-session-provider";
 
 type ScanState = { status: "idle" } | { status: "connecting" } | { status: "error"; message: string };
 
-function ScreenBackButton({ iconColor }: { iconColor: string }) {
+function ScannerStatus({ scanState, onRetry }: { scanState: ScanState; onRetry: () => void }) {
+  const [foreground, accent] = useThemeColor(["foreground", "accent"]);
+
+  if (scanState.status === "error") {
+    return (
+      <Card variant="default" className="gap-4 rounded-3xl p-4">
+        <Alert status="danger">
+          <Alert.Indicator />
+          <Alert.Content>
+            <Alert.Title>Couldn’t connect</Alert.Title>
+            <Alert.Description selectable>{scanState.message}</Alert.Description>
+          </Alert.Content>
+        </Alert>
+        <Button size="md" variant="secondary" onPress={onRetry}>
+          <Button.Label>Scan again</Button.Label>
+        </Button>
+      </Card>
+    );
+  }
+
   return (
-    <Link href="/" dismissTo asChild>
-      <Button
-        size="sm"
-        variant="secondary"
-        isIconOnly
-        accessibilityLabel="Back"
-        className="rounded-full border border-border"
-      >
-        <ChevronLeft size={20} color={iconColor} strokeWidth={2} />
-      </Button>
-    </Link>
+    <Card variant="default" className="rounded-3xl p-4">
+      <Card.Body className="flex-row items-center gap-3">
+        {scanState.status === "connecting" ? (
+          <Surface variant="tertiary" className="size-11 items-center justify-center rounded-2xl p-0">
+            <Spinner size="sm" color={accent} />
+          </Surface>
+        ) : (
+          <Surface variant="tertiary" className="size-11 items-center justify-center rounded-2xl p-0">
+            <ScanLine size={22} color={foreground} strokeWidth={1.75} />
+          </Surface>
+        )}
+        <View className="min-w-0 flex-1 gap-0.5">
+          <Card.Title className="font-sans text-body font-semibold">
+            {scanState.status === "connecting" ? "Connecting your phone…" : "Scan the desktop code"}
+          </Card.Title>
+          <Card.Description className="font-sans text-caption">
+            {scanState.status === "connecting"
+              ? "Verifying the one-time pairing request."
+              : "Keep the QR code centered inside the frame."}
+          </Card.Description>
+        </View>
+      </Card.Body>
+    </Card>
   );
 }
 
 export default function ScanQrCode() {
   const [permission, requestPermission, getPermission] = useCameraPermissions();
   const [scanState, setScanState] = useState<ScanState>({ status: "idle" });
-  const foreground = useThemeColor("foreground");
+  const [foreground, accentForeground] = useThemeColor(["foreground", "accent-foreground"]);
   const { width: windowWidth } = useWindowDimensions();
   const scannerFrameSize = Math.min(windowWidth - 80, 280);
   const { connect: finishSignIn } = useMobileSession();
@@ -72,9 +95,12 @@ export default function ScanQrCode() {
 
   if (!permission) {
     return (
-      <View className="flex-1 items-center justify-center bg-background">
-        <ActivityIndicator color={foreground} accessibilityLabel="Loading camera" />
-      </View>
+      <>
+        <Stack.Screen options={{ headerTintColor: foreground }} />
+        <View className="flex-1 items-center justify-center bg-background">
+          <Spinner color="default" accessibilityLabel="Loading camera" />
+        </View>
+      </>
     );
   }
 
@@ -82,88 +108,74 @@ export default function ScanQrCode() {
     const canRequestPermission = permission.canAskAgain;
 
     return (
-      <ScrollView
-        className="flex-1 bg-background"
-        contentContainerClassName="min-h-full flex-grow px-6 pt-safe-offset-3 pb-safe-offset-8"
-        contentInsetAdjustmentBehavior="automatic"
-      >
-        <ScreenBackButton iconColor={foreground} />
+      <>
+        <Stack.Screen options={{ headerTintColor: foreground }} />
+        <ScrollView
+          className="flex-1 bg-background"
+          contentContainerClassName="min-h-full grow px-5 pb-safe-offset-8 pt-8"
+          contentInsetAdjustmentBehavior="automatic"
+        >
+          <View className="mx-auto w-full max-w-md flex-1 justify-center">
+            <Card variant="secondary" className="gap-6 rounded-3xl p-5">
+              <Card.Header>
+                <Surface variant="tertiary" className="size-14 items-center justify-center rounded-2xl p-0">
+                  <Camera size={27} color={foreground} strokeWidth={1.75} />
+                </Surface>
+              </Card.Header>
 
-        <View className="flex-1 items-center justify-center gap-6 pb-14">
-          <View className="size-20 items-center justify-center rounded-4xl border border-border bg-control">
-            <QrCode size={36} color={foreground} strokeWidth={1.5} />
+              <Card.Body className="gap-2">
+                <Card.Title accessibilityRole="header" className="font-sans text-title font-semibold">
+                  Camera access required
+                </Card.Title>
+                <Card.Description className="font-sans text-body leading-6 text-text-secondary">
+                  {canRequestPermission
+                    ? "OpenBot uses the camera only to scan the one-time QR code shown in the desktop app."
+                    : "Camera access is blocked. Enable it for OpenBot in device settings, then return here to pair your phone."}
+                </Card.Description>
+              </Card.Body>
+
+              <Card.Footer>
+                <Button
+                  size="lg"
+                  className="w-full"
+                  onPress={canRequestPermission ? requestPermission : () => void Linking.openSettings()}
+                >
+                  <Camera size={19} color={accentForeground} strokeWidth={2} />
+                  <Button.Label className="font-sans font-semibold">
+                    {canRequestPermission ? "Allow camera access" : "Open settings"}
+                  </Button.Label>
+                </Button>
+              </Card.Footer>
+            </Card>
           </View>
-          <View className="max-w-sm items-center gap-2">
-            <Text
-              accessibilityRole="header"
-              className="text-center font-sans text-heading font-semibold text-foreground"
-            >
-              Camera access required
-            </Text>
-            <Text className="text-center font-sans text-body text-text-secondary">
-              {canRequestPermission
-                ? "OpenBot uses the camera only to scan the QR code shown in the desktop app."
-                : "Camera access is blocked. Enable it for OpenBot in your device settings, then return to scan the QR code."}
-            </Text>
-          </View>
-          <Button
-            size="md"
-            className="w-full max-w-sm"
-            onPress={canRequestPermission ? requestPermission : () => void Linking.openSettings()}
-          >
-            <Button.Label className="font-sans">
-              {canRequestPermission ? "Allow camera access" : "Open settings"}
-            </Button.Label>
-          </Button>
-        </View>
-      </ScrollView>
+        </ScrollView>
+      </>
     );
   }
 
   return (
-    <View className="flex-1 bg-black">
-      <CameraView
-        style={StyleSheet.absoluteFill}
-        facing="back"
-        barcodeScannerSettings={{ barcodeTypes: ["qr"] }}
-        onBarcodeScanned={scanState.status === "idle" ? ({ data }) => void connect(data) : undefined}
-      />
-
-      <View className="absolute inset-x-0 top-0 flex-row items-center justify-between px-5 pt-safe-offset-3">
-        <ScreenBackButton iconColor={foreground} />
-        <Text className="font-sans text-body font-semibold text-white">Scan QR code</Text>
-        <View className="size-10" />
-      </View>
-
-      <View pointerEvents="none" className="absolute inset-0 items-center justify-center px-10">
-        <View
-          className="rounded-[28px] border-2 border-white"
-          style={{ borderCurve: "continuous", height: scannerFrameSize, width: scannerFrameSize }}
+    <>
+      <Stack.Screen options={{ headerTintColor: "#ffffff" }} />
+      <StatusBar style="light" />
+      <View className="flex-1 bg-black">
+        <CameraView
+          style={StyleSheet.absoluteFill}
+          facing="back"
+          barcodeScannerSettings={{ barcodeTypes: ["qr"] }}
+          onBarcodeScanned={scanState.status === "idle" ? ({ data }) => void connect(data) : undefined}
         />
-        <Text className="mt-6 text-center font-sans text-body text-white">
-          Position the desktop QR code inside the frame.
-        </Text>
-      </View>
 
-      {scanState.status !== "idle" ? (
-        <View className="absolute inset-x-5 bottom-safe-offset-5 gap-4 rounded-3xl border border-border bg-background p-5">
-          <View className="gap-1">
-            <Text className="font-sans text-body font-semibold text-foreground">
-              {scanState.status === "connecting" ? "Connecting your phone…" : "Couldn’t connect"}
-            </Text>
-            {scanState.status === "connecting" ? (
-              <ActivityIndicator color={foreground} accessibilityLabel="Signing in" className="mt-3 self-start" />
-            ) : (
-              <Text className="font-sans text-caption text-muted">{scanState.message}</Text>
-            )}
-          </View>
-          {scanState.status === "error" ? (
-            <Button size="md" variant="secondary" onPress={() => setScanState({ status: "idle" })}>
-              <Button.Label className="font-sans">Scan again</Button.Label>
-            </Button>
-          ) : null}
+        <View pointerEvents="none" className="absolute inset-0 items-center justify-center px-10 pb-24">
+          <View
+            className="rounded-[28px] border-2 border-white"
+            style={{ borderCurve: "continuous", height: scannerFrameSize, width: scannerFrameSize }}
+          />
         </View>
-      ) : null}
-    </View>
+
+        <View className="absolute inset-x-5 bottom-safe-offset-5">
+          <ScannerStatus scanState={scanState} onRetry={() => setScanState({ status: "idle" })} />
+        </View>
+      </View>
+    </>
   );
 }

--- a/apps/mobile/src/lib/mobile-auth.ts
+++ b/apps/mobile/src/lib/mobile-auth.ts
@@ -5,7 +5,8 @@ import { fetch } from "expo/fetch";
 import * as Crypto from "expo-crypto";
 import * as Device from "expo-device";
 import * as SecureStore from "expo-secure-store";
-import { Platform } from "react-native";
+
+import { isAndroid, isIOS } from "@/lib/platform";
 
 const MOBILE_SESSION_KEY = "openbot.mobile.session.v1";
 const MOBILE_DEVICE_ID_KEY = "openbot.mobile.device-id.v1";
@@ -188,7 +189,7 @@ async function mobileDeviceIdentity(): Promise<{
   }
   const rawName = Device.deviceName?.trim() || Device.modelName?.trim() || "Mobile device";
   const name = rawName.normalize("NFC").replace(/\p{C}/gu, "").replace(/\s+/gu, " ").slice(0, 80).trim();
-  const platform = Platform.OS === "ios" || Platform.OS === "android" ? Platform.OS : "unknown";
+  const platform = isIOS ? "ios" : isAndroid ? "android" : "unknown";
   return { id, name: name || "Mobile device", platform };
 }
 

--- a/apps/mobile/src/lib/platform.ts
+++ b/apps/mobile/src/lib/platform.ts
@@ -1,0 +1,5 @@
+export const platform = process.env.EXPO_OS ?? "unknown";
+
+export const isIOS = platform === "ios";
+export const isAndroid = platform === "android";
+export const isWeb = platform === "web";


### PR DESCRIPTION
## Summary

- Add mobile design and execution guidelines for HeroUI Native and native Expo chrome.
- Update documentation with the new design system workflow.
- Refresh navigation, theming, loading states, typography, scanner status, and sign-out interactions.
- Replace custom headers and controls with native Expo Router surfaces where appropriate.

## Testing

- Not run (not requested)