### PR TITLE
Fix provider session recovery after switching

### DIFF
--- a/src/backend/agent-service.test.ts
+++ b/src/backend/agent-service.test.ts
@@ -2724,7 +2724,7 @@ describe.sequential("AgentService", () => {
     );
   });
 
-  it("hands one SQLite conversation across Codex, Grok, and Claude provider sessions", async () => {
+  it("hands one SQLite conversation across repeated provider switches", async () => {
     process.env.OPENBOT_CLAUDE_PATH = await createFakeClaude(root);
     process.env.OPENBOT_GROK_PATH = await createFakeGrok(root);
     const clients = new Map<AgentProvider, FakeAgentClient>();
@@ -2748,12 +2748,20 @@ describe.sequential("AgentService", () => {
     const grokInput = clients.get("grok")?.requests.find((request) => request.method === "turn/start")?.params;
     expect(firstInputText(grokInput)).toContain("CODEX_DONE");
     expect(firstInputText(grokInput)).toContain("Second request");
+    const firstGrokSessionId = store.activeProviderSession("chief")?.externalSessionId;
 
     await service.updateBot({ botId: "chief", provider: "claude", model: "claude-sonnet-5" });
     await service.sendMessage({ botId: "chief", text: "Third request" });
     await waitFor(() => service?.listQueue("chief").deliveries[2]?.status === "completed");
     const claudeInput = clients.get("claude")?.requests.find((request) => request.method === "turn/start")?.params;
     expect(firstInputText(claudeInput)).toContain("GROK_DONE");
+
+    await service.updateBot({ botId: "chief", provider: "grok", model: "grok-4.5" });
+    await service.sendMessage({ botId: "chief", text: "Fourth request" });
+    await waitFor(() => service?.listQueue("chief").deliveries[3]?.status === "completed");
+    const grokTurns = clients.get("grok")?.requests.filter((request) => request.method === "turn/start") ?? [];
+    expect(firstInputText(grokTurns[1]?.params)).toContain("CLAUDE_DONE");
+    expect(store.activeProviderSession("chief")?.externalSessionId).not.toBe(firstGrokSessionId);
 
     const conversation = await service.readConversation("chief");
     expect(conversation.threadId).toBe(publicThreadId);
@@ -2764,8 +2772,92 @@ describe.sequential("AgentService", () => {
     expect(store.database.listProviderSessions(publicThreadId)).toMatchObject([
       { provider: "codex", state: "inactive" },
       { provider: "grok", state: "inactive" },
-      { provider: "claude", state: "active" },
+      { provider: "claude", state: "inactive" },
+      { provider: "grok", state: "active" },
     ]);
+  });
+
+  it("resumes and retries once when Grok loses its in-memory session", async () => {
+    process.env.OPENBOT_GROK_PATH = await createFakeGrok(root);
+    let rejectTurnStart = true;
+    let grokClient: FakeAgentClient | undefined;
+    const { store, mailbox } = stores();
+    service = new AgentService(store, mailbox, fakeBrowser(), 30_000, "codex", (provider) => {
+      const client = new FakeAgentClient(provider, undefined, true, true, {}, async (method) => {
+        if (provider === "grok" && method === "turn/start" && rejectTurnStart) {
+          rejectTurnStart = false;
+          throw new Error("Unknown Grok session: stale-session-id");
+        }
+      });
+      if (provider === "grok") grokClient = client;
+      return client;
+    });
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await service.initialize();
+    await store.getOrCreate("chief");
+    await service.updateBot({ botId: "chief", provider: "grok", model: "grok-4.5" });
+
+    await service.sendMessage({ botId: "chief", text: "Recover this request" });
+    await waitFor(() => service?.listQueue("chief").deliveries[0]?.status === "completed");
+
+    expect(grokClient?.requests.filter((request) => request.method === "thread/start")).toHaveLength(1);
+    expect(grokClient?.requests.filter((request) => request.method === "thread/resume")).toHaveLength(1);
+    expect(grokClient?.requests.filter((request) => request.method === "turn/start")).toHaveLength(2);
+    expect(
+      (await service.readConversation("chief")).messages.filter((message) => message.author === "user"),
+    ).toHaveLength(1);
+    expect(warning).toHaveBeenCalledWith(expect.any(String), {
+      botId: "chief",
+      provider: "grok",
+      outcome: "resumed",
+    });
+    warning.mockRestore();
+  });
+
+  it("replaces a Grok session that the provider can no longer resume", async () => {
+    process.env.OPENBOT_GROK_PATH = await createFakeGrok(root);
+    let rejectResume = false;
+    let grokClient: FakeAgentClient | undefined;
+    const { store, mailbox } = stores();
+    service = new AgentService(store, mailbox, fakeBrowser(), 30_000, "codex", (provider) => {
+      const client = new FakeAgentClient(provider, undefined, true, true, {}, async (method) => {
+        if (provider === "grok" && method === "thread/resume" && rejectResume) {
+          throw new Error("Grok session not found");
+        }
+      });
+      if (provider === "grok") grokClient = client;
+      return client;
+    });
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await service.initialize();
+    await store.getOrCreate("chief");
+    await service.updateBot({ botId: "chief", provider: "grok", model: "grok-4.5" });
+    await service.sendMessage({ botId: "chief", text: "First Grok request" });
+    await waitFor(() => service?.listQueue("chief").deliveries[0]?.status === "completed");
+    const publicThreadId = service.listBots().find((bot) => bot.id === "chief")?.threadId;
+    const originalSessionId = store.activeProviderSession("chief")?.externalSessionId;
+    if (!publicThreadId || !originalSessionId) throw new Error("The first Grok session was not created.");
+
+    rejectResume = true;
+    await service.updateBot({ botId: "chief", description: "Force the provider session to reload." });
+    await service.sendMessage({ botId: "chief", text: "Continue after recovery" });
+    await waitFor(() => service?.listQueue("chief").deliveries[1]?.status === "completed");
+
+    const sessions = store.database.listProviderSessions(publicThreadId);
+    expect(sessions).toMatchObject([
+      { externalSessionId: originalSessionId, provider: "grok", state: "inactive" },
+      { provider: "grok", state: "active" },
+    ]);
+    expect(sessions[1]?.externalSessionId).not.toBe(originalSessionId);
+    const turns = grokClient?.requests.filter((request) => request.method === "turn/start") ?? [];
+    expect(firstInputText(turns[1]?.params)).toContain("GROK_DONE");
+    expect(firstInputText(turns[1]?.params)).toContain("Continue after recovery");
+    expect(warning).toHaveBeenCalledWith(expect.any(String), {
+      botId: "chief",
+      provider: "grok",
+      outcome: "replaced",
+    });
+    warning.mockRestore();
   });
 
   it("stores a visible summary when a provider handoff exceeds its budget", async () => {

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -395,7 +395,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
   readonly #hostedSites: AgentHostedSites | null;
   readonly #snapshots = new Map<string, ConversationSnapshot>();
   readonly #threadToBot = new Map<string, string>();
-  readonly #loadedThreads = new Set<string>();
+  readonly #loadedThreads = new Map<string, AgentClient>();
   readonly #pendingPrompts = new Map<RequestId, PendingPrompt>();
   readonly #pendingApprovals = new Map<RequestId, PendingApproval>();
   readonly #pendingBrowserTakeovers = new Map<RequestId, PendingBrowserTakeover>();
@@ -2357,27 +2357,35 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     const currentBot = this.#store.list().find((candidate) => candidate.id === bot.id) ?? bot;
     const session = this.#store.activeProviderSession(bot.id);
     if (session) {
-      this.#threadToBot.set(session.externalSessionId, bot.id);
-      if (!this.#loadedThreads.has(session.externalSessionId)) {
-        await this.#resumeThread(currentBot, client, session.externalSessionId);
+      if (this.#loadedThreads.get(session.externalSessionId) !== client) {
+        try {
+          await this.#resumeThread(currentBot, client, session.externalSessionId);
+        } catch (error) {
+          if (!isMissingProviderSessionError(error, client.provider)) throw error;
+          this.#retireProviderSession(currentBot, session.externalSessionId);
+          const replacementThreadId = await this.#startProviderThread(currentBot, client, publicThreadId);
+          this.#logProviderSessionRecovery(currentBot.id, client.provider, "replaced");
+          return replacementThreadId;
+        }
       }
+      this.#threadToBot.set(session.externalSessionId, bot.id);
       return session.externalSessionId;
     }
 
+    return this.#startProviderThread(currentBot, client, publicThreadId);
+  }
+
+  async #startProviderThread(bot: BotSummary, client: AgentClient, publicThreadId: string): Promise<string> {
     const response = await client.request(
       "thread/start",
       {
-        model: currentBot.model,
-        effort: currentBot.reasoningEffort,
-        cwd: currentBot.workspacePath,
-        runtimeWorkspaceRoots: [currentBot.workspacePath, this.#store.sharedRoot],
+        model: bot.model,
+        effort: bot.reasoningEffort,
+        cwd: bot.workspacePath,
+        runtimeWorkspaceRoots: [bot.workspacePath, this.#store.sharedRoot],
         approvalPolicy: "on-request",
         sandbox: "danger-full-access",
-        developerInstructions: developerInstructions(
-          currentBot,
-          this.#store.sharedRoot,
-          this.#memories.list(currentBot.id),
-        ),
+        developerInstructions: developerInstructions(bot, this.#store.sharedRoot, this.#memories.list(bot.id)),
         ephemeral: false,
         serviceName: "openbot",
         dynamicTools: [...BROWSER_DYNAMIC_TOOLS, OPENBOT_DYNAMIC_TOOLS],
@@ -2387,7 +2395,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     const externalThreadId = response.thread.id;
     this.#store.bindProviderSession(bot.id, externalThreadId);
     this.#threadToBot.set(externalThreadId, bot.id);
-    this.#loadedThreads.add(externalThreadId);
+    this.#loadedThreads.set(externalThreadId, client);
     this.#ensureSnapshot(bot.id, publicThreadId);
     const handoff = this.#buildProviderHandoff(bot.id, publicThreadId);
     if (handoff) this.#pendingHandoffs.set(externalThreadId, handoff);
@@ -2414,7 +2422,22 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       await client.request("thread/unarchive", { threadId: externalThreadId }, decodeRecordResponse);
       await client.request("thread/resume", params, decodeRecordResponse);
     }
-    this.#loadedThreads.add(externalThreadId);
+    this.#loadedThreads.set(externalThreadId, client);
+  }
+
+  #retireProviderSession(bot: BotSummary, externalThreadId: string): void {
+    const session = this.#store.activeProviderSession(bot.id);
+    if (session?.externalSessionId !== externalThreadId || !bot.threadId) return;
+    this.#store.database.deactivateProviderSessions(bot.threadId);
+    this.#threadToBot.delete(externalThreadId);
+    this.#loadedThreads.delete(externalThreadId);
+    this.#contextBudgets.delete(externalThreadId);
+    this.#clearCompactionTimer(externalThreadId);
+    this.#pendingHandoffs.delete(externalThreadId);
+  }
+
+  #logProviderSessionRecovery(botId: string, provider: AgentProvider, outcome: "resumed" | "replaced"): void {
+    console.warn("Recovered an unavailable provider session.", { botId, provider, outcome });
   }
 
   async #requestWithArchivedThreadRecovery<T>(
@@ -3079,7 +3102,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       this.#applyPendingRuntimeRefresh(bot);
       await this.ensureProvider(providerForBot(bot));
       const client = this.#requireReadyClient(providerForBot(bot));
-      const threadId = await this.#ensureThread(bot, client);
+      let threadId = await this.#ensureThread(bot, client);
       const snapshot = this.#ensureSnapshot(bot.id, threadId);
       if (snapshot.activeTurnId) {
         await this.#mailbox.markTerminal(delivery.id, "failed", "The recipient already has an active turn.");
@@ -3090,11 +3113,6 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       const agentNames = agentNamesById(this.#store.list());
       const displayText = displayMessageReferences(delivery.text, delivery.attachments, agentNames);
       let text = displayText || "The user shared attached local files.";
-      const handoff = this.#pendingHandoffs.get(threadId);
-      if (handoff) {
-        text = `${handoff}\n\n--- current message ---\n${text}`;
-        this.#pendingHandoffs.delete(threadId);
-      }
       if (delivery.sender.kind === "user" && delivery.replyToMessageId) {
         const referenced = snapshot.messages.find((message) => message.id === delivery.replyToMessageId);
         text = [
@@ -3166,6 +3184,15 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
             : { type: "mention", name: attachment.name, path: attachment.path },
         );
       }
+      const inputForThread = (providerThreadId: string): typeof input => {
+        const handoff = this.#pendingHandoffs.get(providerThreadId);
+        if (!handoff) return input;
+        return input.map((item, index) =>
+          index === 0 && item.type === "text"
+            ? { ...item, text: `${handoff}\n\n--- current message ---\n${item.text}` }
+            : item,
+        );
+      };
 
       if (!snapshot.messages.some((message) => message.id === delivery.id)) {
         snapshot.messages.push({
@@ -3183,23 +3210,40 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       }
       this.#emitConversation(snapshot);
 
-      const response = await this.#requestWithArchivedThreadRecovery(
-        bot,
-        client,
-        "turn/start",
-        {
-          threadId,
-          model: bot.model,
-          effort: bot.reasoningEffort,
-          clientUserMessageId: delivery.id,
-          input,
-          cwd: bot.workspacePath,
-          runtimeWorkspaceRoots: [bot.workspacePath, this.#store.sharedRoot],
-          approvalPolicy: "on-request",
-          sandboxPolicy: { type: "dangerFullAccess" },
-        },
-        decodeTurnResponse,
-      );
+      const startTurn = (providerThreadId: string) =>
+        this.#requestWithArchivedThreadRecovery(
+          bot,
+          client,
+          "turn/start",
+          {
+            threadId: providerThreadId,
+            model: bot.model,
+            effort: bot.reasoningEffort,
+            clientUserMessageId: delivery.id,
+            input: inputForThread(providerThreadId),
+            cwd: bot.workspacePath,
+            runtimeWorkspaceRoots: [bot.workspacePath, this.#store.sharedRoot],
+            approvalPolicy: "on-request",
+            sandboxPolicy: { type: "dangerFullAccess" },
+          },
+          decodeTurnResponse,
+        );
+      let response: Awaited<ReturnType<typeof startTurn>>;
+      try {
+        response = await startTurn(threadId);
+      } catch (error) {
+        if (!isMissingProviderSessionError(error, client.provider)) throw error;
+        const unavailableThreadId = threadId;
+        if (this.#loadedThreads.get(unavailableThreadId) === client) {
+          this.#loadedThreads.delete(unavailableThreadId);
+        }
+        threadId = await this.#ensureThread(bot, client);
+        response = await startTurn(threadId);
+        if (threadId === unavailableThreadId) {
+          this.#logProviderSessionRecovery(bot.id, client.provider, "resumed");
+        }
+      }
+      this.#pendingHandoffs.delete(threadId);
       await this.#mailbox.markRunning(delivery.id, response.turn.id);
       confirmedTurnId = response.turn.id;
       const currentDelivery = this.#mailbox.getDelivery(delivery.id)?.delivery;
@@ -3610,7 +3654,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
         return;
       }
       case "thread/archived": {
-        if (threadId) this.#loadedThreads.delete(threadId);
+        if (threadId && this.#loadedThreads.get(threadId) === source) this.#loadedThreads.delete(threadId);
         return;
       }
       case "mcpServer/startupStatus/updated": {
@@ -5623,6 +5667,15 @@ function isNonActionableCodexWarning(message: string): boolean {
 
 function isArchivedThreadError(error: unknown): boolean {
   return error instanceof AppServerError && /\bis archived\b/i.test(error.message);
+}
+
+function isMissingProviderSessionError(error: unknown, provider: AgentProvider): boolean {
+  if (provider !== "grok" || !(error instanceof Error)) return false;
+  return (
+    /\bunknown grok session\b/i.test(error.message) ||
+    /\bsession\b.*\b(?:not found|does not exist|unknown)\b/i.test(error.message) ||
+    /\b(?:not found|unknown)\b.*\bsession\b/i.test(error.message)
+  );
 }
 
 function isDynamicToolCall(value: unknown): value is DynamicToolCallParams {


### PR DESCRIPTION
## Summary

- tie loaded provider sessions to the client instance that owns them
- retry transient missing Grok sessions once and replace sessions that cannot be resumed
- preserve the public conversation, provider handoff, and queued delivery during recovery
- add sanitized recovery diagnostics without provider session IDs

## Tests

- `bun run test -- src/backend/agent-service.test.ts`
- `bun run test -- src/backend/grok-client.test.ts`
- repository pre-commit formatting, lint, and all typechecks

Closes #118