### PR TITLE
test: assert a consequence in the landing SSR test, and sanction the waitFor barrier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,11 @@ SVG and platform colours at their boundaries.
    `bun run check:ui` cover a large class mechanically. If one of them does, skip the test.
 4. **A test that needs a timeout to pass is wrong.** Wait on an observable condition — a state
    change, an emitted event, a resolved promise — never the clock. A sleep long enough to pass on
-   your machine is short enough to flake on a loaded runner.
+   your machine is short enough to flake on a loaded runner. A spy call is such a condition:
+   `await waitFor(() => expect(send).toHaveBeenCalled())` is the sanctioned way to satisfy this
+   rule, and is not the mock-shaped assertion the module-mock warning is about. The barrier
+   synchronizes; the assertions after it carry the consequence. Counting `toHaveBeenCalled*` across
+   the suite cannot tell the two apart, so do not "fix" a barrier by grep.
 5. **Test behaviour, data, and accessible roles and names** — not markup, classes, layout or
    animation timing. Where focus lands *is* behaviour: assert it with `toHaveFocus()`. Assert exact
    text only for a product contract, an error or security message, serialized output, or a

--- a/apps/auth-api/test/landing.test.tsx
+++ b/apps/auth-api/test/landing.test.tsx
@@ -3,11 +3,10 @@ import { describe, expect, it } from "vitest";
 import { AppPreviewPage } from "../src/routes/app-preview.lazy";
 
 describe("landing page", () => {
-  it("keeps the application preview SSR-safe until hydration", () => {
-    expect(() => renderToString(() => <AppPreviewPage />)).not.toThrow();
+  it("serves the loading fallback and no hydrated content until the preview mounts", () => {
     const markup = renderToString(() => <AppPreviewPage />);
 
-    expect(markup).toContain('id="root"');
+    expect(markup).toContain('aria-label="Loading OpenBot preview"');
     expect(markup).not.toContain('aria-label="Bot navigation"');
   });
 });


### PR DESCRIPTION
Acts on the two items from #171 that survived review. Both are the same question — whether an
assertion carries a consequence or restates the markup — which is why they are one PR rather than
two.

## `apps/auth-api/test/landing.test.tsx` (#171 item 2)

`expect(markup).toContain('id="root"')` restates the markup. It sits on the outer div, which renders
unconditionally, so it cannot fail for a reason a user would notice.

It also hid a hole. The remaining `not.toContain('aria-label="Bot navigation"')` is satisfied by a
component that renders *nothing at all*, and `id="root"` could not catch that. Asserting the loading
fallback's accessible name closes it — that fallback is what a user sees before hydration, and
`aria-label="Loading OpenBot preview"` is an accessible name rather than a class.

This stays string matching because the subject is SSR: `renderToString` output has no DOM to query,
which is the counter-example #171 allowed for when it proposed the rule. The test still runs under
`vitest.config.ts` (node + SSR plugin), not the jsdom client config.

The duplicated render also goes. `expect(() => renderToString(…)).not.toThrow()` followed by a second
`renderToString` renders twice; the second call alone surfaces a throw, and with a better failure —
see the first break below.

## `AGENTS.md` rule 4 (#171 item 12)

Four sentences appended to the existing timeout rule rather than a new bullet, since it clarifies
that rule: a spy call is an observable condition, `await waitFor(() => expect(send).toHaveBeenCalled())`
is the sanctioned way to satisfy it, and it is not the mock-shaped assertion the module-mock warning
is about. The barrier synchronizes; the assertions after it carry the consequence.

The distinction is invisible to a grep — 137 of the suite's 810 `toHaveBeenCalled*` references are
barriers. Without the note, the next person auditing test quality by pattern count "fixes" correct
tests. #171's author reports making exactly this mistake.

## Watched it fail

Per Tests rule 2, three breaks, each red for its own reason:

| Break | Result |
| --- | --- |
| Mount during SSR (`createSignal(false)` → `true`) | Red with `lazy() called but no asset manifest is set`, thrown before the assertions |
| Change the fallback's accessible name | `AssertionError: expected '<div id="root"…' to contain 'aria-label="Loading OpenBot preview"'` |
| Leak `aria-label="Bot navigation"` into the server render | The negative assertion fails, naming the leaked attribute |

Two things worth recording. The first break is why the `not.toThrow()` wrapper is not a loss: the raw
error and stack name what broke, where the wrapper would have said "expected function not to throw".
And the old test stayed **green** under the second break — that is the coverage the new positive
assertion adds. Under the third break the old `id="root"` assertion would also still have passed.

## Surfaces touched

Public web (`apps/auth-api`), test only — no product code changed, `app-preview.lazy.tsx` was restored
after each break. Plus repository documentation. Not touched: desktop renderer, mobile, the three
palettes, IPC contracts and `mock-openbot.ts`, migrations, reverse states, `PRIVACY.md`.

## Checks

- `bun run --cwd apps/auth-api test:server -- test/landing.test.tsx` — 1 passed
- `biome check apps/auth-api/test/landing.test.tsx AGENTS.md` — clean
- `bun run --cwd apps/auth-api typecheck` — clean; the pre-commit hook also ran all `typecheck:*` projects green

Auto-approvable: no `biome-ignore`, no `@ts-expect-error`, no `overrides` entry, no widening to `any`
or `unknown`.

## Not in this PR

`vitest.client.config.ts:13-18` and `vitest.config.ts:18-23` both list `test/landing-glow.test.tsx`
and `test/landing-reveal.test.tsx`. Neither file exists. Vitest ignores missing `include` entries, so
it is green and harmless today, but those two lists are what routes a file to the node/SSR or jsdom
project, and stale entries are how a file quietly lands in the wrong environment. Separate topic.

The other ten items in #171 were reviewed and not adopted; reasoning to follow on the issue.

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
