### PR TITLE
fix(landing): point the X and Contact links at @OpenBot_

### DIFF
--- a/apps/auth-api/src/lib/landing-links.ts
+++ b/apps/auth-api/src/lib/landing-links.ts
@@ -6,7 +6,7 @@ export const OPENBOT_DOWNLOAD_LINKS = {
 } as const;
 
 export const OPENBOT_LINKS = {
-  contact: "https://x.com/norbertbodziony",
+  contact: "https://x.com/OpenBot_",
   download: "#download",
   releases: "https://github.com/NorbertBodziony/openbot/releases",
   repository: "https://github.com/NorbertBodziony/openbot",

--- a/apps/auth-api/test/analytics.test.ts
+++ b/apps/auth-api/test/analytics.test.ts
@@ -7,6 +7,7 @@ import {
   OPENPANEL_API_URL,
   shouldEnableLandingAnalytics,
 } from "../src/lib/analytics";
+import { OPENBOT_LINKS } from "../src/lib/landing-links";
 
 describe("landing analytics", () => {
   it("enables only the production landing hostname", () => {
@@ -17,7 +18,7 @@ describe("landing analytics", () => {
 
   it("tracks only allowlisted links and download metadata", () => {
     document.body.innerHTML = `
-      <header class="landing-header"><a id="contact" href="https://x.com/norbertbodziony">Contact</a></header>
+      <header class="landing-header"><a id="contact" href="${OPENBOT_LINKS.contact}">Contact</a></header>
       <section class="landing-download"><a id="mac" href="/download/macos">Download</a></section>
       <a id="private" href="https://private.example/secret">Private</a>
     `;


### PR DESCRIPTION
## What

The landing page's X account link and its Contact buttons pointed at a personal X account. They now point at the product account, `https://x.com/OpenBot_`.

`OPENBOT_LINKS.contact` is the single source for all three of them, so one value change covers:

- header **Contact** button (`LandingPage.tsx`)
- hero **Contact** button (`LandingPage.tsx`)
- footer **X** social icon (`LandingFooter.tsx`, `SOCIALS`)

The analytics allowlist (`LINK_DESTINATIONS`) keys off the same constant, so the `contact` destination keeps tracking without a second edit.

## Surfaces touched

**Public web only** (`apps/auth-api`). No renderer, mobile, IPC contract, palette, migration or Team API change.

Deliberately out of scope — the desktop app's own support links in `src/main/index.ts` (`feedback`, `message`) and the `package.json` author URL still reference the personal account. Say the word and I'll do those in a separate PR.

## Before / after

No visual change — the labels, icon and layout are identical; only the `href` differs.

| | Before | After |
| --- | --- | --- |
| Header Contact | `https://x.com/norbertbodziony` | `https://x.com/OpenBot_` |
| Hero Contact | `https://x.com/norbertbodziony` | `https://x.com/OpenBot_` |
| Footer X icon | `https://x.com/norbertbodziony` | `https://x.com/OpenBot_` |

## Tests

No new test. `apps/auth-api/test/analytics.test.ts` had the old URL hardcoded in its DOM fixture; it now builds the fixture from `OPENBOT_LINKS.contact` so the allowlist test stops drifting whenever the link changes. The test's premise is unchanged — it still asserts that only allowlisted links are tracked, not what the contact URL is.

**Watched it fail:** removed `[OPENBOT_LINKS.contact, "contact"]` from `LINK_DESTINATIONS` and the test went red for the right reason — `expected 2nd "vi.fn()" call to have been called with [ 'landing_link_clicked', … ]`, i.e. the contact click stopped being tracked. Restored, 8/8 pass.

Ran: `biome check` on both files, `bun x vitest run --config vitest.client.config.ts test/analytics.test.ts` in `apps/auth-api`, and the pre-commit hook's full `typecheck:*` sweep. CI owns the rest.

## Model and harness

Claude Opus 5 via Claude Code (t3 worktree harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)