### PR TITLE
Fix agent message thread modal

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -8194,7 +8194,7 @@ describe("OpenBot connected desktop shell", () => {
     expect(await screen.findByText("This approval is no longer active.")).toBeInTheDocument();
   });
 
-  it("opens the recipient chat from a persistent agent exchange", async () => {
+  it("opens the reply-linked message thread from a persistent agent exchange", async () => {
     vi.mocked(window.openbot.agent.readConversation).mockImplementation(async (botId) => ({
       botId,
       threadId: "thread-1",
@@ -8233,9 +8233,12 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
     expect(await screen.findByText("Messaged")).toBeInTheDocument();
-    await fireEvent.click(screen.getByRole("button", { name: "Open chat with Sales Outbound" }));
-    expect(await screen.findByRole("heading", { name: "Sales Outbound" })).toBeInTheDocument();
-    expect(screen.queryByRole("dialog", { name: "Messages with Sales Outbound" })).not.toBeInTheDocument();
+    await fireEvent.click(screen.getByRole("button", { name: "Open message thread with Sales Outbound" }));
+    expect(await screen.findByRole("dialog", { name: "Agent message thread" })).toBeInTheDocument();
+    expect(screen.getByText("Prepare report")).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole("button", { name: "Close message thread" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Agent message thread" })).not.toBeInTheDocument());
+    expect(screen.getByRole("heading", { name: "Chief" })).toBeInTheDocument();
   });
 
   it("shows an incoming agent marker without duplicating raw collaborator input", async () => {
@@ -8284,7 +8287,7 @@ describe("OpenBot connected desktop shell", () => {
     }));
 
     render(() => <App />);
-    expect(await screen.findByRole("button", { name: "Open chat with Sales Outbound" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Open message thread with Sales Outbound" })).toBeInTheDocument();
     expect(screen.queryByText("RAW_COLLABORATOR_RESULT")).not.toBeInTheDocument();
     expect(screen.getByText("Sales Outbound reports that the pipeline is ready.")).toBeInTheDocument();
   });

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -57,6 +57,7 @@ import {
   nextAgentActivityPresentation,
   ThinkingDisclosure,
 } from "./conversation/AgentActivity";
+import { AgentExchangeThreadModal } from "./conversation/AgentExchangeThreadModal";
 import type { AgentRuntimeSettings, AgentRuntimeSettingsPatch } from "./conversation/AgentSettingsPanel";
 import { AttachmentCards, fileBadge, formatFileSize } from "./conversation/AttachmentCards";
 import { attachmentReferenceTone } from "./conversation/AttachmentReference";
@@ -418,6 +419,10 @@ function createConversationViewScope(props: ConversationProps) {
     resources,
   } = controller;
   const [routineSettingsRequest, setRoutineSettingsRequest] = createSignal<RoutineSettingsRequest | null>(null);
+  const [agentExchangeThread, setAgentExchangeThread] = createSignal<{
+    agentId: string;
+    messageId: string;
+  } | null>(null);
   const [installedSkills, setInstalledSkills] = createSignal<InstalledSkill[]>([]);
   const [installedSkillsRetry, setInstalledSkillsRetry] = createSignal(0);
   let installedSkillsRequest = 0;
@@ -426,6 +431,12 @@ function createConversationViewScope(props: ConversationProps) {
   let routineSettingsRequestNonce = 0;
   let imageAttachmentPicker: HTMLInputElement | undefined;
   let contextAttachmentPicker: HTMLInputElement | undefined;
+  createEffect(
+    () => props.bot?.id,
+    () => {
+      setAgentExchangeThread(null);
+    },
+  );
   const currentTarget = (): ConversationTarget | undefined => {
     const botId = props.bot?.id;
     return botId ? { botId, serverId: props.server?.id ?? "local" } : undefined;
@@ -2516,6 +2527,7 @@ function createConversationViewScope(props: ConversationProps) {
     activityPresentation,
     addAttachments,
     agentActivity,
+    agentExchangeThread,
     agentReady,
     agentActivityExitDelayTimer,
     agentActivityExitTimer,
@@ -2640,6 +2652,7 @@ function createConversationViewScope(props: ConversationProps) {
     setActiveChatSearchIndex,
     setActiveRightPanel,
     setAgentActivitySpaceReserved,
+    setAgentExchangeThread,
     setAttachmentBusy,
     setBrowserAddress,
     setBrowserAddressEditing,
@@ -2910,6 +2923,7 @@ export function ConversationTimeline() {
     respondToBrowserTakeover,
     replyToMessage,
     scheduleUnreadDividerVisibilityUpdate,
+    setAgentExchangeThread,
     setChatSearchQuery,
     setComposerError,
     setExpandedEmojiMessageId,
@@ -3080,7 +3094,7 @@ export function ConversationTimeline() {
                               bots={props.bots}
                               announce={animateEntrance}
                               routineAvailable={routineMarkerAvailable(marker(), props.availableRoutineIds)}
-                              onSelectAgent={props.onSelectAgent}
+                              onOpenAgentThread={setAgentExchangeThread}
                               onOpenRoutine={openRoutineSettings}
                               onOpenHostedSite={(url) => void openExternalMessageUrl(url)}
                             />
@@ -3149,7 +3163,7 @@ export function ConversationTimeline() {
                                     bots={props.bots}
                                     announce={animateEntrance}
                                     routineAvailable={routineMarkerAvailable(marker(), props.availableRoutineIds)}
-                                    onSelectAgent={props.onSelectAgent}
+                                    onOpenAgentThread={setAgentExchangeThread}
                                     onOpenRoutine={openRoutineSettings}
                                     onOpenHostedSite={(url) => void openExternalMessageUrl(url)}
                                   />
@@ -3891,71 +3905,106 @@ export function ConversationPanels() {
 
 /** @internal Stable HMR boundary for conversation overlays. */
 export function ConversationOverlays() {
-  const { attachmentAction, mediaPreview, setMediaPreview } = useConversationViewScope();
+  const {
+    agentExchangeThread,
+    attachmentAction,
+    installedSkills,
+    mediaPreview,
+    openExternalMessageUrl,
+    openSharedFile,
+    openWorkspaceFile,
+    previewAttachment,
+    props,
+    setAgentExchangeThread,
+    setMediaPreview,
+  } = useConversationViewScope();
+  const selectedAgent = () => props.bots.find((bot) => bot.id === agentExchangeThread()?.agentId);
   return (
-    <Dialog.Root open={Boolean(mediaPreview())} onOpenChange={(open) => !open && setMediaPreview(null)}>
-      <Show when={mediaPreview()}>
-        {(preview) => (
-          <Dialog.Portal>
-            <Dialog.Overlay class="media-backdrop">
-              <Dialog.Content as="section" class="media-modal" data-dialog-surface="unstyled">
-                <Dialog.Title class="sr-only">{preview().attachment.name}</Dialog.Title>
-                <Button
-                  variant="ghost"
-                  type="button"
-                  class="media-close"
-                  aria-label="Close media preview"
-                  onClick={() => setMediaPreview(null)}
-                >
-                  <CloseIcon />
-                </Button>
-                <Show when={preview().attachment.previewKind === "image"}>
-                  <img
-                    class="media-image"
-                    src={preview().attachment.previewUrl ?? ""}
-                    alt={preview().attachment.name}
-                  />
-                </Show>
-                <Show when={preview().attachment.previewKind === "pdf"}>
-                  <iframe
-                    class="media-document"
-                    title={preview().attachment.name}
-                    src={preview().attachment.previewUrl ?? ""}
-                  />
-                </Show>
-                <Show when={preview().attachment.previewKind === "text"}>
-                  <pre class="media-text">{preview().loading ? "Loading…" : (preview().error ?? preview().text)}</pre>
-                </Show>
-                <div class="media-caption">
-                  <span>{preview().attachment.name}</span>
+    <>
+      <AgentExchangeThreadModal
+        open={Boolean(agentExchangeThread())}
+        messageId={agentExchangeThread()?.messageId ?? null}
+        selectedAgent={selectedAgent()}
+        currentBot={props.bot}
+        bots={props.bots}
+        messages={props.messages}
+        skills={installedSkills()}
+        onOpenChange={(open) => !open && setAgentExchangeThread(null)}
+        onSelectAgent={(botId) => {
+          setAgentExchangeThread(null);
+          props.onSelectAgent(botId);
+        }}
+        onOpenLink={(url) => void openExternalMessageUrl(url)}
+        onPreview={(attachment) => void previewAttachment(attachment)}
+        onAttachmentAction={attachmentAction}
+        onOpenSharedFile={openSharedFile}
+        onOpenWorkspaceFile={openWorkspaceFile}
+      />
+
+      <Dialog.Root open={Boolean(mediaPreview())} onOpenChange={(open) => !open && setMediaPreview(null)}>
+        <Show when={mediaPreview()}>
+          {(preview) => (
+            <Dialog.Portal>
+              <Dialog.Overlay class="media-backdrop">
+                <Dialog.Content as="section" class="media-modal" data-dialog-surface="unstyled">
+                  <Dialog.Title class="sr-only">{preview().attachment.name}</Dialog.Title>
                   <Button
-                    variant="outline"
+                    variant="ghost"
                     type="button"
-                    onClick={() => attachmentAction(preview().attachment, "open")}
+                    class="media-close"
+                    aria-label="Close media preview"
+                    onClick={() => setMediaPreview(null)}
                   >
-                    Open
+                    <CloseIcon />
                   </Button>
-                  <Button
-                    variant="outline"
-                    type="button"
-                    onClick={() => attachmentAction(preview().attachment, "download")}
-                  >
-                    Download
-                  </Button>
-                  <Button
-                    variant="outline"
-                    type="button"
-                    onClick={() => attachmentAction(preview().attachment, "reveal")}
-                  >
-                    Show in Finder
-                  </Button>
-                </div>
-              </Dialog.Content>
-            </Dialog.Overlay>
-          </Dialog.Portal>
-        )}
-      </Show>
-    </Dialog.Root>
+                  <Show when={preview().attachment.previewKind === "image"}>
+                    <img
+                      class="media-image"
+                      src={preview().attachment.previewUrl ?? ""}
+                      alt={preview().attachment.name}
+                    />
+                  </Show>
+                  <Show when={preview().attachment.previewKind === "pdf"}>
+                    <iframe
+                      class="media-document"
+                      title={preview().attachment.name}
+                      src={preview().attachment.previewUrl ?? ""}
+                    />
+                  </Show>
+                  <Show when={preview().attachment.previewKind === "text"}>
+                    <pre class="media-text">{preview().loading ? "Loading…" : (preview().error ?? preview().text)}</pre>
+                  </Show>
+                  <div class="media-caption">
+                    <span>{preview().attachment.name}</span>
+                    <Button
+                      variant="outline"
+                      type="button"
+                      onClick={() => attachmentAction(preview().attachment, "open")}
+                    >
+                      Open
+                    </Button>
+                    <Button
+                      variant="outline"
+                      type="button"
+                      onClick={() => attachmentAction(preview().attachment, "download")}
+                    >
+                      Download
+                    </Button>
+                    <Button
+                      variant="outline"
+                      type="button"
+                      onClick={() => attachmentAction(preview().attachment, "reveal")}
+                    >
+                      Show in Finder
+                    </Button>
+                  </div>
+                </Dialog.Content>
+              </Dialog.Overlay>
+            </Dialog.Portal>
+          )}
+        </Show>
+      </Dialog.Root>
+    </>
   );
 }
 

--- a/src/renderer/src/components/conversation/AgentExchangeThreadModal.test.tsx
+++ b/src/renderer/src/components/conversation/AgentExchangeThreadModal.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import type { BotMessage, BotProfile } from "../../data";
+import { AgentExchangeThreadModal, exchangeThreadMessages } from "./AgentExchangeThreadModal";
+
+const bots = [bot("chief", "Chief"), bot("research", "Research"), bot("sales", "Sales")];
+
+describe("exchangeThreadMessages", () => {
+  it("returns the clicked reply tree in conversation order, including group branches", () => {
+    const messages = [
+      exchange("unrelated", "sales", ["chief"], null, "Unrelated"),
+      exchange("root", "chief", ["research", "sales"], null, "Investigate"),
+      exchange("research-reply", "research", ["chief"], "root", "Research result"),
+      exchange("sales-reply", "sales", ["chief"], "root", "Sales result"),
+      exchange("follow-up", "chief", ["research"], "research-reply", "One more question"),
+    ];
+
+    expect(exchangeThreadMessages(messages, "research-reply").map((message) => message.exchange?.messageId)).toEqual([
+      "root",
+      "research-reply",
+      "sales-reply",
+      "follow-up",
+    ]);
+  });
+
+  it("stops safely at missing parents and reply cycles", () => {
+    const orphan = exchange("orphan", "research", ["chief"], "missing", "Orphan");
+    const child = exchange("child", "chief", ["research"], "orphan", "Child");
+    const cycleA = exchange("cycle-a", "chief", ["sales"], "cycle-b", "A");
+    const cycleB = exchange("cycle-b", "sales", ["chief"], "cycle-a", "B");
+
+    expect(exchangeThreadMessages([orphan, child, cycleA, cycleB], "orphan")).toEqual([orphan, child]);
+    expect(exchangeThreadMessages([orphan, child, cycleA, cycleB], "cycle-a")).toEqual([cycleA, cycleB]);
+    expect(exchangeThreadMessages([orphan], "not-loaded")).toEqual([]);
+  });
+});
+
+describe("AgentExchangeThreadModal", () => {
+  it("shows the reply-linked messages and keeps agent references interactive", async () => {
+    const onSelectAgent = vi.fn();
+    const messages = [
+      exchange("root", "chief", ["research"], null, "Ask @[Research](agent:research) to investigate."),
+      exchange("reply", "research", ["chief"], "root", "The evidence is ready."),
+      exchange("unrelated", "sales", ["chief"], null, "Do not show this."),
+    ];
+    const [open, setOpen] = createSignal(false);
+    render(() => (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open thread
+        </button>
+        <AgentExchangeThreadModal
+          open={open()}
+          messageId="reply"
+          selectedAgent={bots[1]}
+          currentBot={bots[0]}
+          bots={bots}
+          messages={messages}
+          onOpenChange={setOpen}
+          onSelectAgent={onSelectAgent}
+          onOpenLink={vi.fn()}
+          onPreview={vi.fn()}
+          onAttachmentAction={vi.fn()}
+        />
+      </>
+    ));
+
+    const trigger = screen.getByRole("button", { name: "Open thread" });
+    trigger.focus();
+    await fireEvent.click(trigger);
+    expect(await screen.findByRole("dialog", { name: "Agent message thread" })).toBeInTheDocument();
+    expect(screen.getByText("The evidence is ready.")).toBeInTheDocument();
+    expect(screen.queryByText("Do not show this.")).not.toBeInTheDocument();
+
+    await fireEvent.click(screen.getAllByRole("button", { name: "Open agent Research" })[0]);
+    expect(onSelectAgent).toHaveBeenCalledWith("research");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Close message thread" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Agent message thread" })).not.toBeInTheDocument());
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});
+
+function exchange(
+  messageId: string,
+  senderBotId: string,
+  recipientBotIds: string[],
+  replyToMessageId: string | null,
+  body: string,
+): BotMessage {
+  return {
+    id: `row-${messageId}`,
+    author: "bot",
+    body,
+    time: "10:00 AM",
+    createdAt: "2026-09-01T08:00:00.000Z",
+    kind: "exchange",
+    exchange: {
+      direction: senderBotId === "chief" ? "outgoing" : "incoming",
+      messageId,
+      senderBotId,
+      recipientBotIds,
+      replyToMessageId,
+      deliveries: recipientBotIds.map((recipientBotId) => ({
+        id: `${messageId}-${recipientBotId}`,
+        recipientBotId,
+        status: "completed",
+        position: null,
+        error: null,
+      })),
+    },
+  };
+}
+
+function bot(id: string, name: string): BotProfile {
+  return {
+    id,
+    name,
+    title: name,
+    description: "",
+    notifications: true,
+    provider: "codex",
+    model: "gpt-5.6-luna",
+    reasoningEffort: "medium",
+    threadId: null,
+    avatarSeed: id,
+    avatarHue: null,
+    avatarUrl: null,
+    time: "",
+    preview: "",
+  };
+}

--- a/src/renderer/src/components/conversation/AgentExchangeThreadModal.tsx
+++ b/src/renderer/src/components/conversation/AgentExchangeThreadModal.tsx
@@ -1,0 +1,147 @@
+import type { AttachmentSummary, InstalledSkill } from "@openbot/contracts/ipc";
+import { createEffect, createMemo, For, onCleanup, Show } from "solid-js";
+import type { BotMessage, BotProfile } from "../../data";
+import { AgentAvatar } from "../AgentAvatar";
+import { Bubble, BubbleContent, Dialog, IconButton, X } from "../ui";
+import { MessageBody } from "./MessageRendering";
+
+interface AgentExchangeThreadModalProps {
+  open: boolean;
+  messageId: string | null;
+  selectedAgent: BotProfile | undefined;
+  currentBot: BotProfile | undefined;
+  bots: BotProfile[];
+  messages: BotMessage[];
+  skills?: InstalledSkill[];
+  onOpenChange: (open: boolean) => void;
+  onSelectAgent: (botId: string) => void;
+  onOpenLink: (url: string) => void;
+  onPreview: (attachment: AttachmentSummary) => void;
+  onAttachmentAction: (attachment: AttachmentSummary, action: "open" | "reveal" | "download") => void;
+  onOpenSharedFile?: (path: string) => void;
+  onOpenWorkspaceFile?: (path: string) => void;
+}
+
+export function exchangeThreadMessages(messages: BotMessage[], selectedMessageId: string | null): BotMessage[] {
+  if (!selectedMessageId) return [];
+  const exchangeMessages = messages.filter((message) => message.exchange);
+  const byMessageId = new Map(
+    exchangeMessages.flatMap((message) => (message.exchange ? [[message.exchange.messageId, message] as const] : [])),
+  );
+  if (!byMessageId.has(selectedMessageId)) return [];
+
+  const includedIds = new Set<string>();
+  let ancestorId: string | null = selectedMessageId;
+  while (ancestorId && !includedIds.has(ancestorId)) {
+    includedIds.add(ancestorId);
+    ancestorId = byMessageId.get(ancestorId)?.exchange?.replyToMessageId ?? null;
+  }
+
+  let foundDescendant = true;
+  while (foundDescendant) {
+    foundDescendant = false;
+    for (const message of exchangeMessages) {
+      const exchange = message.exchange;
+      if (!exchange || includedIds.has(exchange.messageId) || !exchange.replyToMessageId) continue;
+      if (!includedIds.has(exchange.replyToMessageId)) continue;
+      includedIds.add(exchange.messageId);
+      foundDescendant = true;
+    }
+  }
+
+  return exchangeMessages.filter((message) => includedIds.has(message.exchange?.messageId ?? ""));
+}
+
+export function AgentExchangeThreadModal(props: AgentExchangeThreadModalProps) {
+  const thread = createMemo(() => exchangeThreadMessages(props.messages, props.messageId));
+  let restoreTarget: HTMLElement | null = null;
+  let restoreFrame: number | undefined;
+  createEffect(
+    () => props.open,
+    (open, previousOpen) => {
+      if (open) {
+        restoreTarget = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        return;
+      }
+      if (!previousOpen || !restoreTarget?.isConnected) return;
+      const target = restoreTarget;
+      restoreFrame = window.requestAnimationFrame(() => target.focus());
+    },
+  );
+  onCleanup(() => {
+    if (restoreFrame !== undefined) window.cancelAnimationFrame(restoreFrame);
+  });
+  const referencedMessage = (message: BotMessage) => {
+    const replyToMessageId = message.exchange?.replyToMessageId;
+    return replyToMessageId
+      ? props.messages.find((candidate) => candidate.exchange?.messageId === replyToMessageId)
+      : undefined;
+  };
+
+  return (
+    <Dialog.Root open={props.open} onOpenChange={props.onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay class="agent-exchange-thread-overlay" />
+        <Dialog.Content as="section" class="agent-exchange-thread-modal">
+          <header class="agent-exchange-thread-header">
+            <div class="agent-exchange-thread-heading">
+              <span class="agent-exchange-thread-title-copy">
+                <AgentAvatar bot={props.selectedAgent} class="agent-exchange-thread-title-avatar" />
+                <Dialog.Title>Agent message thread</Dialog.Title>
+              </span>
+              <Dialog.Description>
+                Reply-linked messages involving {props.selectedAgent?.name ?? "the selected agent"}
+              </Dialog.Description>
+            </div>
+            <IconButton label="Close message thread" variant="ghost" onClick={() => props.onOpenChange(false)}>
+              <X aria-hidden="true" />
+            </IconButton>
+          </header>
+
+          <div class="agent-exchange-thread-list" role="log" aria-label="Agent message thread">
+            <Show
+              when={thread().length > 0}
+              fallback={<p class="agent-exchange-thread-empty">This message thread is not in the loaded history.</p>}
+            >
+              <For each={thread()}>
+                {(message) => {
+                  const sender = () => props.bots.find((bot) => bot.id === message.exchange?.senderBotId);
+                  const fromCurrentAgent = () => message.exchange?.senderBotId === props.currentBot?.id;
+                  return (
+                    <article class="agent-exchange-thread-entry" data-align={fromCurrentAgent() ? "end" : "start"}>
+                      <div class="agent-exchange-thread-meta">
+                        <AgentAvatar bot={sender()} class="agent-exchange-thread-avatar" />
+                        <strong>{sender()?.name ?? "Unavailable agent"}</strong>
+                        <time datetime={message.createdAt ?? message.time}>{message.time}</time>
+                      </div>
+                      <Bubble
+                        align={fromCurrentAgent() ? "end" : "start"}
+                        variant={fromCurrentAgent() ? "secondary" : "default"}
+                      >
+                        <BubbleContent>
+                          <MessageBody
+                            message={{ ...message, author: "bot" }}
+                            referencedMessage={referencedMessage(message)}
+                            bots={props.bots}
+                            skills={props.skills}
+                            onSelectAgent={props.onSelectAgent}
+                            onOpenLink={props.onOpenLink}
+                            onPreview={props.onPreview}
+                            onAttachmentAction={props.onAttachmentAction}
+                            onOpenSharedFile={props.onOpenSharedFile}
+                            onOpenWorkspaceFile={props.onOpenWorkspaceFile}
+                            onDownload={(attachment) => props.onAttachmentAction(attachment, "download")}
+                          />
+                        </BubbleContent>
+                      </Bubble>
+                    </article>
+                  );
+                }}
+              </For>
+            </Show>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/renderer/src/components/conversation/AgentExchangeThreadModal.tsx
+++ b/src/renderer/src/components/conversation/AgentExchangeThreadModal.tsx
@@ -114,10 +114,7 @@ export function AgentExchangeThreadModal(props: AgentExchangeThreadModalProps) {
                         <strong>{sender()?.name ?? "Unavailable agent"}</strong>
                         <time datetime={message.createdAt ?? message.time}>{message.time}</time>
                       </div>
-                      <Bubble
-                        align={fromCurrentAgent() ? "end" : "start"}
-                        variant={fromCurrentAgent() ? "secondary" : "default"}
-                      >
+                      <Bubble align={fromCurrentAgent() ? "end" : "start"} variant="secondary">
                         <BubbleContent>
                           <MessageBody
                             message={{ ...message, author: "bot" }}

--- a/src/renderer/src/components/conversation/ChatActionMarker.test.tsx
+++ b/src/renderer/src/components/conversation/ChatActionMarker.test.tsx
@@ -7,22 +7,23 @@ const bots: BotProfile[] = [bot("research", "Research"), bot("sales", "Sales")];
 
 describe("ChatActionMarker", () => {
   it("opens a single outgoing agent target and shows its aggregate state", async () => {
-    const onSelectAgent = vi.fn();
+    const onOpenAgentThread = vi.fn();
     render(() => (
       <ChatActionMarker
         marker={agentMarker([{ agentId: "research", status: "running" }], "in-progress")}
         bots={bots}
-        onSelectAgent={onSelectAgent}
+        onOpenAgentThread={onOpenAgentThread}
       />
     ));
 
     expect(screen.getByRole("group", { name: "Messaged Research, In progress" })).toBeInTheDocument();
     expect(screen.queryByText("In progress")).not.toBeInTheDocument();
-    await fireEvent.click(screen.getByRole("button", { name: "Open chat with Research" }));
-    expect(onSelectAgent).toHaveBeenCalledWith("research");
+    await fireEvent.click(screen.getByRole("button", { name: "Open message thread with Research" }));
+    expect(onOpenAgentThread).toHaveBeenCalledWith({ agentId: "research", messageId: "message-1" });
   });
 
-  it("distinguishes a received agent message from a sent message", () => {
+  it("opens a received message thread from its source agent", async () => {
+    const onOpenAgentThread = vi.fn();
     render(() => (
       <ChatActionMarker
         marker={{
@@ -31,16 +32,19 @@ describe("ChatActionMarker", () => {
           sourceAgentId: "research",
         }}
         bots={bots}
-        onSelectAgent={vi.fn()}
+        onOpenAgentThread={onOpenAgentThread}
       />
     ));
 
     expect(screen.getByText("Message from")).toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Message from Research, Completed" })).toBeInTheDocument();
     expect(screen.queryByText("Completed")).not.toBeInTheDocument();
+    await fireEvent.click(screen.getByRole("button", { name: "Open message thread with Research" }));
+    expect(onOpenAgentThread).toHaveBeenCalledWith({ agentId: "research", messageId: "message-1" });
   });
 
   it("lists each target state for a multi-agent message", async () => {
+    const onOpenAgentThread = vi.fn();
     render(() => (
       <ChatActionMarker
         marker={agentMarker(
@@ -51,7 +55,7 @@ describe("ChatActionMarker", () => {
           "partial",
         )}
         bots={bots}
-        onSelectAgent={vi.fn()}
+        onOpenAgentThread={onOpenAgentThread}
       />
     ));
 
@@ -61,6 +65,8 @@ describe("ChatActionMarker", () => {
     });
     expect(await screen.findByText("Completed")).toBeInTheDocument();
     expect(screen.getByText("Failed")).toBeInTheDocument();
+    await fireEvent.pointerUp(screen.getByRole("menuitem", { name: /Sales.*Failed/u }), { button: 0 });
+    expect(onOpenAgentThread).toHaveBeenCalledWith({ agentId: "sales", messageId: "message-1" });
   });
 
   it("renders missing agents and unavailable routines without an action", () => {
@@ -68,7 +74,7 @@ describe("ChatActionMarker", () => {
       <ChatActionMarker
         marker={agentMarker([{ agentId: "missing", status: "failed" }], "failed")}
         bots={bots}
-        onSelectAgent={vi.fn()}
+        onOpenAgentThread={vi.fn()}
       />
     ));
     expect(screen.getByText("Unavailable agent")).toBeInTheDocument();
@@ -80,7 +86,7 @@ describe("ChatActionMarker", () => {
         marker={routineMarker("cancelled")}
         bots={bots}
         routineAvailable={false}
-        onSelectAgent={vi.fn()}
+        onOpenAgentThread={vi.fn()}
         onOpenRoutine={vi.fn()}
       />
     ));
@@ -94,7 +100,7 @@ describe("ChatActionMarker", () => {
       <ChatActionMarker
         marker={routineMarker("needs-attention")}
         bots={bots}
-        onSelectAgent={vi.fn()}
+        onOpenAgentThread={vi.fn()}
         onOpenRoutine={onOpenRoutine}
       />
     ));
@@ -111,7 +117,7 @@ describe("ChatActionMarker", () => {
       <ChatActionMarker
         marker={siteMarker("publish", "succeeded")}
         bots={bots}
-        onSelectAgent={vi.fn()}
+        onOpenAgentThread={vi.fn()}
         onOpenHostedSite={onOpenHostedSite}
       />
     ));
@@ -129,7 +135,7 @@ describe("ChatActionMarker", () => {
         marker={siteMarker("replace", "failed")}
         bots={bots}
         announce
-        onSelectAgent={vi.fn()}
+        onOpenAgentThread={vi.fn()}
         onOpenHostedSite={onOpenHostedSite}
       />
     ));

--- a/src/renderer/src/components/conversation/ChatActionMarker.tsx
+++ b/src/renderer/src/components/conversation/ChatActionMarker.tsx
@@ -26,7 +26,7 @@ interface ChatActionMarkerProps {
   bots: BotProfile[];
   announce?: boolean;
   routineAvailable?: boolean;
-  onSelectAgent: (botId: string) => void;
+  onOpenAgentThread: (selection: { agentId: string; messageId: string }) => void;
   onOpenRoutine?: (routine: { routineId: string; name: string }) => void;
   onOpenHostedSite?: (url: string) => void;
 }
@@ -55,7 +55,7 @@ export function ChatActionMarker(props: ChatActionMarkerProps) {
       <MarkerContent class="chat-action-marker-content">
         <span class="chat-action-marker-label">{label()}</span>
         <Show when={props.marker.kind === "agent-message" && props.marker}>
-          {(marker) => <AgentTarget marker={marker()} bots={props.bots} onSelectAgent={props.onSelectAgent} />}
+          {(marker) => <AgentTarget marker={marker()} bots={props.bots} onOpenThread={props.onOpenAgentThread} />}
         </Show>
         <Show when={props.marker.kind === "routine-lifecycle" && props.marker}>
           {(marker) => (
@@ -132,7 +132,7 @@ function HostedSiteTarget(props: {
 function AgentTarget(props: {
   marker: Extract<ChatActionMarkerModel, { kind: "agent-message" }>;
   bots: BotProfile[];
-  onSelectAgent: (botId: string) => void;
+  onOpenThread: (selection: { agentId: string; messageId: string }) => void;
 }) {
   const source = () => props.bots.find((bot) => bot.id === props.marker.sourceAgentId);
   const recipients = () => props.marker.targetDeliveries;
@@ -144,7 +144,12 @@ function AgentTarget(props: {
     <Show
       when={props.marker.direction === "outgoing"}
       fallback={
-        <AgentButton bot={source()} fallbackId={props.marker.sourceAgentId} onSelectAgent={props.onSelectAgent} />
+        <AgentButton
+          bot={source()}
+          fallbackId={props.marker.sourceAgentId}
+          messageId={props.marker.messageId}
+          onOpenThread={props.onOpenThread}
+        />
       }
     >
       <Show
@@ -153,7 +158,8 @@ function AgentTarget(props: {
           <AgentButton
             bot={singleRecipient()}
             fallbackId={recipients()[0]?.agentId}
-            onSelectAgent={props.onSelectAgent}
+            messageId={props.marker.messageId}
+            onOpenThread={props.onOpenThread}
           />
         }
       >
@@ -184,7 +190,9 @@ function AgentTarget(props: {
                   <DropdownMenu.Item
                     class="chat-action-agent-menu-item"
                     disabled={!bot()}
-                    onSelect={() => props.onSelectAgent(delivery.agentId)}
+                    onSelect={() =>
+                      props.onOpenThread({ agentId: delivery.agentId, messageId: props.marker.messageId })
+                    }
                   >
                     <AgentAvatar bot={bot()} class="chat-action-agent-avatar" />
                     <span>{bot()?.name ?? "Unavailable agent"}</span>
@@ -203,7 +211,8 @@ function AgentTarget(props: {
 function AgentButton(props: {
   bot: BotProfile | undefined;
   fallbackId: string | undefined;
-  onSelectAgent: (botId: string) => void;
+  messageId: string;
+  onOpenThread: (selection: { agentId: string; messageId: string }) => void;
 }) {
   return (
     <Show
@@ -221,8 +230,8 @@ function AgentButton(props: {
           type="button"
           class="chat-action-target"
           style={agentTargetStyle(bot())}
-          aria-label={`Open chat with ${bot().name}`}
-          onClick={() => props.onSelectAgent(bot().id)}
+          aria-label={`Open message thread with ${bot().name}`}
+          onClick={() => props.onOpenThread({ agentId: bot().id, messageId: props.messageId })}
         >
           <AgentAvatar bot={bot()} class="chat-action-agent-avatar" />
           <span>{bot().name}</span>

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -2355,7 +2355,7 @@
   flex-direction: column;
   gap: var(--openbot-space-6);
   overflow-y: auto;
-  padding: var(--openbot-space-4) 0 var(--openbot-space-4) var(--openbot-space-2);
+  padding: var(--openbot-space-4) var(--openbot-space-1) var(--openbot-space-4) var(--openbot-space-3);
   scrollbar-gutter: stable;
 }
 

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -2353,9 +2353,9 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--openbot-space-5);
+  gap: var(--openbot-space-6);
   overflow-y: auto;
-  padding: var(--openbot-space-5);
+  padding: var(--openbot-space-4) var(--openbot-space-6);
   scrollbar-gutter: stable;
 }
 

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -2355,7 +2355,7 @@
   flex-direction: column;
   gap: var(--openbot-space-6);
   overflow-y: auto;
-  padding: var(--openbot-space-4) var(--openbot-space-6);
+  padding: var(--openbot-space-4);
   scrollbar-gutter: stable;
 }
 
@@ -2412,10 +2412,6 @@
   .agent-exchange-thread-modal {
     width: calc(100vw - 24px);
     height: calc(100dvh - 24px);
-  }
-
-  .agent-exchange-thread-list {
-    padding: var(--openbot-space-4);
   }
 
   .agent-exchange-thread-entry > .ui-bubble {

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -2265,6 +2265,171 @@
   }
 }
 
+.agent-exchange-thread-overlay {
+  position: fixed;
+  z-index: var(--openbot-layer-dialog);
+  inset: 0;
+}
+
+.agent-exchange-thread-overlay[data-expanded] {
+  animation: agent-dialog-overlay-in var(--openbot-duration-dialog) ease;
+}
+
+.agent-exchange-thread-overlay[data-closed] {
+  animation: agent-dialog-overlay-out var(--openbot-duration-dialog) ease;
+}
+
+.agent-exchange-thread-modal {
+  position: fixed;
+  z-index: calc(var(--openbot-layer-dialog) + 1);
+  top: 50%;
+  left: 50%;
+  width: min(640px, calc(100vw - 48px));
+  height: min(620px, calc(100dvh - 48px));
+  min-height: 320px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  overflow: hidden;
+  outline: 0;
+  background: var(--openbot-bg-control);
+  color: var(--openbot-text-primary);
+  transform: translate(-50%, -50%);
+  transform-origin: center;
+}
+
+.agent-exchange-thread-modal[data-expanded] {
+  animation: agent-dialog-content-in var(--openbot-duration-dialog) ease;
+}
+
+.agent-exchange-thread-modal[data-closed] {
+  animation: agent-dialog-content-out var(--openbot-duration-dialog) ease;
+}
+
+.agent-exchange-thread-header {
+  display: flex;
+  min-height: 64px;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--openbot-space-3);
+  border-bottom: 1px solid var(--openbot-border);
+  padding: var(--openbot-space-2) var(--openbot-space-2) var(--openbot-space-2) var(--openbot-space-4);
+}
+
+.agent-exchange-thread-heading {
+  min-width: 0;
+}
+
+.agent-exchange-thread-title-copy,
+.agent-exchange-thread-meta {
+  display: flex;
+  align-items: center;
+}
+
+.agent-exchange-thread-title-copy {
+  gap: var(--openbot-space-2);
+}
+
+.agent-exchange-thread-title-copy h2 {
+  margin: 0;
+  font-size: var(--openbot-text-lg);
+  font-weight: var(--openbot-weight-semibold);
+  line-height: var(--openbot-leading-lg);
+}
+
+.agent-exchange-thread-heading > p {
+  margin: var(--openbot-space-0-5) 0 0 calc(var(--openbot-control-xs) + var(--openbot-space-2));
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-xs);
+  line-height: var(--openbot-leading-xs);
+}
+
+.agent-exchange-thread-title-avatar {
+  width: var(--openbot-control-xs);
+  height: var(--openbot-control-xs);
+  flex: 0 0 var(--openbot-control-xs);
+}
+
+.agent-exchange-thread-list {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--openbot-space-5);
+  overflow-y: auto;
+  padding: var(--openbot-space-5);
+  scrollbar-gutter: stable;
+}
+
+.agent-exchange-thread-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--openbot-space-2);
+}
+
+.agent-exchange-thread-entry[data-align="end"] {
+  align-items: flex-end;
+}
+
+.agent-exchange-thread-meta {
+  min-width: 0;
+  gap: var(--openbot-space-1-5);
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-xs);
+  line-height: var(--openbot-leading-xs);
+}
+
+.agent-exchange-thread-entry[data-align="end"] .agent-exchange-thread-meta {
+  flex-direction: row-reverse;
+}
+
+.agent-exchange-thread-meta strong {
+  overflow: hidden;
+  color: var(--openbot-text-secondary);
+  font-weight: var(--openbot-weight-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-exchange-thread-avatar {
+  width: var(--openbot-icon-md);
+  height: var(--openbot-icon-md);
+  flex: 0 0 var(--openbot-icon-md);
+}
+
+.agent-exchange-thread-entry > .ui-bubble {
+  max-width: 82%;
+}
+
+.agent-exchange-thread-empty {
+  margin: auto;
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-md);
+  line-height: var(--openbot-leading-md);
+  text-align: center;
+}
+
+@media (max-width: 520px) {
+  .agent-exchange-thread-modal {
+    width: calc(100vw - 24px);
+    height: calc(100dvh - 24px);
+  }
+
+  .agent-exchange-thread-list {
+    padding: var(--openbot-space-4);
+  }
+
+  .agent-exchange-thread-entry > .ui-bubble {
+    max-width: 90%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-exchange-thread-overlay,
+  .agent-exchange-thread-modal {
+    animation: none;
+  }
+}
+
 .agent-settings-model {
   margin: 25px 0 20px;
   overflow: visible;

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -2182,7 +2182,7 @@
   width: min(430px, calc(100vw - 32px));
   outline: none;
   background: var(--openbot-bg-control);
-  padding: var(--openbot-space-4) var(--openbot-space-2);
+  padding: var(--openbot-space-4);
   color: var(--openbot-text-primary);
   transform: translate(-50%, -50%);
   transform-origin: center;
@@ -2355,7 +2355,7 @@
   flex-direction: column;
   gap: var(--openbot-space-6);
   overflow-y: auto;
-  padding: var(--openbot-space-4);
+  padding: var(--openbot-space-4) 0 var(--openbot-space-4) var(--openbot-space-2);
   scrollbar-gutter: stable;
 }
 

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -2182,7 +2182,7 @@
   width: min(430px, calc(100vw - 32px));
   outline: none;
   background: var(--openbot-bg-control);
-  padding: var(--openbot-space-4);
+  padding: var(--openbot-space-4) var(--openbot-space-2);
   color: var(--openbot-text-primary);
   transform: translate(-50%, -50%);
   transform-origin: center;

--- a/src/renderer/stories/ChatActionMarker.stories.tsx
+++ b/src/renderer/stories/ChatActionMarker.stories.tsx
@@ -5,7 +5,7 @@ import { Heading, Text } from "../src/components/ui";
 import type { BotProfile, ChatActionMarkerModel } from "../src/data";
 
 const bots: BotProfile[] = [bot("research", "Research"), bot("sales", "Sales")];
-const onSelectAgent = fn();
+const onOpenAgentThread = fn();
 const onOpenRoutine = fn();
 const onOpenHostedSite = fn();
 
@@ -35,7 +35,7 @@ export const AllStates: Story = {
             "in-progress",
           )}
           bots={bots}
-          onSelectAgent={onSelectAgent}
+          onOpenAgentThread={onOpenAgentThread}
         />
         <ChatActionMarker
           marker={{
@@ -44,13 +44,13 @@ export const AllStates: Story = {
             sourceAgentId: "research",
           }}
           bots={bots}
-          onSelectAgent={onSelectAgent}
+          onOpenAgentThread={onOpenAgentThread}
         />
         {routineStatuses.map((status) => (
           <ChatActionMarker
             marker={routineMarker(status)}
             bots={bots}
-            onSelectAgent={onSelectAgent}
+            onOpenAgentThread={onOpenAgentThread}
             onOpenRoutine={onOpenRoutine}
           />
         ))}
@@ -59,7 +59,7 @@ export const AllStates: Story = {
             marker={lifecycleMarker(action)}
             bots={bots}
             routineAvailable={action !== "deleted"}
-            onSelectAgent={onSelectAgent}
+            onOpenAgentThread={onOpenAgentThread}
             onOpenRoutine={onOpenRoutine}
           />
         ))}
@@ -68,7 +68,7 @@ export const AllStates: Story = {
             <ChatActionMarker
               marker={siteMarker(action, status)}
               bots={bots}
-              onSelectAgent={onSelectAgent}
+              onOpenAgentThread={onOpenAgentThread}
               onOpenHostedSite={onOpenHostedSite}
             />
           )),
@@ -76,7 +76,7 @@ export const AllStates: Story = {
         <ChatActionMarker
           marker={{ kind: "unavailable", label: "Action unavailable", timestamp: timestamp }}
           bots={bots}
-          onSelectAgent={onSelectAgent}
+          onOpenAgentThread={onOpenAgentThread}
         />
       </section>
     </main>
@@ -102,13 +102,13 @@ export const CompactAndUnavailable: Story = {
           }}
           bots={bots}
           routineAvailable={false}
-          onSelectAgent={onSelectAgent}
+          onOpenAgentThread={onOpenAgentThread}
           onOpenRoutine={onOpenRoutine}
         />
         <ChatActionMarker
           marker={agentMarker([{ agentId: "missing", status: "failed" }], "failed")}
           bots={bots}
-          onSelectAgent={onSelectAgent}
+          onOpenAgentThread={onOpenAgentThread}
         />
         <ChatActionMarker
           marker={{
@@ -116,7 +116,7 @@ export const CompactAndUnavailable: Story = {
             title: "A very long public launch page title that must remain compact in a narrow conversation",
           }}
           bots={bots}
-          onSelectAgent={onSelectAgent}
+          onOpenAgentThread={onOpenAgentThread}
           onOpenHostedSite={onOpenHostedSite}
         />
       </section>
@@ -134,7 +134,7 @@ export const ReducedMotion: Story = {
         <ChatActionMarker
           marker={siteMarker("replace", "running")}
           bots={bots}
-          onSelectAgent={onSelectAgent}
+          onOpenAgentThread={onOpenAgentThread}
           onOpenHostedSite={onOpenHostedSite}
         />
       </section>


### PR DESCRIPTION
## What changed

- open agent-message markers in a modal instead of navigating to the recipient chat
- show the clicked exchange's reply-linked ancestors and descendants, including group branches
- preserve message rendering, attachments, links, agent tags, responsive layout, and focus restoration
- add regression coverage for single-agent, incoming, multi-agent, thread graph, malformed history, and app-level behavior

## Verification

- [ ] `bun run check`
- [x] Full staged Biome checks and all workspace typechecks passed via the commit hook
- [x] `src/renderer/src/App.test.tsx` — 211 tests passed
- [x] Focused marker, modal, and Conversation HMR suites — 12 tests passed
- [ ] Integrated manual smoke test — blocked because `.env.keys` is unavailable in the fresh worktree; no packaged-app fallback was used
- [x] No credentials, private data, generated output, or real user files are included

## Risk and security impact

Renderer-only interaction change. No permissions, IPC, persistence, filesystem, protocol, or network behavior changes.