### PR TITLE
Persist and restore the main app window position

### DIFF
--- a/scripts/dev-services.test.ts
+++ b/scripts/dev-services.test.ts
@@ -155,7 +155,7 @@ describe("development service runner", () => {
     expect(time).toBe(50);
   });
 
-  it("accepts an inaccessible POSIX process group as already stopped", async () => {
+  it("accepts an inaccessible macOS process group as already stopped", async () => {
     const kill = vi.fn((_pid: number, signal?: NodeJS.Signals | number) => {
       if (signal === 0) throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
       return true;
@@ -172,6 +172,22 @@ describe("development service runner", () => {
     expect(kill).toHaveBeenCalledWith(-321, "SIGTERM");
     expect(kill).toHaveBeenCalledWith(-321, 0);
     expect(kill).not.toHaveBeenCalledWith(-321, "SIGKILL");
+  });
+
+  it("does not hide an inaccessible process group on other POSIX platforms", async () => {
+    const error = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    const kill = vi.fn((_pid: number, signal?: NodeJS.Signals | number) => {
+      if (signal === 0) throw error;
+      return true;
+    });
+    const child = { pid: 321, exitCode: 0, kill: vi.fn(() => true) };
+
+    await expect(
+      stopOwnedProcesses([child], "SIGTERM", {
+        platform: "linux",
+        killProcess: kill,
+      }),
+    ).rejects.toBe(error);
   });
 
   it("escalates only after a surviving process group misses the deadline", async () => {

--- a/scripts/dev-services.test.ts
+++ b/scripts/dev-services.test.ts
@@ -155,6 +155,25 @@ describe("development service runner", () => {
     expect(time).toBe(50);
   });
 
+  it("accepts an inaccessible POSIX process group as already stopped", async () => {
+    const kill = vi.fn((_pid: number, signal?: NodeJS.Signals | number) => {
+      if (signal === 0) throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      return true;
+    });
+    const child = { pid: 321, exitCode: 0, kill: vi.fn(() => true) };
+
+    await expect(
+      stopOwnedProcesses([child], "SIGTERM", {
+        platform: "darwin",
+        killProcess: kill,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(kill).toHaveBeenCalledWith(-321, "SIGTERM");
+    expect(kill).toHaveBeenCalledWith(-321, 0);
+    expect(kill).not.toHaveBeenCalledWith(-321, "SIGKILL");
+  });
+
   it("escalates only after a surviving process group misses the deadline", async () => {
     let time = 0;
     const kill = vi.fn(() => true);

--- a/scripts/dev-services.ts
+++ b/scripts/dev-services.ts
@@ -375,7 +375,7 @@ export function signalOwnedProcess(
       killProcess(-child.pid, signal);
     }
   } catch (error) {
-    if (!isUnavailableProcess(error)) throw error;
+    if (!isUnavailableProcess(error, platform)) throw error;
   }
 }
 
@@ -415,14 +415,18 @@ function ownedProcessIsRunning(child: OwnedProcess, platform: NodeJS.Platform, k
     killProcess(-child.pid, 0);
     return true;
   } catch (error) {
-    if (isUnavailableProcess(error)) return false;
+    if (isUnavailableProcess(error, platform)) return false;
     throw error;
   }
 }
 
-function isUnavailableProcess(error: unknown): error is NodeJS.ErrnoException {
+function isUnavailableProcess(error: unknown, platform: NodeJS.Platform): error is NodeJS.ErrnoException {
   // macOS can report EPERM while a detached Electron group is disappearing and only sandboxed helpers remain.
-  return error instanceof Error && "code" in error && (error.code === "ESRCH" || error.code === "EPERM");
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ESRCH" || (platform === "darwin" && error.code === "EPERM"))
+  );
 }
 
 const invokedFile = process.argv[1] ? resolve(process.argv[1]) : "";

--- a/scripts/dev-services.ts
+++ b/scripts/dev-services.ts
@@ -375,7 +375,7 @@ export function signalOwnedProcess(
       killProcess(-child.pid, signal);
     }
   } catch (error) {
-    if (!isMissingProcess(error)) throw error;
+    if (!isUnavailableProcess(error)) throw error;
   }
 }
 
@@ -415,13 +415,14 @@ function ownedProcessIsRunning(child: OwnedProcess, platform: NodeJS.Platform, k
     killProcess(-child.pid, 0);
     return true;
   } catch (error) {
-    if (isMissingProcess(error)) return false;
+    if (isUnavailableProcess(error)) return false;
     throw error;
   }
 }
 
-function isMissingProcess(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error && error.code === "ESRCH";
+function isUnavailableProcess(error: unknown): error is NodeJS.ErrnoException {
+  // macOS can report EPERM while a detached Electron group is disappearing and only sandboxed helpers remain.
+  return error instanceof Error && "code" in error && (error.code === "ESRCH" || error.code === "EPERM");
 }
 
 const invokedFile = process.argv[1] ? resolve(process.argv[1]) : "";

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1275,6 +1275,9 @@ function createWindow(): BrowserWindow {
       if (systemSessionEndFlushStarted) return;
       systemSessionEndFlushStarted = true;
       updateService?.stop();
+      void flushMainWindowBounds().catch((error) =>
+        console.error("Unable to save the main window position before Windows session end:", error),
+      );
       void browserHost
         ?.flushPersistentStorage()
         .catch((error) => console.error("Unable to flush browser storage before Windows session end:", error));
@@ -1283,6 +1286,9 @@ function createWindow(): BrowserWindow {
     window.on("session-end", () => {
       systemSessionEnding = true;
       isQuitting = true;
+      void flushMainWindowBounds().catch((error) =>
+        console.error("Unable to save the main window position during Windows session end:", error),
+      );
       void browserHost
         ?.flushPersistentStorage()
         .catch((error) => console.error("Unable to flush browser storage during Windows session end:", error));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1222,10 +1222,11 @@ function registerIpcHandlers(
 
 function createWindow(): BrowserWindow {
   let inspectElementModifierPressed = false;
+  const cursor = screen.getCursorScreenPoint();
   const bounds = resolveMainWindowBounds(
     mainWindowBounds,
     screen.getAllDisplays().map((display) => display.workArea),
-    screen.getCursorScreenPoint(),
+    screen.getDisplayNearestPoint(cursor).workArea,
     { width: 1200, height: 820 },
     { width: 960, height: 640 },
   );

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -137,6 +137,7 @@ import { registerTeamIpcHandlers, withLocalHostSummary } from "./ipc/register-te
 import { isObject, optionalBoolean, requireString } from "./ipc/validation";
 import { parseVoiceTranscription } from "./ipc/voice-inputs";
 import { MacHapticFeedback } from "./mac-haptic-feedback";
+import { readMainWindowBounds, resolveMainWindowBounds, writeMainWindowBounds } from "./main-window-state";
 import { exportDiagnostics, exportOpenBotData } from "./maintenance-service";
 import { ManagedSkillService } from "./managed-skill-service";
 import { ProviderRuntimeManager } from "./provider-runtime-manager";
@@ -277,12 +278,23 @@ let isQuitting = false;
 let shutdownStarted = false;
 let systemSessionEnding = false;
 let systemSessionEndFlushStarted = false;
+let mainWindowBounds: Rectangle | null = null;
+let mainWindowBoundsWriteTimer: ReturnType<typeof setTimeout> | null = null;
+let mainWindowBoundsWrite = Promise.resolve();
 let pendingInviteUrl: string | null = findInviteUrl(process.argv);
 let inviteReceiverReady = false;
 
 const SETUP_FILE = "openbot-setup-v2.json";
 const ANALYTICS_PREFERENCE_FILE = "openbot-analytics-preference-v1.json";
 const DYNAMIC_ISLAND_PREFERENCE_FILE = "openbot-dynamic-island-preference-v1.json";
+const MAIN_WINDOW_STATE_FILE = "openbot-main-window-state-v1.json";
+
+if (!app.isPackaged) {
+  const quitAfterDevelopmentSignal = () => app.quit();
+  process.once("SIGINT", quitAfterDevelopmentSignal);
+  process.once("SIGTERM", quitAfterDevelopmentSignal);
+  process.once("SIGHUP", quitAfterDevelopmentSignal);
+}
 const BROWSER_STATE_FILE = "openbot-browser-state-v1.json";
 const SIDEBAR_LAYOUT_FILE = "openbot-sidebar-layout-v1.json";
 const TEAM_FILE = "openbot-team-server-v1.json";
@@ -1210,9 +1222,15 @@ function registerIpcHandlers(
 
 function createWindow(): BrowserWindow {
   let inspectElementModifierPressed = false;
+  const bounds = resolveMainWindowBounds(
+    mainWindowBounds,
+    screen.getAllDisplays().map((display) => display.workArea),
+    screen.getCursorScreenPoint(),
+    { width: 1200, height: 820 },
+    { width: 960, height: 640 },
+  );
   const window = new BrowserWindow({
-    width: 1200,
-    height: 820,
+    ...bounds,
     minWidth: 960,
     minHeight: 640,
     show: false,
@@ -1243,6 +1261,7 @@ function createWindow(): BrowserWindow {
     }
   });
   window.on("close", (event) => {
+    rememberMainWindowBounds(window.getNormalBounds());
     if (process.platform === "darwin" && !isQuitting) {
       // The hidden renderer owns the cross-host Dynamic Island coordinator and must outlive its visible window.
       event.preventDefault();
@@ -1273,6 +1292,8 @@ function createWindow(): BrowserWindow {
   window.on("closed", () => {
     if (mainWindow === window) mainWindow = null;
   });
+  window.on("move", () => rememberMainWindowBounds(window.getNormalBounds()));
+  window.on("resize", () => rememberMainWindowBounds(window.getNormalBounds()));
   window.on("hide", () => computerUseMacSetupController?.close());
 
   window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
@@ -1335,6 +1356,35 @@ function createWindow(): BrowserWindow {
   });
 
   return window;
+}
+
+function rememberMainWindowBounds(bounds: Rectangle): void {
+  mainWindowBounds = { ...bounds };
+  if (mainWindowBoundsWriteTimer) clearTimeout(mainWindowBoundsWriteTimer);
+  mainWindowBoundsWriteTimer = setTimeout(() => {
+    mainWindowBoundsWriteTimer = null;
+    void queueMainWindowBoundsWrite().catch((error) =>
+      console.error("Unable to save the main window position:", error),
+    );
+  }, 250);
+}
+
+function queueMainWindowBoundsWrite(): Promise<void> {
+  if (!mainWindowBounds) return mainWindowBoundsWrite;
+  const bounds = { ...mainWindowBounds };
+  mainWindowBoundsWrite = mainWindowBoundsWrite
+    .catch((error) => console.error("Unable to save the previous main window position:", error))
+    .then(() => writeMainWindowBounds(join(app.getPath("userData"), MAIN_WINDOW_STATE_FILE), bounds));
+  return mainWindowBoundsWrite;
+}
+
+async function flushMainWindowBounds(): Promise<void> {
+  if (mainWindow && !mainWindow.isDestroyed()) mainWindowBounds = mainWindow.getNormalBounds();
+  if (mainWindowBoundsWriteTimer) {
+    clearTimeout(mainWindowBoundsWriteTimer);
+    mainWindowBoundsWriteTimer = null;
+  }
+  await queueMainWindowBoundsWrite();
 }
 
 function createDynamicIslandWindow(bounds: Rectangle, _display: Display): BrowserWindow {
@@ -1679,6 +1729,12 @@ if (!hasSingleInstanceLock) {
       if (process.platform === "darwin") app.dock?.setIcon(appIconPath);
       configureContentSecurityPolicy();
       configureRendererPermissions();
+      mainWindowBounds = await readMainWindowBounds(join(app.getPath("userData"), MAIN_WINDOW_STATE_FILE)).catch(
+        (error) => {
+          console.error("Unable to restore the main window position:", error);
+          return null;
+        },
+      );
       mainWindow = createWindow();
       const computerUseMacSetupService = new ComputerUseMacSetupService({
         getIconDataUrl: async (path) => (await app.getFileIcon(path, { size: "normal" })).toDataURL(),
@@ -2235,6 +2291,7 @@ async function prepareForShutdown(browserAlreadyDestroyed = false): Promise<void
   shutdownStarted = true;
   isQuitting = true;
   updateService?.stop();
+  await flushMainWindowBounds().catch((error) => console.error("Unable to save the main window position:", error));
   dynamicIslandController?.destroy();
   dynamicIslandController = null;
   macHapticFeedback.destroy();

--- a/src/main/main-window-state.test.ts
+++ b/src/main/main-window-state.test.ts
@@ -15,19 +15,19 @@ describe("main window state", () => {
       resolveMainWindowBounds(
         { x: 1700, y: 120, width: 1100, height: 760 },
         [primary, secondary],
-        { x: 200, y: 100 },
+        primary,
         { width: 1200, height: 820 },
         { width: 960, height: 640 },
       ),
     ).toEqual({ x: 1700, y: 120, width: 1100, height: 760 });
   });
 
-  it("centers a new window on the display containing the cursor", () => {
+  it("centers a new window on the work area selected by Electron", () => {
     expect(
       resolveMainWindowBounds(
         null,
         [primary, secondary],
-        { x: 2000, y: 500 },
+        secondary,
         { width: 1200, height: 820 },
         { width: 960, height: 640 },
       ),
@@ -39,7 +39,7 @@ describe("main window state", () => {
       resolveMainWindowBounds(
         { x: 4000, y: 120, width: 1200, height: 820 },
         [primary],
-        { x: 300, y: 200 },
+        primary,
         { width: 1200, height: 820 },
         { width: 960, height: 640 },
       ),

--- a/src/main/main-window-state.test.ts
+++ b/src/main/main-window-state.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readMainWindowBounds, resolveMainWindowBounds, writeMainWindowBounds } from "./main-window-state";
+
+const primary = { x: 0, y: 0, width: 1440, height: 900 };
+const secondary = { x: 1440, y: 0, width: 1920, height: 1080 };
+
+describe("main window state", () => {
+  it("restores the last visible bounds", () => {
+    expect(
+      resolveMainWindowBounds(
+        { x: 1700, y: 120, width: 1100, height: 760 },
+        [primary, secondary],
+        { x: 200, y: 100 },
+        { width: 1200, height: 820 },
+        { width: 960, height: 640 },
+      ),
+    ).toEqual({ x: 1700, y: 120, width: 1100, height: 760 });
+  });
+
+  it("centers a new window on the display containing the cursor", () => {
+    expect(
+      resolveMainWindowBounds(
+        null,
+        [primary, secondary],
+        { x: 2000, y: 500 },
+        { width: 1200, height: 820 },
+        { width: 960, height: 640 },
+      ),
+    ).toEqual({ x: 1800, y: 130, width: 1200, height: 820 });
+  });
+
+  it("moves stale off-screen bounds onto the current display", () => {
+    expect(
+      resolveMainWindowBounds(
+        { x: 4000, y: 120, width: 1200, height: 820 },
+        [primary],
+        { x: 300, y: 200 },
+        { width: 1200, height: 820 },
+        { width: 960, height: 640 },
+      ),
+    ).toEqual({ x: 120, y: 40, width: 1200, height: 820 });
+  });
+
+  it("persists valid bounds and ignores malformed state", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-main-window-state-"));
+    const path = join(root, "state.json");
+    const bounds = { x: 25, y: 30, width: 1200, height: 820 };
+
+    await writeMainWindowBounds(path, bounds);
+    await expect(readMainWindowBounds(path)).resolves.toEqual(bounds);
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ version: 1, ...bounds });
+
+    await writeFile(path, '{"version":1,"x":"bad"}\n');
+    await expect(readMainWindowBounds(path)).resolves.toBeNull();
+  });
+});

--- a/src/main/main-window-state.ts
+++ b/src/main/main-window-state.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { readFile, rename, rm, writeFile } from "node:fs/promises";
 import { isDynamicRecord, isNumber } from "@openbot/contracts/runtime-values";
-import type { Point, Rectangle } from "electron";
+import type { Rectangle } from "electron";
 
 interface WindowSize {
   width: number;
@@ -55,20 +55,17 @@ export async function writeMainWindowBounds(path: string, bounds: Rectangle): Pr
 export function resolveMainWindowBounds(
   stored: Rectangle | null,
   workAreas: Rectangle[],
-  cursor: Point,
+  currentWorkArea: Rectangle,
   defaultSize: WindowSize,
   minimumSize: WindowSize,
 ): Rectangle {
-  const cursorWorkArea = workAreas.find((workArea) => containsPoint(workArea, cursor)) ?? workAreas[0];
-  if (!cursorWorkArea) return { x: 0, y: 0, ...defaultSize };
-
   const storedWorkArea = stored
     ? workAreas
         .map((workArea) => ({ workArea, overlap: intersectionArea(stored, workArea) }))
         .sort((left, right) => right.overlap - left.overlap)[0]
     : undefined;
   const restoreStoredPosition = Boolean(storedWorkArea?.overlap);
-  const workArea = restoreStoredPosition ? storedWorkArea?.workArea : cursorWorkArea;
+  const workArea = restoreStoredPosition ? storedWorkArea?.workArea : currentWorkArea;
   if (!workArea) return { x: 0, y: 0, ...defaultSize };
 
   const requestedSize = stored ?? { x: 0, y: 0, ...defaultSize };
@@ -88,15 +85,6 @@ export function resolveMainWindowBounds(
     width,
     height,
   };
-}
-
-function containsPoint(rectangle: Rectangle, point: Point): boolean {
-  return (
-    point.x >= rectangle.x &&
-    point.x < rectangle.x + rectangle.width &&
-    point.y >= rectangle.y &&
-    point.y < rectangle.y + rectangle.height
-  );
 }
 
 function intersectionArea(left: Rectangle, right: Rectangle): number {

--- a/src/main/main-window-state.ts
+++ b/src/main/main-window-state.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from "node:crypto";
+import { readFile, rename, rm, writeFile } from "node:fs/promises";
+import { isDynamicRecord, isNumber } from "@openbot/contracts/runtime-values";
+import type { Point, Rectangle } from "electron";
+
+interface WindowSize {
+  width: number;
+  height: number;
+}
+
+export async function readMainWindowBounds(path: string): Promise<Rectangle | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    if (
+      !isDynamicRecord(parsed) ||
+      parsed.version !== 1 ||
+      !isNumber(parsed.x) ||
+      !isNumber(parsed.y) ||
+      !isNumber(parsed.width) ||
+      !isNumber(parsed.height) ||
+      !Number.isFinite(parsed.x) ||
+      !Number.isFinite(parsed.y) ||
+      !Number.isFinite(parsed.width) ||
+      !Number.isFinite(parsed.height) ||
+      parsed.width <= 0 ||
+      parsed.height <= 0
+    ) {
+      return null;
+    }
+    return {
+      x: Math.round(parsed.x),
+      y: Math.round(parsed.y),
+      width: Math.round(parsed.width),
+      height: Math.round(parsed.height),
+    };
+  } catch (error) {
+    if (isMissing(error) || error instanceof SyntaxError) return null;
+    throw error;
+  }
+}
+
+export async function writeMainWindowBounds(path: string, bounds: Rectangle): Promise<void> {
+  const temporaryPath = `${path}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporaryPath, `${JSON.stringify({ version: 1, ...bounds })}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(temporaryPath, path);
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+  }
+}
+
+export function resolveMainWindowBounds(
+  stored: Rectangle | null,
+  workAreas: Rectangle[],
+  cursor: Point,
+  defaultSize: WindowSize,
+  minimumSize: WindowSize,
+): Rectangle {
+  const cursorWorkArea = workAreas.find((workArea) => containsPoint(workArea, cursor)) ?? workAreas[0];
+  if (!cursorWorkArea) return { x: 0, y: 0, ...defaultSize };
+
+  const storedWorkArea = stored
+    ? workAreas
+        .map((workArea) => ({ workArea, overlap: intersectionArea(stored, workArea) }))
+        .sort((left, right) => right.overlap - left.overlap)[0]
+    : undefined;
+  const restoreStoredPosition = Boolean(storedWorkArea?.overlap);
+  const workArea = restoreStoredPosition ? storedWorkArea?.workArea : cursorWorkArea;
+  if (!workArea) return { x: 0, y: 0, ...defaultSize };
+
+  const requestedSize = stored ?? { x: 0, y: 0, ...defaultSize };
+  const width = Math.min(Math.max(requestedSize.width, minimumSize.width), workArea.width);
+  const height = Math.min(Math.max(requestedSize.height, minimumSize.height), workArea.height);
+  if (!restoreStoredPosition || !stored) {
+    return {
+      x: Math.round(workArea.x + (workArea.width - width) / 2),
+      y: Math.round(workArea.y + (workArea.height - height) / 2),
+      width,
+      height,
+    };
+  }
+  return {
+    x: clamp(stored.x, workArea.x, workArea.x + workArea.width - width),
+    y: clamp(stored.y, workArea.y, workArea.y + workArea.height - height),
+    width,
+    height,
+  };
+}
+
+function containsPoint(rectangle: Rectangle, point: Point): boolean {
+  return (
+    point.x >= rectangle.x &&
+    point.x < rectangle.x + rectangle.width &&
+    point.y >= rectangle.y &&
+    point.y < rectangle.y + rectangle.height
+  );
+}
+
+function intersectionArea(left: Rectangle, right: Rectangle): number {
+  const width = Math.max(0, Math.min(left.x + left.width, right.x + right.width) - Math.max(left.x, right.x));
+  const height = Math.max(0, Math.min(left.y + left.height, right.y + right.height) - Math.max(left.y, right.y));
+  return width * height;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+function isMissing(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}


### PR DESCRIPTION
## Summary

- Persist and restore main window bounds across launches
- Recenter new windows on the cursor display and recover stale off-screen positions
- Treat macOS EPERM process groups as already stopped during development shutdown
- Add unit coverage for window state persistence, display resolution, and shutdown handling

## Testing

- Unit tests added for main window state and development service shutdown behavior
- Tests not run (not requested)