### PR TITLE
lint: reject circular imports and break the two renderer cycles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ The Biome configuration also loads the repository-owned GritQL rules in
 `tools/biome/anti-slop/rules`. Fix these findings at the domain boundary. Do not suppress a rule or
 replace a concrete contract with a broad dictionary type.
 
+Biome's `suspicious/noImportCycles` rejects circular imports across the whole repository, so runtime
+imports point in one direction. When two modules need each other, move the shared piece into a third
+module both can import — as `app-controller-context.tsx` and `conversation-controller-context.tsx` do
+for their controller contexts. Type-only imports (`import type`) are erased by the compiler and stay
+allowed in both directions.
+
 ## Pull requests
 
 1. Create a branch from `main`.

--- a/biome.json
+++ b/biome.json
@@ -75,6 +75,7 @@
       "suspicious": {
         "noExplicitAny": "error",
         "noFocusedTests": "error",
+        "noImportCycles": "error",
         "noSkippedTests": "warn"
       }
     }

--- a/src/renderer/src/App.read-state.test.tsx
+++ b/src/renderer/src/App.read-state.test.tsx
@@ -1,7 +1,8 @@
 import type { ConversationPage, DirectConversationSnapshot } from "@openbot/contracts/ipc";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { expect, it, vi } from "vitest";
