### PR TITLE
refactor(renderer): prefer one store per concern over walls of createSignal

### DIFF
--- a/.agents/skills/biome-anti-slop/assets/anti-slop/fixtures/no-collections-in-stores.fixture.ts
+++ b/.agents/skills/biome-anti-slop/assets/anti-slop/fixtures/no-collections-in-stores.fixture.ts
@@ -1,0 +1,23 @@
+// Fixture for `no-collections-in-stores`. Every line the rule must reject carries a trailing
+// `// flag`; every other line is correct code the rule must leave alone.
+// Checked by `scripts/anti-slop-rules.test.ts`; not compiled and not linted.
+
+const readOperations = new Map<string, Promise<void>>();
+
+const [collapsed, setCollapsed] = createStore({ sections: [] as string[], pending: false });
+const [duplicating, setDuplicating] = createSignal<Set<string>>(new Set());
+setDuplicating((current) => new Set(current).add(botId));
+
+function reconcileRows(rows: readonly Row[]) {
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  return byId;
+}
+
+const [seen, setSeen] = createStore({ ids: new Set<string>() }); // flag
+const [index, setIndex] = createStore({ rows: new Map<string, Row>() }); // flag
+const [nested, setNested] = createStore({ view: { ids: new Set<string>() } }); // flag
+const [bare, setBare] = createStore({ ids: new Set() }); // flag
+const [seeded, setSeeded] = createStore({ rows: new Map(rows.map((row) => [row.id, row])) }); // flag
+const [typed, setTyped] = createStore<Seen>({ ids: new Set<string>() }); // flag
+const [typedRows, setTypedRows] = createStore<Index>({ rows: new Map<string, Row>() }); // flag
+const [shallow, setShallow] = createStore<Index>({ rows: new Map<string, Row>() }, { shallow: true }); // flag

