### PR TITLE
Fix agent rename propagation across views

### DIFF
--- a/src/renderer/src/App.settings.test.tsx
+++ b/src/renderer/src/App.settings.test.tsx
@@ -6,6 +6,7 @@ import { desktopAnalytics } from "./analytics";
 import {
   BOTS,
   emitAgentEvent,
+  emitScopedAgentEvent,
   emitUpdateStatus,
   installOpenbotStub,
   testServer,
@@ -538,6 +539,48 @@ describe("OpenBot connected desktop shell", () => {
     await waitFor(() => expect(trigger).toBeEnabled());
     expect(trackAnalytics).not.toHaveBeenCalledWith("system_turn_started", expect.anything());
     expect(trackAnalytics).not.toHaveBeenCalledWith("system_turn_completed", expect.anything());
+  });
+
+  it("propagates an agent rename across the workspace without a refresh", async () => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    const started = {
+      type: "turn-started",
+      botId: "chief",
+      threadId: "thread-chief",
+      turnId: "turn-rename",
+    } as const;
+    await waitFor(() => expect(emitScopedAgentEvent).toBeDefined());
+    emitAgentEvent?.(started);
+    emitScopedAgentEvent?.({ serverId: "local", event: started });
+    await waitFor(() =>
+      expect(vi.mocked(window.openbot.dynamicIsland.publishPresentation).mock.calls.at(-1)?.[0]).toMatchObject({
+        mode: "working",
+        working: [{ bot: { id: "chief", name: "Chief" } }],
+      }),
+    );
+
+    await fireEvent.click(screen.getByRole("button", { name: "View agent settings" }));
+    const name = await screen.findByRole("textbox", { name: "Agent name" });
+    await fireEvent.input(name, { target: { value: "Coordinator" } });
+    await fireEvent.blur(name);
+
+    await waitFor(() =>
+      expect(window.openbot.agent.updateBot).toHaveBeenCalledWith({ botId: "chief", name: "Coordinator" }),
+    );
+    expect(await screen.findByRole("heading", { name: "Coordinator" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Message Coordinator")).toHaveAttribute("contenteditable", "true");
+    expect(screen.getByRole("button", { name: /Coordinator, Chief of staff/ })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(vi.mocked(window.openbot.dynamicIsland.publishPresentation).mock.calls.at(-1)?.[0]).toMatchObject({
+        mode: "working",
+        working: [{ bot: { id: "chief", name: "Coordinator" } }],
+      }),
+    );
+
+    await fireEvent.click(screen.getByRole("button", { name: /Sales Outbound/ }));
+    await fireEvent.click(screen.getByRole("button", { name: /Coordinator, Chief of staff/ }));
+    expect(await screen.findByRole("heading", { name: "Coordinator" })).toBeInTheDocument();
   });
 
   it("removes a custom agent avatar and keeps its generated avatar settings", async () => {

--- a/src/renderer/src/agents.tsx
+++ b/src/renderer/src/agents.tsx
@@ -150,7 +150,7 @@ const Agents = createSimpleContext({
           if (existingIndex === -1) return [...current, createStoredProfile(next)];
           const existing = current[existingIndex];
           if (existing) updateStored(existing, next);
-          return current;
+          return [...current];
         });
         analytics.track("agent_action", {
           action: "update",


### PR DESCRIPTION
## Summary

- publish a new agent roster array after applying a persisted profile update
- preserve stable per-agent store identity while invalidating collection-level consumers
- cover rename propagation through settings, chat, navigation, reopening, and Dynamic Island presentation

Fixes #180

## Before / after

| Before | After |
| --- | --- |
| Settings showed the saved name, while collection-driven views and caches could retain the previous name until refresh. | The saved name propagates immediately throughout the active workspace and survives navigating away and back. |

## Surfaces

- Desktop renderer only
- No IPC, Team API, database, mobile, or public-web changes

## Verification

- fnm exec --using=24 -- bun run test:desktop -- src/renderer/src/App.settings.test.tsx (22 passed)
- bunx biome check src/renderer/src/agents.tsx src/renderer/src/App.settings.test.tsx
- bun run typecheck:renderer
- commit hook: all project typechecks passed

The regression test was run before the production change and failed because the Dynamic Island presentation still named Chief after the workspace had renamed the agent to Coordinator. It passed after the roster invalidation change.

Model: GPT-5 Codex. Harness: Vitest renderer project with jsdom on Node 24.