-import { App, AppControllerProvider, createAppController } from "./App";
+import { App, createAppController } from "./App";
+import { AppControllerProvider } from "./app-controller-context";
 import {
   emitAgentEvent,
   emitDirectMessage,

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -2,8 +2,9 @@ import type { BotSummary, ConversationPage, ConversationSnapshot } from "@openbo
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { createSignal, Show } from "solid-js";
 import { expect, it, vi } from "vitest";
-import { App, AppControllerProvider, createAppController, createBotInitialMessage, useAppController } from "./App";
+import { App, createAppController, createBotInitialMessage } from "./App";
 import { desktopAnalytics } from "./analytics";
+import { AppControllerProvider, useAppController } from "./app-controller-context";
 import {
   BOTS,
   confirmOnboardingModel,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -45,20 +45,11 @@ import {
   ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX,
 } from "@openbot/contracts/ipc";
 import type { TeamProtocolV3Capability } from "@openbot/contracts/team-protocol/v3";
-import {
-  createContext,
-  createEffect,
-  createMemo,
-  createSignal,
-  createStore,
-  flush,
-  onSettled,
-  type ParentProps,
-  useContext,
-} from "solid-js";
+import { createEffect, createMemo, createSignal, createStore, flush, onSettled } from "solid-js";
 import { AppAccessGate } from "./AppView";
 import { cleanAgentMessageText } from "./agent-message-text";
 import { desktopAnalytics } from "./analytics";
+import { AppControllerProvider } from "./app-controller-context";
 import {
   botMessagesEqual,
   botProfilesEqual,
@@ -4164,21 +4155,6 @@ export function createAppController(props: AppProps = {}) {
       appFrameElement = element;
     },
   };
-}
-
-export type AppController = ReturnType<typeof createAppController>;
-
-const AppControllerContext = createContext<AppController>();
-
-export function useAppController(): AppController {
-  const controller = useContext(AppControllerContext);
-  if (!controller) throw new Error("App controller is unavailable outside App.");
-  return controller;
-}
-
-/** @internal Test seam for remounting shell views without remounting their controller. */
-export function AppControllerProvider(props: ParentProps<{ controller: AppController }>) {
-  return <AppControllerContext value={props.controller}>{props.children}</AppControllerContext>;
 }
 
 export function App(props: AppProps = {}) {

--- a/src/renderer/src/AppView.tsx
+++ b/src/renderer/src/AppView.tsx
@@ -1,6 +1,6 @@
 import type { ServerSummary } from "@openbot/contracts/ipc";
 import { createMemo, For, Loading, lazy, Show } from "solid-js";
-import { useAppController } from "./App";
+import { useAppController } from "./app-controller-context";
 import { Conversation } from "./components/Conversation";
 import { FIRST_BOT_SUGGESTIONS, FirstBotSetup } from "./components/FirstBotSetup";
 import { PanelResizer, savePanelWidth } from "./components/PanelResizer";

--- a/src/renderer/src/app-controller-context.tsx
+++ b/src/renderer/src/app-controller-context.tsx
@@ -1,0 +1,22 @@
+import { createContext, type ParentProps, useContext } from "solid-js";
+import type { createAppController } from "./App";
+
+/**
+ * The controller context lives outside `App.tsx` so the shell views can read it without importing
+ * `App.tsx` back: `App.tsx` imports the view, the view imports this module, and nothing points back.
+ * Only the controller's *type* is borrowed from `App.tsx`, which the compiler erases.
+ */
+export type AppController = ReturnType<typeof createAppController>;
+
+const AppControllerContext = createContext<AppController>();
+
+export function useAppController(): AppController {
+  const controller = useContext(AppControllerContext);
+  if (!controller) throw new Error("App controller is unavailable outside App.");
+  return controller;
+}
+
+/** @internal Test seam for remounting shell views without remounting their controller. */
+export function AppControllerProvider(props: ParentProps<{ controller: AppController }>) {
+  return <AppControllerContext value={props.controller}>{props.children}</AppControllerContext>;
+}

--- a/src/renderer/src/components/Conversation.hmr.test.tsx
+++ b/src/renderer/src/components/Conversation.hmr.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { createSignal, Show } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ConversationControllerProvider, type ConversationProps, createConversationController } from "./Conversation";
-import { isDragLeavingConversation } from "./ConversationView";
+import { createConversationController } from "./Conversation";
+import { type ConversationProps, isDragLeavingConversation } from "./ConversationView";
+import { ConversationControllerProvider } from "./conversation-controller-context";
 
 function controllerProps(onTypingChange = vi.fn()): Pick<ConversationProps, "onTypingChange"> {
   return { onTypingChange };

--- a/src/renderer/src/components/Conversation.tsx
+++ b/src/renderer/src/components/Conversation.tsx
@@ -1,5 +1,5 @@
 import type { AgentModelId, AgentProviderId, AgentReasoningEffort, BrowserBounds } from "@openbot/contracts/ipc";
-import { createContext, createSignal, onCleanup, type ParentProps, useContext } from "solid-js";
+import { createSignal, onCleanup } from "solid-js";
 import {
   type ComposerDraft,
   type ConversationProps,
@@ -10,6 +10,7 @@ import {
 } from "./ConversationView";
 import type { AgentActivityPresentation } from "./conversation/AgentActivity";
 import type { ChatSearchMatch } from "./conversation/chat-search";
+import { ConversationControllerProvider } from "./conversation-controller-context";
 
 const SETTINGS_PANEL_DEFAULT = 296;
 const BROWSER_PANEL_DEFAULT = 380;
@@ -229,23 +230,6 @@ export function createConversationController(props: Pick<ConversationProps, "onT
     setBrowserPanelWidth,
     resources,
   };
-}
-
-export type ConversationController = ReturnType<typeof createConversationController>;
-export type { ConversationProps } from "./ConversationView";
-
-const ConversationControllerContext = createContext<ConversationController>();
-
-/** @internal Access to the stable controller for Conversation view components. */
-export function useConversationController(): ConversationController {
-  const controller = useContext(ConversationControllerContext);
-  if (!controller) throw new Error("Conversation controller is unavailable outside Conversation.");
-  return controller;
-}
-
-/** @internal Test seam for remounting view boundaries without remounting their controller. */
-export function ConversationControllerProvider(props: ParentProps<{ controller: ConversationController }>) {
-  return <ConversationControllerContext value={props.controller}>{props.children}</ConversationControllerContext>;
 }
 
 export function Conversation(props: ConversationProps) {

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -49,7 +49,6 @@ import type { BotMessage, BotProfile, ChatActionMarkerModel } from "../data";
 import { appendVoiceTranscript, recordingToWav } from "../voice-recording";
 import { AgentAvatar } from "./AgentAvatar";
 import { ComposerEditor, expandComposerMentions } from "./ComposerEditor";
-import { useConversationController } from "./Conversation";
 import { BrowserTakeoverCard } from "./ConversationPrompts";
 import {
   AgentActivityIndicator,
@@ -94,6 +93,7 @@ import {
   voiceCaptureError,
   voiceTranscriptionError,
 } from "./conversation/voice-status";
+import { useConversationController } from "./conversation-controller-context";
 import { ProviderModelPicker } from "./ProviderModelPicker";
 import {
   Bubble,

--- a/src/renderer/src/components/conversation-controller-context.tsx
+++ b/src/renderer/src/components/conversation-controller-context.tsx
@@ -1,0 +1,23 @@
+import { createContext, type ParentProps, useContext } from "solid-js";
+import type { createConversationController } from "./Conversation";
+
+/**
+ * The controller context lives outside `Conversation.tsx` so the view can read it without importing
+ * `Conversation.tsx` back: `Conversation.tsx` imports the view, the view imports this module, and
+ * nothing points back. Only the controller's *type* is borrowed, which the compiler erases.
+ */
+export type ConversationController = ReturnType<typeof createConversationController>;
+
+const ConversationControllerContext = createContext<ConversationController>();
+
+/** @internal Access to the stable controller for Conversation view components. */
+export function useConversationController(): ConversationController {
+  const controller = useContext(ConversationControllerContext);
+  if (!controller) throw new Error("Conversation controller is unavailable outside Conversation.");
+  return controller;
+}
+
+/** @internal Test seam for remounting view boundaries without remounting their controller. */
+export function ConversationControllerProvider(props: ParentProps<{ controller: ConversationController }>) {
+  return <ConversationControllerContext value={props.controller}>{props.children}</ConversationControllerContext>;
+}

--- a/src/renderer/stories/Conversation.stories.tsx
+++ b/src/renderer/stories/Conversation.stories.tsx
@@ -12,13 +12,10 @@ import { createEffect, createSignal, onCleanup, onSettled, Show } from "solid-js
 import { expect, fireEvent, fn, waitFor, within } from "storybook/test";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import { clipboardFiles } from "../../preload/clipboard-files";
-import {
-  Conversation,
-  ConversationControllerProvider,
-  createConversationController,
-} from "../src/components/Conversation";
+import { Conversation, createConversationController } from "../src/components/Conversation";
 import { BrowserTakeoverCard } from "../src/components/ConversationPrompts";
 import { ConversationView } from "../src/components/ConversationView";
+import { ConversationControllerProvider } from "../src/components/conversation-controller-context";
 import type { BotMessage as RendererBotMessage } from "../src/data";
 import browserTakeoverPreviewUrl from "./assets/browser-takeover-preview.svg";
 import {


### PR DESCRIPTION
## What

Enables Biome's `suspicious/noImportCycles` at **error** severity, and fixes the two cycles it found.

A GritQL plugin cannot do this — it only ever sees one file, and a cycle is a property of the module
graph. Biome's built-in rule is in the `project` domain, so it scans the whole repository; the
version already pinned here (2.5.9) has it.

Two deviations from the rule's defaults, both deliberate:

- **`error`, not the default `warn`.** A runtime cycle produces symbols that are `undefined` at
  module init. A warning nobody has to clear rots.
- **`ignoreTypes` left on (its default).** The repo does not set `verbatimModuleSyntax`, so a real
  `import type` statement is erased by the compiler and genuinely cuts the cycle at runtime.

Cost is ~300 ms over 774 files, so the `Check` CI job is unaffected despite the "computationally
expensive" note in the rule's docs.

## The two cycles

Both in the renderer, both the same shape — the controller module renders the view, the view reads
the controller back through context:

- `App.tsx` ↔ `AppView.tsx`
- `components/Conversation.tsx` ↔ `components/ConversationView.tsx`

Each context, hook and provider moves into its own module, which borrows only the controller's
*type* back:

- `src/renderer/src/app-controller-context.tsx`
- `src/renderer/src/components/conversation-controller-context.tsx`

The HMR boundary the controller/view split exists for (`Conversation.hmr.test.tsx`) is unchanged —
only the import direction is. Consumers updated: `AppView.tsx`, `ConversationView.tsx`, the two App
tests, the HMR test, and the Conversation story.

`Conversation.tsx` also loses `export type { ConversationProps } from "./ConversationView"`; the one
consumer (the HMR test) now imports it from `ConversationView` directly.

## Surfaces touched

Code changes are **desktop renderer only**. The check itself is repo-wide — `apps/mobile`,
`apps/auth-api`, `apps/site-router`, `packages/*`, `scripts/` and `remote/` are all covered and were
verified clean. No IPC contract, migration, palette, protocol or reverse-state surface is involved.

`CONTRIBUTING.md` gains a paragraph next to the anti-slop section: runtime imports point one way,
move the shared piece into a third module, `import type` stays legal in both directions.

## Verification

- **Watched the rule fail.** Restored `import { useAppController } from "./App"` in `AppView.tsx`
  and got `× This import is part of a cycle` with the full resolution path, at error severity — then
  reverted it. Without that, "no findings" would only mean the rule matched nothing.
- `biome check .` — clean, 774 files.
- `tsc -p tsconfig.web.json` and `-p tsconfig.storybook.json` — 0 errors (plus the full parallel
  typecheck via the pre-commit hook).
- `bun run test:desktop -- src/renderer/src/components/Conversation.hmr.test.tsx` — 3 passed.
- `bun run test:desktop -- src/renderer/src/App.test.tsx src/renderer/src/App.read-state.test.tsx` —
  55 passed.

No UI change, so there is no before/after to show.

Model: Claude Opus 5 · Harness: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