--- a/.agents/skills/biome-anti-slop/assets/anti-slop/rules/no-collections-in-stores.grit
+++ b/.agents/skills/biome-anti-slop/assets/anti-slop/rules/no-collections-in-stores.grit
@@ -1,0 +1,30 @@
+language js(typescript)
+
+// scope: global
+
+// A `Map` or `Set` in a store's initial value. `isWrappable` rejects platform
+// objects, so the store serves the collection raw and mutating it notifies
+// nothing - only replacing the whole property does.
+//
+// A type argument changes the shape of the call node, and every store in this
+// repository is written `createStore<T>({...})`, so all four spellings have to
+// be listed or the rule walks past every site it exists for. The second
+// argument is the `{ shallow: true }` options object.
+or {
+  `new Map($...)`,
+  `new Set($...)`,
+  `new Map<$...>($...)`,
+  `new Set<$...>($...)`
+} as $collection where {
+  $collection <: within or {
+    `createStore($_)`,
+    `createStore($_, $_)`,
+    `createStore<$_>($_)`,
+    `createStore<$_>($_, $_)`
+  },
+  register_diagnostic(
+    span=$collection,
+    message="A `Map` or `Set` in a store is served raw: mutating it notifies nothing, and only replacing the whole property does. Hold it in a signal written copy-on-write, or store an array - unless you always replace this field whole.",
+    severity="warn"
+  )
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,10 +128,15 @@ for the component patterns, not the imports.
 **Prefer one `createStore` per concern over a row of `createSignal` calls.** Fields that change
 together are one record — a saved-and-draft form pair, a `data`/`loaded`/`loading`/`error` quad, a
 phase plus the numbers only one phase uses, several `Record`s keyed by the same `botId`. Declare the
-shape up front and keep the setter private behind named mutations, as `app-stored-values.ts` does,
-so replacing one field re-renders only what read that field; `FirstBotSetup.tsx` is the form
-version. Ten keyed `Record` signals are one row type shredded into ten columns, every write spreads
-the whole map so every consumer of every key re-runs, and parallel signals let a screen hold states
+shape up front, so replacing one field re-renders only what read that field; `FirstBotSetup.tsx` is
+the form version. Keep the setter private behind named mutations where the store *is* a module's or
+a hook's exported surface, as `app-stored-values.ts` and `createAsyncPanel.ts` do. Inside a
+component, write the field where it changes — `setPanels((state) => { state.x = value; })` at the
+call site, as `SettingsModal.tsx` does — and let a named mutation there earn its name: more than one
+field, a guard or a side effect, or enough call sites that the name deduplicates something. A
+function whose whole body is `state.x = value` is the signal wall one layer down. Ten keyed
+`Record` signals are one row type shredded into ten columns, every write spreads the whole map so
+every consumer of every key re-runs, and parallel signals let a screen hold states
 the product does not have. `createSignal` still fits an element ref, a single measurement, a one-off
 boolean, and a record you always replace whole. Stores come from `"solid-js"` — there is no
 `solid-js/store` in this RC — hold plain values rather than accessors, and are never destructured.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,10 @@ with `@solidjs/signals` and `@solidjs/web` at the same RC, `@kobalte/core@2.0.0-
 here), plus patched `lucide-solid` and `solid-sonner`. Do not trust your memory of these APIs: check
 `package.json`, then read `.agents/skills/react-to-solid/docs/` (`kobalte-patterns.md`,
 `corvu-patterns.md`, `base-ui-mapping.md`, `third-party-deps.md`) and
-`.agents/skills/zaidan/references/`.
+`.agents/skills/zaidan/references/`. Those two skills are vendored and re-synced from upstream, so
+their code samples are 1.x-era and cannot be corrected here — `node_modules/solid-js/CHEATSHEET.md`
+is the source of truth for core APIs, and where they disagree the cheatsheet wins. Read the skills
+for the component patterns, not the imports.
 
 - `bun run dev` for integrated work — it starts the local Auth API and the Electron dev app
   together. `bun run dev:api` is for API-only debugging.
@@ -119,6 +122,22 @@ here), plus patched `lucide-solid` and `solid-sonner`. Do not trust your memory 
 - Never verify UI with `dist/`, a packaged `.app`, a production build, or an ad-hoc preview — those
   are for release verification the user asked for. If the dev app will not start, report the blocker
   instead of falling back to one.
+
+### Reactive state shape
+
+**Prefer one `createStore` per concern over a row of `createSignal` calls.** Fields that change
+together are one record — a saved-and-draft form pair, a `data`/`loaded`/`loading`/`error` quad, a
+phase plus the numbers only one phase uses, several `Record`s keyed by the same `botId`. Declare the
+shape up front and keep the setter private behind named mutations, as `app-stored-values.ts` does,
+so replacing one field re-renders only what read that field; `FirstBotSetup.tsx` is the form
+version. Ten keyed `Record` signals are one row type shredded into ten columns, every write spreads
+the whole map so every consumer of every key re-runs, and parallel signals let a screen hold states
+the product does not have. `createSignal` still fits an element ref, a single measurement, a one-off
+boolean, and a record you always replace whole. Stores come from `"solid-js"` — there is no
+`solid-js/store` in this RC — hold plain values rather than accessors, and are never destructured.
+A `Map` or `Set` never becomes a store — `isWrappable` rejects platform objects — so the
+reference is the reactive unit: write a collection held in a signal by copying
+(`new Set(current).add(id)`), and keep one you never read reactively in a closure.
 
 ### Component reuse
 

--- a/biome.json
+++ b/biome.json
@@ -2,6 +2,7 @@
   "$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
   "plugins": [
     "./tools/biome/anti-slop/rules/no-chained-type-assertions.grit",
+    "./tools/biome/anti-slop/rules/no-collections-in-stores.grit",
     "./tools/biome/anti-slop/rules/no-known-value-widening.grit",
     "./tools/biome/anti-slop/rules/no-module-mocking.grit",
     "./tools/biome/anti-slop/rules/no-object-parameters.grit",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,8 +70,8 @@ renderer ──► @openbot/contracts ◄── preload ◄── main ──►
    `app-providers.tsx`, or through a provider prop; a command that writes to several domains lives
    in a leaf context or a bridge component mounted under all of them. `window.openbot.*` is not a
    dependency. Cycles are rejected by `noImportCycles`, so an upward edge must be `import type`.
-   Prefer one store per concern inside a context over a signal per field: a row of setters is what
-   lets a screen be loading, loaded, and errored at once.
+   Prefer one store per concern inside a context over a signal per field: a row of parallel signals
+   is what lets a screen be loading, loaded, and errored at once.
 8. Read those contexts from the smallest component that needs them. A pane calls the `use*()` of the
    domains it renders and nothing else; `WorkspaceShell` reads only what decides *which* pane
    renders, and passes a value down as a prop when two of them would otherwise derive it twice. A

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,7 +48,9 @@ renderer ──► @openbot/contracts ◄── preload ◄── main ──►
   conversation storage.
 - D1 is the source of truth for central accounts, remote membership, invitations, and logical sessions.
 - A local team host owns conversations, files, agents, and the local member projection used by Team API.
-- Renderer signals are projections for the current screen only. They are not durable state.
+- Renderer signals and stores are projections for the current screen only. They are not durable
+  state, and one concern is one record - a row of parallel signals over its fields lets a screen
+  hold states the product does not have.
 
 ## Change rules
 
@@ -68,6 +70,8 @@ renderer ──► @openbot/contracts ◄── preload ◄── main ──►
    `app-providers.tsx`, or through a provider prop; a command that writes to several domains lives
    in a leaf context or a bridge component mounted under all of them. `window.openbot.*` is not a
    dependency. Cycles are rejected by `noImportCycles`, so an upward edge must be `import type`.
+   Prefer one store per concern inside a context over a signal per field: a row of setters is what
+   lets a screen be loading, loaded, and errored at once.
 8. Read those contexts from the smallest component that needs them. A pane calls the `use*()` of the
    domains it renders and nothing else; `WorkspaceShell` reads only what decides *which* pane
    renders, and passes a value down as a prop when two of them would otherwise derive it twice. A

--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -97,6 +97,7 @@ import {
   voiceTranscriptionError,
 } from "./conversation/voice-status";
 import { useConversationController } from "./conversation-controller-context";
+import { createScrollFades } from "./createScrollFades";
 import { ProviderModelPicker } from "./ProviderModelPicker";
 import {
   Bubble,
@@ -844,8 +845,7 @@ function createConversationViewScope(props: ConversationProps) {
   onCleanup(() => {
     if (queueExitTimer !== undefined) window.clearTimeout(queueExitTimer);
   });
-  const [fadeAtTop, setFadeAtTop] = createSignal(false);
-  const [fadeAtBottom, setFadeAtBottom] = createSignal(false);
+  const scrollFades = createScrollFades();
   const [showScrollToLatest, setShowScrollToLatest] = createSignal(false);
   const [unreadDividerVisible, setUnreadDividerVisible] = createSignal(false);
   const [virtualScrollMargin, setVirtualScrollMargin] = createSignal(0);
@@ -1081,10 +1081,8 @@ function createConversationViewScope(props: ConversationProps) {
 
   function updateScrollFade(element = scrollElement) {
     if (!element) return;
-    const remaining = element.scrollHeight - element.scrollTop - element.clientHeight;
-    setFadeAtTop(element.scrollTop > 2);
-    setFadeAtBottom(remaining > 2);
-    setShowScrollToLatest(remaining > 80);
+    scrollFades.measure();
+    setShowScrollToLatest(element.scrollHeight - element.scrollTop - element.clientHeight > 80);
   }
 
   function updateVirtualScrollMargin(): void {
@@ -2485,6 +2483,7 @@ function createConversationViewScope(props: ConversationProps) {
   };
   const setScrollElement = (element: HTMLDivElement) => {
     scrollElement = element;
+    scrollFades.adopt(element);
     updateVirtualScrollMargin();
   };
   const setStickToLatest = (value: boolean) => {
@@ -2594,8 +2593,7 @@ function createConversationViewScope(props: ConversationProps) {
     editingDraftBackup,
     expandedEmojiMessageId,
     expandedThinkingMessages,
-    fadeAtBottom,
-    fadeAtTop,
+    scrollFades,
     filePreviewOpen,
     finishVoiceRecording,
     handleChatSearchShortcut,
@@ -2680,8 +2678,6 @@ function createConversationViewScope(props: ConversationProps) {
     setEditingDraftBackup,
     setExpandedEmojiMessageId,
     setExpandedThinkingMessages,
-    setFadeAtBottom,
-    setFadeAtTop,
     setMarkingRead,
     setMediaPreview,
     setOpenMoreMessageId,
@@ -2910,8 +2906,7 @@ export function ConversationTimeline() {
     expandedEmojiMessageId,
     expandedThinkingMessages,
     installedSkills,
-    fadeAtBottom,
-    fadeAtTop,
+    scrollFades,
     jumpToLatestMessage,
     jumpToUnreadMessages,
     markMessageSeen,
@@ -2987,13 +2982,7 @@ export function ConversationTimeline() {
       </Show>
 
       <div
-        class={[
-          "conversation-scroll",
-          {
-            "scroll-fade-top": fadeAtTop(),
-            "scroll-fade-bottom": fadeAtBottom(),
-          },
-        ]}
+        class={["conversation-scroll", scrollFades.classes()]}
         ref={setScrollElement}
         onScroll={(event) => {
           const element = event.currentTarget;

--- a/src/renderer/src/components/ServerRail.tsx
+++ b/src/renderer/src/components/ServerRail.tsx
@@ -1,5 +1,6 @@
 import type { ServerSummary } from "@openbot/contracts/ipc";
-import { createEffect, createSignal, For, onCleanup, onSettled, Show } from "solid-js";
+import { createEffect, createSignal, For, onCleanup, Show } from "solid-js";
+import { createScrollFades } from "./createScrollFades";
 import { createVerticalDragPreview } from "./createVerticalDragPreview";
 import { buttonVariants, ContextMenu, ServerGradientLogo, Tooltip } from "./ui";
 
@@ -22,8 +23,7 @@ export function ServerRail(props: ServerRailProps) {
   const [draggedId, setDraggedId] = createSignal<string | null>(null);
   const [dragOverId, setDragOverId] = createSignal<string | null>(null);
   const [announcement, setAnnouncement] = createSignal("");
-  const [fadeAtTop, setFadeAtTop] = createSignal(false);
-  const [fadeAtBottom, setFadeAtBottom] = createSignal(false);
+  const scrollFades = createScrollFades();
   let railList: HTMLDivElement | undefined;
   let remoteList: HTMLUListElement | undefined;
   let dragSlots: DragSlot[] = [];
@@ -38,19 +38,13 @@ export function ServerRail(props: ServerRailProps) {
   onCleanup(() => {
     stopAutoScroll();
     dragPreview.stop();
-  });
-
-  onSettled(() => {
-    const resizeObserver = new ResizeObserver(updateScrollFade);
-    if (railList) resizeObserver.observe(railList);
-    window.requestAnimationFrame(updateScrollFade);
-    return () => resizeObserver.disconnect();
+    scrollFades.stop();
   });
 
   createEffect(
     () => props.servers.length,
     () => {
-      window.requestAnimationFrame(updateScrollFade);
+      scrollFades.remeasure();
     },
   );
 
@@ -107,16 +101,9 @@ export function ServerRail(props: ServerRailProps) {
     railList.scrollTop += autoScrollVelocity;
     if (railList.scrollTop !== previousScrollTop) {
       updateDragTarget(lastDragClientY);
-      updateScrollFade();
+      scrollFades.measure();
     }
     return railList.scrollTop !== previousScrollTop;
-  }
-
-  function updateScrollFade(): void {
-    if (!railList) return;
-    const remaining = railList.scrollHeight - railList.scrollTop - railList.clientHeight;
-    setFadeAtTop(railList.scrollTop > 2);
-    setFadeAtBottom(remaining > 2);
   }
 
   function runAutoScroll(): void {
@@ -212,15 +199,12 @@ export function ServerRail(props: ServerRailProps) {
       }}
     >
       <div
-        class={[
-          "server-rail-list",
-          {
-            "scroll-fade-top": fadeAtTop(),
-            "scroll-fade-bottom": fadeAtBottom(),
-          },
-        ]}
-        ref={(element) => (railList = element)}
-        onScroll={updateScrollFade}
+        class={["server-rail-list", scrollFades.classes()]}
+        ref={(element) => {
+          railList = element;
+          scrollFades.bind(element);
+        }}
+        onScroll={scrollFades.measure}
       >
         <For each={localServers()} keyed={(server) => server.id}>
           {(server) => (

--- a/src/renderer/src/components/ServerSettingsModal.test.tsx
+++ b/src/renderer/src/components/ServerSettingsModal.test.tsx
@@ -129,6 +129,22 @@ describe("ServerSettingsModal", () => {
     expect(onSetPublished).not.toHaveBeenCalled();
   });
 
+  it("clears a rejected server logo error when the draft is reset", async () => {
+    render(() => <ServerSettingsModal {...props()} />);
+
+    const name = screen.getByRole("textbox", { name: "Server name" });
+    await fireEvent.input(name, { target: { value: "Studio Team" } });
+    await fireEvent.change(screen.getByLabelText("Server logo"), {
+      target: { files: [new File(["not-an-image"], "logo.txt", { type: "text/plain" })] },
+    });
+
+    expect(await screen.findByText("Choose a PNG, JPEG, or WebP image.")).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+    expect(screen.queryByText("Choose a PNG, JPEG, or WebP image.")).not.toBeInTheDocument();
+    expect(screen.getByText("Shown to everyone who connects.")).toBeInTheDocument();
+  });
+
   it("shows a failed identity action and keeps the draft", async () => {
     const onSaveIdentity = vi.fn(async () => {
       throw new Error("The identity could not save.");

--- a/src/renderer/src/components/ServerSettingsModal.tsx
+++ b/src/renderer/src/components/ServerSettingsModal.tsx
@@ -10,7 +10,7 @@ import type {
   UpdateTeamMemberInput,
 } from "@openbot/contracts/ipc";
 import { normalizeEmailAddress } from "@openbot/contracts/validation";
-import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, createStore, For, onCleanup, Show, snapshot } from "solid-js";
 import { normalizeAvatarFile } from "../avatar-image";
 import { SettingsDialogShell } from "./SettingsDialogShell";
 import { teamMemberName } from "./TeamPersonAvatar";
@@ -97,26 +97,71 @@ const sections: Record<Section, { title: string; description: string }> = {
   desktop: { title: "Remote desktop", description: "Configure or connect to this server’s desktop." },
 };
 
+/**
+ * The identity form: the name and logo as the server last confirmed them, the draft the user is
+ * editing, and the validation feedback that belongs to that draft. `logo` is `undefined` while the
+ * saved image stands, `null` once the user removes it, and an image once one is chosen, so it
+ * carries the difference between "unchanged" and "cleared" that a save has to send.
+ */
+interface ServerIdentityDraft {
+  editing: boolean;
+  logo: AvatarImageInput | null | undefined;
+  logoError: string | null;
+  logoUrl: string | null;
+  name: string;
+  nameShaking: boolean;
+  nameTouched: boolean;
+  savedLogoUrl: string | null;
+  savedName: string;
+}
+
+/** The invite composer. `mode` picks which of `email` and `link` the panel is filling in. */
+interface InvitePanel {
+  email: string;
+  emailError: string | null;
+  link: string;
+  mode: InviteMode;
+  result: InviteSummary | null;
+  role: InviteRole;
+}
+
+interface MembersPanel {
+  removeId: string | null;
+  search: string;
+}
+
+/**
+ * One record per panel of the dialog. Each group's fields are written together - a reset rewrites
+ * the whole identity draft at once, and switching invite mode clears three of the composer's
+ * fields - so they are one store rather than a signal each, and replacing one field re-renders
+ * only what read that field.
+ */
+interface ServerSettingsPanels {
+  identity: ServerIdentityDraft;
+  invite: InvitePanel;
+  members: MembersPanel;
+}
+
 export function ServerSettingsModal(props: ServerSettingsModalProps) {
+  const [panels, setPanels] = createStore<ServerSettingsPanels>({
+    identity: {
+      editing: false,
+      logo: undefined,
+      logoError: null,
+      logoUrl: null,
+      name: "",
+      nameShaking: false,
+      nameTouched: false,
+      savedLogoUrl: null,
+      savedName: "",
+    },
+    invite: { email: "", emailError: null, link: "", mode: "email", result: null, role: "member" },
+    members: { removeId: null, search: "" },
+  });
   const [section, setSection] = createSignal<Section>("general");
-  const [savedName, setSavedName] = createSignal("");
-  const [draftName, setDraftName] = createSignal("");
-  const [savedLogoUrl, setSavedLogoUrl] = createSignal<string | null>(null);
-  const [draftLogoUrl, setDraftLogoUrl] = createSignal<string | null>(null);
-  const [draftLogo, setDraftLogo] = createSignal<AvatarImageInput | null | undefined>(undefined);
-  const [identityEditing, setIdentityEditing] = createSignal(false);
-  const [nameTouched, setNameTouched] = createSignal(false);
-  const [nameShaking, setNameShaking] = createSignal(false);
-  const [logoError, setLogoError] = createSignal<string | null>(null);
+  /** The key of the one action in flight, gating every panel at once rather than belonging to any. */
   const [busy, setBusy] = createSignal<string | null>(null);
-  const [inviteMode, setInviteMode] = createSignal<InviteMode>("email");
-  const [inviteRole, setInviteRole] = createSignal<InviteRole>("member");
-  const [inviteEmail, setInviteEmail] = createSignal("");
-  const [inviteEmailError, setInviteEmailError] = createSignal<string | null>(null);
-  const [inviteResult, setInviteResult] = createSignal<InviteSummary | null>(null);
-  const [inviteLinkValue, setInviteLinkValue] = createSignal("");
-  const [memberSearch, setMemberSearch] = createSignal("");
-  const [removeMemberId, setRemoveMemberId] = createSignal<string | null>(null);
+  /** A clock, not panel state: it retires an invite row as its `expiresAt` passes. */
   const [now, setNow] = createSignal(Date.now());
   let modalElement: HTMLElement | undefined;
   let logoInput: HTMLInputElement | undefined;
@@ -135,7 +180,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   const actionsAvailable = () => local() || props.server.state === "online";
   const published = () => (local() ? props.hostStatus?.phase === "online" : props.server.state === "online");
   const address = () => (local() ? props.hostStatus?.apiUrl : props.server.apiUrl);
-  const trimmedName = () => draftName().trim();
+  const trimmedName = () => panels.identity.name.trim();
   const nameError = () => {
     if (!canEditIdentity()) return null;
     if (trimmedName().length < INPUT_LIMITS.serverNameMin)
@@ -144,27 +189,29 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
       return `Use no more than ${INPUT_LIMITS.serverName} characters.`;
     return null;
   };
-  const visibleNameError = () => (nameTouched() ? nameError() : null);
+  const visibleNameError = () => (panels.identity.nameTouched ? nameError() : null);
   const identityDirty = () =>
     canEditIdentity() &&
-    (trimmedName() !== savedName() || draftLogo() !== undefined || draftLogoUrl() !== savedLogoUrl());
+    (trimmedName() !== panels.identity.savedName ||
+      panels.identity.logo !== undefined ||
+      panels.identity.logoUrl !== panels.identity.savedLogoUrl);
   const activeInvites = createMemo(() =>
     props.invites.filter((item) => item.usedAt === null && Date.parse(item.expiresAt) > now()),
   );
   const filteredMembers = createMemo(() => {
-    const query = memberSearch().trim().toLowerCase();
+    const query = panels.members.search.trim().toLowerCase();
     if (!query) return props.members;
     return props.members.filter((member) =>
       [teamMemberName(member), member.email, member.username].some((value) => value?.toLowerCase().includes(query)),
     );
   });
-  const removeMember = createMemo(() => props.members.find((member) => member.id === removeMemberId()) ?? null);
+  const removeMember = createMemo(() => props.members.find((member) => member.id === panels.members.removeId) ?? null);
   const canInvite = createMemo(
     () =>
       canManage() &&
       published() &&
       busy() === null &&
-      (inviteMode() === "link" || normalizeEmailAddress(inviteEmail()) !== null),
+      (panels.invite.mode === "link" || normalizeEmailAddress(panels.invite.email) !== null),
   );
 
   createEffect(
@@ -173,28 +220,32 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
       id: props.server.id,
       name: props.server.kind === "local" && !props.hostStatus?.configured ? "" : props.server.name,
       logoUrl: props.server.logoUrl,
-      editing: identityEditing(),
+      editing: panels.identity.editing,
     }),
     ({ open, id, name, logoUrl, editing }) => {
       if (!open) return;
       if (syncedServerId !== id) {
         syncedServerId = id;
         setSection("general");
-        setIdentityEditing(false);
-        setNameTouched(false);
-        setNameShaking(false);
-        setMemberSearch("");
-        setInviteResult(null);
+        setPanels((state) => {
+          state.identity.editing = false;
+          state.identity.nameTouched = false;
+          state.identity.nameShaking = false;
+          state.invite.result = null;
+          state.members.search = "";
+        });
         resetInviteLink();
       }
       if (!editing) {
-        setSavedName(name);
-        setDraftName(name);
-        setSavedLogoUrl(logoUrl);
-        setDraftLogoUrl(logoUrl);
-        setDraftLogo(undefined);
-        setNameTouched(false);
-        setNameShaking(false);
+        setPanels((state) => {
+          state.identity.savedName = name;
+          state.identity.name = name;
+          state.identity.savedLogoUrl = logoUrl;
+          state.identity.logoUrl = logoUrl;
+          state.identity.logo = undefined;
+          state.identity.nameTouched = false;
+          state.identity.nameShaking = false;
+        });
       }
     },
   );
@@ -224,13 +275,17 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
     if (inviteLinkSwapTimer) clearTimeout(inviteLinkSwapTimer);
     inviteLinkSwapTimer = undefined;
     inviteLinkInput?.classList.remove("is-exit", "is-enter-start");
-    setInviteLinkValue("");
+    setPanels((state) => {
+      state.invite.link = "";
+    });
   }
 
   function swapInviteLink(next: string): void {
     const element = inviteLinkInput;
     if (!element || (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false)) {
-      setInviteLinkValue(next);
+      setPanels((state) => {
+        state.invite.link = next;
+      });
       return;
     }
     if (inviteLinkSwapTimer) clearTimeout(inviteLinkSwapTimer);
@@ -239,7 +294,9 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
     element.classList.add("is-exit");
     inviteLinkSwapTimer = setTimeout(() => {
       inviteLinkSwapTimer = undefined;
-      setInviteLinkValue(next);
+      setPanels((state) => {
+        state.invite.link = next;
+      });
       element.classList.remove("is-exit");
       element.classList.add("is-enter-start");
       void element.offsetHeight;
@@ -265,73 +322,93 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
 
   async function chooseLogo(file: File | undefined): Promise<void> {
     if (!file) return;
-    setLogoError(null);
+    setPanels((state) => {
+      state.identity.logoError = null;
+    });
     try {
       const image = await normalizeAvatarFile(file);
       const url = URL.createObjectURL(file);
       objectUrls.push(url);
-      setIdentityEditing(true);
-      setDraftLogo(image);
-      setDraftLogoUrl(url);
+      setPanels((state) => {
+        state.identity.editing = true;
+        state.identity.logo = image;
+        state.identity.logoUrl = url;
+      });
     } catch (error) {
-      setLogoError(error instanceof Error ? error.message : "OpenBot could not read this image.");
+      setPanels((state) => {
+        state.identity.logoError = error instanceof Error ? error.message : "OpenBot could not read this image.";
+      });
     }
   }
 
   function resetIdentity(): void {
-    setDraftName(savedName());
-    setDraftLogoUrl(savedLogoUrl());
-    setDraftLogo(undefined);
-    setIdentityEditing(false);
-    setNameTouched(false);
-    setNameShaking(false);
-    setLogoError(null);
+    setPanels((state) => {
+      state.identity.name = state.identity.savedName;
+      state.identity.logoUrl = state.identity.savedLogoUrl;
+      state.identity.logo = undefined;
+      state.identity.editing = false;
+      state.identity.nameTouched = false;
+      state.identity.nameShaking = false;
+      state.identity.logoError = null;
+    });
   }
 
   function updateDraftName(value: string): void {
-    const namePristine = value.trim() === savedName();
-    const logoPristine = draftLogo() === undefined && draftLogoUrl() === savedLogoUrl();
-    setDraftName(value);
-    setIdentityEditing(!(namePristine && logoPristine));
-    if (namePristine) {
-      setNameTouched(false);
-      setNameShaking(false);
-    } else if (!nameError()) {
-      setNameShaking(false);
-    }
+    const namePristine = value.trim() === panels.identity.savedName;
+    const logoPristine = panels.identity.logo === undefined && panels.identity.logoUrl === panels.identity.savedLogoUrl;
+    // Decided before the write, so `nameError()` still sees the pre-write draft name - the same
+    // value it saw when this was a signal, whose write was equally deferred.
+    const stopShaking = namePristine || !nameError();
+    setPanels((state) => {
+      state.identity.name = value;
+      state.identity.editing = !(namePristine && logoPristine);
+      if (namePristine) state.identity.nameTouched = false;
+      if (stopShaking) state.identity.nameShaking = false;
+    });
   }
 
   function restartNameShake(): void {
-    setNameShaking(false);
+    setPanels((state) => {
+      state.identity.nameShaking = false;
+    });
     queueMicrotask(() => {
       if (!nameInput || !nameError()) return;
       void nameInput.offsetWidth;
-      setNameShaking(true);
+      setPanels((state) => {
+        state.identity.nameShaking = true;
+      });
     });
   }
 
   async function saveIdentity(): Promise<void> {
-    setNameTouched(true);
+    setPanels((state) => {
+      state.identity.nameTouched = true;
+    });
     if (nameError()) {
       restartNameShake();
       queueMicrotask(() => nameInput?.focus({ preventScroll: true }));
       return;
     }
     if (!identityDirty()) return;
-    const logo = draftLogo();
+    const logo = panels.identity.logo;
+    const serverName = trimmedName();
     const saved = await run("identity", () =>
       props.onSaveIdentity({
-        serverName: trimmedName(),
-        ...(logo === undefined ? {} : { logo }),
+        serverName,
+        // The image crosses to IPC, which structured-clones it, so it goes as a snapshot rather
+        // than as whatever the store hands back.
+        ...(logo === undefined ? {} : { logo: snapshot(logo) }),
       }),
     );
     if (!saved) return;
-    setSavedName(trimmedName());
-    setSavedLogoUrl(draftLogoUrl());
-    setDraftLogo(undefined);
-    setIdentityEditing(false);
-    setNameTouched(false);
-    setNameShaking(false);
+    setPanels((state) => {
+      state.identity.savedName = serverName;
+      state.identity.savedLogoUrl = state.identity.logoUrl;
+      state.identity.logo = undefined;
+      state.identity.editing = false;
+      state.identity.nameTouched = false;
+      state.identity.nameShaking = false;
+    });
   }
 
   function showCopyError(): void {
@@ -339,20 +416,26 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   }
 
   async function createInvite(): Promise<void> {
-    const email = inviteMode() === "email" ? normalizeEmailAddress(inviteEmail()) : null;
-    if (inviteMode() === "email" && !email) {
-      setInviteEmailError("Enter a valid email address.");
+    const email = panels.invite.mode === "email" ? normalizeEmailAddress(panels.invite.email) : null;
+    if (panels.invite.mode === "email" && !email) {
+      setPanels((state) => {
+        state.invite.emailError = "Enter a valid email address.";
+      });
       return;
     }
     let result: InviteSummary | undefined;
+    const role = panels.invite.role;
     const saved = await run("invite", async () => {
-      result = await props.onCreateInvite({ role: inviteRole(), ...(email ? { email } : {}) });
+      result = await props.onCreateInvite({ role, ...(email ? { email } : {}) });
     });
     if (!saved || !result) return;
-    setInviteResult(result);
-    if (!result.email) swapInviteLink(result.inviteUrl);
-    setInviteEmailError(null);
-    if (email) setInviteEmail("");
+    const created = result;
+    setPanels((state) => {
+      state.invite.result = created;
+      state.invite.emailError = null;
+      if (email) state.invite.email = "";
+    });
+    if (!created.email) swapInviteLink(created.inviteUrl);
   }
 
   const sectionTabsProps = {
@@ -368,14 +451,16 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
 
   const inviteTabsProps = {
     get value() {
-      return inviteMode();
+      return panels.invite.mode;
     },
     onChange(value: string) {
       if (value !== "link" && value !== "email") return;
-      setInviteMode(value);
-      setInviteResult(null);
+      setPanels((state) => {
+        state.invite.mode = value;
+        state.invite.result = null;
+        state.invite.emailError = null;
+      });
       resetInviteLink();
-      setInviteEmailError(null);
     },
   };
 
@@ -479,7 +564,10 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
       <AlertDialog.Root
         open={Boolean(removeMember())}
         onOpenChange={(open) => {
-          if (!open && busy() !== `remove:${removeMemberId()}`) setRemoveMemberId(null);
+          if (!open && busy() !== `remove:${panels.members.removeId}`)
+            setPanels((state) => {
+              state.members.removeId = null;
+            });
         }}
       >
         <Show when={removeMember()}>
@@ -505,7 +593,11 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                       type="button"
                       variant="outline"
                       disabled={busy() === `remove:${member().id}`}
-                      onClick={() => setRemoveMemberId(null)}
+                      onClick={() =>
+                        setPanels((state) => {
+                          state.members.removeId = null;
+                        })
+                      }
                     >
                       Cancel
                     </Button>
@@ -517,7 +609,9 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                       onClick={() =>
                         void run(`remove:${member().id}`, async () => {
                           await props.onRemoveMember(member().id);
-                          setRemoveMemberId(null);
+                          setPanels((state) => {
+                            state.members.removeId = null;
+                          });
                         })
                       }
                     >
@@ -576,12 +670,16 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 <ItemActions class="settings-identity-name-control" data-invalid={visibleNameError() ? "" : undefined}>
                   <Input
                     ref={(element) => (nameInput = element)}
-                    class={nameShaking() ? "settings-identity-name-input is-shaking" : "settings-identity-name-input"}
+                    class={
+                      panels.identity.nameShaking
+                        ? "settings-identity-name-input is-shaking"
+                        : "settings-identity-name-input"
+                    }
                     id="server-settings-name"
                     size="md"
                     maxlength={INPUT_LIMITS.serverName}
                     placeholder="e.g. Design studio"
-                    value={draftName()}
+                    value={panels.identity.name}
                     aria-labelledby="server-settings-name-label"
                     aria-describedby={
                       visibleNameError() ? "server-settings-name-error" : "server-settings-name-description"
@@ -589,11 +687,17 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                     aria-invalid={visibleNameError() ? "true" : undefined}
                     onValueChange={updateDraftName}
                     onBlur={() => {
-                      if (trimmedName() === savedName()) return;
-                      setNameTouched(true);
+                      if (trimmedName() === panels.identity.savedName) return;
+                      setPanels((state) => {
+                        state.identity.nameTouched = true;
+                      });
                       if (nameError()) restartNameShake();
                     }}
-                    onAnimationEnd={() => setNameShaking(false)}
+                    onAnimationEnd={() =>
+                      setPanels((state) => {
+                        state.identity.nameShaking = false;
+                      })
+                    }
                     onKeyDown={(event) => {
                       if (event.key !== "Enter" || event.isComposing) return;
                       event.preventDefault();
@@ -614,8 +718,8 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
             <Item class="settings-identity-image-row">
               <ItemContent>
                 <ItemTitle>Server logo</ItemTitle>
-                <ItemDescription class={logoError() ? "server-settings-item-error" : undefined}>
-                  {logoError() ??
+                <ItemDescription class={panels.identity.logoError ? "server-settings-item-error" : undefined}>
+                  {panels.identity.logoError ??
                     (canEditIdentity()
                       ? "Shown to everyone who connects."
                       : "Only the server owner can change this logo.")}
@@ -624,7 +728,9 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
               <ItemActions class="settings-identity-image-control">
                 <Show
                   when={canEditIdentity()}
-                  fallback={<ServerLogo name={draftName() || props.server.name} url={draftLogoUrl()} />}
+                  fallback={
+                    <ServerLogo name={panels.identity.name || props.server.name} url={panels.identity.logoUrl} />
+                  }
                 >
                   <div class="settings-identity-image-picker ui-removable-image">
                     <Button
@@ -632,25 +738,27 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                       variant="outline"
                       size="icon-lg"
                       class="settings-identity-image-trigger server-settings-logo-trigger"
-                      aria-label={draftLogoUrl() ? "Edit server logo" : "Add server logo"}
+                      aria-label={panels.identity.logoUrl ? "Edit server logo" : "Add server logo"}
                       onClick={() => logoInput?.click()}
                     >
                       <Show
-                        when={draftLogoUrl()}
+                        when={panels.identity.logoUrl}
                         fallback={<Image class="server-settings-logo-placeholder" aria-hidden="true" />}
                       >
-                        {(logoUrl) => <ServerLogo name={draftName() || props.server.name} url={logoUrl()} />}
+                        {(logoUrl) => <ServerLogo name={panels.identity.name || props.server.name} url={logoUrl()} />}
                       </Show>
                     </Button>
-                    <Show when={draftLogoUrl()}>
+                    <Show when={panels.identity.logoUrl}>
                       <ImageRemoveButton
                         class="server-settings-logo-remove"
                         label="Remove server logo"
                         onClick={() => {
-                          setIdentityEditing(true);
-                          setDraftLogoUrl(null);
-                          setDraftLogo(null);
-                          setLogoError(null);
+                          setPanels((state) => {
+                            state.identity.editing = true;
+                            state.identity.logoUrl = null;
+                            state.identity.logo = null;
+                            state.identity.logoError = null;
+                          });
                         }}
                       />
                     </Show>
@@ -734,8 +842,12 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 size="sm"
                 type="search"
                 placeholder="Search members"
-                value={memberSearch()}
-                onValueChange={setMemberSearch}
+                value={panels.members.search}
+                onValueChange={(value) =>
+                  setPanels((state) => {
+                    state.members.search = value;
+                  })
+                }
               />
             </label>
           }
@@ -778,7 +890,11 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
             <div class="server-settings-invite-composer">
               <SlidingTabs.ContentSlot>
                 <SlidingTabs.Content value="email" class="server-settings-invite-mode-panel">
-                  <Field class="server-settings-invite-email-field" label="Email address" error={inviteEmailError()}>
+                  <Field
+                    class="server-settings-invite-email-field"
+                    label="Email address"
+                    error={panels.invite.emailError}
+                  >
                     <Input
                       size="md"
                       type="email"
@@ -786,15 +902,19 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                       maxlength={INPUT_LIMITS.email}
                       disabled={!published()}
                       placeholder="person@company.com"
-                      value={inviteEmail()}
-                      onValueChange={(value) => {
-                        setInviteEmail(value);
-                        setInviteEmailError(null);
-                      }}
+                      value={panels.invite.email}
+                      onValueChange={(value) =>
+                        setPanels((state) => {
+                          state.invite.email = value;
+                          state.invite.emailError = null;
+                        })
+                      }
                       onBlur={() =>
-                        inviteEmail() &&
-                        !normalizeEmailAddress(inviteEmail()) &&
-                        setInviteEmailError("Enter a valid email address.")
+                        panels.invite.email &&
+                        !normalizeEmailAddress(panels.invite.email) &&
+                        setPanels((state) => {
+                          state.invite.emailError = "Enter a valid email address.";
+                        })
                       }
                     />
                   </Field>
@@ -807,18 +927,23 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                     readonly
                     aria-label="Invitation link"
                     placeholder={INVITE_LINK_PLACEHOLDER}
-                    value={inviteLinkValue()}
-                    title={inviteLinkValue() || undefined}
+                    value={panels.invite.link}
+                    title={panels.invite.link || undefined}
                     onFocus={(event) => event.currentTarget.select()}
                   />
                 </SlidingTabs.Content>
               </SlidingTabs.ContentSlot>
               <Select<string>
                 options={ROLE_OPTIONS}
-                value={roleLabel(inviteRole())}
+                value={roleLabel(panels.invite.role)}
                 disabled={!published()}
                 placement="bottom-end"
-                onChange={(value) => value && setInviteRole(value === "Admin" ? "admin" : "member")}
+                onChange={(value) =>
+                  value &&
+                  setPanels((state) => {
+                    state.invite.role = value === "Admin" ? "admin" : "member";
+                  })
+                }
                 itemComponent={(item) => <SelectItem item={item.item}>{item.item.rawValue}</SelectItem>}
               >
                 <SelectTrigger class="server-settings-role-select" size="sm" aria-label="Invitation role">
@@ -827,7 +952,11 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 <SelectContent />
               </Select>
               <Show
-                when={inviteMode() === "link" && inviteResult() && !inviteResult()?.email ? inviteResult() : null}
+                when={
+                  panels.invite.mode === "link" && panels.invite.result && !panels.invite.result.email
+                    ? panels.invite.result
+                    : null
+                }
                 fallback={
                   <Button
                     type="button"
@@ -837,7 +966,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                     disabled={!canInvite()}
                     onClick={() => void createInvite()}
                   >
-                    {inviteMode() === "email" ? "Send invite" : "Create link"}
+                    {panels.invite.mode === "email" ? "Send invite" : "Create link"}
                   </Button>
                 }
               >
@@ -854,7 +983,7 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 )}
               </Show>
             </div>
-            <Show when={inviteResult()?.email ? inviteResult() : null}>
+            <Show when={panels.invite.result?.email ? panels.invite.result : null}>
               {(result) => (
                 <Alert class="server-settings-invite-result" tone="success" role="status">
                   <AlertIcon>
@@ -897,7 +1026,9 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
                 }
                 onRemove={(trigger) => {
                   removeMemberTrigger = trigger;
-                  setRemoveMemberId(member.id);
+                  setPanels((state) => {
+                    state.members.removeId = member.id;
+                  });
                 }}
               />
             </Show>

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -14,7 +14,7 @@ import type {
 } from "@openbot/contracts/ipc";
 import { isUpdateActivePhase } from "@openbot/contracts/ipc";
 import { normalizeAccountName, validateProfileName } from "@openbot/contracts/validation";
-import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, createStore, For, onCleanup, Show } from "solid-js";
 import { desktopAnalytics } from "../analytics";
 import type { GeneralSettingsValue } from "../app-settings";
 import { normalizeAvatarFile } from "../avatar-image";
@@ -110,6 +110,67 @@ const tabDetails: Record<SettingsTab, { title: string; description: string }> = 
   "hosted-sites": { title: "Hosted sites", description: "View and manage static sites published by your bots." },
 };
 
+interface ProfileNameEdit {
+  busy: boolean;
+  name: string;
+  saveError: string | null;
+  savedName: string;
+  touched: boolean;
+}
+
+interface AvatarUpload {
+  busy: boolean;
+  error: string | null;
+}
+
+/** A generated Mobile Connect code, from the moment it is displayed until it is cleared. */
+interface MobileConnectSession {
+  /** True while the success banner plays its collapse animation. */
+  collapsing: boolean;
+  /**
+   * When this code became able to pair a phone. Null while a replacement code is being generated:
+   * the code on screen is still the old one, and a device that appears now is not its doing.
+   */
+  startedAt: number | null;
+  successDeviceName: string | null;
+  ticket: MobileConnectTicket;
+}
+
+interface MobileConnectPanel {
+  busy: boolean;
+  error: string | null;
+  /** Carries `startedAt`, so neither can exist without the other. */
+  session: MobileConnectSession | null;
+}
+
+interface MobileDeviceList {
+  devices: MobileConnectedDevice[];
+  error: string | null;
+  /** Stays true across a refresh, so the list keeps rendering while `loading` is also true. */
+  loaded: boolean;
+  loading: boolean;
+  revokingSessionId: string | null;
+}
+
+interface HostedSitesPanel {
+  busy: boolean;
+  error: string | null;
+  sites: HostedSiteSummary[];
+}
+
+/**
+ * One record per panel of the dialog. Each group's fields are written together — a save touches
+ * the draft, its error and its busy flag at once — so they are one store rather than a signal
+ * each, and replacing one field re-renders only what read that field.
+ */
+interface SettingsPanels {
+  avatar: AvatarUpload;
+  connect: MobileConnectPanel;
+  devices: MobileDeviceList;
+  hosting: HostedSitesPanel;
+  profile: ProfileNameEdit;
+}
+
 const linkTargetOptions: GeneralSettingsValue["externalLinkTarget"][] = ["Default browser", "OpenBot"];
 type UpdateTrack = "Stable";
 const updateTrackOptions: UpdateTrack[] = ["Stable"];
@@ -119,31 +180,18 @@ const MOBILE_DEVICES_REFRESH_INTERVAL_MS = 60_000;
 const MOBILE_CONNECT_PENDING_REFRESH_INTERVAL_MS = 5_000;
 
 export function SettingsModal(props: SettingsModalProps) {
+  const [panels, setPanels] = createStore<SettingsPanels>({
+    avatar: { busy: false, error: null },
+    connect: { busy: false, error: null, session: null },
+    devices: { devices: [], error: null, loaded: false, loading: false, revokingSessionId: null },
+    hosting: { busy: false, error: null, sites: [] },
+    profile: { busy: false, name: "", saveError: null, savedName: "", touched: false },
+  });
   const [activeTab, setActiveTab] = createSignal<SettingsTab>("general");
-  const [savedProfileName, setSavedProfileName] = createSignal("");
-  const [profileName, setProfileName] = createSignal("");
-  const [profileNameTouched, setProfileNameTouched] = createSignal(false);
-  const [profileNameBusy, setProfileNameBusy] = createSignal(false);
-  const [profileSaveError, setProfileSaveError] = createSignal<string | null>(null);
-  const [avatarBusy, setAvatarBusy] = createSignal(false);
-  const [avatarError, setAvatarError] = createSignal<string | null>(null);
-  const [updateError, setUpdateError] = createSignal<string | null>(null);
-  const [mobileConnect, setMobileConnect] = createSignal<MobileConnectTicket | null>(null);
-  const [mobileConnectBusy, setMobileConnectBusy] = createSignal(false);
-  const [mobileConnectError, setMobileConnectError] = createSignal<string | null>(null);
-  const [mobileConnectNow, setMobileConnectNow] = createSignal(Date.now());
-  const [mobileConnectStartedAt, setMobileConnectStartedAt] = createSignal<number | null>(null);
-  const [mobileConnectSuccessDeviceName, setMobileConnectSuccessDeviceName] = createSignal<string | null>(null);
-  const [mobileConnectCollapsing, setMobileConnectCollapsing] = createSignal(false);
-  const [mobileDevices, setMobileDevices] = createSignal<MobileConnectedDevice[]>([]);
-  const [mobileDevicesLoaded, setMobileDevicesLoaded] = createSignal(false);
-  const [mobileDevicesLoading, setMobileDevicesLoading] = createSignal(false);
-  const [mobileDevicesError, setMobileDevicesError] = createSignal<string | null>(null);
-  const [revokingMobileSessionId, setRevokingMobileSessionId] = createSignal<string | null>(null);
   const [selectedProvider, setSelectedProvider] = createSignal<AgentProviderId | null>(null);
-  const [hostedSites, setHostedSites] = createSignal<HostedSiteSummary[]>([]);
-  const [hostedSitesError, setHostedSitesError] = createSignal<string | null>(null);
-  const [hostingBusy, setHostingBusy] = createSignal(false);
+  const [updateError, setUpdateError] = createSignal<string | null>(null);
+  /** A clock, not panel state: it ticks the code's countdown and the device list's "3m ago" labels. */
+  const [mobileNow, setMobileNow] = createSignal(Date.now());
   let modalElement: HTMLElement | undefined;
   let avatarFileInput: HTMLInputElement | undefined;
   let profileNameInput: HTMLInputElement | undefined;
@@ -160,10 +208,12 @@ export function SettingsModal(props: SettingsModalProps) {
     () => props.account.name,
     () => {
       const name = accountName();
-      setSavedProfileName(normalizeAccountName(name));
-      setProfileName(name);
-      setProfileNameTouched(false);
-      setProfileSaveError(null);
+      setPanels((state) => {
+        state.profile.savedName = normalizeAccountName(name);
+        state.profile.name = name;
+        state.profile.touched = false;
+        state.profile.saveError = null;
+      });
     },
   );
 
@@ -172,7 +222,7 @@ export function SettingsModal(props: SettingsModalProps) {
       open: props.open,
       active: activeTab() === "mobile-connect",
       list: props.onListMobileConnectedDevices,
-      ticketExpiresAt: mobileConnect()?.expiresAt ?? null,
+      ticketExpiresAt: panels.connect.session?.ticket.expiresAt ?? null,
     }),
     ({ open, active, list }) => {
       mobileDevicesRequestRevision += 1;
@@ -181,7 +231,7 @@ export function SettingsModal(props: SettingsModalProps) {
       let timer: number | undefined;
 
       const scheduleRefresh = () => {
-        const ticket = mobileConnect();
+        const ticket = panels.connect.session?.ticket;
         const refreshInterval =
           ticket && ticket.expiresAt > Date.now()
             ? MOBILE_CONNECT_PENDING_REFRESH_INTERVAL_MS
@@ -202,7 +252,7 @@ export function SettingsModal(props: SettingsModalProps) {
     },
   );
 
-  const profileNameValidation = createMemo(() => validateProfileName(profileName()));
+  const profileNameValidation = createMemo(() => validateProfileName(panels.profile.name));
   const normalizedProfileName = () => profileNameValidation().name;
   const profileNameError = () => {
     switch (profileNameValidation().error) {
@@ -218,12 +268,13 @@ export function SettingsModal(props: SettingsModalProps) {
         return null;
     }
   };
-  const visibleProfileNameError = () => profileSaveError() ?? (profileNameTouched() ? profileNameError() : null);
-  const profileNameDirty = () => normalizedProfileName() !== savedProfileName();
+  const visibleProfileNameError = () =>
+    panels.profile.saveError ?? (panels.profile.touched ? profileNameError() : null);
+  const profileNameDirty = () => normalizedProfileName() !== panels.profile.savedName;
   const mobileConnectSecondsRemaining = createMemo(() =>
-    Math.max(0, Math.ceil(((mobileConnect()?.expiresAt ?? 0) - mobileConnectNow()) / 1_000)),
+    Math.max(0, Math.ceil(((panels.connect.session?.ticket.expiresAt ?? 0) - mobileNow()) / 1_000)),
   );
-  const mobileConnectExpired = () => Boolean(mobileConnect() && mobileConnectSecondsRemaining() === 0);
+  const mobileConnectExpired = () => Boolean(panels.connect.session && mobileConnectSecondsRemaining() === 0);
   const mobileConnectExpiryLabel = () => {
     const seconds = mobileConnectSecondsRemaining();
     const minutes = Math.floor(seconds / 60);
@@ -231,11 +282,11 @@ export function SettingsModal(props: SettingsModalProps) {
   };
 
   createEffect(
-    () => ({ open: props.open, ticket: mobileConnect() }),
+    () => ({ open: props.open, ticket: panels.connect.session?.ticket ?? null }),
     ({ open, ticket }) => {
       if (!open || !ticket) return;
-      setMobileConnectNow(Date.now());
-      const timer = window.setInterval(() => setMobileConnectNow(Date.now()), 1_000);
+      setMobileNow(Date.now());
+      const timer = window.setInterval(() => setMobileNow(Date.now()), 1_000);
       return () => window.clearInterval(timer);
     },
   );
@@ -336,86 +387,114 @@ export function SettingsModal(props: SettingsModalProps) {
   }
 
   async function createMobileConnect(): Promise<void> {
-    if (mobileConnectBusy() || !props.onCreateMobileConnect) return;
+    if (panels.connect.busy || !props.onCreateMobileConnect) return;
     clearMobileConnectFeedbackTimers();
-    setMobileConnectBusy(true);
-    setMobileConnectError(null);
-    setMobileConnectSuccessDeviceName(null);
-    setMobileConnectCollapsing(false);
-    setMobileConnectStartedAt(null);
+    setPanels((state) => {
+      state.connect.busy = true;
+      state.connect.error = null;
+      // The old code stays on screen while the new one is generated, but stops being able to pair.
+      if (state.connect.session) {
+        state.connect.session.collapsing = false;
+        state.connect.session.startedAt = null;
+        state.connect.session.successDeviceName = null;
+      }
+    });
     try {
-      let baselineDevices = mobileDevices();
+      let baselineDevices = panels.devices.devices;
       if (props.onListMobileConnectedDevices) {
         const refreshedDevices = await refreshMobileDevices(true);
         if (!refreshedDevices) {
-          throw new Error(mobileDevicesError() ?? "Could not load connected devices before generating a code.");
+          throw new Error(panels.devices.error ?? "Could not load connected devices before generating a code.");
         }
         baselineDevices = refreshedDevices;
       }
       mobileConnectBaselineSessionIds = new Set(baselineDevices.map((device) => device.sessionId));
       const ticket = await props.onCreateMobileConnect();
       const now = Date.now();
-      setMobileConnect(ticket);
-      setMobileConnectStartedAt(now);
-      setMobileConnectNow(now);
+      setPanels((state) => {
+        state.connect.session = { collapsing: false, startedAt: now, successDeviceName: null, ticket };
+      });
+      setMobileNow(now);
     } catch (error) {
-      setMobileConnect(null);
-      setMobileConnectStartedAt(null);
-      setMobileConnectError(error instanceof Error ? error.message : "Could not generate a Mobile Connect code.");
+      setPanels((state) => {
+        state.connect.session = null;
+        state.connect.error = error instanceof Error ? error.message : "Could not generate a Mobile Connect code.";
+      });
     } finally {
-      setMobileConnectBusy(false);
+      setPanels((state) => {
+        state.connect.busy = false;
+      });
     }
   }
 
   async function refreshMobileDevices(showLoading: boolean): Promise<MobileConnectedDevice[] | null> {
     const list = props.onListMobileConnectedDevices;
-    if (!list || revokingMobileSessionId()) return null;
+    if (!list || panels.devices.revokingSessionId) return null;
     const revision = ++mobileDevicesRequestRevision;
-    if (showLoading) setMobileDevicesLoading(true);
+    if (showLoading)
+      setPanels((state) => {
+        state.devices.loading = true;
+      });
     try {
       const devices = await list();
       if (revision !== mobileDevicesRequestRevision) return null;
       const connectedDevice = newlyConnectedMobileDevice(devices);
-      setMobileDevices(devices);
-      setMobileDevicesLoaded(true);
-      setMobileDevicesError(null);
-      setMobileConnectNow(Date.now());
+      setPanels((state) => {
+        state.devices.devices = devices;
+        state.devices.loaded = true;
+        state.devices.error = null;
+      });
+      setMobileNow(Date.now());
       if (connectedDevice) showMobileConnectSuccess(connectedDevice);
       return devices;
     } catch (error) {
       if (revision !== mobileDevicesRequestRevision) return null;
-      setMobileDevicesError(error instanceof Error ? error.message : "Could not load connected devices.");
+      setPanels((state) => {
+        state.devices.error = error instanceof Error ? error.message : "Could not load connected devices.";
+      });
       return null;
     } finally {
-      if (revision === mobileDevicesRequestRevision) setMobileDevicesLoading(false);
+      if (revision === mobileDevicesRequestRevision)
+        setPanels((state) => {
+          state.devices.loading = false;
+        });
     }
   }
 
   function newlyConnectedMobileDevice(devices: MobileConnectedDevice[]): MobileConnectedDevice | null {
-    const startedAt = mobileConnectStartedAt();
-    const ticket = mobileConnect();
-    if (!ticket || startedAt === null || mobileConnectSuccessDeviceName() || Date.now() > ticket.expiresAt + 5_000) {
+    const session = panels.connect.session;
+    const startedAt = session?.startedAt;
+    if (
+      !session ||
+      startedAt === null ||
+      startedAt === undefined ||
+      session.successDeviceName ||
+      Date.now() > session.ticket.expiresAt + 5_000
+    ) {
       return null;
     }
     return (
       devices.find(
         (device) =>
           !mobileConnectBaselineSessionIds.has(device.sessionId) &&
-          (mobileDevicesLoaded() || device.connectedAt >= startedAt - 5_000),
+          (panels.devices.loaded || device.connectedAt >= startedAt - 5_000),
       ) ?? null
     );
   }
 
   function showMobileConnectSuccess(device: MobileConnectedDevice): void {
     clearMobileConnectFeedbackTimers();
-    setMobileConnectSuccessDeviceName(device.name);
+    setPanels((state) => {
+      if (state.connect.session) state.connect.session.successDeviceName = device.name;
+    });
     mobileConnectSuccessTimer = window.setTimeout(() => {
-      setMobileConnectCollapsing(true);
+      setPanels((state) => {
+        if (state.connect.session) state.connect.session.collapsing = true;
+      });
       mobileConnectCleanupTimer = window.setTimeout(() => {
-        setMobileConnect(null);
-        setMobileConnectStartedAt(null);
-        setMobileConnectSuccessDeviceName(null);
-        setMobileConnectCollapsing(false);
+        setPanels((state) => {
+          state.connect.session = null;
+        });
       }, MOBILE_CONNECT_COLLAPSE_MS);
     }, MOBILE_CONNECT_SUCCESS_FEEDBACK_MS);
   }
@@ -430,18 +509,26 @@ export function SettingsModal(props: SettingsModalProps) {
   onCleanup(clearMobileConnectFeedbackTimers);
 
   async function revokeMobileDevice(device: MobileConnectedDevice): Promise<void> {
-    if (!props.onRevokeMobileConnectedDevice || revokingMobileSessionId()) return;
+    if (!props.onRevokeMobileConnectedDevice || panels.devices.revokingSessionId) return;
     mobileDevicesRequestRevision += 1;
-    setMobileDevicesLoading(false);
-    setRevokingMobileSessionId(device.sessionId);
-    setMobileDevicesError(null);
+    setPanels((state) => {
+      state.devices.loading = false;
+      state.devices.revokingSessionId = device.sessionId;
+      state.devices.error = null;
+    });
     try {
       await props.onRevokeMobileConnectedDevice(device.sessionId);
-      setMobileDevices((current) => current.filter((candidate) => candidate.sessionId !== device.sessionId));
+      setPanels((state) => {
+        state.devices.devices = state.devices.devices.filter((candidate) => candidate.sessionId !== device.sessionId);
+      });
     } catch (error) {
-      setMobileDevicesError(error instanceof Error ? error.message : "Could not disconnect this device.");
+      setPanels((state) => {
+        state.devices.error = error instanceof Error ? error.message : "Could not disconnect this device.";
+      });
     } finally {
-      setRevokingMobileSessionId(null);
+      setPanels((state) => {
+        state.devices.revokingSessionId = null;
+      });
     }
   }
 
@@ -452,7 +539,7 @@ export function SettingsModal(props: SettingsModalProps) {
   }
 
   function mobileDeviceTimeLabel(timestamp: number): string {
-    const elapsedSeconds = Math.max(0, Math.floor((mobileConnectNow() - timestamp) / 1_000));
+    const elapsedSeconds = Math.max(0, Math.floor((mobileNow() - timestamp) / 1_000));
     if (elapsedSeconds < 60) return "Just now";
     const elapsedMinutes = Math.floor(elapsedSeconds / 60);
     if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
@@ -462,66 +549,91 @@ export function SettingsModal(props: SettingsModalProps) {
   }
 
   async function updateAvatar(image: AvatarImageInput | null): Promise<void> {
-    if (avatarBusy()) return;
-    setAvatarBusy(true);
-    setAvatarError(null);
+    if (panels.avatar.busy) return;
+    setPanels((state) => {
+      state.avatar.busy = true;
+      state.avatar.error = null;
+    });
     try {
       await props.onUpdateAccountAvatar(image);
     } catch (error) {
-      setAvatarError(error instanceof Error ? error.message : "Could not update your profile photo.");
+      setPanels((state) => {
+        state.avatar.error = error instanceof Error ? error.message : "Could not update your profile photo.";
+      });
     } finally {
-      setAvatarBusy(false);
+      setPanels((state) => {
+        state.avatar.busy = false;
+      });
     }
   }
 
   function updateProfileName(value: string): void {
-    setProfileName(value);
-    setProfileSaveError(null);
-    if (validateProfileName(value).error) return;
-    setProfileNameTouched(false);
+    setPanels((state) => {
+      state.profile.name = value;
+      state.profile.saveError = null;
+      if (!validateProfileName(value).error) state.profile.touched = false;
+    });
   }
 
   function resetProfileName(): void {
-    setProfileName(savedProfileName());
-    setProfileNameTouched(false);
-    setProfileSaveError(null);
+    setPanels((state) => {
+      state.profile.name = state.profile.savedName;
+      state.profile.touched = false;
+      state.profile.saveError = null;
+    });
   }
 
   async function saveProfileName(): Promise<void> {
-    if (profileNameBusy()) return;
-    setProfileNameTouched(true);
-    setProfileSaveError(null);
+    if (panels.profile.busy) return;
+    setPanels((state) => {
+      state.profile.touched = true;
+      state.profile.saveError = null;
+    });
     if (profileNameError()) {
       queueMicrotask(() => profileNameInput?.focus({ preventScroll: true }));
       return;
     }
     if (!profileNameDirty()) return;
     const name = normalizedProfileName();
-    setProfileNameBusy(true);
+    setPanels((state) => {
+      state.profile.busy = true;
+    });
     try {
       await props.onUpdateAccountName(name);
-      setSavedProfileName(name);
-      setProfileName(name);
-      setProfileNameTouched(false);
+      setPanels((state) => {
+        state.profile.savedName = name;
+        state.profile.name = name;
+        state.profile.touched = false;
+      });
     } catch (error) {
-      setProfileSaveError(error instanceof Error ? error.message : "Could not update your display name.");
+      setPanels((state) => {
+        state.profile.saveError = error instanceof Error ? error.message : "Could not update your display name.";
+      });
       queueMicrotask(() => profileNameInput?.focus({ preventScroll: true }));
     } finally {
-      setProfileNameBusy(false);
+      setPanels((state) => {
+        state.profile.busy = false;
+      });
     }
   }
 
   async function uploadAvatar(file: File | undefined): Promise<void> {
-    if (!file || avatarBusy()) return;
-    setAvatarBusy(true);
-    setAvatarError(null);
+    if (!file || panels.avatar.busy) return;
+    setPanels((state) => {
+      state.avatar.busy = true;
+      state.avatar.error = null;
+    });
     try {
       const image = await (props.processAvatarFile ?? normalizeAvatarFile)(file);
       await props.onUpdateAccountAvatar(image);
     } catch (error) {
-      setAvatarError(error instanceof Error ? error.message : "Could not process your profile photo.");
+      setPanels((state) => {
+        state.avatar.error = error instanceof Error ? error.message : "Could not process your profile photo.";
+      });
     } finally {
-      setAvatarBusy(false);
+      setPanels((state) => {
+        state.avatar.busy = false;
+      });
       if (avatarFileInput) avatarFileInput.value = "";
     }
   }
@@ -534,12 +646,21 @@ export function SettingsModal(props: SettingsModalProps) {
       try {
         while (hostedSitesReloadRequested) {
           hostedSitesReloadRequested = false;
-          setHostedSitesError(null);
+          setPanels((state) => {
+            state.hosting.error = null;
+          });
           try {
             const api = props.hostedSitesApi;
-            if (api) setHostedSites(await api.list());
+            if (api) {
+              const sites = await api.list();
+              setPanels((state) => {
+                state.hosting.sites = sites;
+              });
+            }
           } catch (error) {
-            setHostedSitesError(error instanceof Error ? error.message : "Could not load hosted sites.");
+            setPanels((state) => {
+              state.hosting.error = error instanceof Error ? error.message : "Could not load hosted sites.";
+            });
           }
         }
       } finally {
@@ -557,11 +678,13 @@ export function SettingsModal(props: SettingsModalProps) {
   );
 
   async function deleteSite(site: HostedSiteSummary): Promise<void> {
-    if (!props.hostedSitesApi || hostingBusy()) return;
+    if (!props.hostedSitesApi || panels.hosting.busy) return;
     if (!window.confirm(`Delete ${site.hostname}? This address will immediately return 410 Gone.`)) return;
     const analytics = desktopAnalytics.scope();
-    setHostingBusy(true);
-    setHostedSitesError(null);
+    setPanels((state) => {
+      state.hosting.busy = true;
+      state.hosting.error = null;
+    });
     try {
       try {
         await props.hostedSitesApi.delete({ siteId: site.id });
@@ -572,7 +695,9 @@ export function SettingsModal(props: SettingsModalProps) {
           result: "failed",
           failure_code: "delete_failed",
         });
-        setHostedSitesError(error instanceof Error ? error.message : "Could not delete the site.");
+        setPanels((state) => {
+          state.hosting.error = error instanceof Error ? error.message : "Could not delete the site.";
+        });
         return;
       }
       analytics.track("hosted_site_action", {
@@ -582,9 +707,13 @@ export function SettingsModal(props: SettingsModalProps) {
       });
       await loadHostedSites();
     } catch (error) {
-      setHostedSitesError(error instanceof Error ? error.message : "Could not reload hosted sites.");
+      setPanels((state) => {
+        state.hosting.error = error instanceof Error ? error.message : "Could not reload hosted sites.";
+      });
     } finally {
-      setHostingBusy(false);
+      setPanels((state) => {
+        state.hosting.busy = false;
+      });
     }
   }
 
@@ -606,16 +735,22 @@ export function SettingsModal(props: SettingsModalProps) {
                 Changes not saved
               </Text>
               <div class="settings-modal-save-actions">
-                <Button type="button" size="sm" variant="ghost" disabled={profileNameBusy()} onClick={resetProfileName}>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  disabled={panels.profile.busy}
+                  onClick={resetProfileName}
+                >
                   Reset
                 </Button>
                 <Button
                   type="button"
                   size="sm"
                   variant="default"
-                  loading={profileNameBusy()}
+                  loading={panels.profile.busy}
                   loadingLabel="Saving…"
-                  disabled={profileNameBusy()}
+                  disabled={panels.profile.busy}
                   onClick={() => void saveProfileName()}
                 >
                   Save
@@ -806,7 +941,7 @@ export function SettingsModal(props: SettingsModalProps) {
                     class="settings-identity-name-input"
                     id="settings-profile-name"
                     size="md"
-                    value={profileName()}
+                    value={panels.profile.name}
                     aria-labelledby="settings-profile-name-label"
                     aria-describedby={
                       visibleProfileNameError() ? "settings-profile-name-error" : "settings-profile-name-description"
@@ -815,7 +950,9 @@ export function SettingsModal(props: SettingsModalProps) {
                     onValueChange={updateProfileName}
                     onBlur={() => {
                       if (!profileNameDirty()) return;
-                      setProfileNameTouched(true);
+                      setPanels((state) => {
+                        state.profile.touched = true;
+                      });
                     }}
                     onKeyDown={(event) => {
                       if (event.key !== "Enter" || event.isComposing) return;
@@ -836,8 +973,8 @@ export function SettingsModal(props: SettingsModalProps) {
               <Item class="settings-identity-image-row">
                 <ItemContent>
                   <ItemTitle>Profile photo</ItemTitle>
-                  <ItemDescription class={avatarError() ? "settings-modal-error" : undefined}>
-                    {avatarError() ?? "Shown with your profile in OpenBot."}
+                  <ItemDescription class={panels.avatar.error ? "settings-modal-error" : undefined}>
+                    {panels.avatar.error ?? "Shown with your profile in OpenBot."}
                   </ItemDescription>
                 </ItemContent>
                 <ItemActions class="settings-identity-image-control">
@@ -848,12 +985,12 @@ export function SettingsModal(props: SettingsModalProps) {
                       size="icon-lg"
                       class="settings-identity-image-trigger settings-modal-profile-photo-trigger"
                       aria-label={props.account.avatarUrl ? "Edit profile photo" : "Add profile photo"}
-                      disabled={avatarBusy()}
+                      disabled={panels.avatar.busy}
                       onClick={() => avatarFileInput?.click()}
                     >
                       <UserAvatar user={props.account} class="settings-modal-avatar" decorative />
                     </Button>
-                    <Show when={props.account.avatarUrl && !avatarBusy()}>
+                    <Show when={props.account.avatarUrl && !panels.avatar.busy}>
                       <ImageRemoveButton label="Remove profile photo" onClick={() => void updateAvatar(null)} />
                     </Show>
                   </div>
@@ -891,7 +1028,7 @@ export function SettingsModal(props: SettingsModalProps) {
                   <ItemDescription>
                     The code expires after two minutes and stops working after the first successful scan.
                   </ItemDescription>
-                  <Show when={mobileConnectError()}>
+                  <Show when={panels.connect.error}>
                     {(error) => (
                       <ItemDescription class="settings-modal-error" role="alert">
                         {error()}
@@ -903,22 +1040,22 @@ export function SettingsModal(props: SettingsModalProps) {
                   <Button
                     type="button"
                     size="sm"
-                    loading={mobileConnectBusy()}
+                    loading={panels.connect.busy}
                     loadingLabel="Generating…"
                     disabled={!props.onCreateMobileConnect}
                     onClick={() => void createMobileConnect()}
                   >
-                    {mobileConnect() ? "Generate new code" : "Generate QR code"}
+                    {panels.connect.session ? "Generate new code" : "Generate QR code"}
                   </Button>
                 </ItemActions>
               </Item>
 
-              <Show when={mobileConnect()}>
-                {(ticket) => (
+              <Show when={panels.connect.session}>
+                {(session) => (
                   <div
                     class="settings-mobile-connect-code-collapse"
-                    data-collapsing={mobileConnectCollapsing() ? "" : undefined}
-                    aria-hidden={mobileConnectCollapsing() ? "true" : undefined}
+                    data-collapsing={session().collapsing ? "" : undefined}
+                    aria-hidden={session().collapsing ? "true" : undefined}
                   >
                     <div class="settings-mobile-connect-code-collapse-body">
                       <div class="settings-mobile-connect-code" aria-live="polite">
@@ -938,10 +1075,10 @@ export function SettingsModal(props: SettingsModalProps) {
                         >
                           <div
                             class="settings-mobile-connect-qr-stage"
-                            data-success={mobileConnectSuccessDeviceName() ? "" : undefined}
+                            data-success={session().successDeviceName ? "" : undefined}
                           >
-                            <QrCode value={ticket().qrData} label="Mobile Connect sign-in QR code" />
-                            <Show when={mobileConnectSuccessDeviceName()}>
+                            <QrCode value={session().ticket.qrData} label="Mobile Connect sign-in QR code" />
+                            <Show when={session().successDeviceName}>
                               <div class="settings-mobile-connect-success-mark" aria-hidden="true">
                                 <CircleCheck />
                               </div>
@@ -949,7 +1086,7 @@ export function SettingsModal(props: SettingsModalProps) {
                           </div>
                           <div class="settings-mobile-connect-code-copy">
                             <Show
-                              when={mobileConnectSuccessDeviceName()}
+                              when={session().successDeviceName}
                               fallback={
                                 <>
                                   <Text class="settings-mobile-connect-code-title" variant="body">
@@ -990,7 +1127,7 @@ export function SettingsModal(props: SettingsModalProps) {
             <section class="settings-mobile-devices" aria-labelledby="settings-mobile-devices-title">
               <div class="settings-mobile-devices-heading">
                 <h3 id="settings-mobile-devices-title">Connected devices</h3>
-                <Show when={mobileDevicesLoading()}>
+                <Show when={panels.devices.loading}>
                   <Text as="span" variant="caption" tone="muted" role="status">
                     Refreshing…
                   </Text>
@@ -1011,8 +1148,8 @@ export function SettingsModal(props: SettingsModalProps) {
               <div class="settings-mobile-devices-states">
                 <div
                   class="settings-mobile-devices-state"
-                  data-expanded={mobileDevices().length === 0 ? "" : undefined}
-                  aria-hidden={mobileDevices().length > 0 ? "true" : undefined}
+                  data-expanded={panels.devices.devices.length === 0 ? "" : undefined}
+                  aria-hidden={panels.devices.devices.length > 0 ? "true" : undefined}
                 >
                   <div class="settings-mobile-devices-state-body">
                     <div class="settings-mobile-devices-empty" role="status">
@@ -1030,8 +1167,8 @@ export function SettingsModal(props: SettingsModalProps) {
                 </div>
                 <div
                   class="settings-mobile-devices-state"
-                  data-expanded={mobileDevices().length > 0 ? "" : undefined}
-                  aria-hidden={mobileDevices().length === 0 ? "true" : undefined}
+                  data-expanded={panels.devices.devices.length > 0 ? "" : undefined}
+                  aria-hidden={panels.devices.devices.length === 0 ? "true" : undefined}
                 >
                   <div class="settings-mobile-devices-state-body">
                     <div class="settings-mobile-devices-table-frame">
@@ -1048,7 +1185,7 @@ export function SettingsModal(props: SettingsModalProps) {
                           </tr>
                         </thead>
                         <tbody>
-                          <For each={mobileDevices()}>
+                          <For each={panels.devices.devices}>
                             {(device) => (
                               <tr>
                                 <td>
@@ -1065,7 +1202,7 @@ export function SettingsModal(props: SettingsModalProps) {
                                     type="button"
                                     variant="destructive-ghost"
                                     size="xs"
-                                    loading={revokingMobileSessionId() === device.sessionId}
+                                    loading={panels.devices.revokingSessionId === device.sessionId}
                                     loadingLabel="Disconnecting…"
                                     disabled={!props.onRevokeMobileConnectedDevice}
                                     aria-label={`Disconnect ${device.name}`}
@@ -1083,7 +1220,7 @@ export function SettingsModal(props: SettingsModalProps) {
                   </div>
                 </div>
               </div>
-              <Show when={mobileDevicesError()}>
+              <Show when={panels.devices.error}>
                 {(error) => (
                   <Text class="settings-modal-error" variant="caption" role="alert">
                     {error()}
@@ -1153,18 +1290,18 @@ export function SettingsModal(props: SettingsModalProps) {
           <SettingsSection title="Your sites">
             <Show when={props.hostedSitesApi} fallback={<Text tone="muted">Site hosting is unavailable.</Text>}>
               <div class="hosted-sites-overview">
-                <span class="settings-modal-row-title">{hostedSites().length} of 10 sites</span>
+                <span class="settings-modal-row-title">{panels.hosting.sites.length} of 10 sites</span>
                 <Text tone="muted" variant="caption">
                   Sites expire 30 days after publication. Ask a bot to publish or update a site.
                 </Text>
               </div>
-              <Show when={hostedSitesError()}>{(message) => <p class="settings-modal-error">{message()}</p>}</Show>
+              <Show when={panels.hosting.error}>{(message) => <p class="settings-modal-error">{message()}</p>}</Show>
               <Show
-                when={hostedSites().length > 0}
+                when={panels.hosting.sites.length > 0}
                 fallback={<Text tone="muted">You do not have a hosted site yet. Ask a bot to publish one.</Text>}
               >
                 <ItemGroup class="settings-modal-card hosted-sites-list" surface="subtle">
-                  <For each={hostedSites()}>
+                  <For each={panels.hosting.sites}>
                     {(site) => (
                       <Item class="hosted-sites-row">
                         <ItemContent>
@@ -1205,7 +1342,7 @@ export function SettingsModal(props: SettingsModalProps) {
                             variant="destructive-ghost"
                             size="sm"
                             aria-label={`Delete ${site.hostname}`}
-                            disabled={hostingBusy()}
+                            disabled={panels.hosting.busy}
                             onClick={() => void deleteSite(site)}
                           >
                             <Trash2 size={14} aria-hidden="true" />

--- a/src/renderer/src/components/Sidebar.test.tsx
+++ b/src/renderer/src/components/Sidebar.test.tsx
@@ -429,7 +429,10 @@ describe("Sidebar sections", () => {
 
     dragStartAt(researchItem, dataTransfer, { clientX: 30, clientY: 100 });
     await dragOverFrame(unassigned, dataTransfer, { clientX: 250, clientY: 330 });
+    // With nothing pinned yet, the drag opens a place to pin into; the drop has to close it again.
+    expect(screen.getByText("Drag here to pin")).toBeInTheDocument();
     dropAt(unassigned, dataTransfer, { clientX: 250, clientY: 330 });
+    await waitFor(() => expect(screen.queryByText("Drag here to pin")).not.toBeInTheDocument());
 
     expect(props.onMutateLayout).toHaveBeenCalledWith({
       type: "move-agent",
@@ -697,10 +700,23 @@ describe("Sidebar sections", () => {
     const props = sidebarProps();
     render(() => <Sidebar {...props} layout={sectionLayout()} />);
 
+    // A failed delete keeps the confirmation open to say why, and that message must not still be
+    // waiting there the next time the user opens it.
+    props.onMutateLayout.mockRejectedValueOnce(new Error("Section is in use."));
     await fireEvent.contextMenu(screen.getByRole("button", { name: "Demo" }));
     let sectionMenu = await screen.findByRole("menu", { name: "Section actions" });
     await fireEvent.pointerUp(within(sectionMenu).getByRole("menuitem", { name: "Delete" }), { button: 0 });
-    const dialog = await screen.findByRole("alertdialog", { name: "Delete Demo?" });
+    let dialog = await screen.findByRole("alertdialog", { name: "Delete Demo?" });
+    await fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+    expect(await within(dialog).findByText("Section is in use.")).toBeInTheDocument();
+    await fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByRole("alertdialog", { name: "Delete Demo?" })).not.toBeInTheDocument());
+
+    await fireEvent.contextMenu(screen.getByRole("button", { name: "Demo" }));
+    sectionMenu = await screen.findByRole("menu", { name: "Section actions" });
+    await fireEvent.pointerUp(within(sectionMenu).getByRole("menuitem", { name: "Delete" }), { button: 0 });
+    dialog = await screen.findByRole("alertdialog", { name: "Delete Demo?" });
+    expect(within(dialog).queryByText("Section is in use.")).not.toBeInTheDocument();
     expect(dialog).toHaveTextContent("Agents in this section will move to Unassigned");
     await fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
     expect(props.onMutateLayout).toHaveBeenCalledWith({ type: "delete", sectionId: demoId });

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -6,11 +6,12 @@ import {
   type SidebarLayoutAction,
   type SidebarLayoutSnapshot,
 } from "@openbot/contracts/ipc";
-import { createEffect, createMemo, createSignal, For, onCleanup, onSettled, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, createStore, For, onCleanup, Show } from "solid-js";
 import type { BotProfile } from "../data";
 import { MAX_SIDEBAR_PINNED_ITEMS, type SidebarPinnedItem, sidebarPinnedItemKey } from "../sidebar-pins";
 import { AgentAvatar } from "./AgentAvatar";
 import { createBoundedDragPreview } from "./createBoundedDragPreview";
+import { createScrollFades } from "./createScrollFades";
 import { TeamPersonAvatar, teamMemberName } from "./TeamPersonAvatar";
 import { TypingDots } from "./TypingDots";
 import {
@@ -169,6 +170,62 @@ interface SidebarNativeDragStart {
   source: SidebarDragSource;
 }
 
+/**
+ * The one delete confirmation the sidebar can have open: an agent, or a custom section, never both.
+ * The attempt's progress and the reason it failed live inside the record rather than beside it, so
+ * closing the dialog cannot leave a "Deleting…" button or the previous attempt's message behind.
+ */
+interface SidebarPendingDelete {
+  deleting: boolean;
+  error: string | null;
+  /** The agent or the section, whichever `kind` names. */
+  id: string;
+  /** Which of the two confirmations is on screen. Each dialog renders from one arm. */
+  kind: "agent" | "section";
+}
+
+/** What the section editor is editing: a section about to exist, or the one being renamed. */
+type SidebarSectionEditorTarget = { kind: "create"; agentId?: string } | { kind: "rename"; sectionId: string };
+
+/**
+ * The open section-name editor. The name as typed, its validation message and the save in flight
+ * hang off the editor because none of them means anything without one - a name left behind by a
+ * closed editor is what every `startCreateSection` had to remember to clear.
+ */
+interface SidebarSectionEditor {
+  error: string | null;
+  name: string;
+  saving: boolean;
+  target: SidebarSectionEditorTarget;
+}
+
+/** The two changes the sidebar can have half-made, each waiting on the user rather than on data. */
+interface SidebarPending {
+  deletion: SidebarPendingDelete | null;
+  sectionEditor: SidebarSectionEditor | null;
+}
+
+/**
+ * The reactive projection of the drag in flight: what is being dragged, where it would land, and the
+ * two pieces of drop chrome that outlive a single frame. It is one record because a drag is one
+ * thing - four parallel `dragged*Id` signals let the sidebar claim an agent and a section are being
+ * dragged at once, which is why the list header needed a four-way ternary to pick between them.
+ *
+ * The imperative half of the drag stays in plain locals (`dragSession`, `dragTarget`, the slot
+ * caches) because the pointer pipeline reads its own writes inside one tick, and neither a signal
+ * nor a store publishes a write before the next flush.
+ */
+interface SidebarDrag {
+  /** The empty pinned row, held open so an agent dragged out of a section has somewhere to land. */
+  emptyPinnedDropVisible: boolean;
+  /** How far each section has shifted to make room for the section being dragged. */
+  sectionOffsets: Record<string, number>;
+  /** What is being dragged. Every dragged id below is one arm of this union. */
+  source: SidebarDragSource | null;
+  /** Where it would land. Every drop highlight below is one arm of this union. */
+  target: SidebarDropTarget | null;
+}
+
 function sidebarDropTargetsEqual(left: SidebarDropTarget | null, right: SidebarDropTarget | null): boolean {
   if (left === right) return true;
   if (!left || !right || left.kind !== right.kind) return false;
@@ -317,31 +374,65 @@ function DeleteIcon() {
 export function Sidebar(props: SidebarProps) {
   const layoutMutable = () => props.layoutMutable !== false;
   const [query, setQuery] = createSignal("");
-  const [deleteTargetId, setDeleteTargetId] = createSignal<string | null>(null);
-  const [deleting, setDeleting] = createSignal(false);
-  const [deleteError, setDeleteError] = createSignal<string | null>(null);
-  const [sectionDeleteTargetId, setSectionDeleteTargetId] = createSignal<string | null>(null);
-  const [sectionDeleteError, setSectionDeleteError] = createSignal<string | null>(null);
-  const [deletingSection, setDeletingSection] = createSignal(false);
-  const [sectionEditor, setSectionEditor] = createSignal<
-    { kind: "create"; agentId?: string } | { kind: "rename"; sectionId: string } | null
-  >(null);
-  const [sectionName, setSectionName] = createSignal("");
-  const [sectionNameError, setSectionNameError] = createSignal<string | null>(null);
-  const [savingSection, setSavingSection] = createSignal(false);
-  const [fadeAtTop, setFadeAtTop] = createSignal(false);
-  const [fadeAtBottom, setFadeAtBottom] = createSignal(false);
-  const [draggedPinnedKey, setDraggedPinnedKey] = createSignal<string | null>(null);
-  const [dragOverPinnedKey, setDragOverPinnedKey] = createSignal<string | null>(null);
-  const [pinnedDropActive, setPinnedDropActive] = createSignal(false);
-  const [emptyPinnedDropVisible, setEmptyPinnedDropVisible] = createSignal(false);
-  const [draggedAgentId, setDraggedAgentId] = createSignal<string | null>(null);
-  const [dragOverAgentId, setDragOverAgentId] = createSignal<string | null>(null);
-  const [draggedPersonId, setDraggedPersonId] = createSignal<string | null>(null);
-  const [agentDropSectionId, setAgentDropSectionId] = createSignal<string | null>(null);
-  const [draggedSectionId, setDraggedSectionId] = createSignal<string | null>(null);
-  const [sectionDropTarget, setSectionDropTarget] = createSignal<SectionDropTarget | null>(null);
-  const [sectionDragOffsets, setSectionDragOffsets] = createSignal<Record<string, number>>({});
+  const [pending, setPending] = createStore<SidebarPending>({ deletion: null, sectionEditor: null });
+  // Both dialogs read these: only one confirmation exists, and each dialog only renders while it is
+  // the one. That is also why a section delete no longer needs its own pair of flags.
+  const deleting = () => pending.deletion?.deleting === true;
+  const deleteError = () => pending.deletion?.error ?? null;
+  const scrollFades = createScrollFades();
+  const [drag, setDrag] = createStore<SidebarDrag>({
+    emptyPinnedDropVisible: false,
+    sectionOffsets: {},
+    source: null,
+    target: null,
+  });
+  // The arms of the two unions above. Each one is a memo so that hovering a pinned tile invalidates
+  // the pinned rows only: `drag.target` changes on every hover, these change when their own answer
+  // does. Being derived is also why they can no longer disagree about which drag is in flight.
+  const draggedPinnedKey = createMemo(() => {
+    const source = drag.source;
+    return source?.kind === "agent" && source.origin === "pinned" ? source.key : null;
+  });
+  const draggedAgentId = createMemo(() => {
+    const source = drag.source;
+    return source?.kind === "agent" && source.origin === "section" ? source.id : null;
+  });
+  const draggedSectionId = createMemo(() => {
+    const source = drag.source;
+    return source?.kind === "section" ? source.id : null;
+  });
+  /** Which kind of drag the list is in, for the styling that dims everything the drag cannot reach. */
+  const draggingKind = createMemo(() => {
+    const source = drag.source;
+    if (!source) return undefined;
+    if (source.kind === "agent") return source.origin === "pinned" ? "pinned" : "agent";
+    return source.kind;
+  });
+  const dragOverPinnedKey = createMemo(() => {
+    const target = drag.target;
+    return target?.kind === "pinned" ? target.key : null;
+  });
+  const dragOverAgentId = createMemo(() => {
+    const target = drag.target;
+    return target?.kind === "agent" ? target.target.agentId : null;
+  });
+  /** The section a dragged agent would land in, whether it aims at a row inside it or at the section. */
+  const agentDropSectionId = createMemo(() => {
+    const target = drag.target;
+    if (target?.kind === "agent") return target.target.sectionId;
+    if (target?.kind === "section" && drag.source?.kind === "agent") return target.sectionId;
+    return null;
+  });
+  const sectionDropTarget = createMemo(() => {
+    const target = drag.target;
+    return target?.kind === "section-order" ? target.target : null;
+  });
+  /** The pinned group highlights only while an agent from the list could actually land in it. */
+  const pinnedDropActive = createMemo(() => {
+    const source = drag.source;
+    const pinningFromSidebar = Boolean(source && "origin" in source && source.origin !== "pinned");
+    return drag.target?.kind === "pinned" && pinningFromSidebar && canPinDraggedSidebarItem();
+  });
   const [reorderAnnouncement, setReorderAnnouncement] = createSignal("");
   let botList: HTMLElement | undefined;
   let searchInput: HTMLInputElement | undefined;
@@ -358,8 +449,6 @@ export function Sidebar(props: SidebarProps) {
   let dragTargetFrame: number | null = null;
   let dragScrollFrame: number | null = null;
   let dragScrollSpeed = 0;
-  let currentAgentDropSectionId: string | null = null;
-  let currentAgentDropTarget: AgentDropTarget | null = null;
   let currentSectionDropTarget: SectionDropTarget | null = null;
   let currentPersonDropTarget: PersonDropTarget | null = null;
   let personDragSlots = new Map<string, PersonDragSlot>();
@@ -423,7 +512,10 @@ export function Sidebar(props: SidebarProps) {
       return personMatchesQuery(member, thread, normalizedQuery());
     }),
   );
-  const deleteTarget = createMemo(() => props.bots.find((bot) => bot.id === deleteTargetId()));
+  const deleteTarget = createMemo(() => {
+    const deletion = pending.deletion;
+    return deletion?.kind === "agent" ? props.bots.find((bot) => bot.id === deletion.id) : undefined;
+  });
   const customSectionById = createMemo(() => new Map(props.layout.sections.map((section) => [section.id, section])));
   const collapsedSectionIds = createMemo(() => new Set(props.collapsedSectionIds));
   const filteredBotsBySection = createMemo(() => {
@@ -445,49 +537,65 @@ export function Sidebar(props: SidebarProps) {
       return (filteredBotsBySection().get(sectionId)?.length ?? 0) > 0;
     }),
   );
-  const sectionDeleteTarget = createMemo(() =>
-    props.layout.sections.find((section) => section.id === sectionDeleteTargetId()),
-  );
+  const sectionDeleteTarget = createMemo(() => {
+    const deletion = pending.deletion;
+    return deletion?.kind === "section"
+      ? props.layout.sections.find((section) => section.id === deletion.id)
+      : undefined;
+  });
 
   onCleanup(() => {
     stopSidebarDragging();
+    scrollFades.stop();
   });
-
-  function updateScrollFade() {
-    if (!botList) return;
-    const remaining = botList.scrollHeight - botList.scrollTop - botList.clientHeight;
-    setFadeAtTop(botList.scrollTop > 2);
-    setFadeAtBottom(remaining > 2);
-  }
 
   createEffect(
     () => [resolvedPinnedItems(), filteredBots(), filteredPeople()],
     () => {
-      requestAnimationFrame(updateScrollFade);
+      scrollFades.remeasure();
     },
   );
 
-  onSettled(() => {
-    const resizeObserver = new ResizeObserver(updateScrollFade);
-    if (botList) resizeObserver.observe(botList);
-    requestAnimationFrame(updateScrollFade);
-    return () => {
-      resizeObserver.disconnect();
-    };
-  });
+  function openDelete(kind: SidebarPendingDelete["kind"], id: string): void {
+    setPending((state) => {
+      state.deletion = { deleting: false, error: null, id, kind };
+    });
+  }
+
+  /** Closing the confirmation is what discards a failed attempt's message; nothing else has to. */
+  function closeDelete(): void {
+    setPending((state) => {
+      state.deletion = null;
+    });
+  }
+
+  /** Marks the confirmation as running and drops what the previous attempt said. */
+  function beginDelete(): void {
+    setPending((state) => {
+      if (!state.deletion) return;
+      state.deletion.deleting = true;
+      state.deletion.error = null;
+    });
+  }
+
+  /** A failed delete leaves the confirmation open, no longer running, saying why. */
+  function failDelete(cause: unknown): void {
+    setPending((state) => {
+      if (!state.deletion) return;
+      state.deletion.deleting = false;
+      state.deletion.error = cause instanceof Error ? cause.message : String(cause);
+    });
+  }
 
   async function confirmDelete() {
-    const botId = deleteTargetId();
-    if (!botId || deleting()) return;
-    setDeleting(true);
-    setDeleteError(null);
+    const deletion = pending.deletion;
+    if (deletion?.kind !== "agent" || deletion.deleting) return;
+    beginDelete();
     try {
-      await props.onDeleteBot(botId);
-      setDeleteTargetId(null);
+      await props.onDeleteBot(deletion.id);
+      closeDelete();
     } catch (error) {
-      setDeleteError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setDeleting(false);
+      failDelete(error);
     }
   }
 
@@ -500,9 +608,14 @@ export function Sidebar(props: SidebarProps) {
 
   function startCreateSection(agentId?: string): void {
     props.onExpand();
-    setSectionEditor({ kind: "create", ...(agentId ? { agentId } : {}) });
-    setSectionName("");
-    setSectionNameError(null);
+    setPending((state) => {
+      state.sectionEditor = {
+        error: null,
+        name: "",
+        saving: false,
+        target: { kind: "create", ...(agentId ? { agentId } : {}) },
+      };
+    });
     focusSectionName();
   }
 
@@ -510,66 +623,80 @@ export function Sidebar(props: SidebarProps) {
     const section = customSectionById().get(sectionId);
     if (!section) return;
     props.onExpand();
-    setSectionEditor({ kind: "rename", sectionId });
-    setSectionName(section.name);
-    setSectionNameError(null);
+    setPending((state) => {
+      state.sectionEditor = { error: null, name: section.name, saving: false, target: { kind: "rename", sectionId } };
+    });
     focusSectionName();
   }
 
   function cancelSectionEditor(): void {
-    if (savingSection()) return;
-    setSectionEditor(null);
-    setSectionNameError(null);
+    if (pending.sectionEditor?.saving) return;
+    setPending((state) => {
+      state.sectionEditor = null;
+    });
+  }
+
+  /** The editor owns its validation message, so it cannot be read once the editor has closed. */
+  function setSectionNameError(message: string): void {
+    setPending((state) => {
+      if (state.sectionEditor) state.sectionEditor.error = message;
+    });
   }
 
   async function saveSectionEditor(): Promise<void> {
-    const editor = sectionEditor();
-    if (!editor || savingSection()) return;
-    const name = sectionName().trim();
+    const editor = pending.sectionEditor;
+    if (!editor || editor.saving) return;
+    const name = editor.name.trim();
     if (!name) {
       setSectionNameError("Section name is required.");
       focusSectionName();
       return;
     }
+    const target = editor.target;
     const duplicate = props.layout.sections.some(
       (section) =>
         section.name.toLocaleLowerCase() === name.toLocaleLowerCase() &&
-        !(editor.kind === "rename" && editor.sectionId === section.id),
+        !(target.kind === "rename" && target.sectionId === section.id),
     );
     if (duplicate) {
       setSectionNameError("Section names must be unique.");
       focusSectionName();
       return;
     }
-    setSavingSection(true);
-    setSectionNameError(null);
+    setPending((state) => {
+      if (!state.sectionEditor) return;
+      state.sectionEditor.error = null;
+      state.sectionEditor.saving = true;
+    });
     try {
       await props.onMutateLayout(
-        editor.kind === "create"
-          ? { type: "create", name, ...(editor.agentId ? { agentId: editor.agentId } : {}) }
-          : { type: "rename", sectionId: editor.sectionId, name },
+        target.kind === "create"
+          ? { type: "create", name, ...(target.agentId ? { agentId: target.agentId } : {}) }
+          : { type: "rename", sectionId: target.sectionId, name },
       );
-      setSectionEditor(null);
+      // The editor closes on success, which is also what releases the save it was holding.
+      setPending((state) => {
+        state.sectionEditor = null;
+      });
     } catch (error) {
-      setSectionNameError(error instanceof Error ? error.message : String(error));
+      setPending((state) => {
+        if (!state.sectionEditor) return;
+        state.sectionEditor.error = error instanceof Error ? error.message : String(error);
+        state.sectionEditor.saving = false;
+      });
       focusSectionName();
-    } finally {
-      setSavingSection(false);
     }
   }
 
   async function confirmSectionDelete(): Promise<void> {
-    const sectionId = sectionDeleteTargetId();
-    if (!sectionId || deletingSection()) return;
-    setDeletingSection(true);
-    setSectionDeleteError(null);
+    const deletion = pending.deletion;
+    if (deletion?.kind !== "section" || deletion.deleting) return;
+    beginDelete();
     try {
-      await props.onMutateLayout({ type: "delete", sectionId });
-      setSectionDeleteTargetId(null);
+      await props.onMutateLayout({ type: "delete", sectionId: deletion.id });
+      closeDelete();
     } catch (error) {
-      setSectionDeleteError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setDeletingSection(false);
+      failDelete(error);
     }
   }
 
@@ -620,20 +747,15 @@ export function Sidebar(props: SidebarProps) {
     dragScrollFrame = null;
     dragScrollSpeed = 0;
     dragGeometry = { list: null, pinned: null };
-    currentAgentDropSectionId = null;
-    currentAgentDropTarget = null;
     currentSectionDropTarget = null;
     currentPersonDropTarget = null;
-    setPinnedDropActive(false);
-    setEmptyPinnedDropVisible(false);
-    setDraggedAgentId(null);
-    setDragOverAgentId(null);
-    setDraggedPersonId(null);
-    setAgentDropSectionId(null);
+    setDrag((state) => {
+      state.emptyPinnedDropVisible = false;
+      state.sectionOffsets = {};
+      state.source = null;
+      state.target = null;
+    });
     applyPersonDragOffsets({});
-    setDraggedSectionId(null);
-    setSectionDropTarget(null);
-    setSectionDragOffsets({});
     botList?.querySelector(".sidebar-pinned-group")?.classList.remove("sidebar-pinned-group-agent-drop-target");
     for (const section of botList?.querySelectorAll<HTMLElement>(".sidebar-section") ?? []) {
       section.classList.remove(
@@ -648,8 +770,6 @@ export function Sidebar(props: SidebarProps) {
     sectionDragSlots.clear();
     pinnedDragSlots = [];
     dragPreview.stop();
-    setDraggedPinnedKey(null);
-    setDragOverPinnedKey(null);
   }
 
   function sidebarClickIsSuppressed(event: MouseEvent): boolean {
@@ -657,14 +777,6 @@ export function Sidebar(props: SidebarProps) {
     event.preventDefault();
     event.stopPropagation();
     return true;
-  }
-
-  function activeDraggedSectionId(): string | null {
-    return dragSession?.source.kind === "section" ? dragSession.source.id : null;
-  }
-
-  function activeDraggedPersonId(): string | null {
-    return dragSession?.source.kind === "person" ? dragSession.source.id : null;
   }
 
   function measureSidebarDragTargets(): void {
@@ -748,6 +860,11 @@ export function Sidebar(props: SidebarProps) {
     dragSession = { source: options.source, startScrollTop: botList?.scrollTop ?? 0 };
     dragPoint = { clientX: event.clientX, clientY: event.clientY };
     dragTarget = null;
+    setDrag((state) => {
+      state.sectionOffsets = {};
+      state.source = options.source;
+      state.target = null;
+    });
     measureSidebarDragTargets();
     if (!botList) return;
     dragPreview.start({
@@ -764,8 +881,6 @@ export function Sidebar(props: SidebarProps) {
 
   function startAgentDragging(event: DragEvent & { currentTarget: HTMLElement }, bot: BotProfile): void {
     if (props.compact) return;
-    currentAgentDropSectionId = null;
-    currentAgentDropTarget = null;
     startNativeItemDragging(event, {
       className: "sidebar-agent-drag-preview",
       createPreview: createSidebarAgentDragCard,
@@ -773,9 +888,6 @@ export function Sidebar(props: SidebarProps) {
       previewSize: { height: 94, width: 72 },
       source: { kind: "agent", id: bot.id, origin: "section" },
     });
-    setDraggedAgentId(bot.id);
-    setDragOverAgentId(bot.id);
-    setAgentDropSectionId(null);
   }
 
   function startPersonDragging(event: DragEvent & { currentTarget: HTMLElement }, member: TeamPresenceMember): void {
@@ -787,7 +899,6 @@ export function Sidebar(props: SidebarProps) {
       previewSize: { height: 94, width: 72 },
       source: { kind: "person", id: member.id, origin: "people" },
     });
-    setDraggedPersonId(member.id);
     personDragSlots.get(member.id)?.element.classList.add("sidebar-person-item-dragging");
     applyPersonDragOffsets({});
   }
@@ -800,29 +911,13 @@ export function Sidebar(props: SidebarProps) {
       horizontal: false,
       source: { kind: "section", id: sectionId },
     });
-    setDraggedSectionId(sectionId);
-    setSectionDropTarget(null);
-    setSectionDragOffsets({});
-  }
-
-  function setAgentTarget(target: AgentDropTarget | null, sectionId: string | null): void {
-    const currentTarget = currentAgentDropTarget;
-    if (
-      currentTarget?.agentId === target?.agentId &&
-      currentTarget?.placement === target?.placement &&
-      currentTarget?.sectionId === target?.sectionId &&
-      currentAgentDropSectionId === sectionId
-    ) {
-      return;
-    }
-    currentAgentDropTarget = target;
-    currentAgentDropSectionId = sectionId;
-    setDragOverAgentId(target?.agentId ?? null);
-    setAgentDropSectionId(sectionId);
   }
 
   function computePersonDragOffsets(target: PersonDropTarget | null): Record<string, number> {
-    const sourceMemberId = activeDraggedPersonId();
+    // From the session rather than from `drag.source`: this runs in the same tick as the target
+    // writes that drive it, and a store publishes a write only at the next flush.
+    const source = dragSession?.source;
+    const sourceMemberId = source?.kind === "person" ? source.id : null;
     if (!sourceMemberId || !target) return {};
     const currentIds = filteredPeople().map((member) => member.id);
     const desiredIds = currentIds.filter((memberId) => memberId !== sourceMemberId);
@@ -894,7 +989,8 @@ export function Sidebar(props: SidebarProps) {
   }
 
   function computeSectionDragOffsets(target: SectionDropTarget | null): Record<string, number> {
-    const sourceSectionId = activeDraggedSectionId();
+    const source = dragSession?.source;
+    const sourceSectionId = source?.kind === "section" ? source.id : null;
     if (!sourceSectionId || !target) return {};
     const currentOrder = visibleSectionIds();
     const desiredOrder = currentOrder.filter((candidate) => candidate !== sourceSectionId);
@@ -920,8 +1016,10 @@ export function Sidebar(props: SidebarProps) {
     const currentTarget = currentSectionDropTarget;
     if (currentTarget?.sectionId === target?.sectionId && currentTarget?.placement === target?.placement) return;
     currentSectionDropTarget = target;
-    setSectionDropTarget(target);
-    setSectionDragOffsets(computeSectionDragOffsets(target));
+    const offsets = computeSectionDragOffsets(target);
+    setDrag((state) => {
+      state.sectionOffsets = offsets;
+    });
   }
 
   function targetAgentAt(sourceAgentId: string, agentId: string, clientY: number): AgentDropTarget | null {
@@ -993,7 +1091,6 @@ export function Sidebar(props: SidebarProps) {
   }
 
   function draggedSidebarItem(): SidebarPinnedItem | null {
-    if (draggedPinnedKey()) return null;
     const agentId = draggedAgentId();
     return agentId ? { kind: "agent", id: agentId } : null;
   }
@@ -1133,14 +1230,9 @@ export function Sidebar(props: SidebarProps) {
   function applySidebarDropTarget(target: SidebarDropTarget | null): void {
     if (sidebarDropTargetsEqual(dragTarget, target)) return;
     dragTarget = target;
-    const source = dragSession?.source;
-    const pinningFromSidebar = Boolean(source && "origin" in source && source.origin !== "pinned");
-    setPinnedDropActive(target?.kind === "pinned" && pinningFromSidebar && canPinDraggedSidebarItem());
-    setDragOverPinnedKey(target?.kind === "pinned" ? target.key : null);
-    if (target?.kind === "agent") setAgentTarget(target.target, target.target.sectionId);
-    else if (target?.kind === "section" && dragSession?.source.kind === "agent") {
-      setAgentTarget(null, target.sectionId);
-    } else setAgentTarget(null, null);
+    setDrag((state) => {
+      state.target = target;
+    });
     if (target?.kind === "person") setPersonTarget(target.target);
     else setPersonTarget(null);
     if (target?.kind === "section-order") setSectionTarget(target.target);
@@ -1178,7 +1270,7 @@ export function Sidebar(props: SidebarProps) {
       return;
     }
     applySidebarDropTarget(resolveSidebarDropTarget(dragPoint));
-    updateScrollFade();
+    scrollFades.measure();
     dragScrollFrame = requestAnimationFrame(runSidebarDragAutoScroll);
   }
 
@@ -1286,13 +1378,15 @@ export function Sidebar(props: SidebarProps) {
   function updateSidebarNativeDrag(event: DragEvent): void {
     if (!dragSession) return;
     if (
-      !emptyPinnedDropVisible() &&
+      !drag.emptyPinnedDropVisible &&
       agentPinnedItems().length === 0 &&
       dragSession.source.kind === "agent" &&
       dragSession.source.origin === "section"
     ) {
       const activeSession = dragSession;
-      setEmptyPinnedDropVisible(true);
+      setDrag((state) => {
+        state.emptyPinnedDropVisible = true;
+      });
       queueMicrotask(() => {
         if (dragSession !== activeSession) return;
         measureSidebarDragTargets();
@@ -1312,8 +1406,8 @@ export function Sidebar(props: SidebarProps) {
     if (!dragSession) return;
     event.preventDefault();
     event.stopPropagation();
-    const animatedPinnedTarget = emptyPinnedDropVisible() && dragTarget?.kind === "pinned" ? dragTarget : null;
-    if (emptyPinnedDropVisible() && !animatedPinnedTarget) measureSidebarDragTargets();
+    const animatedPinnedTarget = drag.emptyPinnedDropVisible && dragTarget?.kind === "pinned" ? dragTarget : null;
+    if (drag.emptyPinnedDropVisible && !animatedPinnedTarget) measureSidebarDragTargets();
     const target = animatedPinnedTarget ?? flushSidebarDragTarget({ clientX: event.clientX, clientY: event.clientY });
     commitSidebarDrop(target);
     suppressSidebarClickUntil = Date.now() + 250;
@@ -1322,7 +1416,7 @@ export function Sidebar(props: SidebarProps) {
 
   function endAgentDragging(event: DragEvent): void {
     const canCommitAnimatedPin =
-      emptyPinnedDropVisible() &&
+      drag.emptyPinnedDropVisible &&
       dragSession?.source.kind === "agent" &&
       dragSession.source.origin === "section" &&
       dragTarget?.kind === "pinned" &&
@@ -1336,7 +1430,7 @@ export function Sidebar(props: SidebarProps) {
   }
 
   function sectionDragOffset(sectionId: string): number {
-    return sectionDragOffsets()[sectionId] ?? 0;
+    return drag.sectionOffsets[sectionId] ?? 0;
   }
 
   function sectionDragClasses(sectionId: string) {
@@ -1500,12 +1594,7 @@ export function Sidebar(props: SidebarProps) {
               </ContextMenu.Portal>
             </ContextMenu.Sub>
           </Show>
-          <ContextMenu.Item
-            onSelect={() => {
-              setDeleteError(null);
-              props.onEditBot(bot.id);
-            }}
-          >
+          <ContextMenu.Item onSelect={() => props.onEditBot(bot.id)}>
             <EditIcon />
             <span>Edit agent</span>
           </ContextMenu.Item>
@@ -1521,10 +1610,7 @@ export function Sidebar(props: SidebarProps) {
           <ContextMenu.Separator />
           <ContextMenu.Item
             class="ui-action-menu-danger bot-context-danger"
-            onSelect={() => {
-              setDeleteError(null);
-              setDeleteTargetId(bot.id);
-            }}
+            onSelect={() => openDelete("agent", bot.id)}
           >
             <DeleteIcon />
             <span>Delete agent</span>
@@ -1562,10 +1648,7 @@ export function Sidebar(props: SidebarProps) {
               <ContextMenu.Separator />
               <ContextMenu.Item
                 class="ui-action-menu-danger bot-context-danger"
-                onSelect={() => {
-                  setSectionDeleteError(null);
-                  setSectionDeleteTargetId(sectionId);
-                }}
+                onSelect={() => openDelete("section", sectionId)}
               >
                 <Trash2 class="bot-context-icon bot-context-danger-icon size-4" aria-hidden="true" />
                 <span>Delete</span>
@@ -1578,21 +1661,25 @@ export function Sidebar(props: SidebarProps) {
   }
 
   function sectionEditorHeader() {
+    const editor = () => pending.sectionEditor;
     return (
       <header class="sidebar-section-editor-wrap">
         <Input
           ref={(element) => (sectionNameInput = element)}
           class="sidebar-section-editor"
-          value={sectionName()}
+          value={editor()?.name ?? ""}
           onValueChange={(value) => {
-            setSectionName(value);
-            if (sectionNameError()) setSectionNameError(null);
+            setPending((state) => {
+              if (!state.sectionEditor) return;
+              state.sectionEditor.name = value;
+              state.sectionEditor.error = null;
+            });
           }}
           maxlength={INPUT_LIMITS.sidebarSectionName}
-          aria-label={sectionEditor()?.kind === "rename" ? "Rename section" : "New section name"}
-          aria-invalid={sectionNameError() ? "true" : undefined}
-          title={sectionNameError() ?? undefined}
-          disabled={savingSection()}
+          aria-label={editor()?.target.kind === "rename" ? "Rename section" : "New section name"}
+          aria-invalid={editor()?.error ? "true" : undefined}
+          title={editor()?.error ?? undefined}
+          disabled={editor()?.saving === true}
           onKeyDown={(event) => {
             if (event.key === "Enter") {
               event.preventDefault();
@@ -1605,7 +1692,7 @@ export function Sidebar(props: SidebarProps) {
           onBlur={cancelSectionEditor}
         />
         <ChevronDown class="sidebar-section-editor-chevron size-4" aria-hidden="true" />
-        <Show when={sectionNameError()}>
+        <Show when={editor()?.error}>
           {(message) => (
             <span class="sr-only" role="alert">
               {message()}
@@ -1618,8 +1705,8 @@ export function Sidebar(props: SidebarProps) {
 
   function sectionHeader(sectionId: string, name: string) {
     const editing = () => {
-      const editor = sectionEditor();
-      return editor?.kind === "rename" && editor.sectionId === sectionId;
+      const target = pending.sectionEditor?.target;
+      return target?.kind === "rename" && target.sectionId === sectionId;
     };
     const collapsed = () => sectionIsCollapsed(sectionId);
     return (
@@ -1809,26 +1896,13 @@ export function Sidebar(props: SidebarProps) {
       </div>
 
       <nav
-        ref={(element) => (botList = element)}
+        ref={(element) => {
+          botList = element;
+          scrollFades.bind(element);
+        }}
         aria-label="Chat list"
-        class={[
-          "bot-list",
-          {
-            "scroll-fade-top": fadeAtTop(),
-            "scroll-fade-bottom": fadeAtBottom(),
-          },
-        ]}
-        data-sidebar-dragging={
-          draggedPinnedKey()
-            ? "pinned"
-            : draggedAgentId()
-              ? "agent"
-              : draggedPersonId()
-                ? "person"
-                : draggedSectionId()
-                  ? "section"
-                  : undefined
-        }
+        class={["bot-list", scrollFades.classes()]}
+        data-sidebar-dragging={draggingKind()}
         onDragOver={updateSidebarNativeDrag}
         onDragLeave={(event) => {
           const point = { clientX: event.clientX, clientY: event.clientY };
@@ -1836,7 +1910,7 @@ export function Sidebar(props: SidebarProps) {
           scheduleSidebarDragTarget(point);
         }}
         onDrop={dropSidebarNativeDrag}
-        onScroll={() => updateScrollFade()}
+        onScroll={scrollFades.measure}
       >
         <div class="bot-list-content">
           <Show
@@ -1844,7 +1918,7 @@ export function Sidebar(props: SidebarProps) {
               resolvedPinnedItems().length > 0 ||
               filteredBots().length > 0 ||
               (props.showPeople !== false && filteredPeople().length > 0) ||
-              sectionEditor()?.kind === "create"
+              pending.sectionEditor?.target.kind === "create"
             }
             fallback={
               <Show
@@ -1884,13 +1958,13 @@ export function Sidebar(props: SidebarProps) {
               </Show>
             }
           >
-            <Show when={resolvedPinnedItems().length > 0 || emptyPinnedDropVisible()}>
+            <Show when={resolvedPinnedItems().length > 0 || drag.emptyPinnedDropVisible}>
               <section
                 class={[
                   "sidebar-chat-group sidebar-pinned-group",
                   {
                     "sidebar-pinned-group-agent-drop-target": pinnedDropActive(),
-                    "sidebar-pinned-group-empty-target": emptyPinnedDropVisible(),
+                    "sidebar-pinned-group-empty-target": drag.emptyPinnedDropVisible,
                   },
                 ]}
                 aria-label="Pinned chats"
@@ -1902,7 +1976,7 @@ export function Sidebar(props: SidebarProps) {
                 }}
               >
                 <ul class="sidebar-pinned-list" data-dragging={draggedPinnedKey() ? "" : undefined}>
-                  <Show when={emptyPinnedDropVisible()}>
+                  <Show when={drag.emptyPinnedDropVisible}>
                     <li class="sidebar-pinned-empty-drop">Drag here to pin</li>
                   </Show>
                   <For each={resolvedPinnedItems()}>
@@ -1929,9 +2003,6 @@ export function Sidebar(props: SidebarProps) {
                               data: key(),
                               source: { kind: "agent", id: item.bot.id, key: key(), origin: "pinned" },
                             });
-                            setPinnedDropActive(false);
-                            setDraggedPinnedKey(key());
-                            setDragOverPinnedKey(key());
                           }}
                           onDragEnd={stopSidebarDragging}
                           onKeyDown={(event) => {
@@ -2115,7 +2186,7 @@ export function Sidebar(props: SidebarProps) {
                 );
               }}
             </For>
-            <Show when={sectionEditor()?.kind === "create"}>
+            <Show when={pending.sectionEditor?.target.kind === "create"}>
               <section class="sidebar-chat-group sidebar-section sidebar-section-draft" aria-label="New section">
                 {sectionEditorHeader()}
               </section>
@@ -2143,7 +2214,7 @@ export function Sidebar(props: SidebarProps) {
       <AlertDialog.Root
         open={Boolean(deleteTarget())}
         onOpenChange={(open) => {
-          if (!open && !deleting()) setDeleteTargetId(null);
+          if (!open && !deleting()) closeDelete();
         }}
       >
         <Show when={deleteTarget()}>
@@ -2166,12 +2237,7 @@ export function Sidebar(props: SidebarProps) {
                   </AlertDialog.Description>
                   <Show when={deleteError()}>{(message) => <p class="bot-delete-error">{message()}</p>}</Show>
                   <div class="bot-delete-actions">
-                    <Button
-                      variant="outline"
-                      type="button"
-                      disabled={deleting()}
-                      onClick={() => setDeleteTargetId(null)}
-                    >
+                    <Button variant="outline" type="button" disabled={deleting()} onClick={closeDelete}>
                       Cancel
                     </Button>
                     <Button
@@ -2194,7 +2260,7 @@ export function Sidebar(props: SidebarProps) {
       <AlertDialog.Root
         open={Boolean(sectionDeleteTarget())}
         onOpenChange={(open) => {
-          if (!open && !deletingSection()) setSectionDeleteTargetId(null);
+          if (!open && !deleting()) closeDelete();
         }}
       >
         <Show when={sectionDeleteTarget()}>
@@ -2209,24 +2275,19 @@ export function Sidebar(props: SidebarProps) {
                   <AlertDialog.Description>
                     Agents in this section will move to Unassigned. No agents will be deleted.
                   </AlertDialog.Description>
-                  <Show when={sectionDeleteError()}>{(message) => <p class="bot-delete-error">{message()}</p>}</Show>
+                  <Show when={deleteError()}>{(message) => <p class="bot-delete-error">{message()}</p>}</Show>
                   <div class="bot-delete-actions">
-                    <Button
-                      variant="outline"
-                      type="button"
-                      disabled={deletingSection()}
-                      onClick={() => setSectionDeleteTargetId(null)}
-                    >
+                    <Button variant="outline" type="button" disabled={deleting()} onClick={closeDelete}>
                       Cancel
                     </Button>
                     <Button
                       variant="destructive"
                       type="button"
                       class="bot-delete-confirm"
-                      disabled={deletingSection()}
+                      disabled={deleting()}
                       onClick={() => void confirmSectionDelete()}
                     >
-                      {deletingSection() ? "Deleting…" : "Delete"}
+                      {deleting() ? "Deleting…" : "Delete"}
                     </Button>
                   </div>
                 </AlertDialog.Content>

--- a/src/renderer/src/components/SkillsMarketplaceModal.tsx
+++ b/src/renderer/src/components/SkillsMarketplaceModal.tsx
@@ -13,11 +13,12 @@ import type {
   SkillSubmission,
 } from "@openbot/contracts/ipc";
 import { isSkillCategory, SKILL_CATEGORIES } from "@openbot/contracts/ipc";
-import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, createStore, For, onCleanup, Show, snapshot } from "solid-js";
 import { desktopAnalytics } from "../analytics";
 import { normalizeAvatarFile } from "../avatar-image";
 import { AgentAvatar } from "./AgentAvatar";
 import { routineScheduleSummary } from "./conversation/routine-schedule-ui";
+import { createAsyncPanel } from "./createAsyncPanel";
 import {
   ArrowLeft,
   Button,
@@ -60,64 +61,110 @@ const CATEGORY_LABELS: Record<SkillCategory, string> = {
   other: "Other",
 };
 
+/**
+ * What the detail layer shows. Three signals allowed a combination the product does not have - a
+ * loaded skill and a loaded submission at once - and turned "is anything open" into a chain of
+ * three reads that every caller had to spell the same way.
+ */
+type SkillDetail =
+  | { kind: "none" }
+  | { kind: "loading" }
+  | { kind: "skill"; skill: MarketplaceSkillDetail }
+  | { kind: "submission"; submission: SkillSubmission };
+
+/** Which listing is on screen and what narrows it: every field a tab switch resets together. */
+interface SkillsBrowse {
+  category: SkillCategory | null;
+  kind: MarketplaceKind;
+  query: string;
+  tab: Tab;
+  targetBotId: string;
+}
+
+/** The publish form. Meaningful only while `preview` holds a chosen package, and cleared with it. */
+interface SkillPublication {
+  category: SkillCategory;
+  icon: AvatarImageInput | null;
+  iconPreviewUrl: string | null;
+  preview: SkillPackagePreview | null;
+  skillId: string | undefined;
+}
+
+/** Everything the skills half of the marketplace shows, grouped by the surface that owns it. */
+interface SkillsMarketplace {
+  browse: SkillsBrowse;
+  detail: SkillDetail;
+  installed: InstalledSkill[];
+  publication: SkillPublication;
+  skills: MarketplaceSkillSummary[];
+  submissions: SkillSubmission[];
+}
+
 export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
-  const [kind, setKind] = createSignal<MarketplaceKind>("skills");
-  const [tab, setTab] = createSignal<Tab>("discover");
-  const [skills, setSkills] = createSignal<MarketplaceSkillSummary[]>([]);
-  const [submissions, setSubmissions] = createSignal<SkillSubmission[]>([]);
-  const [installed, setInstalled] = createSignal<InstalledSkill[]>([]);
-  const [query, setQuery] = createSignal("");
-  const [category, setCategory] = createSignal<SkillCategory | null>(null);
-  const [targetBotId, setTargetBotId] = createSignal("");
-  const [loading, setLoading] = createSignal(false);
-  const [busyId, setBusyId] = createSignal<string | null>(null);
-  const [detail, setDetail] = createSignal<MarketplaceSkillDetail | null>(null);
-  const [submissionDetail, setSubmissionDetail] = createSignal<SkillSubmission | null>(null);
-  const [detailLoading, setDetailLoading] = createSignal(false);
-  const [error, setError] = createSignal<string | null>(null);
-  const [preview, setPreview] = createSignal<SkillPackagePreview | null>(null);
-  const [publishCategory, setPublishCategory] = createSignal<SkillCategory>("other");
-  const [publishIcon, setPublishIcon] = createSignal<AvatarImageInput | null>(null);
-  const [publishIconPreviewUrl, setPublishIconPreviewUrl] = createSignal<string | null>(null);
-  const [publishSkillId, setPublishSkillId] = createSignal<string | undefined>();
+  const [market, setMarket] = createStore<SkillsMarketplace>({
+    browse: { category: null, kind: "skills", query: "", tab: "discover", targetBotId: "" },
+    detail: { kind: "none" },
+    installed: [],
+    publication: { category: "other", icon: null, iconPreviewUrl: null, preview: null, skillId: undefined },
+    skills: [],
+    submissions: [],
+  });
+  /** Pulse counters, not marketplace state: each one asks the agent panel to do something once. */
   const [agentRefreshVersion, setAgentRefreshVersion] = createSignal(0);
   const [agentAddVersion, setAgentAddVersion] = createSignal(0);
+  const { panel, run, setBusy, setError, setLoading } = createAsyncPanel(marketplaceErrorMessage);
   let marketplaceBody: HTMLDivElement | undefined;
   let listScrollTop = 0;
   let searchTimer: number | undefined;
   let searchInitialized = false;
 
-  const installedById = createMemo(() => new Map(installed().map((item) => [item.skillId, item])));
-  const targetBot = createMemo(() => props.bots.find((bot) => bot.id === targetBotId()) ?? null);
+  const installedById = createMemo(() => new Map(market.installed.map((item) => [item.skillId, item])));
+  const targetBot = createMemo(() => props.bots.find((bot) => bot.id === market.browse.targetBotId) ?? null);
+  // The arms of the detail union, so the JSX narrows here once instead of at every read.
+  const detailOpen = () => market.detail.kind !== "none";
+  const detailLoading = () => market.detail.kind === "loading";
+  const skillDetail = () => (market.detail.kind === "skill" ? market.detail.skill : null);
+  const submissionDetail = () => (market.detail.kind === "submission" ? market.detail.submission : null);
+
+  function setQuery(value: string): void {
+    setMarket((state) => {
+      state.browse.query = value;
+    });
+  }
+
+  function setTargetBotId(botId: string): void {
+    setMarket((state) => {
+      state.browse.targetBotId = botId;
+    });
+  }
 
   createEffect(
     () => props.open,
     (open) => {
       if (!open) {
-        setDetail(null);
-        setSubmissionDetail(null);
+        closeDetail();
         return;
       }
-      setTargetBotId((current) => current || props.activeBotId || props.bots[0]?.id || "");
+      setTargetBotId(market.browse.targetBotId || props.activeBotId || props.bots[0]?.id || "");
       void loadSkills();
     },
   );
 
   createEffect(
-    () => query(),
+    () => market.browse.query,
     () => {
       if (searchTimer !== undefined) window.clearTimeout(searchTimer);
       if (!searchInitialized) {
         searchInitialized = true;
         return;
       }
-      if (!props.open || tab() !== "discover") return;
+      if (!props.open || market.browse.tab !== "discover") return;
       searchTimer = window.setTimeout(() => void loadSkills(), SKILLS_SEARCH_DEBOUNCE_MS);
     },
   );
 
   createEffect(
-    () => [props.open, targetBotId()] as const,
+    () => [props.open, market.browse.targetBotId] as const,
     ([open, botId]) => {
       if (open && botId) void loadInstalled(botId);
       else setInstalled([]);
@@ -128,31 +175,31 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
     if (searchTimer !== undefined) window.clearTimeout(searchTimer);
   });
 
-  function clearPublishIcon() {
-    setPublishIcon(null);
-    setPublishIconPreviewUrl(null);
+  /** Clears the detail layer whichever arm it is on. */
+  function closeDetail(): void {
+    setMarket((state) => {
+      state.detail = { kind: "none" };
+    });
+  }
+
+  function setInstalled(items: InstalledSkill[]): void {
+    setMarket((state) => {
+      state.installed = items;
+    });
   }
 
   function selectCategory(nextCategory: SkillCategory | null) {
     if (searchTimer !== undefined) window.clearTimeout(searchTimer);
-    setCategory(nextCategory);
+    setMarket((state) => {
+      state.browse.category = nextCategory;
+    });
     void loadSkills();
-  }
-
-  async function run<T>(work: () => Promise<T>): Promise<T | undefined> {
-    setError(null);
-    try {
-      return await work();
-    } catch (cause) {
-      setError(marketplaceErrorMessage(cause));
-      return undefined;
-    }
   }
 
   async function loadSkills() {
     setLoading(true);
-    const search = query().trim();
-    const selectedCategory = category();
+    const search = market.browse.query.trim();
+    const selectedCategory = market.browse.category;
     const pages = await run(() =>
       selectedCategory
         ? Promise.all([
@@ -173,11 +220,16 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
             ),
           ),
     );
-    if (pages) setSkills(pages.flatMap((page) => page.skills));
+    if (pages) {
+      const skills = pages.flatMap((page) => page.skills);
+      setMarket((state) => {
+        state.skills = skills;
+      });
+    }
     setLoading(false);
   }
 
-  async function loadInstalled(botId = targetBotId()) {
+  async function loadInstalled(botId = market.browse.targetBotId) {
     if (!botId) {
       setInstalled([]);
       return;
@@ -189,48 +241,55 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
   async function loadMine() {
     setLoading(true);
     const values = await run(() => window.openbot.skills.listMine());
-    if (values) setSubmissions(values);
+    if (values) {
+      setMarket((state) => {
+        state.submissions = values;
+      });
+    }
     setLoading(false);
   }
 
-  function refresh(next: Tab = tab()) {
+  function refresh(next: Tab = market.browse.tab) {
     if (next === "discover") void loadSkills();
     if (next === "mine") void loadMine();
     if (next === "installed") void loadInstalled();
   }
 
   function selectTab(next: Tab) {
-    setTab(next);
+    const marketplaceKind = market.browse.kind;
     if (marketplaceBody) marketplaceBody.scrollTop = 0;
-    setDetail(null);
-    setSubmissionDetail(null);
-    setPreview(null);
-    clearPublishIcon();
+    setMarket((state) => {
+      state.browse.tab = next;
+      state.detail = { kind: "none" };
+      state.publication.preview = null;
+      state.publication.icon = null;
+      state.publication.iconPreviewUrl = null;
+    });
     setError(null);
-    if (kind() === "skills") refresh(next);
+    if (marketplaceKind === "skills") refresh(next);
   }
 
   function selectKind(next: MarketplaceKind) {
-    setKind(next);
-    setTab("discover");
     if (marketplaceBody) marketplaceBody.scrollTop = 0;
-    setDetail(null);
-    setSubmissionDetail(null);
-    setPreview(null);
+    setMarket((state) => {
+      state.browse.kind = next;
+      state.browse.tab = "discover";
+      state.detail = { kind: "none" };
+      state.publication.preview = null;
+    });
     setError(null);
     if (next === "skills") void loadSkills();
   }
 
   function enterDetails() {
-    if (!detail() && !submissionDetail() && !detailLoading()) {
+    if (!detailOpen()) {
       listScrollTop = marketplaceBody?.scrollTop ?? 0;
     }
     if (marketplaceBody) marketplaceBody.scrollTop = 0;
   }
 
   function leaveDetails() {
-    setDetail(null);
-    setSubmissionDetail(null);
+    closeDetail();
     queueMicrotask(() => {
       if (marketplaceBody) marketplaceBody.scrollTop = listScrollTop;
     });
@@ -239,9 +298,9 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
   async function openDetails(skill: MarketplaceSkillSummary) {
     const analytics = desktopAnalytics.scope();
     enterDetails();
-    setSubmissionDetail(null);
-    setDetail(null);
-    setDetailLoading(true);
+    setMarket((state) => {
+      state.detail = { kind: "loading" };
+    });
     const value = await run(() => window.openbot.skills.get(skill.id));
     analytics.track("marketplace_action", {
       entity: "skill",
@@ -249,22 +308,26 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
       result: value ? "succeeded" : "failed",
       ...(value ? {} : { failure_code: "load_failed" }),
     });
-    if (value) setDetail(value);
-    setDetailLoading(false);
-    if (!value) leaveDetails();
+    if (!value) {
+      leaveDetails();
+      return;
+    }
+    setMarket((state) => {
+      state.detail = { kind: "skill", skill: value };
+    });
   }
 
   async function openDetailsById(skillId: string) {
-    const summary = skills().find((skill) => skill.id === skillId);
+    const summary = market.skills.find((skill) => skill.id === skillId);
     if (summary) {
       await openDetails(summary);
       return;
     }
     enterDetails();
     const analytics = desktopAnalytics.scope();
-    setSubmissionDetail(null);
-    setDetail(null);
-    setDetailLoading(true);
+    setMarket((state) => {
+      state.detail = { kind: "loading" };
+    });
     const value = await run(() => window.openbot.skills.get(skillId));
     analytics.track("marketplace_action", {
       entity: "skill",
@@ -272,9 +335,13 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
       result: value ? "succeeded" : "failed",
       ...(value ? {} : { failure_code: "load_failed" }),
     });
-    if (value) setDetail(value);
-    setDetailLoading(false);
-    if (!value) leaveDetails();
+    if (!value) {
+      leaveDetails();
+      return;
+    }
+    setMarket((state) => {
+      state.detail = { kind: "skill", skill: value };
+    });
   }
 
   function openSubmissionDetails(submission: SkillSubmission) {
@@ -283,8 +350,9 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
       return;
     }
     enterDetails();
-    setDetail(null);
-    setSubmissionDetail(submission);
+    setMarket((state) => {
+      state.detail = { kind: "submission", submission };
+    });
   }
 
   async function install(
@@ -292,13 +360,13 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
     replaceModified = false,
     action: "install" | "update" = "install",
   ) {
-    const botId = targetBotId();
+    const botId = market.browse.targetBotId;
     if (!botId) {
       setError("Switch to Local and create an agent before installing skills.");
       return;
     }
     const analytics = desktopAnalytics.scope();
-    setBusyId(skill.id);
+    setBusy(skill.id);
     const result = await run(() => window.openbot.skills.install({ botId, skillId: skill.id, replaceModified }));
     analytics.track("marketplace_action", {
       entity: "skill",
@@ -307,13 +375,14 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
       ...(result ? {} : { failure_code: action === "update" ? "update_failed" : "install_failed" }),
     });
     if (result) await loadInstalled(botId);
-    setBusyId(null);
+    setBusy(null);
   }
 
   async function updateInstalled(item: InstalledSkill) {
     const analytics = desktopAnalytics.scope();
     const listing =
-      skills().find((skill) => skill.id === item.skillId) ?? (await run(() => window.openbot.skills.get(item.skillId)));
+      market.skills.find((skill) => skill.id === item.skillId) ??
+      (await run(() => window.openbot.skills.get(item.skillId)));
     if (!listing) {
       analytics.track("marketplace_action", {
         entity: "skill",
@@ -332,10 +401,10 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
     const modified = item.state === "modified";
     if (!window.confirm(modified ? `Delete ${item.name} and its local changes?` : `Uninstall ${item.name}?`)) return;
     const analytics = desktopAnalytics.scope();
-    setBusyId(item.skillId);
+    setBusy(item.skillId);
     const removed = await run(async () => {
       await window.openbot.skills.uninstall({
-        botId: targetBotId(),
+        botId: market.browse.targetBotId,
         skillId: item.skillId,
         ...(modified ? { removeModified: true } : {}),
       });
@@ -348,31 +417,35 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
       ...(removed ? {} : { failure_code: "uninstall_failed" }),
     });
     if (removed) await loadInstalled();
-    setBusyId(null);
+    setBusy(null);
   }
 
   async function choosePackage(skillId?: string) {
     const value = await run(() => window.openbot.skills.choosePackage());
     if (!value) return;
-    setPublishSkillId(skillId);
-    setPreview(value);
-    setPublishCategory(
-      skillId ? (submissions().find((item) => item.skillId === skillId)?.category ?? "other") : "other",
-    );
-    clearPublishIcon();
+    const category = skillId
+      ? (market.submissions.find((item) => item.skillId === skillId)?.category ?? "other")
+      : "other";
+    setMarket((state) => {
+      state.publication = { category, icon: null, iconPreviewUrl: null, preview: value, skillId };
+    });
   }
 
   async function submit() {
-    const value = preview();
+    const value = market.publication.preview;
     if (!value) return;
     const analytics = desktopAnalytics.scope();
-    setBusyId("publish");
+    const { category, skillId } = market.publication;
+    // The icon crosses to IPC, which structured-clones it, so it goes as a snapshot rather than as
+    // whatever the store hands back.
+    const icon = snapshot(market.publication.icon);
+    setBusy("publish");
     const created = await run(() =>
       window.openbot.skills.submit({
         draftId: value.draftId,
-        category: publishCategory(),
-        icon: publishIcon(),
-        ...(publishSkillId() ? { skillId: publishSkillId() } : {}),
+        category,
+        icon,
+        ...(skillId ? { skillId } : {}),
       }),
     );
     analytics.track("marketplace_action", {
@@ -382,19 +455,30 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
       ...(created ? {} : { failure_code: "publish_failed" }),
     });
     if (created) {
-      setPreview(null);
-      clearPublishIcon();
+      discardPublication();
       await loadMine();
     }
-    setBusyId(null);
+    setBusy(null);
   }
 
   async function chooseIcon(file: File | undefined) {
     if (!file) return;
     const icon = await run(() => normalizeAvatarFile(file));
     if (!icon) return;
-    setPublishIcon(icon);
-    setPublishIconPreviewUrl(avatarImageDataUrl(icon));
+    const iconPreviewUrl = avatarImageDataUrl(icon);
+    setMarket((state) => {
+      state.publication.icon = icon;
+      state.publication.iconPreviewUrl = iconPreviewUrl;
+    });
+  }
+
+  /** Drops the chosen package and the icon picked for it: neither outlives the other. */
+  function discardPublication(): void {
+    setMarket((state) => {
+      state.publication.preview = null;
+      state.publication.icon = null;
+      state.publication.iconPreviewUrl = null;
+    });
   }
 
   return (
@@ -407,20 +491,20 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
               <nav class="skills-marketplace-kind-tabs" aria-label="Marketplace content types">
                 <Button
                   class="skills-marketplace-kind-tab"
-                  data-active={kind() === "skills" ? "" : undefined}
+                  data-active={market.browse.kind === "skills" ? "" : undefined}
                   variant="ghost"
                   size="sm"
-                  aria-current={kind() === "skills" ? "page" : undefined}
+                  aria-current={market.browse.kind === "skills" ? "page" : undefined}
                   onClick={() => selectKind("skills")}
                 >
                   Skills
                 </Button>
                 <Button
                   class="skills-marketplace-kind-tab"
-                  data-active={kind() === "agents" ? "" : undefined}
+                  data-active={market.browse.kind === "agents" ? "" : undefined}
                   variant="ghost"
                   size="sm"
-                  aria-current={kind() === "agents" ? "page" : undefined}
+                  aria-current={market.browse.kind === "agents" ? "page" : undefined}
                   onClick={() => selectKind("agents")}
                 >
                   Agents
@@ -429,11 +513,11 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
               <span class="skills-marketplace-topbar-divider" aria-hidden="true" />
               <nav
                 class="skills-marketplace-view-tabs"
-                aria-label={`${kind() === "skills" ? "Skills" : "Agent"} views`}
+                aria-label={`${market.browse.kind === "skills" ? "Skills" : "Agent"} views`}
               >
                 <Button
                   class="skills-marketplace-tab"
-                  data-active={tab() === "discover" ? "" : undefined}
+                  data-active={market.browse.tab === "discover" ? "" : undefined}
                   variant="ghost"
                   size="sm"
                   onClick={() => selectTab("discover")}
@@ -442,7 +526,7 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                 </Button>
                 <Button
                   class="skills-marketplace-tab"
-                  data-active={tab() === "installed" ? "" : undefined}
+                  data-active={market.browse.tab === "installed" ? "" : undefined}
                   variant="ghost"
                   size="sm"
                   onClick={() => selectTab("installed")}
@@ -451,7 +535,7 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                 </Button>
                 <Button
                   class="skills-marketplace-tab"
-                  data-active={tab() === "mine" ? "" : undefined}
+                  data-active={market.browse.tab === "mine" ? "" : undefined}
                   variant="ghost"
                   size="sm"
                   onClick={() => selectTab("mine")}
@@ -461,9 +545,11 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
               </nav>
               <div class="skills-marketplace-actions">
                 <IconButton
-                  label={kind() === "skills" ? "Refresh skills" : "Refresh agents"}
+                  label={market.browse.kind === "skills" ? "Refresh skills" : "Refresh agents"}
                   variant="ghost"
-                  onClick={() => (kind() === "skills" ? refresh() : setAgentRefreshVersion((version) => version + 1))}
+                  onClick={() =>
+                    market.browse.kind === "skills" ? refresh() : setAgentRefreshVersion((version) => version + 1)
+                  }
                 >
                   <RefreshCw />
                 </IconButton>
@@ -472,11 +558,11 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                   size="sm"
                   onClick={() => {
                     selectTab("mine");
-                    if (kind() === "skills") void choosePackage();
+                    if (market.browse.kind === "skills") void choosePackage();
                     else setAgentAddVersion((version) => version + 1);
                   }}
                 >
-                  <Plus /> Add {kind() === "skills" ? "skill" : "agent"}
+                  <Plus /> Add {market.browse.kind === "skills" ? "skill" : "agent"}
                 </Button>
                 <IconButton label="Close marketplace" variant="ghost" onClick={() => props.onOpenChange(false)}>
                   <X />
@@ -486,37 +572,37 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
 
             <div
               class="skills-marketplace-body"
-              data-detail-open={detailLoading() || detail() || submissionDetail() ? "" : undefined}
+              data-detail-open={detailOpen() ? "" : undefined}
               ref={(element) => (marketplaceBody = element)}
             >
-              <Show when={kind() === "skills"}>
-                <Show when={tab() === "discover"}>
+              <Show when={market.browse.kind === "skills"}>
+                <Show when={market.browse.tab === "discover"}>
                   <section
                     class="skills-marketplace-discover"
                     aria-label="Discover skills"
-                    aria-hidden={detail() || detailLoading() ? "true" : undefined}
-                    inert={detail() || detailLoading() ? true : undefined}
+                    aria-hidden={skillDetail() || detailLoading() ? "true" : undefined}
+                    inert={skillDetail() || detailLoading() ? true : undefined}
                   >
                     <div class="skills-marketplace-heading">
                       <div>
                         <h1>Skills</h1>
                         <p>Give your agents focused capabilities for repeatable work.</p>
                       </div>
-                      <AgentSelect bots={props.bots} value={targetBotId()} onChange={setTargetBotId} />
+                      <AgentSelect bots={props.bots} value={market.browse.targetBotId} onChange={setTargetBotId} />
                     </div>
                     <div class="skills-marketplace-search">
                       <Search aria-hidden="true" />
                       <Input
                         aria-label="Search skills"
                         placeholder="Search skills"
-                        value={query()}
+                        value={market.browse.query}
                         onValueChange={setQuery}
                       />
                     </div>
                     <div class="skills-marketplace-categories">
                       <Button
                         size="sm"
-                        data-active={category() === null ? "" : undefined}
+                        data-active={market.browse.category === null ? "" : undefined}
                         onClick={() => selectCategory(null)}
                       >
                         All
@@ -525,7 +611,7 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                         {(item) => (
                           <Button
                             size="sm"
-                            data-active={category() === item ? "" : undefined}
+                            data-active={market.browse.category === item ? "" : undefined}
                             onClick={() => selectCategory(item)}
                           >
                             {CATEGORY_LABELS[item]}
@@ -533,19 +619,19 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                         )}
                       </For>
                     </div>
-                    <Show when={!loading()} fallback={<SkillsListSkeleton category={category()} />}>
+                    <Show when={!panel.loading} fallback={<SkillsListSkeleton category={market.browse.category} />}>
                       <Show
-                        when={skills().length}
+                        when={market.skills.length}
                         fallback={<div class="skills-marketplace-state">No skills match this search.</div>}
                       >
                         <Show
-                          when={category() === null}
+                          when={market.browse.category === null}
                           fallback={
                             <SkillCategorySection
-                              label={CATEGORY_LABELS[category() ?? "other"]}
-                              skills={skills()}
+                              label={CATEGORY_LABELS[market.browse.category ?? "other"]}
+                              skills={market.skills}
                               installedById={installedById()}
-                              busyId={busyId()}
+                              busyId={panel.busy}
                               onInstall={install}
                               onOpen={openDetails}
                             />
@@ -553,14 +639,14 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                         >
                           <For each={SKILL_CATEGORIES}>
                             {(item) => {
-                              const categorySkills = () => skills().filter((skill) => skill.category === item);
+                              const categorySkills = () => market.skills.filter((skill) => skill.category === item);
                               return (
                                 <Show when={categorySkills().length > 0}>
                                   <SkillCategorySection
                                     label={CATEGORY_LABELS[item]}
                                     skills={categorySkills()}
                                     installedById={installedById()}
-                                    busyId={busyId()}
+                                    busyId={panel.busy}
                                     onInstall={install}
                                     onOpen={openDetails}
                                   />
@@ -574,14 +660,14 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                   </section>
                 </Show>
 
-                <Show when={tab() === "installed"}>
+                <Show when={market.browse.tab === "installed"}>
                   <section class="skills-marketplace-panel">
                     <div class="skills-marketplace-heading">
                       <div>
                         <h1>Installed</h1>
                         <p>Manage marketplace-owned skills for one local agent.</p>
                       </div>
-                      <AgentSelect bots={props.bots} value={targetBotId()} onChange={setTargetBotId} />
+                      <AgentSelect bots={props.bots} value={market.browse.targetBotId} onChange={setTargetBotId} />
                     </div>
                     <Show
                       when={targetBot()}
@@ -592,7 +678,7 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                       }
                     >
                       <Show
-                        when={installed().length}
+                        when={market.installed.length}
                         fallback={
                           <div class="skills-marketplace-state">
                             No marketplace skills are installed for this agent.
@@ -600,7 +686,7 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                         }
                       >
                         <div class="skills-installed-list">
-                          <For each={installed()}>
+                          <For each={market.installed}>
                             {(item) => (
                               <article class="skills-installed-row">
                                 <Button
@@ -627,7 +713,7 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                                 </span>
                                 <Button
                                   size="sm"
-                                  loading={busyId() === item.skillId}
+                                  loading={panel.busy === item.skillId}
                                   onClick={() => void updateInstalled(item)}
                                 >
                                   <RefreshCw /> {item.state === "installed" ? "Repair" : "Update"}
@@ -648,7 +734,7 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                   </section>
                 </Show>
 
-                <Show when={tab() === "mine"}>
+                <Show when={market.browse.tab === "mine"}>
                   <section class="skills-marketplace-panel">
                     <div class="skills-marketplace-heading">
                       <div>
@@ -722,12 +808,12 @@ description: Turn merged work into clear, consistent release notes.
                         Limits: 5 skills total · 5 submitted versions per skill · 10 submitted versions per 24 hours
                       </p>
                     </section>
-                    <Show when={preview()}>
+                    <Show when={market.publication.preview}>
                       {(value) => (
                         <div class="skills-publish-card">
                           <div class="skills-publish-summary">
                             <Show
-                              when={publishIconPreviewUrl()}
+                              when={market.publication.iconPreviewUrl}
                               fallback={
                                 <span class="skills-marketplace-default-icon">
                                   <Puzzle />
@@ -753,10 +839,14 @@ description: Turn merged work into clear, consistent release notes.
                             <label class="skills-publish-category">
                               Category
                               <NativeSelect
-                                value={publishCategory()}
+                                value={market.publication.category}
                                 onChange={(event) => {
                                   const category = event.currentTarget.value;
-                                  if (isSkillCategory(category)) setPublishCategory(category);
+                                  if (isSkillCategory(category)) {
+                                    setMarket((state) => {
+                                      state.publication.category = category;
+                                    });
+                                  }
                                 }}
                               >
                                 <For each={SKILL_CATEGORIES}>
@@ -775,18 +865,12 @@ description: Turn merged work into clear, consistent release notes.
                             </label>
                           </div>
                           <div class="skills-publish-actions">
-                            <Button
-                              variant="ghost"
-                              onClick={() => {
-                                setPreview(null);
-                                clearPublishIcon();
-                              }}
-                            >
+                            <Button variant="ghost" onClick={discardPublication}>
                               Cancel
                             </Button>
                             <Button
                               variant="default"
-                              loading={busyId() === "publish"}
+                              loading={panel.busy === "publish"}
                               loadingLabel="Submitting…"
                               onClick={() => void submit()}
                             >
@@ -796,9 +880,9 @@ description: Turn merged work into clear, consistent release notes.
                         </div>
                       )}
                     </Show>
-                    <Show when={!preview()}>
+                    <Show when={!market.publication.preview}>
                       <Show
-                        when={submissions().length}
+                        when={market.submissions.length}
                         fallback={
                           <div class="skills-marketplace-state">
                             No submissions yet. Choose a skill folder or ZIP to publish.
@@ -806,7 +890,7 @@ description: Turn merged work into clear, consistent release notes.
                         }
                       >
                         <div class="skills-submission-list">
-                          <For each={submissions()}>
+                          <For each={market.submissions}>
                             {(item) => (
                               <article class="skills-submission-row">
                                 <Button
@@ -842,15 +926,15 @@ description: Turn merged work into clear, consistent release notes.
                     </Show>
                   </section>
                 </Show>
-                <Show when={detailLoading() || detail() || submissionDetail()}>
+                <Show when={detailOpen()}>
                   <div class="skills-marketplace-detail-layer">
                     <Show when={!detailLoading()} fallback={<SkillDetailSkeleton />}>
-                      <Show when={detail()} keyed>
+                      <Show when={skillDetail()} keyed>
                         {(skill) => (
                           <SkillDetailView
                             skill={skill}
                             installed={installedById().get(skill.id)}
-                            busy={busyId() === skill.id}
+                            busy={panel.busy === skill.id}
                             onBack={leaveDetails}
                             onInstall={install}
                           />
@@ -862,7 +946,7 @@ description: Turn merged work into clear, consistent release notes.
                     </Show>
                   </div>
                 </Show>
-                <Show when={error()}>
+                <Show when={panel.error}>
                   {(message) => (
                     <div class="skills-marketplace-error" role="alert">
                       {message()}
@@ -870,10 +954,10 @@ description: Turn merged work into clear, consistent release notes.
                   )}
                 </Show>
               </Show>
-              <Show when={kind() === "agents"}>
+              <Show when={market.browse.kind === "agents"}>
                 <AgentMarketplacePanel
                   bots={props.bots}
-                  view={tab()}
+                  view={market.browse.tab}
                   refreshVersion={agentRefreshVersion()}
                   addVersion={agentAddVersion()}
                   onInstalled={props.onAgentInstalled}
@@ -889,6 +973,20 @@ description: Turn merged work into clear, consistent release notes.
   );
 }
 
+/** The agent half's listing, its detail layer, and the one publication being prepared. */
+interface AgentsMarketplace {
+  agents: MarketplaceAgentSummary[];
+  detail: MarketplaceAgentDetail | null;
+  publication: {
+    /** The agent a new version is for, or `undefined` for a first submission. */
+    agentId: string | undefined;
+    preview: AgentPublicationPreview | null;
+    sourceBotId: string;
+  };
+  query: string;
+  submissions: AgentSubmission[];
+}
+
 function AgentMarketplacePanel(props: {
   bots: Array<Pick<BotSummary, "id" | "name" | "marketplaceSource">>;
   view: Tab;
@@ -898,16 +996,14 @@ function AgentMarketplacePanel(props: {
   onEnterDetail: () => void;
   onLeaveDetail: () => void;
 }) {
-  const [agents, setAgents] = createSignal<MarketplaceAgentSummary[]>([]);
-  const [submissions, setSubmissions] = createSignal<AgentSubmission[]>([]);
-  const [query, setQuery] = createSignal("");
-  const [detail, setDetail] = createSignal<MarketplaceAgentDetail | null>(null);
-  const [preview, setPreview] = createSignal<AgentPublicationPreview | null>(null);
-  const [sourceBotId, setSourceBotId] = createSignal(props.bots[0]?.id ?? "");
-  const [updateAgentId, setUpdateAgentId] = createSignal<string | undefined>();
-  const [loading, setLoading] = createSignal(false);
-  const [busy, setBusy] = createSignal(false);
-  const [error, setError] = createSignal<string | null>(null);
+  const [market, setMarket] = createStore<AgentsMarketplace>({
+    agents: [],
+    detail: null,
+    publication: { agentId: undefined, preview: null, sourceBotId: props.bots[0]?.id ?? "" },
+    query: "",
+    submissions: [],
+  });
+  const { panel, run, setBusy, setError, setLoading } = createAsyncPanel(marketplaceErrorMessage);
   const installedAgents = createMemo(
     () => new Map(props.bots.flatMap((bot) => (bot.marketplaceSource ? [[bot.marketplaceSource.agentId, bot]] : []))),
   );
@@ -918,8 +1014,10 @@ function AgentMarketplacePanel(props: {
   createEffect(
     () => [props.view, props.refreshVersion] as const,
     ([view]) => {
-      setDetail(null);
-      setPreview(null);
+      setMarket((state) => {
+        state.detail = null;
+        state.publication.preview = null;
+      });
       setError(null);
       if (view === "discover") void loadAgents();
       if (view === "mine") void loadMine();
@@ -940,35 +1038,36 @@ function AgentMarketplacePanel(props: {
     if (searchTimer !== undefined) window.clearTimeout(searchTimer);
   });
 
-  async function run<T>(work: () => Promise<T>): Promise<T | undefined> {
-    setError(null);
-    try {
-      return await work();
-    } catch (cause) {
-      setError(marketplaceErrorMessage(cause));
-      return undefined;
-    }
-  }
-
   async function loadAgents() {
     setLoading(true);
-    const search = query().trim();
+    const search = market.query.trim();
     const page = await run(() =>
       window.openbot.marketplaceAgents.list({ ...(search ? { query: search } : {}), limit: 50 }),
     );
-    if (page) setAgents(page.agents);
+    if (page) {
+      const agents = page.agents;
+      setMarket((state) => {
+        state.agents = agents;
+      });
+    }
     setLoading(false);
   }
 
   async function loadMine() {
     setLoading(true);
     const values = await run(() => window.openbot.marketplaceAgents.listMine());
-    if (values) setSubmissions(values);
+    if (values) {
+      setMarket((state) => {
+        state.submissions = values;
+      });
+    }
     setLoading(false);
   }
 
   function updateSearch(value: string) {
-    setQuery(value);
+    setMarket((state) => {
+      state.query = value;
+    });
     if (searchTimer !== undefined) window.clearTimeout(searchTimer);
     searchTimer = window.setTimeout(() => void loadAgents(), SKILLS_SEARCH_DEBOUNCE_MS);
   }
@@ -984,13 +1083,18 @@ function AgentMarketplacePanel(props: {
       result: value ? "succeeded" : "failed",
       ...(value ? {} : { failure_code: "load_failed" }),
     });
-    if (value) setDetail(value);
-    else props.onLeaveDetail();
+    if (value) {
+      setMarket((state) => {
+        state.detail = value;
+      });
+    } else props.onLeaveDetail();
     setLoading(false);
   }
 
   function closeAgent() {
-    setDetail(null);
+    setMarket((state) => {
+      state.detail = null;
+    });
     props.onLeaveDetail();
   }
 
@@ -1024,7 +1128,7 @@ function AgentMarketplacePanel(props: {
     )
       return;
     const analytics = desktopAnalytics.scope();
-    setBusy(true);
+    setBusy(agent.id);
     const value = await run(() =>
       window.openbot.marketplaceAgents.install({
         agentId: agent.id,
@@ -1040,7 +1144,7 @@ function AgentMarketplacePanel(props: {
       ...(value ? {} : { failure_code: updating ? "update_failed" : "install_failed" }),
     });
     if (value) await props.onInstalled?.(value.bot);
-    setBusy(false);
+    setBusy(null);
   }
 
   function installedAgent(agent: MarketplaceAgentSummary) {
@@ -1057,27 +1161,42 @@ function AgentMarketplacePanel(props: {
   }
 
   async function preparePublication(agentId?: string) {
-    const botId = sourceBotId() || props.bots[0]?.id;
+    const botId = market.publication.sourceBotId || props.bots[0]?.id;
     if (!botId) {
       setError("Switch to Local and choose an agent to publish.");
       return;
     }
-    setUpdateAgentId(agentId);
-    setBusy(true);
+    setMarket((state) => {
+      state.publication.agentId = agentId;
+    });
+    setBusy("publish");
     const value = await run(() => window.openbot.marketplaceAgents.preview(botId));
-    if (value) setPreview(value);
-    setBusy(false);
+    if (value) {
+      setMarket((state) => {
+        state.publication.preview = value;
+      });
+    }
+    setBusy(null);
+  }
+
+  /** Drops the previewed publication and the agent it was going to update. */
+  function discardPublication(): void {
+    setMarket((state) => {
+      state.publication.preview = null;
+      state.publication.agentId = undefined;
+    });
   }
 
   async function submitPublication() {
-    const value = preview();
+    const value = market.publication.preview;
     if (!value) return;
     const analytics = desktopAnalytics.scope();
-    setBusy(true);
+    const agentId = market.publication.agentId;
+    setBusy("submit");
     const result = await run(() =>
       window.openbot.marketplaceAgents.submit({
         botId: value.botId,
-        ...(updateAgentId() ? { agentId: updateAgentId() } : {}),
+        ...(agentId ? { agentId } : {}),
       }),
     );
     analytics.track("marketplace_action", {
@@ -1087,18 +1206,17 @@ function AgentMarketplacePanel(props: {
       ...(result ? {} : { failure_code: "publish_failed" }),
     });
     if (result) {
-      setPreview(null);
-      setUpdateAgentId(undefined);
+      discardPublication();
       await loadMine();
     }
-    setBusy(false);
+    setBusy(null);
   }
 
   return (
     <section class="skills-marketplace-panel agent-marketplace-panel" aria-label="Agent marketplace">
       <Show when={props.view === "discover"}>
         <Show
-          when={detail()}
+          when={market.detail}
           keyed
           fallback={
             <>
@@ -1113,18 +1231,18 @@ function AgentMarketplacePanel(props: {
                 <Input
                   aria-label="Search agents"
                   placeholder="Search agents"
-                  value={query()}
+                  value={market.query}
                   onValueChange={updateSearch}
                 />
               </div>
-              <Show when={!loading()} fallback={<div class="skills-marketplace-state">Loading agents…</div>}>
+              <Show when={!panel.loading} fallback={<div class="skills-marketplace-state">Loading agents…</div>}>
                 <Show
-                  when={agents().length}
+                  when={market.agents.length}
                   fallback={<div class="skills-marketplace-state">No agents match this search.</div>}
                 >
                   <AgentCardSection
-                    agents={agents()}
-                    busy={busy()}
+                    agents={market.agents}
+                    busy={panel.busy !== null}
                     action={agentAction}
                     onOpen={openAgent}
                     onInstall={installAgentSummary}
@@ -1153,7 +1271,7 @@ function AgentMarketplacePanel(props: {
                 </div>
                 <Button
                   disabled={agentAction(agent) === "Installed"}
-                  loading={busy()}
+                  loading={panel.busy !== null}
                   loadingLabel={agentAction(agent) === "Update" ? "Updating…" : "Installing…"}
                   onClick={() => void installAgent(agent)}
                 >
@@ -1253,8 +1371,13 @@ function AgentMarketplacePanel(props: {
             <span class="skills-agent-select-control">
               <NativeSelect
                 aria-label="Agent to publish"
-                value={sourceBotId()}
-                onChange={(event) => setSourceBotId(event.currentTarget.value)}
+                value={market.publication.sourceBotId}
+                onChange={(event) => {
+                  const botId = event.currentTarget.value;
+                  setMarket((state) => {
+                    state.publication.sourceBotId = botId;
+                  });
+                }}
                 disabled={!props.bots.length}
               >
                 <Show when={props.bots.length} fallback={<option value="">No local agents</option>}>
@@ -1263,12 +1386,12 @@ function AgentMarketplacePanel(props: {
               </NativeSelect>
               <ChevronDown aria-hidden="true" />
             </span>
-            <Button loading={busy()} onClick={() => void preparePublication()}>
+            <Button loading={panel.busy !== null} onClick={() => void preparePublication()}>
               <Plus /> Add agent
             </Button>
           </div>
         </div>
-        <Show when={preview()} keyed>
+        <Show when={market.publication.preview} keyed>
           {(value) => (
             <div class="skills-publish-card agent-publish-card">
               <div class="skills-publish-summary">
@@ -1283,24 +1406,28 @@ function AgentMarketplacePanel(props: {
               </div>
               <p>Conversation history, memories, model settings, and workspace files are not included.</p>
               <div class="skills-publish-actions">
-                <Button variant="ghost" onClick={() => setPreview(null)}>
+                <Button variant="ghost" onClick={discardPublication}>
                   Cancel
                 </Button>
-                <Button loading={busy()} loadingLabel="Submitting…" onClick={() => void submitPublication()}>
+                <Button
+                  loading={panel.busy !== null}
+                  loadingLabel="Submitting…"
+                  onClick={() => void submitPublication()}
+                >
                   Submit for review
                 </Button>
               </div>
             </div>
           )}
         </Show>
-        <Show when={!preview()}>
-          <Show when={!loading()} fallback={<div class="skills-marketplace-state">Loading submissions…</div>}>
+        <Show when={!market.publication.preview}>
+          <Show when={!panel.loading} fallback={<div class="skills-marketplace-state">Loading submissions…</div>}>
             <Show
-              when={submissions().length}
+              when={market.submissions.length}
               fallback={<div class="skills-marketplace-state">No agent submissions yet.</div>}
             >
               <div class="skills-submission-list">
-                <For each={submissions()}>
+                <For each={market.submissions}>
                   {(item) => (
                     <article class="skills-submission-row agent-submission-row">
                       <AgentAvatar seed={item.avatarSeed} hue={item.avatarHue} url={item.avatarUrl} motion="hover" />
@@ -1329,7 +1456,7 @@ function AgentMarketplacePanel(props: {
           </Show>
         </Show>
       </Show>
-      <Show when={error()}>
+      <Show when={panel.error}>
         {(message) => (
           <div class="skills-marketplace-error" role="alert">
             {message()}

--- a/src/renderer/src/components/SkillsMarketplaceModal.tsx
+++ b/src/renderer/src/components/SkillsMarketplaceModal.tsx
@@ -126,18 +126,6 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
   const skillDetail = () => (market.detail.kind === "skill" ? market.detail.skill : null);
   const submissionDetail = () => (market.detail.kind === "submission" ? market.detail.submission : null);
 
-  function setQuery(value: string): void {
-    setMarket((state) => {
-      state.browse.query = value;
-    });
-  }
-
-  function setTargetBotId(botId: string): void {
-    setMarket((state) => {
-      state.browse.targetBotId = botId;
-    });
-  }
-
   createEffect(
     () => props.open,
     (open) => {
@@ -145,7 +133,9 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
         closeDetail();
         return;
       }
-      setTargetBotId(market.browse.targetBotId || props.activeBotId || props.bots[0]?.id || "");
+      setMarket((state) => {
+        state.browse.targetBotId = state.browse.targetBotId || props.activeBotId || props.bots[0]?.id || "";
+      });
       void loadSkills();
     },
   );
@@ -167,7 +157,11 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
     () => [props.open, market.browse.targetBotId] as const,
     ([open, botId]) => {
       if (open && botId) void loadInstalled(botId);
-      else setInstalled([]);
+      else {
+        setMarket((state) => {
+          state.installed = [];
+        });
+      }
     },
   );
 
@@ -179,12 +173,6 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
   function closeDetail(): void {
     setMarket((state) => {
       state.detail = { kind: "none" };
-    });
-  }
-
-  function setInstalled(items: InstalledSkill[]): void {
-    setMarket((state) => {
-      state.installed = items;
     });
   }
 
@@ -231,11 +219,17 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
 
   async function loadInstalled(botId = market.browse.targetBotId) {
     if (!botId) {
-      setInstalled([]);
+      setMarket((state) => {
+        state.installed = [];
+      });
       return;
     }
     const values = await run(() => window.openbot.skills.listInstalled(botId));
-    if (values) setInstalled(values);
+    if (values) {
+      setMarket((state) => {
+        state.installed = values;
+      });
+    }
   }
 
   async function loadMine() {
@@ -588,7 +582,15 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                         <h1>Skills</h1>
                         <p>Give your agents focused capabilities for repeatable work.</p>
                       </div>
-                      <AgentSelect bots={props.bots} value={market.browse.targetBotId} onChange={setTargetBotId} />
+                      <AgentSelect
+                        bots={props.bots}
+                        value={market.browse.targetBotId}
+                        onChange={(botId) =>
+                          setMarket((state) => {
+                            state.browse.targetBotId = botId;
+                          })
+                        }
+                      />
                     </div>
                     <div class="skills-marketplace-search">
                       <Search aria-hidden="true" />
@@ -596,7 +598,11 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                         aria-label="Search skills"
                         placeholder="Search skills"
                         value={market.browse.query}
-                        onValueChange={setQuery}
+                        onValueChange={(value) =>
+                          setMarket((state) => {
+                            state.browse.query = value;
+                          })
+                        }
                       />
                     </div>
                     <div class="skills-marketplace-categories">
@@ -667,7 +673,15 @@ export function SkillsMarketplaceModal(props: SkillsMarketplaceModalProps) {
                         <h1>Installed</h1>
                         <p>Manage marketplace-owned skills for one local agent.</p>
                       </div>
-                      <AgentSelect bots={props.bots} value={market.browse.targetBotId} onChange={setTargetBotId} />
+                      <AgentSelect
+                        bots={props.bots}
+                        value={market.browse.targetBotId}
+                        onChange={(botId) =>
+                          setMarket((state) => {
+                            state.browse.targetBotId = botId;
+                          })
+                        }
+                      />
                     </div>
                     <Show
                       when={targetBot()}

--- a/src/renderer/src/components/conversation/AgentMemoriesModal.tsx
+++ b/src/renderer/src/components/conversation/AgentMemoriesModal.tsx
@@ -2,6 +2,7 @@ import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type { BotMemory } from "@openbot/contracts/ipc";
 import { createEffect, createSignal, For, onSettled, Show } from "solid-js";
 import { desktopAnalytics } from "../../analytics";
+import { createScrollFades } from "../createScrollFades";
 import { Button, Dialog, IconButton, Plus, Textarea, Trash2, X } from "../ui";
 
 interface AgentMemoriesModalProps {
@@ -22,31 +23,13 @@ export function AgentMemoriesModal(props: AgentMemoriesModalProps) {
   const [editingText, setEditingText] = createSignal("");
   const [savingId, setSavingId] = createSignal<string | null>(null);
   const [clearConfirmation, setClearConfirmation] = createSignal(false);
-  const [fadeAtTop, setFadeAtTop] = createSignal(false);
-  const [fadeAtBottom, setFadeAtBottom] = createSignal(false);
+  const scrollFades = createScrollFades();
   let modalContent: HTMLDivElement | undefined;
-  let memoryList: HTMLUListElement | undefined;
-  let memoryListResizeObserver: ResizeObserver | undefined;
   let newMemoryInput: HTMLTextAreaElement | undefined;
   let editingInput: HTMLTextAreaElement | undefined;
   let confirmationTrigger: HTMLButtonElement | undefined;
 
-  function updateScrollFades(): void {
-    if (!memoryList) return;
-    const remaining = memoryList.scrollHeight - memoryList.scrollTop - memoryList.clientHeight;
-    setFadeAtTop(memoryList.scrollTop > 2);
-    setFadeAtBottom(remaining > 2);
-  }
-
-  function bindMemoryList(element: HTMLUListElement): void {
-    memoryList = element;
-    memoryListResizeObserver?.disconnect();
-    memoryListResizeObserver = new ResizeObserver(updateScrollFades);
-    memoryListResizeObserver.observe(element);
-    window.requestAnimationFrame(updateScrollFades);
-  }
-
-  onSettled(() => () => memoryListResizeObserver?.disconnect());
+  onSettled(() => scrollFades.stop);
 
   async function loadMemories(showLoading = true): Promise<void> {
     if (showLoading) setLoading(true);
@@ -303,15 +286,9 @@ export function AgentMemoriesModal(props: AgentMemoriesModalProps) {
                   fallback={<p class="agent-memory-state">This agent has no saved memories yet.</p>}
                 >
                   <ul
-                    ref={bindMemoryList}
-                    class={[
-                      "agent-memory-list",
-                      {
-                        "scroll-fade-top": fadeAtTop(),
-                        "scroll-fade-bottom": fadeAtBottom(),
-                      },
-                    ]}
-                    onScroll={updateScrollFades}
+                    ref={scrollFades.bind}
+                    class={["agent-memory-list", scrollFades.classes()]}
+                    onScroll={scrollFades.measure}
                   >
                     <For each={memories()}>
                       {(memory) => (

--- a/src/renderer/src/components/conversation/AgentRoutinesSettings.tsx
+++ b/src/renderer/src/components/conversation/AgentRoutinesSettings.tsx
@@ -2,13 +2,12 @@ import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type { Routine, RoutineRun, RoutineSchedule } from "@openbot/contracts/ipc";
 import { createEffect, createSignal, For, onCleanup, onSettled, Show } from "solid-js";
 import { type DesktopAnalyticsScope, desktopAnalytics } from "../../analytics";
+import { createScrollFades } from "../createScrollFades";
 import { Button, CirclePause, Clock3, Dialog, Input, Plus, Switch, Textarea } from "../ui";
 import { BackIcon, SettingsForwardIcon } from "./ConversationIcons";
 import { RoutineRunHistory } from "./RoutineRunHistory";
 import { RoutineScheduleEditor } from "./RoutineScheduleEditor";
 import { defaultRoutineSchedule, routineScheduleSummary } from "./routine-schedule-ui";
-
-export type AgentRoutinesView = "list" | "editor";
 
 export interface RoutineSelectionRequest {
   routineId: string;
@@ -33,7 +32,6 @@ interface RoutineDraft {
 interface AgentRoutinesSettingsProps {
   botId: string;
   onCountChange: (count: number) => void;
-  onViewChange?: (view: AgentRoutinesView) => void;
   onBack?: () => void;
   onClose?: () => void;
   selectionRequest?: RoutineSelectionRequest | null;
@@ -54,35 +52,10 @@ export function AgentRoutinesSettings(props: AgentRoutinesSettingsProps) {
   const [confirmDelete, setConfirmDelete] = createSignal(false);
   const [scheduleExpanded, setScheduleExpanded] = createSignal(false);
   const [pendingExit, setPendingExit] = createSignal<PendingRoutineExit | null>(null);
-  const [fadeAtTop, setFadeAtTop] = createSignal(false);
-  const [fadeAtBottom, setFadeAtBottom] = createSignal(false);
-  let routinesBody: HTMLDivElement | undefined;
-  let routinesBodyResizeObserver: ResizeObserver | undefined;
+  const scrollFades = createScrollFades();
   let draftRevision = 0;
 
-  function updateScrollFades(): void {
-    if (!routinesBody) return;
-    const remaining = routinesBody.scrollHeight - routinesBody.scrollTop - routinesBody.clientHeight;
-    setFadeAtTop(routinesBody.scrollTop > 2);
-    setFadeAtBottom(remaining > 2);
-  }
-
-  function bindRoutinesBody(element: HTMLDivElement): void {
-    routinesBody = element;
-    routinesBodyResizeObserver?.disconnect();
-    routinesBodyResizeObserver = new ResizeObserver(updateScrollFades);
-    routinesBodyResizeObserver.observe(element);
-    window.requestAnimationFrame(updateScrollFades);
-  }
-
-  onCleanup(() => routinesBodyResizeObserver?.disconnect());
-
-  createEffect(
-    () => (draft() ? "editor" : "list"),
-    (view) => {
-      props.onViewChange?.(view);
-    },
-  );
+  onCleanup(scrollFades.stop);
 
   async function loadRoutines(): Promise<void> {
     try {
@@ -154,7 +127,7 @@ export function AgentRoutinesSettings(props: AgentRoutinesSettingsProps) {
   createEffect(
     () => [draft(), routines().length, runs().length, loading(), scheduleExpanded(), confirmDelete(), error()] as const,
     () => {
-      window.requestAnimationFrame(updateScrollFades);
+      scrollFades.remeasure();
     },
   );
 
@@ -400,17 +373,7 @@ export function AgentRoutinesSettings(props: AgentRoutinesSettingsProps) {
           </Button>
         </Show>
       </header>
-      <div
-        ref={bindRoutinesBody}
-        class={[
-          "agent-routines-body",
-          {
-            "scroll-fade-top": fadeAtTop(),
-            "scroll-fade-bottom": fadeAtBottom(),
-          },
-        ]}
-        onScroll={updateScrollFades}
-      >
+      <div ref={scrollFades.bind} class={["agent-routines-body", scrollFades.classes()]} onScroll={scrollFades.measure}>
         <Show
           when={draft()}
           fallback={

--- a/src/renderer/src/components/conversation/AgentSettingsPanel.test.tsx
+++ b/src/renderer/src/components/conversation/AgentSettingsPanel.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { STORY_AGENT_STATUS, STORY_BOTS, STORY_MODELS } from "../../preview/fixtures";
+import { createMockOpenBot, type MockOpenBotControls } from "../../preview/mock-openbot";
+import AgentSettingsPanel, { type AgentRuntimeSettings } from "./AgentSettingsPanel";
+
+let mock: MockOpenBotControls | undefined;
+
+afterEach(() => {
+  mock?.dispose();
+  mock = undefined;
+});
+
+describe("AgentSettingsPanel", () => {
+  it("restores the previous model when saving runtime settings fails", async () => {
+    mock = createMockOpenBot();
+    window.openbot = mock.api;
+    // Sol does not run under Claude, and Claude does not offer Extra high, so a rejected save has
+    // all three runtime fields to put back at once.
+    const runtimeSettings: AgentRuntimeSettings = {
+      provider: "codex",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "xhigh",
+    };
+    const onUpdateRuntimeSettings = vi.fn(async () => false);
+    render(() => (
+      <AgentSettingsPanel
+        bot={{ ...STORY_BOTS[0], provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "xhigh" }}
+        runtimeSettings={runtimeSettings}
+        agentStatus={STORY_AGENT_STATUS}
+        modelOptions={STORY_MODELS}
+        working={false}
+        maxWidth={() => 640}
+        onClose={vi.fn()}
+        onWidthChange={vi.fn()}
+        onUpdateBot={vi.fn(async () => undefined)}
+        onUpdateRuntimeSettings={onUpdateRuntimeSettings}
+        onSetAgentAvatar={vi.fn(async () => undefined)}
+      />
+    ));
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Agent model: Sol" }));
+    const dialog = screen.getByRole("dialog", { name: "Choose agent model" });
+    await fireEvent.click(within(dialog).getByRole("tab", { name: /^Claude:/ }));
+    await fireEvent.click(within(dialog).getByRole("option", { name: "Claude Sonnet 5" }));
+
+    await waitFor(() =>
+      expect(onUpdateRuntimeSettings).toHaveBeenCalledWith(
+        STORY_BOTS[0].id,
+        { provider: "claude", model: "claude-sonnet-5", reasoningEffort: "high" },
+        { provider: "claude", model: "claude-sonnet-5", reasoningEffort: "high" },
+      ),
+    );
+    await fireEvent.keyDown(dialog, { key: "Escape" });
+
+    expect(await screen.findByText("Could not save agent settings.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Agent model: Sol" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Agent reasoning level/ })).toHaveTextContent("Extra high");
+  });
+});

--- a/src/renderer/src/components/conversation/AgentSettingsPanel.tsx
+++ b/src/renderer/src/components/conversation/AgentSettingsPanel.tsx
@@ -10,7 +10,7 @@ import type {
   ProviderRuntimeStatus,
   UpdateBotInput,
 } from "@openbot/contracts/ipc";
-import { createEffect, createMemo, createSignal, For, onSettled, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, createStore, For, onSettled, Show } from "solid-js";
 import { normalizeAvatarFile } from "../../avatar-image";
 import { AVATAR_HUE_OPTIONS, avatarCandidateSeeds, avatarHueSwatch } from "../../bloub-avatar";
 import type { BotProfile } from "../../data";
@@ -31,7 +31,7 @@ import {
   Textarea,
 } from "../ui";
 import { AgentMemoriesModal } from "./AgentMemoriesModal";
-import { AgentRoutinesSettings, type AgentRoutinesView, type RoutineSelectionRequest } from "./AgentRoutinesSettings";
+import { AgentRoutinesSettings, type RoutineSelectionRequest } from "./AgentRoutinesSettings";
 import { BackIcon, SettingsForwardIcon } from "./ConversationIcons";
 
 const SETTINGS_PANEL_STORAGE_KEY = "openbot:settings-panel-width";
@@ -72,36 +72,105 @@ interface AgentSettingsPanelProps {
   onOpenRoutineRun?: (messageId: string) => void;
 }
 
+/** The three free-text fields of the panel, each with a flag for edits made since the last save. */
+interface AgentTextFields {
+  description: string;
+  name: string;
+  title: string;
+}
+
+interface AvatarEditor {
+  batch: number;
+  candidateSeed: string;
+  hue: BotAvatarHue | null;
+  pickerOpen: boolean;
+  seed: string;
+  uploadBusy: boolean;
+}
+
+/**
+ * Everything the panel is editing for the agent it currently shows. `fields` and `dirty` stay
+ * parallel records so the props sync can write every field the user has not touched; `runtime` is
+ * one record because the three settings are sent, and rolled back, together.
+ */
+interface AgentSettingsDraft {
+  avatar: AvatarEditor;
+  dirty: Record<keyof AgentTextFields, boolean>;
+  fields: AgentTextFields;
+  memories: { count: number; open: boolean };
+  notifications: boolean;
+  routines: { count: number; open: boolean };
+  runtime: AgentRuntimeSettings;
+  saveError: string | null;
+}
+
 export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
   const [panelWidth, setPanelWidth] = createSignal(
     readPanelWidth(SETTINGS_PANEL_STORAGE_KEY, SETTINGS_PANEL_DEFAULT, SETTINGS_PANEL_MIN, SETTINGS_PANEL_MAX),
   );
-  const [saveError, setSaveError] = createSignal<string | null>(null);
-  const [name, setName] = createSignal("");
-  const [title, setTitle] = createSignal("");
-  const [description, setDescription] = createSignal("");
-  const [dirty, setDirty] = createSignal({ name: false, title: false, description: false });
-  const [notifications, setNotifications] = createSignal(true);
-  const [provider, setProvider] = createSignal<AgentProviderId>(props.bot.provider);
-  const [model, setModel] = createSignal<AgentModelId>("gpt-5.6-luna");
-  const [reasoning, setReasoning] = createSignal<AgentReasoningEffort>("medium");
-  const [avatarPickerOpen, setAvatarPickerOpen] = createSignal(false);
-  const [avatarSeed, setAvatarSeed] = createSignal("agent");
-  const [avatarHue, setAvatarHue] = createSignal<BotAvatarHue | null>(null);
-  const [avatarUploadBusy, setAvatarUploadBusy] = createSignal(false);
-  const [avatarCandidateSeed, setAvatarCandidateSeed] = createSignal("agent");
-  const [avatarBatch, setAvatarBatch] = createSignal(0);
-  const [memoryModalOpen, setMemoryModalOpen] = createSignal(false);
-  const [memoryCount, setMemoryCount] = createSignal(0);
-  const [routinesOpen, setRoutinesOpen] = createSignal(false);
-  const [, setRoutineView] = createSignal<AgentRoutinesView>("list");
-  const [routineCount, setRoutineCount] = createSignal(0);
+  const [draft, setDraft] = createStore<AgentSettingsDraft>({
+    avatar: {
+      batch: 0,
+      candidateSeed: "agent",
+      hue: null,
+      pickerOpen: false,
+      seed: "agent",
+      uploadBusy: false,
+    },
+    dirty: { description: false, name: false, title: false },
+    fields: { description: "", name: "", title: "" },
+    memories: { count: 0, open: false },
+    notifications: true,
+    routines: { count: 0, open: false },
+    runtime: { model: "gpt-5.6-luna", provider: props.bot.provider, reasoningEffort: "medium" },
+    saveError: null,
+  });
   const avatarUrl = () => props.bot.avatarUrl ?? null;
+
+  function setSaveError(message: string | null): void {
+    setDraft((state) => {
+      state.saveError = message;
+    });
+  }
+
+  function setAvatarUploadBusy(busy: boolean): void {
+    setDraft((state) => {
+      state.avatar.uploadBusy = busy;
+    });
+  }
+
+  function setMemoryModalOpen(open: boolean): void {
+    setDraft((state) => {
+      state.memories.open = open;
+    });
+  }
+
+  function setMemoryCount(count: number): void {
+    setDraft((state) => {
+      state.memories.count = count;
+    });
+  }
+
+  function setRoutinesOpen(open: boolean): void {
+    setDraft((state) => {
+      state.routines.open = open;
+    });
+  }
+
+  function setRoutineCount(count: number): void {
+    setDraft((state) => {
+      state.routines.count = count;
+    });
+  }
   const selectedModel = createMemo(() =>
-    props.modelOptions.find((option) => option.provider === provider() && option.id === model()),
+    props.modelOptions.find(
+      (option) => option.provider === draft.runtime.provider && option.id === draft.runtime.model,
+    ),
   );
   const reasoningOptions = createMemo(() => selectedModel()?.supportedReasoningEfforts ?? ["medium" as const]);
-  const avatarCandidates = createMemo(() => avatarCandidateSeeds(props.bot.id, avatarCandidateSeed(), avatarBatch()));
+  const avatarCandidates = createMemo(() =>
+    avatarCandidateSeeds(props.bot.id, draft.avatar.candidateSeed, draft.avatar.batch),
+  );
   let avatarPickerRoot: HTMLDivElement | undefined;
   let avatarFileInput: HTMLInputElement | undefined;
   let lastSignature: string | undefined;
@@ -138,25 +207,39 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
     ({ bot, runtimeSettings, signature }) => {
       if (signature === lastSignature) return;
       const botChanged = bot.id !== lastBotId;
-      const currentDirty = botChanged ? { name: false, title: false, description: false } : dirty();
+      // A field the user has edited keeps its draft, unless this is a different agent, whose values
+      // replace the panel wholesale. Read before the write, so a fresh agent clears the flags here.
+      const keep = {
+        description: !botChanged && draft.dirty.description,
+        name: !botChanged && draft.dirty.name,
+        title: !botChanged && draft.dirty.title,
+      };
       lastSignature = signature;
       lastBotId = bot.id;
-      if (botChanged) setDirty(currentDirty);
-      if (!currentDirty.name) setName(bot.name);
-      if (!currentDirty.title) setTitle(bot.title);
-      if (!currentDirty.description) setDescription(bot.description);
-      setNotifications(bot.notifications);
-      setProvider(runtimeSettings.provider);
-      setModel(runtimeSettings.model);
-      setReasoning(runtimeSettings.reasoningEffort);
-      setAvatarSeed(bot.avatarSeed);
-      setAvatarHue(bot.avatarHue);
+      setDraft((state) => {
+        if (botChanged) {
+          state.dirty.description = false;
+          state.dirty.name = false;
+          state.dirty.title = false;
+        }
+        if (!keep.name) state.fields.name = bot.name;
+        if (!keep.title) state.fields.title = bot.title;
+        if (!keep.description) state.fields.description = bot.description;
+        state.notifications = bot.notifications;
+        state.runtime.provider = runtimeSettings.provider;
+        state.runtime.model = runtimeSettings.model;
+        state.runtime.reasoningEffort = runtimeSettings.reasoningEffort;
+        state.avatar.seed = bot.avatarSeed;
+        state.avatar.hue = bot.avatarHue;
+        if (botChanged) {
+          state.avatar.candidateSeed = bot.avatarSeed;
+          state.avatar.batch = 0;
+          state.avatar.pickerOpen = false;
+          state.memories.open = false;
+          state.routines.open = false;
+        }
+      });
       if (botChanged) {
-        setAvatarCandidateSeed(bot.avatarSeed);
-        setAvatarBatch(0);
-        setAvatarPickerOpen(false);
-        setMemoryModalOpen(false);
-        setRoutinesOpen(false);
         void window.openbot.agent
           .listMemories(bot.id)
           .then((items) => setMemoryCount(items.length))
@@ -178,9 +261,11 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
 
   onSettled(() => {
     const closeAvatarPicker = (event: PointerEvent) => {
-      if (!avatarPickerOpen()) return;
+      if (!draft.avatar.pickerOpen) return;
       if (event.target instanceof Node && avatarPickerRoot?.contains(event.target)) return;
-      setAvatarPickerOpen(false);
+      setDraft((state) => {
+        state.avatar.pickerOpen = false;
+      });
     };
     window.addEventListener("pointerdown", closeAvatarPicker);
     return () => window.removeEventListener("pointerdown", closeAvatarPicker);
@@ -217,38 +302,48 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
 
   function saveName(): void {
     const botId = props.bot.id;
-    const value = name().trim() || "New agent";
-    setName(value);
+    const value = draft.fields.name.trim() || "New agent";
+    setDraft((state) => {
+      state.fields.name = value;
+    });
     void saveBotPatch({ name: value }).then((saved) => {
-      if (saved && props.bot.id === botId && name() === value) {
-        setDirty((current) => ({ ...current, name: false }));
+      if (saved && props.bot.id === botId && draft.fields.name === value) {
+        setDraft((state) => {
+          state.dirty.name = false;
+        });
       }
     });
   }
 
   function saveTitle(): void {
     const botId = props.bot.id;
-    const value = title().trim();
-    setTitle(value);
+    const value = draft.fields.title.trim();
+    setDraft((state) => {
+      state.fields.title = value;
+    });
     void saveBotPatch({ title: value }).then((saved) => {
-      if (saved && props.bot.id === botId && title() === value) {
-        setDirty((current) => ({ ...current, title: false }));
+      if (saved && props.bot.id === botId && draft.fields.title === value) {
+        setDraft((state) => {
+          state.dirty.title = false;
+        });
       }
     });
   }
 
   function saveDescription(): void {
     const botId = props.bot.id;
-    const value = description();
+    const value = draft.fields.description;
     void saveBotPatch({ description: value }).then((saved) => {
-      if (saved && props.bot.id === botId && description() === value) {
-        setDirty((current) => ({ ...current, description: false }));
+      if (saved && props.bot.id === botId && draft.fields.description === value) {
+        setDraft((state) => {
+          state.dirty.description = false;
+        });
       }
     });
   }
 
   async function setCustomAvatar(image: AvatarImageInput | null): Promise<boolean> {
-    if (avatarUploadBusy()) return false;
+    if (draft.avatar.uploadBusy) return false;
     setAvatarUploadBusy(true);
     setSaveError(null);
     try {
@@ -279,7 +374,9 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
 
   async function selectGeneratedAvatar(seed: string): Promise<void> {
     if (avatarUrl() && !(await setCustomAvatar(null))) return;
-    setAvatarSeed(seed);
+    setDraft((state) => {
+      state.avatar.seed = seed;
+    });
     await saveBotPatch({ avatarSeed: seed });
   }
 
@@ -288,44 +385,52 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
       (candidate) => candidate.provider === nextProvider && candidate.id === nextModel,
     );
     if (!option) return;
-    const nextReasoning = option.supportedReasoningEfforts.includes(reasoning())
-      ? reasoning()
-      : option.defaultReasoningEffort;
-    const previousModel = model();
-    const previousProvider = provider();
-    const previousReasoning = reasoning();
+    // A plain copy, not `snapshot`: a snapshot of an unmodified subtree is the store's own object,
+    // which the write below would mutate, leaving nothing to roll back to.
+    const previous: AgentRuntimeSettings = {
+      model: draft.runtime.model,
+      provider: draft.runtime.provider,
+      reasoningEffort: draft.runtime.reasoningEffort,
+    };
     const botId = props.bot.id;
-    const settings = { provider: nextProvider, model: nextModel, reasoningEffort: nextReasoning };
-    setProvider(nextProvider);
-    setModel(nextModel);
-    setReasoning(nextReasoning);
+    const settings: AgentRuntimeSettings = {
+      model: nextModel,
+      provider: nextProvider,
+      reasoningEffort: option.supportedReasoningEfforts.includes(previous.reasoningEffort)
+        ? previous.reasoningEffort
+        : option.defaultReasoningEffort,
+    };
+    setDraft((state) => {
+      state.runtime.provider = settings.provider;
+      state.runtime.model = settings.model;
+      state.runtime.reasoningEffort = settings.reasoningEffort;
+    });
     if (await saveRuntimeSettings(settings, settings, botId)) return;
-    if (
-      props.bot.id !== botId ||
-      provider() !== settings.provider ||
-      model() !== settings.model ||
-      reasoning() !== settings.reasoningEffort
-    ) {
-      return;
-    }
-    setProvider(previousProvider);
-    setModel(previousModel);
-    setReasoning(previousReasoning);
+    // Roll back only what this call wrote: another agent, or a later pick, owns the panel now.
+    if (props.bot.id !== botId || !sameRuntimeSettings(draft.runtime, settings)) return;
+    setDraft((state) => {
+      state.runtime.provider = previous.provider;
+      state.runtime.model = previous.model;
+      state.runtime.reasoningEffort = previous.reasoningEffort;
+    });
   }
 
   async function selectReasoning(nextReasoning: AgentReasoningEffort): Promise<void> {
     const botId = props.bot.id;
-    const previousReasoning = reasoning();
-    const settings = { provider: provider(), model: model(), reasoningEffort: nextReasoning };
-    setReasoning(nextReasoning);
+    const previousReasoning = draft.runtime.reasoningEffort;
+    const settings: AgentRuntimeSettings = {
+      model: draft.runtime.model,
+      provider: draft.runtime.provider,
+      reasoningEffort: nextReasoning,
+    };
+    setDraft((state) => {
+      state.runtime.reasoningEffort = nextReasoning;
+    });
     if (await saveRuntimeSettings(settings, { reasoningEffort: nextReasoning }, botId)) return;
-    if (
-      props.bot.id === botId &&
-      provider() === settings.provider &&
-      model() === settings.model &&
-      reasoning() === nextReasoning
-    ) {
-      setReasoning(previousReasoning);
+    if (props.bot.id === botId && sameRuntimeSettings(draft.runtime, settings)) {
+      setDraft((state) => {
+        state.runtime.reasoningEffort = previousReasoning;
+      });
     }
   }
 
@@ -343,7 +448,7 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
         onResize={setPanelWidth}
         onResizeEnd={(value) => savePanelWidth(SETTINGS_PANEL_STORAGE_KEY, value)}
       />
-      <Show when={!routinesOpen()}>
+      <Show when={!draft.routines.open}>
         <header class="agent-settings-header">
           <Button
             variant="ghost"
@@ -366,25 +471,27 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
           </Button>
         </header>
       </Show>
-      <Show when={!routinesOpen()}>
+      <Show when={!draft.routines.open}>
         <div class="agent-settings-content">
           <div ref={(element) => (avatarPickerRoot = element)} class="agent-settings-avatar-picker">
             <Popover.Root
-              open={avatarPickerOpen()}
+              open={draft.avatar.pickerOpen}
               placement="bottom"
               gutter={11}
-              onOpenChange={(open) => {
-                if (open) {
-                  setAvatarCandidateSeed(avatarSeed());
-                  setAvatarBatch(0);
-                }
-                setAvatarPickerOpen(open);
-              }}
+              onOpenChange={(open) =>
+                setDraft((state) => {
+                  if (open) {
+                    state.avatar.candidateSeed = state.avatar.seed;
+                    state.avatar.batch = 0;
+                  }
+                  state.avatar.pickerOpen = open;
+                })
+              }
             >
               <Popover.Trigger class="agent-settings-avatar" aria-label="Edit agent avatar">
-                <AgentAvatar seed={avatarSeed()} hue={avatarHue()} url={avatarUrl()} motion="always" />
+                <AgentAvatar seed={draft.avatar.seed} hue={draft.avatar.hue} url={avatarUrl()} motion="always" />
               </Popover.Trigger>
-              <Popover.Content class="avatar-editor" aria-hidden={avatarPickerOpen() ? undefined : "true"}>
+              <Popover.Content class="avatar-editor" aria-hidden={draft.avatar.pickerOpen ? undefined : "true"}>
                 <Popover.Title class="sr-only">Avatar editor</Popover.Title>
                 <Input
                   ref={(element) => (avatarFileInput = element)}
@@ -401,7 +508,7 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                       <Button
                         variant="outline"
                         type="button"
-                        disabled={avatarUploadBusy()}
+                        disabled={draft.avatar.uploadBusy}
                         onClick={() => void setCustomAvatar(null)}
                       >
                         Remove
@@ -413,7 +520,7 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                   variant="ghost"
                   type="button"
                   class={["avatar-image-upload", { "avatar-image-upload-active": Boolean(avatarUrl()) }]}
-                  disabled={avatarUploadBusy()}
+                  disabled={draft.avatar.uploadBusy}
                   onClick={() => avatarFileInput?.click()}
                 >
                   <span class="avatar-image-upload-preview">
@@ -425,7 +532,7 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                         </svg>
                       }
                     >
-                      <AgentAvatar seed={avatarSeed()} hue={avatarHue()} url={avatarUrl()} />
+                      <AgentAvatar seed={draft.avatar.seed} hue={draft.avatar.hue} url={avatarUrl()} />
                     </Show>
                   </span>
                   <span>
@@ -437,13 +544,15 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                 <div class="avatar-editor-heading">
                   <span>Generated face</span>
                   <div class="avatar-editor-actions">
-                    <Show when={avatarSeed() !== props.bot.id}>
+                    <Show when={draft.avatar.seed !== props.bot.id}>
                       <Button
                         variant="outline"
                         type="button"
                         onClick={() => {
-                          setAvatarCandidateSeed(props.bot.id);
-                          setAvatarBatch(0);
+                          setDraft((state) => {
+                            state.avatar.candidateSeed = props.bot.id;
+                            state.avatar.batch = 0;
+                          });
                           void selectGeneratedAvatar(props.bot.id);
                         }}
                       >
@@ -453,10 +562,12 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                     <Button
                       variant="outline"
                       type="button"
-                      onClick={() => {
-                        setAvatarCandidateSeed(avatarSeed());
-                        setAvatarBatch((batch) => batch + 1);
-                      }}
+                      onClick={() =>
+                        setDraft((state) => {
+                          state.avatar.candidateSeed = state.avatar.seed;
+                          state.avatar.batch += 1;
+                        })
+                      }
                     >
                       New set
                     </Button>
@@ -470,15 +581,17 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                         type="button"
                         class={[
                           "avatar-face-choice",
-                          { "avatar-choice-selected": !avatarUrl() && avatarSeed() === seed },
+                          { "avatar-choice-selected": !avatarUrl() && draft.avatar.seed === seed },
                         ]}
                         aria-label={
-                          !avatarUrl() && avatarSeed() === seed ? "Selected avatar" : `Avatar option ${index() + 1}`
+                          !avatarUrl() && draft.avatar.seed === seed
+                            ? "Selected avatar"
+                            : `Avatar option ${index() + 1}`
                         }
-                        aria-pressed={!avatarUrl() && avatarSeed() === seed ? "true" : "false"}
+                        aria-pressed={!avatarUrl() && draft.avatar.seed === seed ? "true" : "false"}
                         onClick={() => void selectGeneratedAvatar(seed)}
                       >
-                        <AgentAvatar seed={seed} hue={avatarHue()} />
+                        <AgentAvatar seed={seed} hue={draft.avatar.hue} />
                       </Button>
                     )}
                   </For>
@@ -491,11 +604,13 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                   <Button
                     variant="ghost"
                     type="button"
-                    class={["avatar-color-choice", { "avatar-choice-selected": avatarHue() === null }]}
+                    class={["avatar-color-choice", { "avatar-choice-selected": draft.avatar.hue === null }]}
                     aria-label="Automatic avatar color"
-                    aria-pressed={avatarHue() === null ? "true" : "false"}
+                    aria-pressed={draft.avatar.hue === null ? "true" : "false"}
                     onClick={() => {
-                      setAvatarHue(null);
+                      setDraft((state) => {
+                        state.avatar.hue = null;
+                      });
                       void saveBotPatch({ avatarHue: null });
                     }}
                   >
@@ -506,11 +621,13 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                       <Button
                         variant="ghost"
                         type="button"
-                        class={["avatar-color-choice", { "avatar-choice-selected": avatarHue() === option.hue }]}
+                        class={["avatar-color-choice", { "avatar-choice-selected": draft.avatar.hue === option.hue }]}
                         aria-label={`${option.label} avatar color`}
-                        aria-pressed={avatarHue() === option.hue ? "true" : "false"}
+                        aria-pressed={draft.avatar.hue === option.hue ? "true" : "false"}
                         onClick={() => {
-                          setAvatarHue(option.hue);
+                          setDraft((state) => {
+                            state.avatar.hue = option.hue;
+                          });
                           void saveBotPatch({ avatarHue: option.hue });
                         }}
                       >
@@ -525,27 +642,31 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
           <label class="agent-settings-field">
             <span>Name</span>
             <Input
-              value={name()}
+              value={draft.fields.name}
               aria-label="Agent name"
               maxlength={INPUT_LIMITS.agentName}
-              onValueChange={(value) => {
-                setName(value);
-                setDirty((current) => ({ ...current, name: true }));
-              }}
+              onValueChange={(value) =>
+                setDraft((state) => {
+                  state.fields.name = value;
+                  state.dirty.name = true;
+                })
+              }
               onBlur={saveName}
             />
           </label>
           <label class="agent-settings-field">
             <span>Title</span>
             <Input
-              value={title()}
+              value={draft.fields.title}
               aria-label="Agent title"
               placeholder="Describe what your agent does"
               maxlength={INPUT_LIMITS.agentTitle}
-              onValueChange={(value) => {
-                setTitle(value);
-                setDirty((current) => ({ ...current, title: true }));
-              }}
+              onValueChange={(value) =>
+                setDraft((state) => {
+                  state.fields.title = value;
+                  state.dirty.title = true;
+                })
+              }
               onBlur={saveTitle}
             />
           </label>
@@ -553,14 +674,16 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
             <span>Description</span>
             <Textarea
               rows="4"
-              value={description()}
+              value={draft.fields.description}
               aria-label="Agent description"
               placeholder="What this agent is for"
               maxlength={INPUT_LIMITS.agentDescription}
-              onValueChange={(value) => {
-                setDescription(value);
-                setDirty((current) => ({ ...current, description: true }));
-              }}
+              onValueChange={(value) =>
+                setDraft((state) => {
+                  state.fields.description = value;
+                  state.dirty.description = true;
+                })
+              }
               onBlur={saveDescription}
             />
           </label>
@@ -568,14 +691,14 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
             <Button variant="ghost" type="button" class="agent-settings-link" onClick={() => setMemoryModalOpen(true)}>
               <span class="agent-settings-link-label">Memories</span>
               <span class="agent-settings-link-value">
-                {memoryCount()} saved
+                {draft.memories.count} saved
                 <ChevronRight />
               </span>
             </Button>
             <Button variant="ghost" type="button" class="agent-settings-link" onClick={() => setRoutinesOpen(true)}>
               <span class="agent-settings-link-label">Routines</span>
               <span class="agent-settings-link-value">
-                {routineCount()} configured
+                {draft.routines.count} configured
                 <ChevronRight />
               </span>
             </Button>
@@ -590,8 +713,8 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                 <ProviderModelPicker
                   variant="field"
                   ariaLabel="Agent model"
-                  provider={provider()}
-                  value={model()}
+                  provider={draft.runtime.provider}
+                  value={draft.runtime.model}
                   agentStatus={props.agentStatus}
                   modelOptions={props.modelOptions}
                   runtimeStatuses={props.providerRuntimeStatuses}
@@ -612,9 +735,9 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                 <Select<AgentReasoningEffort>
                   class="agent-settings-reasoning-control"
                   options={reasoningOptions()}
-                  value={reasoning()}
+                  value={draft.runtime.reasoningEffort}
                   onChange={(nextReasoning) => {
-                    if (!nextReasoning || nextReasoning === reasoning()) return;
+                    if (!nextReasoning || nextReasoning === draft.runtime.reasoningEffort) return;
                     void selectReasoning(nextReasoning);
                   }}
                   itemComponent={(item) => (
@@ -634,7 +757,7 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
               </div>
             </div>
           </section>
-          <Show when={saveError()}>
+          <Show when={draft.saveError}>
             {(message) => (
               <p class="agent-settings-save-error" role="alert">
                 {message()}
@@ -649,21 +772,22 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
             <Switch
               size="sm"
               aria-label="Notifications"
-              checked={notifications()}
+              checked={draft.notifications}
               onChange={(next) => {
-                setNotifications(next);
+                setDraft((state) => {
+                  state.notifications = next;
+                });
                 void saveBotPatch({ notifications: next });
               }}
             />
           </div>
         </div>
       </Show>
-      <Show when={routinesOpen()}>
+      <Show when={draft.routines.open}>
         <div class="agent-routines-overlay">
           <AgentRoutinesSettings
             botId={props.bot.id}
             onCountChange={setRoutineCount}
-            onViewChange={setRoutineView}
             onBack={() => setRoutinesOpen(false)}
             onClose={props.onClose}
             selectionRequest={props.routineSelectionRequest}
@@ -675,11 +799,20 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
       <AgentMemoriesModal
         botId={props.bot.id}
         botName={props.bot.name}
-        open={memoryModalOpen()}
+        open={draft.memories.open}
         onOpenChange={setMemoryModalOpen}
         onCountChange={setMemoryCount}
       />
     </aside>
+  );
+}
+
+/** True when the panel still shows exactly the settings a save was issued for. */
+function sameRuntimeSettings(current: AgentRuntimeSettings, settings: AgentRuntimeSettings): boolean {
+  return (
+    current.provider === settings.provider &&
+    current.model === settings.model &&
+    current.reasoningEffort === settings.reasoningEffort
   );
 }
 

--- a/src/renderer/src/components/conversation/AgentSettingsPanel.tsx
+++ b/src/renderer/src/components/conversation/AgentSettingsPanel.tsx
@@ -127,41 +127,13 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
   });
   const avatarUrl = () => props.bot.avatarUrl ?? null;
 
+  /** The message under the form: every save path clears it first and reports its failure through it. */
   function setSaveError(message: string | null): void {
     setDraft((state) => {
       state.saveError = message;
     });
   }
 
-  function setAvatarUploadBusy(busy: boolean): void {
-    setDraft((state) => {
-      state.avatar.uploadBusy = busy;
-    });
-  }
-
-  function setMemoryModalOpen(open: boolean): void {
-    setDraft((state) => {
-      state.memories.open = open;
-    });
-  }
-
-  function setMemoryCount(count: number): void {
-    setDraft((state) => {
-      state.memories.count = count;
-    });
-  }
-
-  function setRoutinesOpen(open: boolean): void {
-    setDraft((state) => {
-      state.routines.open = open;
-    });
-  }
-
-  function setRoutineCount(count: number): void {
-    setDraft((state) => {
-      state.routines.count = count;
-    });
-  }
   const selectedModel = createMemo(() =>
     props.modelOptions.find(
       (option) => option.provider === draft.runtime.provider && option.id === draft.runtime.model,
@@ -242,12 +214,20 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
       if (botChanged) {
         void window.openbot.agent
           .listMemories(bot.id)
-          .then((items) => setMemoryCount(items.length))
-          .catch(() => setMemoryCount(0));
+          .catch(() => [])
+          .then((items) => {
+            setDraft((state) => {
+              state.memories.count = items.length;
+            });
+          });
         void window.openbot.agent
           .listRoutines(bot.id)
-          .then((items) => setRoutineCount(items.length))
-          .catch(() => setRoutineCount(0));
+          .catch(() => [])
+          .then((items) => {
+            setDraft((state) => {
+              state.routines.count = items.length;
+            });
+          });
       }
     },
   );
@@ -255,7 +235,11 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
   createEffect(
     () => ({ request: props.routineSelectionRequest, botId: props.bot.id }),
     ({ request }) => {
-      if (request) setRoutinesOpen(true);
+      if (request) {
+        setDraft((state) => {
+          state.routines.open = true;
+        });
+      }
     },
   );
 
@@ -344,8 +328,10 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
 
   async function setCustomAvatar(image: AvatarImageInput | null): Promise<boolean> {
     if (draft.avatar.uploadBusy) return false;
-    setAvatarUploadBusy(true);
-    setSaveError(null);
+    setDraft((state) => {
+      state.avatar.uploadBusy = true;
+      state.saveError = null;
+    });
     try {
       await props.onSetAgentAvatar(props.bot.id, image);
       return true;
@@ -353,21 +339,27 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
       setSaveError(error instanceof Error ? error.message : "Could not save the agent avatar.");
       return false;
     } finally {
-      setAvatarUploadBusy(false);
+      setDraft((state) => {
+        state.avatar.uploadBusy = false;
+      });
     }
   }
 
   async function uploadAgentAvatar(file: File | undefined): Promise<void> {
     if (!file) return;
-    setAvatarUploadBusy(true);
-    setSaveError(null);
+    setDraft((state) => {
+      state.avatar.uploadBusy = true;
+      state.saveError = null;
+    });
     try {
       const image = await normalizeAvatarFile(file);
       await props.onSetAgentAvatar(props.bot.id, image);
     } catch (error) {
       setSaveError(error instanceof Error ? error.message : "Could not process the agent avatar.");
     } finally {
-      setAvatarUploadBusy(false);
+      setDraft((state) => {
+        state.avatar.uploadBusy = false;
+      });
       if (avatarFileInput) avatarFileInput.value = "";
     }
   }
@@ -688,14 +680,32 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
             />
           </label>
           <div class="agent-settings-links">
-            <Button variant="ghost" type="button" class="agent-settings-link" onClick={() => setMemoryModalOpen(true)}>
+            <Button
+              variant="ghost"
+              type="button"
+              class="agent-settings-link"
+              onClick={() =>
+                setDraft((state) => {
+                  state.memories.open = true;
+                })
+              }
+            >
               <span class="agent-settings-link-label">Memories</span>
               <span class="agent-settings-link-value">
                 {draft.memories.count} saved
                 <ChevronRight />
               </span>
             </Button>
-            <Button variant="ghost" type="button" class="agent-settings-link" onClick={() => setRoutinesOpen(true)}>
+            <Button
+              variant="ghost"
+              type="button"
+              class="agent-settings-link"
+              onClick={() =>
+                setDraft((state) => {
+                  state.routines.open = true;
+                })
+              }
+            >
               <span class="agent-settings-link-label">Routines</span>
               <span class="agent-settings-link-value">
                 {draft.routines.count} configured
@@ -787,8 +797,16 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
         <div class="agent-routines-overlay">
           <AgentRoutinesSettings
             botId={props.bot.id}
-            onCountChange={setRoutineCount}
-            onBack={() => setRoutinesOpen(false)}
+            onCountChange={(count) =>
+              setDraft((state) => {
+                state.routines.count = count;
+              })
+            }
+            onBack={() =>
+              setDraft((state) => {
+                state.routines.open = false;
+              })
+            }
             onClose={props.onClose}
             selectionRequest={props.routineSelectionRequest}
             onSelectionRequestHandled={props.onRoutineSelectionRequestHandled}
@@ -800,8 +818,16 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
         botId={props.bot.id}
         botName={props.bot.name}
         open={draft.memories.open}
-        onOpenChange={setMemoryModalOpen}
-        onCountChange={setMemoryCount}
+        onOpenChange={(open) =>
+          setDraft((state) => {
+            state.memories.open = open;
+          })
+        }
+        onCountChange={(count) =>
+          setDraft((state) => {
+            state.memories.count = count;
+          })
+        }
       />
     </aside>
   );

--- a/src/renderer/src/components/createAsyncPanel.ts
+++ b/src/renderer/src/components/createAsyncPanel.ts
@@ -1,0 +1,56 @@
+import { createStore } from "solid-js";
+
+interface AsyncPanel {
+  /** The key of the one action in flight, or `null`. A list load is `loading`, not an action. */
+  busy: string | null;
+  error: string | null;
+  loading: boolean;
+}
+
+/**
+ * The three fields every remote-backed panel carries: the list load, the one action in flight, and
+ * the message the last failure left behind. They are one record because a panel is in exactly one
+ * of these situations at a time - three signals let it be loading, busy and errored at once - and
+ * because `run` writes `error` on every call, which a caller would otherwise have to remember.
+ *
+ * `describeError` turns a rejection into the message the panel shows, so the domain keeps its own
+ * wording. Read through the returned store; write through the named mutations.
+ */
+export function createAsyncPanel(describeError: (cause: unknown) => string) {
+  const [panel, setPanel] = createStore<AsyncPanel>({ busy: null, error: null, loading: false });
+
+  function setBusy(key: string | null): void {
+    setPanel((state) => {
+      state.busy = key;
+    });
+  }
+
+  function setError(message: string | null): void {
+    setPanel((state) => {
+      state.error = message;
+    });
+  }
+
+  function setLoading(loading: boolean): void {
+    setPanel((state) => {
+      state.loading = loading;
+    });
+  }
+
+  /**
+   * Clears the error, awaits `work`, and reports a rejection as the panel's error rather than
+   * letting it escape. `undefined` is the failure result, so a caller applies what it got only
+   * when it got something.
+   */
+  async function run<T>(work: () => Promise<T>): Promise<T | undefined> {
+    setError(null);
+    try {
+      return await work();
+    } catch (cause) {
+      setError(describeError(cause));
+      return undefined;
+    }
+  }
+
+  return { panel, run, setBusy, setError, setLoading };
+}

--- a/src/renderer/src/components/createScrollFades.ts
+++ b/src/renderer/src/components/createScrollFades.ts
@@ -1,0 +1,60 @@
+import { createStore } from "solid-js";
+
+/** Slack in pixels before an edge counts as reached, absorbing sub-pixel scroll positions. */
+const EDGE_EPSILON = 2;
+
+/**
+ * Tracks whether a scrollable element has content hidden above or below it, as the one
+ * `scroll-fade-top` / `scroll-fade-bottom` pair every list in the app styles against. The two
+ * booleans are measured together and held in one store, so a scroll that only reveals the bottom
+ * edge does not invalidate readers of the top one, and the class names live here rather than being
+ * retyped at each call site.
+ *
+ * Bind the element with `ref={fades.bind}`, pass `measure` to `onScroll`, and call `remeasure`
+ * from an effect over whatever changes the content's height. A caller that already runs its own
+ * `ResizeObserver` uses `adopt` instead and keeps `measure` in its existing callback order — a
+ * second observer on the same element would race the one that scrolls it.
+ */
+export function createScrollFades() {
+  const [fades, setFades] = createStore({ bottom: false, top: false });
+  let element: Element | undefined;
+  let resizeObserver: ResizeObserver | undefined;
+
+  function measure(): void {
+    if (!element) return;
+    const remaining = element.scrollHeight - element.scrollTop - element.clientHeight;
+    const top = element.scrollTop > EDGE_EPSILON;
+    const bottom = remaining > EDGE_EPSILON;
+    setFades((state) => {
+      state.top = top;
+      state.bottom = bottom;
+    });
+  }
+
+  function remeasure(): void {
+    window.requestAnimationFrame(measure);
+  }
+
+  function adopt(next: Element): void {
+    element = next;
+  }
+
+  function bind(next: Element): void {
+    adopt(next);
+    resizeObserver?.disconnect();
+    resizeObserver = new ResizeObserver(measure);
+    resizeObserver.observe(next);
+    remeasure();
+  }
+
+  function classes(): Record<string, boolean> {
+    return { "scroll-fade-top": fades.top, "scroll-fade-bottom": fades.bottom };
+  }
+
+  function stop(): void {
+    resizeObserver?.disconnect();
+    resizeObserver = undefined;
+  }
+
+  return { adopt, bind, classes, measure, remeasure, stop };
+}

--- a/tools/biome/anti-slop/fixtures/no-collections-in-stores.fixture.ts
+++ b/tools/biome/anti-slop/fixtures/no-collections-in-stores.fixture.ts
@@ -1,0 +1,23 @@
+// Fixture for `no-collections-in-stores`. Every line the rule must reject carries a trailing
+// `// flag`; every other line is correct code the rule must leave alone.
+// Checked by `scripts/anti-slop-rules.test.ts`; not compiled and not linted.
+
+const readOperations = new Map<string, Promise<void>>();
+
+const [collapsed, setCollapsed] = createStore({ sections: [] as string[], pending: false });
+const [duplicating, setDuplicating] = createSignal<Set<string>>(new Set());
+setDuplicating((current) => new Set(current).add(botId));
+
+function reconcileRows(rows: readonly Row[]) {
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  return byId;
+}
+
+const [seen, setSeen] = createStore({ ids: new Set<string>() }); // flag
+const [index, setIndex] = createStore({ rows: new Map<string, Row>() }); // flag
+const [nested, setNested] = createStore({ view: { ids: new Set<string>() } }); // flag
+const [bare, setBare] = createStore({ ids: new Set() }); // flag
+const [seeded, setSeeded] = createStore({ rows: new Map(rows.map((row) => [row.id, row])) }); // flag
+const [typed, setTyped] = createStore<Seen>({ ids: new Set<string>() }); // flag
+const [typedRows, setTypedRows] = createStore<Index>({ rows: new Map<string, Row>() }); // flag
+const [shallow, setShallow] = createStore<Index>({ rows: new Map<string, Row>() }, { shallow: true }); // flag

--- a/tools/biome/anti-slop/rules/no-collections-in-stores.grit
+++ b/tools/biome/anti-slop/rules/no-collections-in-stores.grit
@@ -1,0 +1,30 @@
+language js(typescript)
+
+// scope: global
+
+// A `Map` or `Set` in a store's initial value. `isWrappable` rejects platform
+// objects, so the store serves the collection raw and mutating it notifies
+// nothing - only replacing the whole property does.
+//
+// A type argument changes the shape of the call node, and every store in this
+// repository is written `createStore<T>({...})`, so all four spellings have to
+// be listed or the rule walks past every site it exists for. The second
+// argument is the `{ shallow: true }` options object.
+or {
+  `new Map($...)`,
+  `new Set($...)`,
+  `new Map<$...>($...)`,
+  `new Set<$...>($...)`
+} as $collection where {
+  $collection <: within or {
+    `createStore($_)`,
+    `createStore($_, $_)`,
+    `createStore<$_>($_)`,
+    `createStore<$_>($_, $_)`
+  },
+  register_diagnostic(
+    span=$collection,
+    message="A `Map` or `Set` in a store is served raw: mutating it notifies nothing, and only replacing the whole property does. Hold it in a signal written copy-on-write, or store an array - unless you always replace this field whole.",
+    severity="warn"
+  )
+}


### PR DESCRIPTION
Asked for after looking at [`anomalyco/opencode`](https://github.com/anomalyco/opencode), whose
`packages/app/AGENTS.md` SolidJS section is a single line — "Always prefer `createStore` over
multiple `createSignal` calls" — and whose app package backs it up: stores outnumber signals there
roughly 2:1, and the surviving signals are element refs, single measurements and one-off booleans.

Here it was **565 `createSignal` declarations across 114 files against two `createStore` calls**,
and 164 of those signals sat in six files where they were not independent state — they were the
fields of one record, declared side by side.

## Five commits

1. **`docs:`** the convention, in `AGENTS.md` "Renderer UI" and `docs/ARCHITECTURE.md` (state
   ownership + change rule 7). Written first, so the wall stops growing on its own.
2. **`lint:`** one `warn` rule — a `Map` or `Set` inside a store. Droppable on its own if you
   don't want it; see the note below.
3. **`refactor(renderer):`** the six worst files.
4. **`refactor(renderer):`** the second pass — the per-field setters the first pass left behind, see
   below.
5. **`docs:`** the convention from commit 1, reconciled with what commit 4 shipped.

## What the wall was costing

- **Every write invalidated every reader.** A keyed `Record` in a signal is replaced by a whole-record
  spread, so a change to one row re-rendered every consumer of every key.
- **Illegal states were representable.** `Sidebar.tsx` had four parallel `dragged*Id` signals that can
  never be simultaneously non-null but were typed as though they can — and `draggedAgentId` could be
  set while the drag session was `null`. The four-way ternary at the list header existed only to paper
  over that. `SettingsModal.tsx` could hold a mobile-connect ticket and an error at once, with a
  `startedAt` that meant nothing without a ticket.
- **The same shape got written twice.** `SkillsMarketplaceModal.tsx` declared the same eight-field
  browser record in two places and held two byte-identical copies of `run<T>`.

## Per file

| File | Before | After |
| --- | --- | --- |
| `SettingsModal.tsx` | 25 | 1 store + 4 |
| `ServerSettingsModal.tsx` | 20 | 1 store + 3 |
| `AgentSettingsPanel.tsx` | 21 | 1 store + a deletion |
| `SkillsMarketplaceModal.tsx` | 32 | 2 stores + 2 pulse counters |
| `Sidebar.tsx` | 21 | 2 stores |
| 5 files reimplementing scroll fades | 10 | `createScrollFades()` |

The clearest win is `AgentSettingsPanel`'s `selectModel`/`selectReasoning`: a field-by-field rollback
on IPC failure became one `snapshot()` and one restore, so a rejected save can no longer leave the
new provider sitting beside the old model.

## The wall the first pass left behind

Review caught it: the conversion replaced 21 `createSignal` calls in `AgentSettingsPanel` with one
store, then added a named private setter per field — six of them in a row, each one a
`setDraft((state) => { state.x = value; })`. That is the same wall one layer down, and the branch's
own prose was telling future readers to build it.

opencode does not do that either. `packages/app/AGENTS.md` says only "Always prefer `createStore`
over multiple `createSignal` calls"; `toast.tsx` writes `setStore("currentToast", …)` inline inside
the `show()` method, and `comments.tsx` writes inline inside `add`/`remove`/`update`. A name goes to
a *behaviour*, or to a context's exported surface (`setRef`, `setFocus`) — never to one field write.

The rule commit 4 applies, and commit 5 writes down: a named mutation earns its name by writing more
than one field, carrying a guard or a side effect, or being a hook's returned API. Everything else
writes the field where it changes, which is what `SettingsModal.tsx` in commit 3 already did at 20+
sites.

- **Deleted, eight pure indirections:** `setAvatarUploadBusy`, `setMemoryModalOpen`, `setMemoryCount`,
  `setRoutinesOpen`, `setRoutineCount` in `AgentSettingsPanel`; `setQuery`, `setTargetBotId`,
  `setInstalled` in `SkillsMarketplaceModal`. The paired busy/error writes on the two avatar paths
  collapse into one store write, since those fields always change together.
- **Kept, because they earn it:** `setSaveError` (seven error paths, now with a comment saying so),
  `Sidebar`'s three (guards and the drag-offset side effect), `createAsyncPanel`'s
  `setBusy`/`setError`/`setLoading` (the hook's API, consumed by four components), and
  `ConversationView`'s two.
- **The cost, stated plainly:** `onOpenChange={setMemoryModalOpen}` becomes a five-line inline
  callback. That is the price of Solid 2's draft-mutating setter, whose only form is
  `set((state) => { … })`. `storePath` — `setDraft(storePath("memories", "open", open))` — would give
  opencode's one-liners back, but its own doc calls it a 1.x porting helper and nothing in this repo
  uses it, so introducing a second idiom mid-branch is your call, not mine.
- The other four converted files needed nothing: no `function set*` or `const set*` field wrapper
  exists in `ServerRail`, `ServerSettingsModal`, `SettingsModal`, `AgentMemoriesModal`,
  `AgentRoutinesSettings` or `createScrollFades`.

## Deliberately not converted

`ConversationResources` (recorders, streams, `Blob[]`, timers, `Map`/`Set`, and two supersede
generation counters — collection mutations would be invisible, and making a generation counter
reactive turns a guard into a dependency). `mobileDevicesLoaded` + `mobileDevicesLoading` as a
union: both are true during a refresh-after-load, and a union loses the stale list still on screen.
`messageMenus` as a union — `copiedId` is genuinely independent. The sidebar's imperative drag half
stays in plain locals: signal and store reads are equally stale until the microtask flush, so the
conversion is timing-neutral, but the pointer pipeline reads its own writes inside one tick and
compares `dragSession` by identity, and a store read returns a proxy.

## Watch it fail

Done per conversion. Two worth naming:

- Rejecting the runtime save **between** the provider and the model write goes red without the atomic
  rollback — that mixed state is the bug the store fixes. One new test file
  (`AgentSettingsPanel.test.tsx`), justified because it sits at an IPC boundary with zero coverage.
- Dropping `deleting = false` from the sidebar's failed-delete path leaves Cancel disabled, so the
  dialog can never be left. Red at `Sidebar.test.tsx:713`.
- The lint rule: a generic `createStore<T>(…)` line added to the fixture went red against the
  single-spelling pattern the rule started as — the same blindness `no-class-selector-queries`
  documents for `querySelector<HTMLElement>`. Every store in this repo uses the generic form, so
  without that fix the rule would have enforced nothing.

**Honest gap:** breaking the sidebar's drag projection stays **green**. `commitSidebarDrop` dispatches
on the drag session rather than on the projection, and no test asserts a *successful* drag-to-pin
(`grep onPin` finds only `not.toHaveBeenCalled()`). That chrome is guarded by `tsc` and the
`EmptyPinDropTarget` story only, and stories are not run by vitest. No costume test was added.

## Two things to flag

- **This is deliberately not one topic per PR**, at the developer's explicit request ("zrób PR ze
  wszystkim"). The natural split is 8 PRs; three of them touch `Sidebar.tsx` and two touch
  `SkillsMarketplaceModal.tsx`, so splitting the commits further would mean reconstructing
  intermediate file states rather than describing real boundaries.
- **The `lint:` commit is separable.** An earlier decision in the same conversation was *no* Biome
  rule for this — that was about a rule policing the signal wall itself, which is a judgement no
  pattern can make. This rule covers a different, mechanical trap (`isWrappable` rejects platform
  objects, so a `Map` or `Set` in a store is served raw and mutating it notifies nothing). It is a
  `warn`, because always replacing the field whole is a legitimate counter-example. Drop the commit
  if you'd rather keep the prose only.

## Surfaces

Desktop renderer only. No IPC contract, migration, palette, mobile or `apps/auth-api` change.

## Verification

`biome check` on all changed paths, `typecheck:renderer`, `typecheck:storybook`, and the eight
affected test files (`SettingsModal`, `ServerSettingsModal`, `SkillsMarketplaceModal`, `Sidebar`,
`AgentSettingsPanel`, `AgentRoutinesSettings`, `AgentMemoriesModal`, `anti-slop-rules`) — 99 passed.
Commit 4 re-verified with `biome check` on both files it touches, the full `typecheck:*` set through
the pre-commit hook, and its two affected test files (`AgentSettingsPanel` 1, `SkillsMarketplaceModal`
11); commit 5 is prose. It adds no test: the rule it applies is a naming convention with no
consequence a user or a caller could observe, so a test asserting it would be a costume. Repo-wide
checks left to CI, green on every job. Model: Claude Opus 5, harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

