### PR TITLE
Set up Bun through one composite action, and split main-process IPC by domain

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,0 +1,52 @@
+name: Set up Bun
+description: >-
+  Install the repository's pinned Bun and Node and, unless the job installs
+  later, its dependencies. Node is not optional: every caller builds, packages
+  or tests something that needs it. Checkout is the caller's job: a composite action in
+  this repository cannot run before the repository is on disk.
+
+  `remote-desktop-runtime.yml` deliberately does not use this action. Its
+  toolchain is part of a versioned build recipe: the workflow makes a change to
+  itself require a `remoteDesktop.recipeVersion` bump, and an edit here would
+  change that recipe without tripping the check.
+
+inputs:
+  install:
+    description: >-
+      `frozen` for `bun install --frozen-lockfile`, `ignore-scripts` to add
+      `--ignore-scripts` (no native build, for jobs that only typecheck or test),
+      or `none` for a job that must install later - after a secret check, a cache
+      restore, or a platform toolchain.
+    default: frozen
+
+runs:
+  using: composite
+  steps:
+    # A typo in `install` would otherwise silently drop `--ignore-scripts` or
+    # skip the install, and the job would fail somewhere less obvious.
+    - name: Validate inputs
+      shell: bash
+      env:
+        INSTALL: ${{ inputs.install }}
+      run: |
+        case "$INSTALL" in
+          frozen | ignore-scripts | none) ;;
+          *) echo "install must be frozen, ignore-scripts or none (got '$INSTALL')." >&2; exit 1 ;;
+        esac
+
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      with:
+        bun-version: 1.4.0
+
+    - name: Set up Node
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        # `.nvmrc` and nothing else. An overridable version input is the drift
+        # this action exists to remove, one level down.
+        node-version-file: .nvmrc
+
+    - name: Install dependencies
+      if: inputs.install != 'none'
+      shell: bash
+      run: bun install --frozen-lockfile ${{ inputs.install == 'ignore-scripts' && '--ignore-scripts' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/setup-bun
 
       - name: Check desktop application
         run: bun run check:desktop
@@ -56,17 +46,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+          install: ignore-scripts
 
       - name: Run desktop tests
         run: bun run test:desktop
@@ -88,17 +70,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+          install: ignore-scripts
 
       - name: Typecheck mobile
         run: bun run mobile:typecheck
@@ -118,17 +92,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+          install: ignore-scripts
 
       - name: Check API
         run: bun run check:api
@@ -142,17 +108,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+          install: ignore-scripts
 
       - name: Build Storybook
         run: bun run build-storybook
@@ -171,17 +129,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/setup-bun
 
       - name: Build isolated preview
         run: bun run api:build
@@ -247,17 +195,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/setup-bun
 
       - name: Build production Worker
         run: bun run api:build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,14 +39,9 @@ jobs:
           fi
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
+          install: none
 
       - name: Validate release version
         id: release
@@ -102,14 +97,9 @@ jobs:
           persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
+          install: none
 
       - name: Require signing and notarization credentials
         shell: bash
@@ -303,17 +293,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.4.0
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/setup-bun
 
       - name: Run Windows checks
         run: bun run lint && bun run typecheck && bunx vitest run src/backend/cli.test.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,10 @@ aside. Never argue back by citing this file.
 - **The licence is PolyForm Noncommercial 1.0.0.** No dependency that conflicts with it, no
   relicensed file.
 
-The first two have their own sections below. `CONTRIBUTING.md` "Security-sensitive changes" lists the
-boundaries in full; `docs/ARCHITECTURE.md` "Change rules" says where a change belongs.
+The first three are spelled out where they are enforced — `src/backend/AGENTS.md`,
+`packages/contracts/AGENTS.md` and `src/main/AGENTS.md`. `CONTRIBUTING.md` "Security-sensitive
+changes" lists the boundaries in full; `docs/ARCHITECTURE.md` "Change rules" says where a change
+belongs.
 
 ## Do not run repo-wide checks. CI owns the full suite.
 
@@ -104,100 +106,21 @@ something else.
 - **Teammates persist.** An agent keeps its workspace, thread and identity across provider switches
   and restarts. Resetting an agent to get a cleaner state changes the product.
 
-## Renderer UI
+## Where the rest of this lives
 
-The UI stack sits on prerelease channels your training data does not cover: `solid-js@2.0.0-rc.0`
-with `@solidjs/signals` and `@solidjs/web` at the same RC, `@kobalte/core@2.0.0-alpha.0` (patched
-here), plus patched `lucide-solid` and `solid-sonner`. Do not trust your memory of these APIs: check
-`package.json`, then read `.agents/skills/react-to-solid/docs/` (`kobalte-patterns.md`,
-`corvu-patterns.md`, `base-ui-mapping.md`, `third-party-deps.md`) and
-`.agents/skills/zaidan/references/`. Those two skills are vendored and re-synced from upstream, so
-their code samples are 1.x-era and cannot be corrected here — `node_modules/solid-js/CHEATSHEET.md`
-is the source of truth for core APIs, and where they disagree the cheatsheet wins. Read the skills
-for the component patterns, not the imports.
+Five directories carry rules this file used to hold. Each is loaded when you open a file under it,
+and each says what its own boundary costs and how to wait in its tests.
 
-- `bun run dev` for integrated work — it starts the local Auth API and the Electron dev app
-  together. `bun run dev:api` is for API-only debugging.
-- `bun run storybook` verifies isolated components. CI builds it; do not run `build-storybook`.
-- Never verify UI with `dist/`, a packaged `.app`, a production build, or an ad-hoc preview — those
-  are for release verification the user asked for. If the dev app will not start, report the blocker
-  instead of falling back to one.
+| File | What it owns |
+| --- | --- |
+| `src/renderer/AGENTS.md` | the prerelease SolidJS stack, one store per concern, component reuse, the palette |
+| `src/main/AGENTS.md` | the renderer-to-main trust boundary, and where an IPC endpoint is registered |
+| `src/backend/AGENTS.md` | the user's SQLite: irreversible migrations, and the two database build paths |
+| `packages/contracts/AGENTS.md` | the Team API wire protocol, and the one channel list with its three mirrors |
+| `apps/auth-api/AGENTS.md` | the account Worker, and why its D1 migrations must survive a deploy race |
 
-### Reactive state shape
-
-**Prefer one `createStore` per concern over a row of `createSignal` calls.** Fields that change
-together are one record — a saved-and-draft form pair, a `data`/`loaded`/`loading`/`error` quad, a
-phase plus the numbers only one phase uses, several `Record`s keyed by the same `botId`. Declare the
-shape up front, so replacing one field re-renders only what read that field; `FirstBotSetup.tsx` is
-the form version. Keep the setter private behind named mutations where the store *is* a module's or
-a hook's exported surface, as `app-stored-values.ts` and `createAsyncPanel.ts` do. Inside a
-component, write the field where it changes — `setPanels((state) => { state.x = value; })` at the
-call site, as `SettingsModal.tsx` does — and let a named mutation there earn its name: more than one
-field, a guard or a side effect, or enough call sites that the name deduplicates something. A
-function whose whole body is `state.x = value` is the signal wall one layer down. Ten keyed
-`Record` signals are one row type shredded into ten columns, every write spreads the whole map so
-every consumer of every key re-runs, and parallel signals let a screen hold states
-the product does not have. `createSignal` still fits an element ref, a single measurement, a one-off
-boolean, and a record you always replace whole. Stores come from `"solid-js"` — there is no
-`solid-js/store` in this RC — hold plain values rather than accessors, and are never destructured.
-A `Map` or `Set` never becomes a store — `isWrappable` rejects platform objects — so the
-reference is the reactive unit: write a collection held in a signal by copying
-(`new Set(current).add(id)`), and keep one you never read reactively in a closure.
-
-### Component reuse
-
-Search for an existing component, hook, style, utility or story first, and prefer reuse, composition
-or a small extension. The shared layer is `src/renderer/src/components/ui` over patched Kobalte:
-extend a primitive there rather than copying one into a feature, and update its story when it gains
-a visual or interactive state. Build from scratch only after the search comes up empty, and keep it
-reusable. The [Zaidan catalog](https://zaidan.carere.dev/docs/components) is a source of reference
-*patterns*, not a dependency — it is not installed here; adapt its source to this repository's
-SolidJS conventions, tokens, typography, spacing, icons and accessibility requirements.
-
-### Design system
-
-Use `lucide-solid` icons, and reuse a suitable one before adding an inline SVG or a local icon
-component — document the exception next to any custom icon. The `:root` properties in
-`src/renderer/src/styles.css` are the palette: use the closest semantic `--openbot-*` token,
-including opacity variants, instead of a colour literal, and add a token only for a new semantic
-role. Keep compatibility aliases that are in use, and isolate fixed integration, generated-asset,
-SVG and platform colours at their boundaries.
-
-## Database migrations
-
-- Nothing copies `openbot.db` before an upgrade. Every migration is an irreversible production data
-  operation: preserve all user data, support every shipped source schema, never depend on a backup.
-- Keep each schema change and its `schema_migrations` marker in one transaction. Roll back on any
-  error, restore foreign-key enforcement in `finally`, and run the integrity checks before startup
-  continues.
-- Never edit or delete a migration that may have shipped, including the frozen version 8 baseline.
-  Append the next contiguous version and update the separate latest schema for new databases.
-- A migration change needs data-preservation fixtures for every affected released schema, plus
-  failure, rollback, retry, downgrade, missing-version, foreign-key and integrity coverage at the
-  stable database boundary.
-- No automatic full-database backups: conversation history lives in SQLite, so their time and disk
-  cost is unbounded. Make the migration itself safe instead.
-- The account service has a second, unrelated database. CI applies the D1 migrations under
-  `apps/auth-api/migrations/` **before** deploying the new Worker, so every D1 migration must be
-  backward compatible with the Worker still running. One that is not needs a test proving the old
-  Worker tolerates the new schema, or a two-step release.
-
-## Team API protocol compatibility
-
-- Never use the application SemVer as a wire protocol version; application versions are diagnostic
-  metadata only.
-- Keep a frozen codec, adapter, and client and host fixtures for each released protocol under
-  `packages/contracts/src/team-protocol`, and one registered adapter per supported protocol. Do not
-  serialize current IPC types across the boundary.
-- Use capabilities for additive, optional behaviour; a missing capability disables only its own
-  feature.
-- A required field, a removed field, or a semantic change needs a new protocol version. Never change
-  the meaning of a released one.
-- Age, release count and SemVer distance are not reasons to remove an adapter. Removal needs a
-  separate architecture decision — a security issue, data-loss risk, semantics that cannot be kept,
-  or cost an adapter cannot contain — plus a changelog entry, update instructions, both
-  update-direction tests, and clear UI text.
-- Malformed known payloads fail closed as `protocol_error`. Unknown optional events are ignored.
+Read the one for the directory you are changing before you change it. `docs/ARCHITECTURE.md`
+"Change rules" says where a change belongs when it is not obvious.
 
 ## Tests
 

--- a/apps/auth-api/AGENTS.md
+++ b/apps/auth-api/AGENTS.md
@@ -1,0 +1,20 @@
+# `apps/auth-api`
+
+The Cloudflare Worker behind accounts, avatars, host configuration, memberships, invitations and
+logical sessions. It never holds chats, files or commands, and the app works without it — a change
+here must not become something core function depends on.
+
+## D1 migrations run before the Worker that needs them
+
+`migrations/` is a second, unrelated database to the user's SQLite in `src/backend`. CI applies
+these migrations **before** deploying the new Worker, so for the length of that gap the old Worker
+is running against the new schema. Every migration must be backward compatible with it: adding a
+`NOT NULL` column without a default, renaming one, or dropping one the deployed Worker still reads
+takes production down between the two steps.
+
+One that cannot be backward compatible needs a test proving the old Worker tolerates the new schema,
+or a two-step release — expand the schema, deploy the Worker that uses it, then contract in a later
+change.
+
+This is a different rule from the one in `src/backend/AGENTS.md`. There, migrations are irreversible
+because they run on the user's own machine with no backup; here they are reversible but *raced*.

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -1,0 +1,50 @@
+# `packages/contracts`
+
+The IPC channel list, the IPC payload types, and the frozen Team API wire protocol. Everything here
+is a contract someone else already implements — a shipped desktop build, a remote host, a renderer
+mock — so the cost of a change is paid by code you cannot edit.
+
+## Team API protocol compatibility
+
+- Never use the application SemVer as a wire protocol version; application versions are diagnostic
+  metadata only.
+- Keep a frozen codec, adapter, and client and host fixtures for each released protocol under
+  `src/team-protocol`, and one registered adapter per supported protocol. Do not serialize current
+  IPC types across the boundary.
+- Use capabilities for additive, optional behaviour; a missing capability disables only its own
+  feature.
+- A required field, a removed field, or a semantic change needs a new protocol version. Never change
+  the meaning of a released one.
+- Age, release count and SemVer distance are not reasons to remove an adapter. Removal needs a
+  separate architecture decision — a security issue, data-loss risk, semantics that cannot be kept,
+  or cost an adapter cannot contain — plus a changelog entry, update instructions, both
+  update-direction tests, and clear UI text.
+- Malformed known payloads fail closed as `protocol_error`. Unknown optional events are ignored.
+
+## One channel list, four hand-written mirrors
+
+`src/ipc-channels.ts` declares every channel. Three files mirror it by hand:
+
+| Mirror | What it is |
+| --- | --- |
+| `src/main/index.ts` and `src/main/ipc/` | the `handleTrusted` registrations |
+| `src/preload/index.ts` | the `invoke` calls the renderer actually reaches |
+| `src/renderer/src/preview/mock-openbot.ts` | the second implementation Storybook and the preview run against |
+
+The three mirrors are not enforced the same way, and the difference is worth knowing before you
+reach for a test.
+
+Between main and preload, `tsc` links the payload types but not the existence of either end: a
+channel invoked with no handler type-checks and rejects at runtime.
+`src/main/ipc-channel-coverage.test.ts` is that link — it reads both process sources statically and
+fails on a channel either side is missing, an endpoint registered twice, or an orphan on either
+side.
+
+The mock needs no such test. Both it and the preload bridge are annotated `: OpenBotDesktopApi`, so
+a missing method is `TS2741` and a method the interface never declared is `TS2353` — the type
+checker already covers both directions, and under Tests rule 3 that is the end of it. What it cannot
+cover is the *behaviour*: `mock-openbot.ts` is a product surface, not a test double, and it is what
+the preview and every Storybook story exercise. A method that satisfies the type by returning an
+empty array is a story that silently shows nothing.
+
+Adding a channel still means all four files in the same change.

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -1,0 +1,67 @@
+# `src/backend`
+
+The stores, the SQLite database, the provider clients and `agent-service.ts`. The user's SQLite is
+the source of truth here, not a cache of something remote — which is what makes the first section
+below non-negotiable.
+
+## Database migrations
+
+- Nothing copies `openbot.db` before an upgrade. Every migration is an irreversible production data
+  operation: preserve all user data, support every shipped source schema, never depend on a backup.
+- Keep each schema change and its `schema_migrations` marker in one transaction. Roll back on any
+  error, restore foreign-key enforcement in `finally`, and run the integrity checks before startup
+  continues.
+- Never edit or delete a migration that may have shipped, including the frozen version 8 baseline.
+  Append the next contiguous version and update the separate latest schema for new databases.
+- A migration change needs data-preservation fixtures for every affected released schema, plus
+  failure, rollback, retry, downgrade, missing-version, foreign-key and integrity coverage at the
+  stable database boundary.
+- No automatic full-database backups: conversation history lives in SQLite, so their time and disk
+  cost is unbounded. Make the migration itself safe instead.
+
+### The two build paths
+
+`openbot-database-schema.ts` builds a database twice. `createLatestDatabase` execs
+`LATEST_SCHEMA_SQL` and then stamps every entry in `MIGRATIONS` as applied **without running it**;
+an existing database runs them for real. A DDL migration that is not also mirrored by hand into
+`LATEST_SCHEMA_SQL` therefore ships new installs a database missing that column while upgraded
+installs get it, silently, on the user's machine.
+
+`openbot-database-schema-parity.test.ts` builds a database both ways and compares the normalised
+`sqlite_master` SQL and `PRAGMA table_info` per table, so that divergence is a red test rather than a
+support ticket. Do not weaken it; a new DDL migration means editing `LATEST_SCHEMA_SQL` in the same
+change.
+
+The account service has a second, unrelated database — Cloudflare D1 — and its rule is the opposite
+shape: those migrations are reversible but race a deploy. `apps/auth-api/AGENTS.md` owns it — nothing in this
+directory touches `apps/auth-api/migrations/`.
+
+## Waiting in a backend test
+
+`*.test.ts` here runs in the `node` vitest project with no DOM. The barriers this directory already
+offers, in order of preference:
+
+| Barrier | Use it for |
+| --- | --- |
+| `waitFor(predicate)` — `agent-service-test-harness.ts` | Anything driven by the fake provider process. Polls to a deadline and fails naming *the predicate that never held*, printing the source of the check. |
+| `nextRoutinesChanged(service, botId)` — same file | One named `AgentEvent`. Resolves on the event; the pattern generalizes to any other event you need. |
+| `callOpenBotTool(...)` / `expectOpenBotToolError(...)` | A tool round trip. Both already contain the wait. |
+| `await service.someMethod()` | A promise the code under test already returns. Prefer it over observing a side effect of the same call. |
+| `vi.waitFor(() => expect(...))` | A spy or a fake reaching a count, where there is no domain event to hang off. |
+| `vi.useFakeTimers()` + `vi.advanceTimersByTime(n)` | A debounce, a retry backoff, a schedule. Advancing the clock is input, not waiting. |
+
+`test-deadlines.ts` is why `waitFor` reports before vitest does: `NODE_TEST_TIMEOUT_MS` is derived
+from `HARNESS_WAIT_TIMEOUT_MS` rather than written down twice, so a stalled wait fails with the
+condition rather than with vitest's generic "test timed out". Never raise a `vi.waitFor` timeout to
+make a test pass — a longer timeout is the sleep the `no-sleep-in-tests` rule rejected, one layer
+down. Find the barrier, or add one.
+
+**A fixed delay is only ever right as input**, never as a wait: modelling latency in a fake, testing
+that a debounce does *not* fire early, and mtime granularity on a filesystem. All three read as
+"this delay is the thing under test". If the delay is there so the code has time to finish, it is
+wrong.
+
+## Size
+
+`agent-service.ts` is the largest hand-written file in the repository by a wide margin. Do not add a
+new concern to it; extract one when a change gives you the excuse.

--- a/src/main/AGENTS.md
+++ b/src/main/AGENTS.md
@@ -1,0 +1,81 @@
+# `src/main`
+
+The Electron main process: the trust boundary, the windows, the lifecycle, and the services the
+renderer is not allowed to reach directly. Everything here runs with the user's full privileges, so
+the question for any change is not "does the renderer need this" but "what can a compromised
+renderer do with it".
+
+## Where an IPC endpoint goes
+
+A renderer-to-main endpoint is **declared in `packages/contracts`** and **registered in
+`src/main/ipc/`, one file per domain** — never inline in `index.ts`. `registerIpcHandlers` there is
+a dispatcher and nothing else: it wires dependencies and calls one `register*IpcHandlers` per
+domain, so a reviewer can read a domain's whole surface in one file instead of finding it
+interleaved with window and lifecycle code. `register-team-handlers.ts` is the shape to copy — a
+`*IpcDependencies` interface, object destructuring in the signature, no imports from `index.ts`.
+
+Three things run at module scope in `index.ts` — `app.setPath`, `app.enableSandbox`,
+`protocol.registerSchemesAsPrivileged` — which is why nothing in the main process can be imported
+by a test that has not mocked `electron`, and why the coverage test below reads sources instead.
+
+- `handleTrusted` / `handleTrustedWithEvent` from `./trusted-ipc` are the only registration
+  primitives. `ipc-channel-coverage.test.ts` fails on the *name* `ipcMain` anywhere else in
+  `src/main`, because an aliased import would register an endpoint with no sender check that no
+  scan can see.
+- Parse every argument. The renderer sends `unknown`: `./ipc/validation.ts` has `requireString`,
+  `isObject` and `optionalBoolean`, and the `*-inputs.ts` files hold the per-domain parsers. A
+  handler that reads `input.path` off an untyped value is the boundary failing open.
+- Never write a channel name as a string literal. Every reference goes through `IPC_CHANNELS`, and
+  the coverage test rejects a channel argument that is not a direct `IPC_CHANNELS.x` reference —
+  a literal or a variable would hide the endpoint from every assertion in that file.
+- Sending to the renderer goes through `sendToRenderer` in `./renderer-ipc.ts`, which drops the
+  message on a destroyed or still-loading window rather than throwing into the emitter.
+
+A domain module that is never called from `registerIpcHandlers` would otherwise be invisible: the
+coverage scan reads sources, so an orphaned file still looks registered while every channel in it
+rejects at runtime. `tsc` catches only half of it — deleting the call alone is `TS6133`, because the
+call site is the import's only use, but deleting the import along with it compiles, and so does a
+new registrar nobody wired up. "Calls every registrar under `src/main/ipc` exactly once from the
+dispatcher" in `ipc-channel-coverage.test.ts` is the other half. Do not silence a `TS6133` here by
+deleting the import; that turns the loud failure into the quiet one.
+
+Adding a channel touches four files in one change: the contract, `src/main/ipc/`,
+`src/preload/index.ts`, and `src/renderer/src/preview/mock-openbot.ts`. See
+`packages/contracts/AGENTS.md` for what enforces which pair.
+
+## The boundary is a Non-negotiable
+
+Sandboxing, context isolation, navigation policy and sender validation are the whole reason the
+process split exists — agents already run with `danger-full-access`, so nothing behind the boundary
+is defence in depth. `trusted-renderer.ts` decides what an origin is, `renderer-permissions.ts` what
+it may ask for, `content-security-policy.ts` what it may load. Each has a test, and a change to any
+of them needs one. Widening `isTrustedRendererUrl` to accept a development convenience is the
+single most expensive edit available in this directory.
+
+## Waiting in a main-process test
+
+A test that needs a timeout to pass is wrong (root AGENTS.md, Tests rule 4). These are the barriers
+this directory already has, in the order to reach for them:
+
+| Situation | Wait on |
+| --- | --- |
+| A service emits a status event | its own emitter — `provider-runtime-manager.test.ts` has the four-line `waitFor(manager, predicate)` that resolves on the first matching snapshot |
+| A handler returns a promise | the promise. `handleTrusted` returns whatever the handler returns, so the registration captured by a mocked `ipcMain` is awaitable |
+| A spy will be called, with no event to hold | `await vi.waitFor(() => expect(spy).toHaveBeenCalledOnce())` |
+| A socket or server must be listening | `await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))` — the callback, never a delay |
+| A debounce, retry backoff or poll interval | `vi.useFakeTimers()` and advance it. A real 300 ms wait is a flake on a loaded runner |
+
+A fixed delay is only ever right as *input* — the interval a test configures a service with, an
+artificial provider latency — never as the thing a test waits on.
+
+`electron` cannot be imported outside an Electron process, so a test for anything in here mocks it.
+`trusted-ipc.test.ts` shows the pattern: `vi.hoisted` a registrations `Map`, `vi.mock("electron")`
+to capture into it, then invoke the captured listener with a fabricated sender frame. Mocking is
+what the file under test forces, not a preference — a service that can be tested without it should
+not import `electron` in the first place.
+
+## Size
+
+`index.ts` is the dispatcher plus window and lifecycle code and should not grow handlers again.
+`remote-server-manager.ts` is the outlier here; splitting it is its own change, but do not add a
+concern to it because it is already the file that has too many.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,37 +1,17 @@
-import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { chmod, copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { basename, extname, isAbsolute, join, relative, resolve } from "node:path";
-import {
-  ATTACHMENT_FILE_EXTENSIONS,
-  IMAGE_ATTACHMENT_EXTENSIONS,
-  isSupportedAttachmentName,
-  SUPPORTED_ATTACHMENT_DESCRIPTION,
-} from "@openbot/contracts/attachment-files";
-import { ATTACHMENT_LIMITS, INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import { extname, isAbsolute, join, relative, resolve } from "node:path";
 import { parseInviteUrl } from "@openbot/contracts/invite-links";
 import {
   type AgentEvent,
-  type AppInfo,
-  type AppSetupState,
   type BrowserDisplayState,
   type CentralAuthState,
-  type DuplicateBotResult,
-  type ExternalDestination,
-  type FilePreview,
-  type ImportAttachmentsInput,
   IPC_CHANNELS,
-  isSkillCategory,
   type MacPermissionId,
-  type SendMessageInput,
-  type SidebarLayoutSnapshot,
-  type UpdateBotInput,
   type VoiceModelStatus,
-  type VoiceTranscriptionResult,
 } from "@openbot/contracts/ipc";
-import { isNumber, isString } from "@openbot/contracts/runtime-values";
-import { validateProfileName } from "@openbot/contracts/validation";
+
 import {
   app,
   BrowserWindow,
@@ -39,7 +19,6 @@ import {
   dialog,
   Menu,
   Notification,
-  type OpenDialogOptions,
   powerMonitor,
   protocol,
   type Rectangle,
@@ -61,7 +40,7 @@ import { AgentInitializationGate } from "./agent-initialization";
 import { AgentMarketplaceService } from "./agent-marketplace-service";
 import { notificationForAgentEvent } from "./agent-notifications";
 import { HostAnalytics } from "./analytics";
-import { readAnalyticsPreference, writeAnalyticsPreference } from "./analytics-preference-store";
+import { readAnalyticsPreference } from "./analytics-preference-store";
 import { readAppVariant, resolveAppIconPath } from "./app-icon";
 import { BrowserPictureInPicture } from "./browser-picture-in-picture";
 import { CentralAuthManager, readCentralAuthApiUrl, readMobileConnectApiUrl } from "./central-auth-manager";
@@ -77,97 +56,35 @@ import {
   shouldShowDevelopmentWindow,
 } from "./development-profile";
 import { performDynamicIslandCriticalAction } from "./dynamic-island-actions";
-import {
-  DynamicIslandWindowController,
-  dynamicIslandNotchSizeForDisplay,
-  requireDynamicIslandSender,
-} from "./dynamic-island-window";
-import { filePreviewFromBytes, localFilePreview, mimeTypeForName } from "./file-preview";
+import { DynamicIslandWindowController, dynamicIslandNotchSizeForDisplay } from "./dynamic-island-window";
 import { DEVELOPMENT_REMOTE_CLIENT_USERNAME, HostService } from "./host-service";
 import { HostedSiteDesktopService } from "./hosted-site-service";
-import {
-  parseAcknowledgeFailedTurn,
-  parseAgentRequest,
-  parseApprovalResponse,
-  parseBrowserTakeoverResponse,
-  parseCancelQueuedMessage,
-  parseChooseAttachments,
-  parseCreateBot,
-  parseCreateBotMemory,
-  parseCreateRoutine,
-  parseDeleteBotMemory,
-  parseDeleteRoutine,
-  parseImportAttachments,
-  parseInterrupt,
-  parseListRoutineRuns,
-  parseMarkConversationRead,
-  parseMessageReaction,
-  parseOpenAttachment,
-  parseOpenSharedFile,
-  parseOpenWorkspaceFile,
-  parsePromptResponse,
-  parseReadConversationPage,
-  parseReorderQueue,
-  parseSearchConversationMessages,
-  parseSendMessage,
-  parseSetAgentAvatar,
-  parseSidebarLayoutAction,
-  parseSteerQueuedMessage,
-  parseTestRoutine,
-  parseUpdateBot,
-  parseUpdateBotMemory,
-  parseUpdateQueuedMessage,
-  parseUpdateRoutine,
-} from "./ipc/agent-inputs";
-import {
-  parseAnalyticsPreference,
-  parseDynamicIslandAction,
-  parseDynamicIslandInteractive,
-  parseDynamicIslandPreference,
-  parseDynamicIslandPresentation,
-  parseExternalDestination,
-  parseMacPermission,
-  parseProvider,
-  parseProviderId,
-  parseUpdatePreference,
-} from "./ipc/app-inputs";
-import { parseAvatarImage } from "./ipc/avatar-inputs";
-import { parseBrowserBounds, parseBrowserNavigate, parseBrowserOpen, parseVisibility } from "./ipc/browser-inputs";
+
+import { registerAccountIpcHandlers } from "./ipc/register-account-handlers";
+import { registerAgentIpcHandlers } from "./ipc/register-agent-handlers";
+import { registerAppIpcHandlers } from "./ipc/register-app-handlers";
+import { registerAttachmentIpcHandlers } from "./ipc/register-attachment-handlers";
+import { registerBrowserIpcHandlers } from "./ipc/register-browser-handlers";
+import { registerComputerUseIpcHandlers } from "./ipc/register-computer-use-handlers";
+import { registerDynamicIslandIpcHandlers } from "./ipc/register-dynamic-island-handlers";
+import { registerHostedSiteIpcHandlers } from "./ipc/register-hosted-site-handlers";
+import { registerMarketplaceAgentIpcHandlers } from "./ipc/register-marketplace-agent-handlers";
+import { registerMemoryIpcHandlers } from "./ipc/register-memory-handlers";
+import { registerProviderIpcHandlers } from "./ipc/register-provider-handlers";
+import { registerRoutineIpcHandlers } from "./ipc/register-routine-handlers";
+import { registerSkillIpcHandlers } from "./ipc/register-skill-handlers";
 import { registerTeamIpcHandlers, withLocalHostSummary } from "./ipc/register-team-handlers";
-import { isObject, optionalBoolean, requireString } from "./ipc/validation";
-import { parseVoiceTranscription } from "./ipc/voice-inputs";
+import { registerUpdateIpcHandlers } from "./ipc/register-update-handlers";
+import { registerVoiceIpcHandlers } from "./ipc/register-voice-handlers";
+
 import { MacHapticFeedback } from "./mac-haptic-feedback";
 import { readMainWindowBounds, resolveMainWindowBounds, writeMainWindowBounds } from "./main-window-state";
-import { exportDiagnostics, exportOpenBotData } from "./maintenance-service";
 import { ManagedSkillService } from "./managed-skill-service";
 import { ProviderRuntimeManager } from "./provider-runtime-manager";
 import { RemoteDesktopManager } from "./remote-desktop-manager";
 import { resolveRemoteDesktopRuntime } from "./remote-desktop-runtime-artifact";
 import { loadOrCreateRemoteDesktopCredentials } from "./remote-desktop-secret-store";
-import {
-  type DevelopmentRemoteServerConnection,
-  decodeAccountUsage,
-  decodeAgentModelOptions,
-  decodeAgentStatus,
-  decodeBotMemories,
-  decodeBotMemory,
-  decodeBotSummaries,
-  decodeBotSummary,
-  decodeBrowserControlState,
-  decodeBrowserPreview,
-  decodeBrowserTab,
-  decodeBrowserTabs,
-  decodeInstalledSkills,
-  decodeQueuedMessageReceipt,
-  decodeQueueSnapshot,
-  decodeRoutine,
-  decodeRoutineRun,
-  decodeRoutineRuns,
-  decodeRoutines,
-  decodeSidebarLayoutSnapshot,
-  decodeVoid,
-  RemoteServerManager,
-} from "./remote-server-manager";
+import { type DevelopmentRemoteServerConnection, decodeVoid, RemoteServerManager } from "./remote-server-manager";
 import { sendToRenderer } from "./renderer-ipc";
 import { canCheckRendererPermission, canRequestRendererPermission } from "./renderer-permissions";
 import { readSetupState, writeSetupState } from "./setup-store";
@@ -175,9 +92,8 @@ import { SkillMarketplaceService } from "./skill-marketplace-service";
 import { TeamStore } from "./team-store";
 import { TeamWebRtcBridge } from "./team-webrtc-bridge";
 import { TeamWebRtcClientTransport } from "./team-webrtc-client-transport";
-import { handleTrusted, handleTrustedWithEvent } from "./trusted-ipc";
 import { isTrustedRendererUrl } from "./trusted-renderer";
-import { readUpdatePreference, writeUpdatePreference } from "./update-preference-store";
+import { readUpdatePreference } from "./update-preference-store";
 import { supportsInstalledUpdates, UpdateService } from "./update-service";
 import { WHISPER_MODEL_NAME, WHISPER_MODEL_URL } from "./voice-model-service";
 import { VoiceTranscriptionService } from "./voice-transcription-service";
@@ -305,13 +221,6 @@ const REMOTE_SERVERS_FILE = "openbot-remote-servers-v1.json";
 const CENTRAL_AUTH_FILE = "openbot-central-auth-v1.bin";
 const LEGACY_REMOTE_DESKTOP_CREDENTIAL_FILE = "openbot-remote-desktop-credential-v1.json";
 const REMOTE_DESKTOP_RUNTIME_SECRET_FILE = "openbot-remote-desktop-runtime-v1.json";
-const EXTERNAL_DESTINATIONS: Record<ExternalDestination, string> = {
-  "agent-setup": "https://github.com/NorbertBodziony/openbot/blob/main/docs/TROUBLESHOOTING.md",
-  "claude-install": "https://code.claude.com/docs",
-  "claude-sign-in": "https://code.claude.com/docs/en/authentication",
-  feedback: "https://x.com/intent/post?text=Feedback%20for%20OpenBot%20%40norbertbodziony%3A%20",
-  message: "https://x.com/norbertbodziony",
-};
 
 function configureContentSecurityPolicy(): void {
   const policy = buildContentSecurityPolicy(app.isPackaged);
@@ -330,293 +239,84 @@ function configureContentSecurityPolicy(): void {
   });
 }
 
-function registerIpcHandlers(
-  service: AgentService,
-  providerRuntimes: ProviderRuntimeManager,
-  mailbox: MailboxStore,
-  browser: BrowserHost,
-  browserPictureInPicture: BrowserPictureInPicture,
-  updater: UpdateService,
-  setupFile: string,
-  analyticsPreferenceFile: string,
-  updatePreferenceFile: string,
-  initializeAgent: () => Promise<void>,
-  sidebarLayout: SidebarLayoutStore,
-  host: HostService,
-  remoteDesktop: RemoteDesktopManager,
-  remoteServers: RemoteServerManager,
-  centralAuth: CentralAuthManager,
-  skills: SkillMarketplaceService,
-  hostedSites: HostedSiteDesktopService,
-  marketplaceAgents: AgentMarketplaceService,
-  voice: VoiceTranscriptionService,
-  dynamicIsland: DynamicIslandWindowController,
-  computerUseMacSetup: ComputerUseMacSetupWindowController,
-): void {
-  handleTrusted(IPC_CHANNELS.getAppInfo, (): AppInfo => {
-    const platform = process.platform;
-    if (platform !== "darwin" && platform !== "win32" && platform !== "linux") {
-      throw new Error(`Unsupported desktop platform: ${platform}`);
-    }
-    return { name: app.getName(), version: app.getVersion(), platform, variant: appVariant };
-  });
-  handleTrusted(IPC_CHANNELS.getSetupState, () => readSetupState(setupFile));
-  handleTrusted(IPC_CHANNELS.getAnalyticsPreference, () => readAnalyticsPreference(analyticsPreferenceFile));
-  handleTrusted(IPC_CHANNELS.setAnalyticsPreference, async (input: unknown) => {
-    const preference = await writeAnalyticsPreference(analyticsPreferenceFile, parseAnalyticsPreference(input).enabled);
-    hostAnalytics?.setTrackingEnabled(preference.enabled);
-    return preference;
-  });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandGetPreference, (event) => {
-    requireDynamicIslandSender(
-      event.sender.id,
-      new Set([...dynamicIsland.mainRendererIds, ...dynamicIsland.overlayRendererIds]),
-      "main or Dynamic Island renderer",
-    );
-    return dynamicIsland.preference;
-  });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetPreference, (event, input: unknown) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer");
-    return dynamicIsland.setPreference(parseDynamicIslandPreference(input));
-  });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPublishPresentation, (event, input: unknown) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer");
-    dynamicIsland.publish(parseDynamicIslandPresentation(input));
-  });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandGetPresentation, (event) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
-    return dynamicIsland.presentation;
-  });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPerformAction, (event, input: unknown) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
-    return dynamicIsland.performAction(parseDynamicIslandAction(input));
-  });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPerformHaptic, (event) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
-    dynamicIsland.performHaptic();
-  });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetInteractive, (event, input: unknown) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
-    dynamicIsland.setInteractive(event.sender.id, parseDynamicIslandInteractive(input).interactive);
-  });
-  handleTrusted(IPC_CHANNELS.saveSetup, async (input: unknown): Promise<AppSetupState> => {
-    const preferredProvider = parseProvider(input);
-    const state = await writeSetupState(setupFile, preferredProvider);
-    await service.setPreferredProvider(preferredProvider);
-    await initializeAgent();
-    return state;
-  });
-  handleTrusted(IPC_CHANNELS.computerUseGetMacSetupState, () => computerUseMacSetup.getState());
-  handleTrusted(IPC_CHANNELS.computerUseOpenMacPermissionSetup, (permission: unknown) =>
-    computerUseMacSetup.open(parseMacPermission(permission)),
-  );
-  handleTrustedWithEvent(IPC_CHANNELS.computerUseStartHelperDrag, (event) =>
-    computerUseMacSetup.startDrag(event.sender),
-  );
-  handleTrusted(IPC_CHANNELS.computerUseRevealHelper, () => computerUseMacSetup.revealHelper());
-  handleTrusted(IPC_CHANNELS.computerUseCloseMacPermissionSetup, () => computerUseMacSetup.close());
-  handleTrusted(IPC_CHANNELS.openExternal, (destination: unknown) => {
-    return shell.openExternal(EXTERNAL_DESTINATIONS[parseExternalDestination(destination)]);
-  });
-  handleTrusted(IPC_CHANNELS.connectChatGPT, () =>
-    service.connectChatGPT(async (value) => {
-      const url = new URL(value);
-      if (url.protocol !== "https:") throw new Error("Only HTTPS ChatGPT login links can open in the browser.");
-      await shell.openExternal(url.toString());
-    }),
-  );
-  handleTrusted(IPC_CHANNELS.connectClaude, () => service.connectClaude());
-  handleTrusted(IPC_CHANNELS.connectGrok, () => service.connectGrok());
-  handleTrusted(IPC_CHANNELS.refreshAgentProviders, () => service.refreshProviders());
-  handleTrusted(IPC_CHANNELS.providerRuntimesGetStatus, () => providerRuntimes.getStatus());
-  handleTrusted(IPC_CHANNELS.providerRuntimesDownload, (provider: unknown) =>
-    providerRuntimes.download(parseProviderId(provider)),
-  );
-  handleTrusted(IPC_CHANNELS.providerRuntimesCancel, (provider: unknown) =>
-    providerRuntimes.cancel(parseProviderId(provider)),
-  );
-  handleTrusted(IPC_CHANNELS.openUrl, (value: unknown) => {
-    const url = new URL(requireString(value, "URL", INPUT_LIMITS.browserUrl));
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-      throw new Error("Only HTTP(S) links can open in the external browser.");
-    }
-    return shell.openExternal(url.toString());
-  });
-  handleTrusted(IPC_CHANNELS.voiceGetModelStatus, (): Promise<VoiceModelStatus> => voice.getModelStatus());
-  handleTrusted(IPC_CHANNELS.voicePrepareModel, (): Promise<VoiceModelStatus> => voice.prepareModel());
-  handleTrusted(
-    IPC_CHANNELS.voiceTranscribe,
-    (input: unknown): Promise<VoiceTranscriptionResult> => voice.transcribe(parseVoiceTranscription(input).audio),
-  );
-  handleTrusted(IPC_CHANNELS.authGetState, () => centralAuth.getState());
-  handleTrusted(IPC_CHANNELS.authRetry, () => centralAuth.retry());
-  handleTrusted(IPC_CHANNELS.authRequestEmailCode, (email: unknown) =>
-    centralAuth.requestEmailCode(requireString(email, "email", INPUT_LIMITS.email)),
-  );
-  handleTrusted(IPC_CHANNELS.authVerifyEmailCode, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Sign-in code details are required.");
-    return centralAuth.verifyEmailCode(
-      requireString(input.challengeId, "challengeId", INPUT_LIMITS.identifier),
-      requireString(input.code, "code", 32),
-    );
-  });
-  handleTrusted(IPC_CHANNELS.authUpdateName, (input: unknown) => {
-    const rawName = requireString(input, "name", INPUT_LIMITS.accountName);
-    const validation = validateProfileName(rawName);
-    if (validation.error) {
-      throw new Error(
-        `name must contain ${INPUT_LIMITS.profileNameMin} to ${INPUT_LIMITS.profileName} safe characters.`,
-      );
-    }
-    return centralAuth.updateName(validation.name);
-  });
-  handleTrusted(IPC_CHANNELS.authUpdateAvatar, (input: unknown) => centralAuth.updateAvatar(parseAvatarImage(input)));
-  handleTrusted(IPC_CHANNELS.authCreateMobileConnect, () => centralAuth.createMobileConnect());
-  handleTrusted(IPC_CHANNELS.authListMobileConnectedDevices, () => centralAuth.listMobileConnectedDevices());
-  handleTrusted(IPC_CHANNELS.authRevokeMobileConnectedDevice, (input: unknown) =>
-    centralAuth.revokeMobileConnectedDevice(requireString(input, "sessionId", INPUT_LIMITS.identifier)),
-  );
-  handleTrusted(IPC_CHANNELS.authLogout, () => centralAuth.logout());
-  handleTrusted(IPC_CHANNELS.skillsList, (input: unknown) => {
-    if (input === null || input === undefined) return skills.list();
-    if (!isObject(input)) throw new Error("Invalid marketplace query.");
-    const category = input.category;
-    if (category !== undefined && !isSkillCategory(category)) throw new Error("Unknown skill category.");
-    if (input.sort !== undefined && input.sort !== "installs") throw new Error("Unknown skill sort order.");
-    return skills.list({
-      ...(isString(input.query) ? { query: input.query.slice(0, 100) } : {}),
-      ...(category ? { category } : {}),
-      ...(input.featured === true ? { featured: true } : {}),
-      ...(input.sort === "installs" ? { sort: "installs" as const } : {}),
-      ...(isString(input.cursor) ? { cursor: input.cursor } : {}),
-      ...(isNumber(input.limit) ? { limit: input.limit } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.skillsGet, (input: unknown) => skills.get(requireString(input, "skillId")));
-  handleTrusted(IPC_CHANNELS.skillsListMine, () => skills.listMine());
-  handleTrusted(IPC_CHANNELS.skillsChoosePackage, async () => {
-    const options: OpenDialogOptions = {
-      title: "Choose a skill folder or ZIP",
-      properties: ["openFile", "openDirectory"],
-      filters: [{ name: "Skill packages", extensions: ["zip"] }],
-    };
-    const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
-    return result.canceled || !result.filePaths[0] ? null : skills.stage(result.filePaths[0]);
-  });
-  handleTrusted(IPC_CHANNELS.skillsSubmit, (input: unknown) => {
-    if (!isObject(input) || !isSkillCategory(input.category)) throw new Error("Invalid skill submission.");
-    return skills.submit({
-      draftId: requireString(input.draftId, "draftId"),
-      category: input.category,
-      icon: parseAvatarImage(input.icon),
-      ...(input.skillId === undefined ? {} : { skillId: requireString(input.skillId, "skillId") }),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.skillsListInstalled, (input: unknown) =>
-    skills.listInstalled(requireString(input, "botId")),
-  );
-  handleTrusted(IPC_CHANNELS.skillsInstall, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid skill installation.");
-    return skills.install({
-      botId: requireString(input.botId, "botId"),
-      skillId: requireString(input.skillId, "skillId"),
-      ...(input.replaceModified === true ? { replaceModified: true } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.skillsUninstall, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid skill removal.");
-    return skills.uninstall({
-      botId: requireString(input.botId, "botId"),
-      skillId: requireString(input.skillId, "skillId"),
-      ...(input.removeModified === true ? { removeModified: true } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.hostedSitesList, () => hostedSites.list());
-  handleTrusted(IPC_CHANNELS.hostedSitesChooseDirectory, async () => {
-    const options: OpenDialogOptions = {
-      title: "Choose a static site directory",
-      properties: ["openDirectory"],
-    };
-    const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
-    return result.canceled ? null : (result.filePaths[0] ?? null);
-  });
-  handleTrusted(IPC_CHANNELS.hostedSitesPublish, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid site publication.");
-    const spaFallback = optionalBoolean(input.spaFallback, "spaFallback");
-    return hostedSites.publish({
-      sourcePath: requireString(input.sourcePath, "sourcePath", INPUT_LIMITS.path),
-      title: requireString(input.title, "title", 120),
-      description: requireString(input.description, "description", 500),
-      ...(spaFallback !== undefined ? { spaFallback } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.hostedSitesReplace, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid site replacement.");
-    const spaFallback = optionalBoolean(input.spaFallback, "spaFallback");
-    return hostedSites.replace({
-      siteId: requireString(input.siteId, "siteId", INPUT_LIMITS.identifier),
-      sourcePath: requireString(input.sourcePath, "sourcePath", INPUT_LIMITS.path),
-      title: requireString(input.title, "title", 120),
-      description: requireString(input.description, "description", 500),
-      ...(spaFallback !== undefined ? { spaFallback } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.hostedSitesDelete, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid site deletion.");
-    return hostedSites.delete(requireString(input.siteId, "siteId", INPUT_LIMITS.identifier));
-  });
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsList, (input: unknown) => {
-    if (input === null || input === undefined) return marketplaceAgents.list();
-    if (!isObject(input)) throw new Error("Invalid agent marketplace query.");
-    if (input.sort !== undefined && input.sort !== "installs") throw new Error("Unknown agent sort order.");
-    return marketplaceAgents.list({
-      ...(isString(input.query) ? { query: input.query.slice(0, 100) } : {}),
-      ...(input.featured === true ? { featured: true } : {}),
-      ...(input.sort === "installs" ? { sort: "installs" as const } : {}),
-      ...(isString(input.cursor) ? { cursor: input.cursor } : {}),
-      ...(isNumber(input.limit) ? { limit: input.limit } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsGet, (input: unknown) =>
-    marketplaceAgents.get(requireString(input, "agentId")),
-  );
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsListMine, () => marketplaceAgents.listMine());
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsPreview, (input: unknown) =>
-    marketplaceAgents.preview(requireString(input, "botId")),
-  );
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsSubmit, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid agent submission.");
-    return marketplaceAgents.submit({
-      botId: requireString(input.botId, "botId"),
-      ...(input.agentId === undefined ? {} : { agentId: requireString(input.agentId, "agentId") }),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsInstall, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid agent installation.");
-    return marketplaceAgents.install({
-      agentId: requireString(input.agentId, "agentId"),
-      ...(input.botId === undefined ? {} : { botId: requireString(input.botId, "botId", INPUT_LIMITS.identifier) }),
-      timezone: requireString(input.timezone, "timezone", 255),
-      receiptId: requireString(input.receiptId, "receiptId", INPUT_LIMITS.identifier),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.updateGetStatus, () => updater.getStatus());
-  handleTrusted(IPC_CHANNELS.updateCheck, () => updater.checkForUpdates());
-  handleTrusted(IPC_CHANNELS.updateDownload, () => updater.downloadUpdate());
-  handleTrusted(IPC_CHANNELS.updateInstall, () => updater.installUpdate());
-  handleTrusted(IPC_CHANNELS.updateGetPreference, () => readUpdatePreference(updatePreferenceFile));
-  handleTrusted(IPC_CHANNELS.updateSetPreference, async (input: unknown) => {
-    const preference = await writeUpdatePreference(updatePreferenceFile, parseUpdatePreference(input).autoDownload);
-    updater.setAutoDownload(preference.autoDownload);
-    return preference;
-  });
-  handleTrusted(IPC_CHANNELS.maintenanceExportData, () =>
-    exportOpenBotData({ service, mailbox, parentWindow: mainWindow }),
-  );
-  handleTrusted(IPC_CHANNELS.maintenanceExportDiagnostics, () =>
-    exportDiagnostics({ service, browser, updater, parentWindow: mainWindow }),
-  );
+// Named rather than positional, like the per-domain registrars below.
+// `setupFile`, `analyticsPreferenceFile` and `updatePreferenceFile` are three
+// paths of the same type: passed positionally, swapping two compiles cleanly
+// and writes one preference into another's file, which nothing would catch.
+interface IpcHandlerDependencies {
+  service: AgentService;
+  providerRuntimes: ProviderRuntimeManager;
+  mailbox: MailboxStore;
+  browser: BrowserHost;
+  browserPictureInPicture: BrowserPictureInPicture;
+  updater: UpdateService;
+  setupFile: string;
+  analyticsPreferenceFile: string;
+  updatePreferenceFile: string;
+  initializeAgent: () => Promise<void>;
+  sidebarLayout: SidebarLayoutStore;
+  host: HostService;
+  remoteDesktop: RemoteDesktopManager;
+  remoteServers: RemoteServerManager;
+  centralAuth: CentralAuthManager;
+  skills: SkillMarketplaceService;
+  hostedSites: HostedSiteDesktopService;
+  marketplaceAgents: AgentMarketplaceService;
+  voice: VoiceTranscriptionService;
+  dynamicIsland: DynamicIslandWindowController;
+  computerUseMacSetup: ComputerUseMacSetupWindowController;
+}
 
+function registerIpcHandlers({
+  service,
+  providerRuntimes,
+  mailbox,
+  browser,
+  browserPictureInPicture,
+  updater,
+  setupFile,
+  analyticsPreferenceFile,
+  updatePreferenceFile,
+  initializeAgent,
+  sidebarLayout,
+  host,
+  remoteDesktop,
+  remoteServers,
+  centralAuth,
+  skills,
+  hostedSites,
+  marketplaceAgents,
+  voice,
+  dynamicIsland,
+  computerUseMacSetup,
+}: IpcHandlerDependencies): void {
+  // Every renderer-to-main endpoint is registered by one of these, one file per
+  // domain under ./ipc. Nothing is registered inline here: this is the trust
+  // boundary, and a reviewer should be able to read a domain's whole surface in
+  // one file rather than find it interleaved with window and lifecycle code.
+  const getMainWindow = () => mainWindow;
+
+  registerAppIpcHandlers({
+    service,
+    mailbox,
+    browser,
+    updater,
+    setupFile,
+    analyticsPreferenceFile,
+    initializeAgent,
+    appVariant,
+    getMainWindow,
+    setAnalyticsTrackingEnabled: (enabled) => hostAnalytics?.setTrackingEnabled(enabled),
+  });
+  registerDynamicIslandIpcHandlers({ dynamicIsland });
+  registerComputerUseIpcHandlers({ computerUseMacSetup });
+  registerProviderIpcHandlers({ service, providerRuntimes });
+  registerVoiceIpcHandlers({ voice });
+  registerAccountIpcHandlers({ centralAuth });
+  registerSkillIpcHandlers({ skills, getMainWindow });
+  registerHostedSiteIpcHandlers({ hostedSites, getMainWindow });
+  registerMarketplaceAgentIpcHandlers({ marketplaceAgents });
+  registerUpdateIpcHandlers({ updater, updatePreferenceFile });
   registerTeamIpcHandlers({
     host,
     remoteDesktop,
@@ -628,623 +328,11 @@ function registerIpcHandlers(
       return inviteUrl;
     },
   });
-
-  handleTrusted(IPC_CHANNELS.agentGetStatus, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
-    return serverId === "local"
-      ? service.getStatus()
-      : remoteServers.request("/v1/agents/status", {}, serverId, decodeAgentStatus);
-  });
-  handleTrusted(IPC_CHANNELS.agentGetUsage, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
-    return serverId === "local"
-      ? service.getUsage()
-      : remoteServers.request("/v1/agents/usage", {}, serverId, decodeAccountUsage);
-  });
-  handleTrusted(IPC_CHANNELS.agentListModels, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
-    return serverId === "local"
-      ? service.listModels()
-      : remoteServers.request("/v1/agents/models", {}, serverId, decodeAgentModelOptions);
-  });
-  handleTrusted(IPC_CHANNELS.agentListBots, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
-    return serverId === "local"
-      ? service.listBots()
-      : remoteServers.request("/v1/agents", {}, serverId, decodeBotSummaries);
-  });
-  handleTrusted(IPC_CHANNELS.agentListInstalledSkills, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
-    return scoped.serverId === "local"
-      ? skills.listInstalledForChatTags(botId)
-      : remoteServers
-            .list()
-            .find((server) => server.id === scoped.serverId)
-            ?.compatibility?.capabilities.includes("installed-skills")
-        ? remoteServers.request(
-            `/v1/agents/${encodeURIComponent(botId)}/skills`,
-            {},
-            scoped.serverId,
-            decodeInstalledSkills,
-          )
-        : Promise.resolve([]);
-  });
-  handleTrusted(IPC_CHANNELS.agentGetSidebarLayout, (input: unknown): Promise<SidebarLayoutSnapshot> => {
-    const { serverId } = parseAgentRequest(input);
-    return serverId === "local"
-      ? Promise.resolve(sidebarLayout.getSnapshot())
-      : remoteServers.request("/v1/sidebar-layout", {}, serverId, decodeSidebarLayoutSnapshot);
-  });
-  handleTrusted(IPC_CHANNELS.agentMutateSidebarLayout, (input: unknown): Promise<SidebarLayoutSnapshot> => {
-    const scoped = parseAgentRequest(input);
-    const action = parseSidebarLayoutAction(scoped.payload);
-    return scoped.serverId === "local"
-      ? sidebarLayout.mutate(action, new Set(service.listBots().map((bot) => bot.id)))
-      : remoteServers.request(
-          "/v1/sidebar-layout/actions",
-          { method: "POST", body: action },
-          scoped.serverId,
-          decodeSidebarLayoutSnapshot,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentCreateBot, (input: unknown) => {
-    const { serverId, payload } = parseAgentRequest(input);
-    const parsed = parseCreateBot(payload);
-    return serverId === "local"
-      ? service.createBot(parsed)
-      : remoteServers.request("/v1/agents", { method: "POST", body: parsed }, serverId, decodeBotSummary);
-  });
-  handleTrusted(IPC_CHANNELS.agentDuplicateBot, (input: unknown): Promise<DuplicateBotResult> => {
-    const scoped = parseAgentRequest(input);
-    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
-    return routeDuplicateBot(service, sidebarLayout, remoteServers, scoped.serverId, botId);
-  });
-  handleTrusted(IPC_CHANNELS.agentUpdateBot, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    return routeUpdateBot(service, remoteServers, scoped.serverId, parseUpdateBot(scoped.payload));
-  });
-  handleTrusted(IPC_CHANNELS.agentSetAvatar, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseSetAgentAvatar(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.setAvatar(parsed.botId, parsed.image)
-      : remoteServers.setAgentAvatar(parsed.botId, parsed.image, scoped.serverId);
-  });
-  handleTrusted(IPC_CHANNELS.agentDeleteBot, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const botId = requireString(scoped.payload, "botId");
-    return routeDeleteBot(service, sidebarLayout, remoteServers, scoped.serverId, botId);
-  });
-  handleTrusted(IPC_CHANNELS.agentListMemories, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
-    return scoped.serverId === "local"
-      ? service.listMemories(botId)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(botId)}/memories`,
-          {},
-          scoped.serverId,
-          decodeBotMemories,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentCreateMemory, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseCreateBotMemory(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.createMemory(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/memories`,
-          { method: "POST", body: { text: parsed.text } },
-          scoped.serverId,
-          decodeBotMemory,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentUpdateMemory, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseUpdateBotMemory(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.updateMemory(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/memories/${encodeURIComponent(parsed.memoryId)}`,
-          { method: "PATCH", body: { text: parsed.text } },
-          scoped.serverId,
-          decodeBotMemory,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentDeleteMemory, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseDeleteBotMemory(scoped.payload);
-    if (scoped.serverId === "local") return service.deleteMemory(parsed);
-    return remoteServers.request(
-      `/v1/agents/${encodeURIComponent(parsed.botId)}/memories/${encodeURIComponent(parsed.memoryId)}`,
-      { method: "DELETE" },
-      scoped.serverId,
-      decodeVoid,
-    );
-  });
-  handleTrusted(IPC_CHANNELS.agentClearMemories, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
-    if (scoped.serverId === "local") return service.clearMemories(botId);
-    return remoteServers.request(
-      `/v1/agents/${encodeURIComponent(botId)}/memories`,
-      { method: "DELETE" },
-      scoped.serverId,
-      decodeVoid,
-    );
-  });
-  handleTrusted(IPC_CHANNELS.agentListRoutines, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
-    return scoped.serverId === "local"
-      ? service.listRoutines(botId)
-      : remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}/routines`, {}, scoped.serverId, decodeRoutines);
-  });
-  handleTrusted(IPC_CHANNELS.agentCreateRoutine, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseCreateRoutine(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.createRoutine(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines`,
-          { method: "POST", body: parsed },
-          scoped.serverId,
-          decodeRoutine,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentUpdateRoutine, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseUpdateRoutine(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.updateRoutine(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}`,
-          { method: "PATCH", body: parsed },
-          scoped.serverId,
-          decodeRoutine,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentDeleteRoutine, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseDeleteRoutine(scoped.payload);
-    if (scoped.serverId === "local") return service.deleteRoutine(parsed);
-    return remoteServers.request(
-      `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}`,
-      { method: "DELETE" },
-      scoped.serverId,
-      decodeVoid,
-    );
-  });
-  handleTrusted(IPC_CHANNELS.agentTestRoutine, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseTestRoutine(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.testRoutine(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}/test`,
-          { method: "POST" },
-          scoped.serverId,
-          decodeRoutineRun,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentListRoutineRuns, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseListRoutineRuns(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.listRoutineRuns(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}/runs?limit=${parsed.limit}`,
-          {},
-          scoped.serverId,
-          decodeRoutineRuns,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentReadConversation, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    return routeReadConversation(host, remoteServers, scoped.serverId, requireString(scoped.payload, "botId"));
-  });
-  handleTrusted(IPC_CHANNELS.agentReadConversationPage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseReadConversationPage(scoped.payload);
-    return scoped.serverId === "local"
-      ? host.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit)
-      : remoteServers.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit, scoped.serverId);
-  });
-  handleTrusted(IPC_CHANNELS.agentSearchConversationMessages, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseSearchConversationMessages(scoped.payload);
-    return scoped.serverId === "local"
-      ? host.searchAgentConversationMessages(parsed.query, parsed.botId, parsed.cursor, parsed.limit)
-      : remoteServers.searchAgentConversationMessages(
-          parsed.query,
-          parsed.botId,
-          parsed.cursor,
-          parsed.limit,
-          scoped.serverId,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentListConversationReads, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
-    return serverId === "local"
-      ? host.listAgentConversationReads()
-      : remoteServers.listAgentConversationReads(serverId);
-  });
-  handleTrusted(IPC_CHANNELS.agentMarkConversationRead, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseMarkConversationRead(scoped.payload);
-    return scoped.serverId === "local"
-      ? host.markAgentConversationRead(parsed)
-      : remoteServers.markAgentConversationRead(parsed, scoped.serverId);
-  });
-  handleTrusted(IPC_CHANNELS.agentSendMessage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    return routeSendMessage(service, remoteServers, scoped.serverId, parseSendMessage(scoped.payload));
-  });
-  handleTrusted(IPC_CHANNELS.agentSetMessageReaction, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseMessageReaction(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.setMessageReaction(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/reactions`,
-          {
-            method: "POST",
-            body: parsed,
-          },
-          scoped.serverId,
-          decodeVoid,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentChooseAttachments, async (input: unknown) => {
-    const { serverId, payload } = parseAgentRequest(input);
-    const { filter } = parseChooseAttachments(payload);
-    const options: OpenDialogOptions = {
-      properties: ["openFile", "multiSelections"],
-      filters:
-        filter === "images"
-          ? [{ name: "Images", extensions: [...IMAGE_ATTACHMENT_EXTENSIONS] }]
-          : [{ name: "Supported files", extensions: [...ATTACHMENT_FILE_EXTENSIONS] }],
-    };
-    const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
-    if (result.canceled) return [];
-    if (serverId === "local") return service.prepareAttachments(result.filePaths);
-    return uploadRemotePaths(remoteServers, serverId, result.filePaths);
-  });
-  handleTrusted(IPC_CHANNELS.agentImportAttachments, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseImportAttachments(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.prepareImportedAttachments(parsed.paths, parsed.data)
-      : uploadRemoteImports(remoteServers, scoped.serverId, parsed);
-  });
-  handleTrusted(IPC_CHANNELS.agentDiscardDraftAttachment, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const attachmentId = requireString(scoped.payload, "attachmentId");
-    return scoped.serverId === "local"
-      ? service.discardDraftAttachment(attachmentId)
-      : remoteServers.request(
-          `/v1/attachments/${encodeURIComponent(attachmentId)}`,
-          { method: "DELETE" },
-          scoped.serverId,
-          decodeVoid,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentOpenAttachment, async (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseOpenAttachment(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadAttachment(parsed.attachmentId, scoped.serverId);
-      const suggestedName = basename(downloaded.name) || `attachment-${parsed.attachmentId}`;
-      if (parsed.action === "download") {
-        const extension = extname(suggestedName).slice(1).toLowerCase();
-        const saveOptions: Electron.SaveDialogOptions = {
-          defaultPath: join(app.getPath("downloads"), suggestedName),
-          filters: [{ name: "Attachment", extensions: extension ? [extension] : ["*"] }],
-          showsTagField: false,
-        };
-        const result =
-          mainWindow && !mainWindow.isDestroyed()
-            ? await dialog.showSaveDialog(mainWindow, saveOptions)
-            : await dialog.showSaveDialog(saveOptions);
-        if (result.canceled || !result.filePath) return;
-        await writeFile(result.filePath, downloaded.bytes, { mode: 0o600 });
-        return;
-      }
-      const cacheRoot = join(app.getPath("userData"), "remote-attachments");
-      await mkdir(cacheRoot, { recursive: true });
-      const safeName = `${parsed.attachmentId}-${suggestedName}`;
-      const target = join(cacheRoot, safeName);
-      await writeFile(target, downloaded.bytes, { mode: 0o600 });
-      if (parsed.action === "reveal") shell.showItemInFolder(target);
-      else {
-        const openError = await shell.openPath(target);
-        if (openError) throw new Error(openError);
-      }
-      return;
-    }
-    const attachment = await mailbox.resolveAttachment(parsed.attachmentId);
-    if (!attachment) throw new Error("Attachment was not found.");
-    if (parsed.action === "download") {
-      const safeId = basename(parsed.attachmentId).replace(/[^a-z0-9_-]/gi, "-") || "attachment";
-      const mimeExtension = attachment.mimeType.split("/")[1]?.replace(/[^a-z0-9]/gi, "");
-      const suggestedName = `attachment-${safeId}${mimeExtension ? `.${mimeExtension}` : ""}`;
-      const extension = extname(suggestedName).slice(1).toLowerCase();
-      const saveOptions: Electron.SaveDialogOptions = {
-        defaultPath: join(app.getPath("downloads"), suggestedName),
-        filters: [{ name: "Attachment", extensions: extension ? [extension] : ["*"] }],
-        showsTagField: false,
-      };
-      const result =
-        mainWindow && !mainWindow.isDestroyed()
-          ? await dialog.showSaveDialog(mainWindow, saveOptions)
-          : await dialog.showSaveDialog(saveOptions);
-      if (result.canceled || !result.filePath) return;
-      await copyFile(attachment.path, result.filePath);
-      return;
-    }
-    if (parsed.action === "reveal") {
-      shell.showItemInFolder(attachment.path);
-      return;
-    }
-    const error = await shell.openPath(attachment.path);
-    if (error) throw new Error(error);
-  });
-  handleTrusted(IPC_CHANNELS.agentOpenSharedFile, async (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseOpenSharedFile(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadSharedFile(parsed.path, scoped.serverId);
-      const cacheRoot = join(app.getPath("userData"), "remote-shared-files");
-      await mkdir(cacheRoot, { recursive: true, mode: 0o700 });
-      const cacheKey = createHash("sha256").update(`${scoped.serverId}:${parsed.path}`).digest("hex");
-      const target = join(cacheRoot, `${cacheKey}-${basename(downloaded.name)}`);
-      await writeFile(target, downloaded.bytes, { mode: 0o600 });
-      await chmod(target, 0o600);
-      const openError = await shell.openPath(target);
-      if (openError) throw new Error(openError);
-      return;
-    }
-    const sharedFile = await service.resolveSharedFile(parsed.path);
-    const openError = await shell.openPath(sharedFile.path);
-    if (openError) throw new Error(openError);
-  });
-  handleTrusted(IPC_CHANNELS.agentOpenWorkspaceFile, async (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseOpenWorkspaceFile(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, scoped.serverId);
-      const cacheRoot = join(app.getPath("userData"), "remote-workspace-files");
-      await mkdir(cacheRoot, { recursive: true, mode: 0o700 });
-      const cacheKey = createHash("sha256").update(`${scoped.serverId}:${parsed.botId}:${parsed.path}`).digest("hex");
-      const target = join(cacheRoot, `${cacheKey}-${basename(downloaded.name)}`);
-      await writeFile(target, downloaded.bytes, { mode: 0o600 });
-      await chmod(target, 0o600);
-      const openError = await shell.openPath(target);
-      if (openError) throw new Error(openError);
-      return;
-    }
-    const workspaceFile = await service.resolveWorkspaceFile(parsed.botId, parsed.path);
-    const openError = await shell.openPath(workspaceFile.path);
-    if (openError) throw new Error(openError);
-  });
-  handleTrusted(IPC_CHANNELS.agentPreviewSharedFile, async (input: unknown): Promise<FilePreview> => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseOpenSharedFile(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadSharedFile(parsed.path, scoped.serverId);
-      return filePreviewFromBytes(downloaded.name, downloaded.bytes);
-    }
-    const sharedFile = await service.resolveSharedFile(parsed.path);
-    return localFilePreview(sharedFile.path, sharedFile.name, sharedFile.size);
-  });
-  handleTrusted(IPC_CHANNELS.agentPreviewWorkspaceFile, async (input: unknown): Promise<FilePreview> => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseOpenWorkspaceFile(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, scoped.serverId);
-      return filePreviewFromBytes(downloaded.name, downloaded.bytes);
-    }
-    const workspaceFile = await service.resolveWorkspaceFile(parsed.botId, parsed.path);
-    return localFilePreview(workspaceFile.path, workspaceFile.name, workspaceFile.size);
-  });
-  handleTrusted(IPC_CHANNELS.agentListQueue, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    return routeListQueue(service, remoteServers, scoped.serverId, requireString(scoped.payload, "botId"));
-  });
-  handleTrusted(IPC_CHANNELS.agentAcknowledgeFailedTurn, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseAcknowledgeFailedTurn(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.acknowledgeFailedTurn(parsed.botId, parsed.turnId)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/failures/acknowledge`,
-          { method: "POST", body: { turnId: parsed.turnId } },
-          scoped.serverId,
-          decodeVoid,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentCancelQueuedMessage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseCancelQueuedMessage(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.cancelQueuedMessage(parsed.botId, parsed.deliveryId)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/cancel`,
-          {
-            method: "POST",
-            body: { deliveryId: parsed.deliveryId },
-          },
-          scoped.serverId,
-          decodeVoid,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentSteerQueuedMessage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseSteerQueuedMessage(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.steerQueuedMessage(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/steer`,
-          {
-            method: "POST",
-            body: { deliveryId: parsed.deliveryId, expectedTurnId: parsed.expectedTurnId },
-          },
-          scoped.serverId,
-          decodeVoid,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentUpdateQueuedMessage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseUpdateQueuedMessage(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.updateQueuedMessage(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/update`,
-          {
-            method: "POST",
-            body: {
-              deliveryId: parsed.deliveryId,
-              text: parsed.text,
-              keepAttachmentIds: parsed.keepAttachmentIds,
-              attachmentDraftIds: parsed.attachmentDraftIds,
-            },
-          },
-          scoped.serverId,
-          decodeVoid,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentReorderQueue, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseReorderQueue(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.reorderQueue(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/reorder`,
-          { method: "POST", body: { deliveryIds: parsed.deliveryIds } },
-          scoped.serverId,
-          decodeVoid,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentInterrupt, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseInterrupt(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.interrupt(parsed.botId, parsed.turnId)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/interrupt`,
-          {
-            method: "POST",
-            body: { turnId: parsed.turnId },
-          },
-          scoped.serverId,
-          decodeVoid,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.agentRespondToPrompt, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parsePromptResponse(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.respondToPrompt(parsed)
-      : remoteServers.request("/v1/prompts/respond", { method: "POST", body: parsed }, scoped.serverId, decodeVoid);
-  });
-  handleTrusted(IPC_CHANNELS.agentRespondToApproval, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseApprovalResponse(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.respondToApproval(parsed)
-      : remoteServers.request("/v1/approvals/respond", { method: "POST", body: parsed }, scoped.serverId, decodeVoid);
-  });
-  handleTrusted(IPC_CHANNELS.agentRespondToBrowserTakeover, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
-    const parsed = parseBrowserTakeoverResponse(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.respondToBrowserTakeover(parsed)
-      : remoteServers.request(
-          "/v1/browser-takeovers/respond",
-          { method: "POST", body: parsed },
-          scoped.serverId,
-          decodeVoid,
-        );
-  });
-
-  handleTrusted(IPC_CHANNELS.browserOpen, (input: unknown) => {
-    const parsed = parseBrowserOpen(input);
-    return remoteServers.activeServerId === "local"
-      ? browser.open(parsed.url, parsed.ownerThreadId ?? null, parsed.ownerBotId ?? null, parsed.focus)
-      : remoteServers.request("/v1/browser/open", { method: "POST", body: parsed }, undefined, decodeBrowserTab);
-  });
-  handleTrusted(IPC_CHANNELS.browserActivate, (tabId: unknown) =>
-    remoteServers.activeServerId === "local"
-      ? browser.activate(requireString(tabId, "tabId"))
-      : remoteServers.request(
-          "/v1/browser/activate",
-          { method: "POST", body: { tabId: requireString(tabId, "tabId") } },
-          undefined,
-          decodeVoid,
-        ),
-  );
-  handleTrusted(IPC_CHANNELS.browserNavigate, (input: unknown) => {
-    const parsed = parseBrowserNavigate(input);
-    return remoteServers.activeServerId === "local"
-      ? browser.navigate(parsed.tabId, parsed.direction)
-      : remoteServers.request("/v1/browser/navigate", { method: "POST", body: parsed }, undefined, decodeVoid);
-  });
-  handleTrusted(IPC_CHANNELS.browserReload, (tabId: unknown) =>
-    remoteServers.activeServerId === "local"
-      ? browser.reload(requireString(tabId, "tabId"))
-      : remoteServers.request(
-          "/v1/browser/reload",
-          { method: "POST", body: { tabId: requireString(tabId, "tabId") } },
-          undefined,
-          decodeVoid,
-        ),
-  );
-  handleTrusted(IPC_CHANNELS.browserClose, (tabId: unknown) =>
-    remoteServers.activeServerId === "local"
-      ? browser.close(requireString(tabId, "tabId"))
-      : remoteServers.request(
-          "/v1/browser/close",
-          { method: "POST", body: { tabId: requireString(tabId, "tabId") } },
-          undefined,
-          decodeVoid,
-        ),
-  );
-  handleTrusted(IPC_CHANNELS.browserListTabs, () =>
-    remoteServers.activeServerId === "local"
-      ? browser.listTabs()
-      : remoteServers.request("/v1/browser/tabs", {}, undefined, decodeBrowserTabs),
-  );
-  handleTrusted(IPC_CHANNELS.browserGetDisplayState, (): BrowserDisplayState => browser.getDisplayState());
-  handleTrusted(IPC_CHANNELS.browserGetControlState, () =>
-    remoteServers.activeServerId === "local"
-      ? browser.getControlState()
-      : remoteServers.request("/v1/browser/control", {}, undefined, decodeBrowserControlState),
-  );
-  handleTrusted(IPC_CHANNELS.browserCapturePreview, (tabId: unknown) => {
-    const parsedTabId = requireString(tabId, "tabId");
-    return remoteServers.activeServerId === "local"
-      ? browser.capturePreview(parsedTabId)
-      : remoteServers.request(
-          "/v1/browser/preview",
-          { method: "POST", body: { tabId: parsedTabId } },
-          undefined,
-          decodeBrowserPreview,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.browserSetVisible, async (input: unknown) => {
-    const parsed = parseVisibility(input);
-    if (remoteServers.activeServerId === "local") await browser.setVisible(parsed);
-    else {
-      await remoteServers.request("/v1/browser/visible", { method: "POST", body: parsed }, undefined, decodeVoid);
-    }
-  });
-  handleTrusted(IPC_CHANNELS.browserPictureInPictureOpen, (input: unknown) =>
-    browserPictureInPicture.open(input === undefined ? undefined : parseBrowserBounds(input)),
-  );
-  handleTrusted(IPC_CHANNELS.browserPictureInPictureClose, () => browserPictureInPicture.close());
-  handleTrusted(IPC_CHANNELS.browserPictureInPictureDock, () => browserPictureInPicture.dock());
-  handleTrusted(IPC_CHANNELS.browserPictureInPictureHide, () => browserPictureInPicture.hide());
+  registerMemoryIpcHandlers({ service, remoteServers });
+  registerRoutineIpcHandlers({ service, remoteServers });
+  registerAttachmentIpcHandlers({ service, mailbox, remoteServers, getMainWindow });
+  registerAgentIpcHandlers({ service, sidebarLayout, host, remoteServers, skills });
+  registerBrowserIpcHandlers({ browserPictureInPicture, browser, remoteServers });
 }
 
 function createWindow(): BrowserWindow {
@@ -2175,29 +1263,29 @@ if (!hasSingleInstanceLock) {
       updateService.on("status", forwardUpdateStatus);
       updateService.start();
       const agentInitialization = new AgentInitializationGate(() => service.initialize());
-      registerIpcHandlers(
+      registerIpcHandlers({
         service,
-        providerRuntimeManager,
-        mailboxStore,
-        browserHost,
+        providerRuntimes: providerRuntimeManager,
+        mailbox: mailboxStore,
+        browser: browserHost,
         browserPictureInPicture,
-        updateService,
+        updater: updateService,
         setupFile,
         analyticsPreferenceFile,
         updatePreferenceFile,
-        () => agentInitialization.start(),
-        sidebarLayoutStore,
+        initializeAgent: () => agentInitialization.start(),
+        sidebarLayout: sidebarLayoutStore,
         host,
         remoteDesktop,
         remoteServers,
-        centralAuthManager,
-        skillMarketplace,
+        centralAuth: centralAuthManager,
+        skills: skillMarketplace,
         hostedSites,
-        agentMarketplace,
-        voiceTranscriptionService,
-        dynamicIslandController,
-        computerUseMacSetupController,
-      );
+        marketplaceAgents: agentMarketplace,
+        voice: voiceTranscriptionService,
+        dynamicIsland: dynamicIslandController,
+        computerUseMacSetup: computerUseMacSetupController,
+      });
       configureApplicationMenu(service, updateService);
       await dynamicIslandController
         .initialize()
@@ -2356,164 +1444,6 @@ function configureRendererPermissions(): void {
     const mediaTypes = ("mediaTypes" in details ? details.mediaTypes : undefined) ?? [];
     callback(canRequestRendererPermission(permission, webContents.getURL(), { mediaTypes }));
   });
-}
-
-function routeUpdateBot(
-  service: AgentService,
-  remoteServers: RemoteServerManager,
-  serverId: string,
-  input: UpdateBotInput,
-) {
-  return serverId === "local"
-    ? service.updateBot(input)
-    : remoteServers.request(
-        `/v1/agents/${encodeURIComponent(input.botId)}`,
-        {
-          method: "PATCH",
-          body: input,
-        },
-        serverId,
-        decodeBotSummary,
-      );
-}
-
-async function routeDeleteBot(
-  service: AgentService,
-  sidebarLayout: SidebarLayoutStore,
-  remoteServers: RemoteServerManager,
-  serverId: string,
-  botId: string,
-): Promise<void> {
-  if (serverId === "local") {
-    await service.deleteBot(botId);
-    await sidebarLayout.removeAgent(botId);
-    return;
-  }
-  await remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}`, { method: "DELETE" }, serverId, decodeVoid);
-}
-
-async function routeDuplicateBot(
-  service: AgentService,
-  sidebarLayout: SidebarLayoutStore,
-  remoteServers: RemoteServerManager,
-  serverId: string,
-  botId: string,
-): Promise<DuplicateBotResult> {
-  if (serverId !== "local") {
-    return remoteServers.duplicateBot(botId, serverId);
-  }
-  const bot = await service.duplicateBot(botId);
-  try {
-    const layout = await sidebarLayout.placeDuplicateAfter(botId, bot.id, [
-      ...service.listBots().map((candidate) => candidate.id),
-      bot.id,
-    ]);
-    return service.commitBotDuplication(bot.id, layout);
-  } catch (error) {
-    const rollbackResults = await Promise.allSettled([service.deleteBot(bot.id), sidebarLayout.removeAgent(bot.id)]);
-    const rollbackErrors = rollbackResults.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
-    if (rollbackErrors.length > 0) {
-      throw new AggregateError(
-        [error, ...rollbackErrors],
-        "Agent duplication failed and the incomplete copy could not be removed.",
-      );
-    }
-    throw error;
-  }
-}
-
-function routeReadConversation(host: HostService, remoteServers: RemoteServerManager, serverId: string, botId: string) {
-  return serverId === "local"
-    ? host.readAgentConversation(botId)
-    : remoteServers.readAgentConversation(botId, serverId);
-}
-
-function routeSendMessage(
-  service: AgentService,
-  remoteServers: RemoteServerManager,
-  serverId: string,
-  input: SendMessageInput,
-) {
-  return serverId === "local"
-    ? service.sendMessage(input)
-    : remoteServers.request(
-        `/v1/agents/${encodeURIComponent(input.botId)}/messages`,
-        {
-          method: "POST",
-          body: input,
-        },
-        serverId,
-        decodeQueuedMessageReceipt,
-      );
-}
-
-function routeListQueue(service: AgentService, remoteServers: RemoteServerManager, serverId: string, botId: string) {
-  return serverId === "local"
-    ? service.listQueue(botId)
-    : remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}/queue`, {}, serverId, decodeQueueSnapshot);
-}
-
-async function uploadRemotePaths(remoteServers: RemoteServerManager, serverId: string, paths: string[]) {
-  if (paths.length > INPUT_LIMITS.attachments) {
-    throw new Error(`Choose at most ${INPUT_LIMITS.attachments} files.`);
-  }
-  for (const path of paths) assertSupportedAttachmentName(basename(path));
-  const files = await Promise.all(
-    paths.map(async (path) => ({
-      name: basename(path),
-      bytes: new Uint8Array(await readFile(path)),
-    })),
-  );
-  const total = files.reduce((sum, file) => sum + file.bytes.byteLength, 0);
-  if (files.some((file) => file.bytes.byteLength > ATTACHMENT_LIMITS.fileBytes)) {
-    throw new Error("A file exceeds the 100 MB limit.");
-  }
-  if (total > ATTACHMENT_LIMITS.totalBytes) {
-    throw new Error("Attachments exceed the 250 MB total limit.");
-  }
-  return Promise.all(
-    files.map((file) => remoteServers.uploadAttachment(file.name, mimeTypeForName(file.name), file.bytes, serverId)),
-  );
-}
-
-async function uploadRemoteImports(
-  remoteServers: RemoteServerManager,
-  serverId: string,
-  input: ImportAttachmentsInput,
-) {
-  if (input.paths.length + input.data.length > INPUT_LIMITS.attachments) {
-    throw new Error(`Choose at most ${INPUT_LIMITS.attachments} files.`);
-  }
-  const pathFiles = await Promise.all(
-    input.paths.map(async (path) => ({
-      name: basename(path),
-      mimeType: mimeTypeForName(path),
-      bytes: new Uint8Array(await readFile(path)),
-    })),
-  );
-  const files = [
-    ...pathFiles,
-    ...input.data.map((item) => ({
-      name: basename(item.name),
-      mimeType: item.mimeType,
-      bytes: item.bytes,
-    })),
-  ];
-  for (const file of files) assertSupportedAttachmentName(file.name);
-  if (files.some((file) => file.bytes.byteLength > ATTACHMENT_LIMITS.fileBytes)) {
-    throw new Error("A file exceeds the 100 MB limit.");
-  }
-  if (files.reduce((sum, file) => sum + file.bytes.byteLength, 0) > ATTACHMENT_LIMITS.totalBytes) {
-    throw new Error("Attachments exceed the 250 MB total limit.");
-  }
-  return Promise.all(
-    files.map((file) => remoteServers.uploadAttachment(file.name, file.mimeType, file.bytes, serverId)),
-  );
-}
-
-function assertSupportedAttachmentName(name: string): void {
-  if (isSupportedAttachmentName(name)) return;
-  throw new Error(`${name} is not supported. Attach ${SUPPORTED_ATTACHMENT_DESCRIPTION}.`);
 }
 
 function configureAttachmentProtocol(mailbox: MailboxStore, agents: AgentService): void {

--- a/src/main/ipc-channel-coverage.test.ts
+++ b/src/main/ipc-channel-coverage.test.ts
@@ -56,6 +56,14 @@ const sources = new Map<string, string>();
 const mainSources = sourceFilesUnder("src/main");
 const preloadSources = ["src/preload/index.ts"];
 
+// The dispatcher, and the directory whose modules it has to reach.
+const DISPATCHER_MODULE = "src/main/index.ts";
+const REGISTRAR_DIRECTORY = "src/main/ipc/";
+
+// `export function registerSomethingIpcHandlers(` - the shape src/main/AGENTS.md
+// requires of every module under src/main/ipc.
+const REGISTRAR_EXPORT = /export function (register[A-Za-z0-9_]*IpcHandlers)\s*\(/g;
+
 // The one module allowed to touch ipcMain, because it is the sender check.
 const TRUSTED_IPC_MODULE = "src/main/trusted-ipc.ts";
 
@@ -76,6 +84,15 @@ const FORWARDED_CHANNEL_ARGUMENTS: readonly string[] = [
 
 const mainCalls = collectCalls(mainSources);
 const preloadCalls = collectCalls(preloadSources);
+
+const registrars = mainSources
+  .filter((file) => file.startsWith(REGISTRAR_DIRECTORY))
+  .flatMap((file) =>
+    [...readSource(file).matchAll(REGISTRAR_EXPORT)]
+      .map((match) => match[1])
+      .filter((name): name is string => name !== undefined)
+      .map((name) => ({ file, name })),
+  );
 
 const handled = channelsCalledBy(mainCalls, MAIN_HANDLER_CALLEES);
 const sent = channelsCalledBy(mainCalls, MAIN_SEND_CALLEES);
@@ -141,6 +158,26 @@ describe("IPC channel coverage", () => {
       .sort();
 
     expect(duplicated).toEqual([]);
+  });
+
+  // Every test above reads sources, so a registrar the dispatcher never calls
+  // still looks registered while every channel in it rejects at runtime. The
+  // type checker only sees half of that: deleting the call alone is TS6133,
+  // because the call site is the import's only use, but deleting the import
+  // with it compiles. So does a new registrar nobody ever wired up. This is
+  // the other half.
+  it("calls every registrar under src/main/ipc exactly once from the dispatcher", () => {
+    // A blind regex would make this test vacuous rather than red.
+    expect(registrars.length).toBeGreaterThan(10);
+
+    const dispatcher = readSource(DISPATCHER_MODULE);
+    const unreachable = registrars
+      .map(({ file, name }) => ({ file, name, calls: callCount(dispatcher, name) }))
+      .filter(({ calls }) => calls !== 1)
+      .map(({ file, name, calls }) => `${name} (${file}) is called ${calls} times by ${DISPATCHER_MODULE}`)
+      .sort();
+
+    expect(unreachable).toEqual([]);
   });
 
   it("gives every event channel the preload listens for a main process sender", () => {
@@ -227,6 +264,12 @@ function sourceFilesUnder(directory: string): readonly string[] {
     else if (entry.name.endsWith(".ts") && !entry.name.includes(".test.")) files.push(path);
   }
   return files;
+}
+
+// The import specifier carries no parenthesis, so this counts call sites and
+// not the name's other appearance in the dispatcher.
+function callCount(source: string, name: string): number {
+  return [...source.matchAll(new RegExp(`\\b${name}\\s*\\(`, "g"))].length;
 }
 
 function readSource(file: string): string {

--- a/src/main/ipc/register-account-handlers.ts
+++ b/src/main/ipc/register-account-handlers.ts
@@ -1,0 +1,45 @@
+// The cloud account: email sign-in, profile, and the mobile devices connected to it.
+
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { validateProfileName } from "@openbot/contracts/validation";
+import type { CentralAuthManager } from "../central-auth-manager";
+import { handleTrusted } from "../trusted-ipc";
+import { parseAvatarImage } from "./avatar-inputs";
+import { isObject, requireString } from "./validation";
+
+export interface AccountIpcDependencies {
+  centralAuth: CentralAuthManager;
+}
+
+export function registerAccountIpcHandlers({ centralAuth }: AccountIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.authGetState, () => centralAuth.getState());
+  handleTrusted(IPC_CHANNELS.authRetry, () => centralAuth.retry());
+  handleTrusted(IPC_CHANNELS.authRequestEmailCode, (email: unknown) =>
+    centralAuth.requestEmailCode(requireString(email, "email", INPUT_LIMITS.email)),
+  );
+  handleTrusted(IPC_CHANNELS.authVerifyEmailCode, (input: unknown) => {
+    if (!isObject(input)) throw new Error("Sign-in code details are required.");
+    return centralAuth.verifyEmailCode(
+      requireString(input.challengeId, "challengeId", INPUT_LIMITS.identifier),
+      requireString(input.code, "code", 32),
+    );
+  });
+  handleTrusted(IPC_CHANNELS.authUpdateName, (input: unknown) => {
+    const rawName = requireString(input, "name", INPUT_LIMITS.accountName);
+    const validation = validateProfileName(rawName);
+    if (validation.error) {
+      throw new Error(
+        `name must contain ${INPUT_LIMITS.profileNameMin} to ${INPUT_LIMITS.profileName} safe characters.`,
+      );
+    }
+    return centralAuth.updateName(validation.name);
+  });
+  handleTrusted(IPC_CHANNELS.authUpdateAvatar, (input: unknown) => centralAuth.updateAvatar(parseAvatarImage(input)));
+  handleTrusted(IPC_CHANNELS.authCreateMobileConnect, () => centralAuth.createMobileConnect());
+  handleTrusted(IPC_CHANNELS.authListMobileConnectedDevices, () => centralAuth.listMobileConnectedDevices());
+  handleTrusted(IPC_CHANNELS.authRevokeMobileConnectedDevice, (input: unknown) =>
+    centralAuth.revokeMobileConnectedDevice(requireString(input, "sessionId", INPUT_LIMITS.identifier)),
+  );
+  handleTrusted(IPC_CHANNELS.authLogout, () => centralAuth.logout());
+}

--- a/src/main/ipc/register-agent-handlers.ts
+++ b/src/main/ipc/register-agent-handlers.ts
@@ -1,0 +1,427 @@
+// An agent's core surface: status, bots, conversations, the queue and the prompts
+// a turn can raise. Memories, routines and attachments are their own registrars.
+// Every one of these routes to the local service or to a remote server by the
+// `serverId` in the request.
+
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import {
+  type DuplicateBotResult,
+  IPC_CHANNELS,
+  type SendMessageInput,
+  type SidebarLayoutSnapshot,
+  type UpdateBotInput,
+} from "@openbot/contracts/ipc";
+import type { AgentService } from "../../backend/agent-service";
+import type { SidebarLayoutStore } from "../../backend/sidebar-layout-store";
+import type { HostService } from "../host-service";
+import {
+  decodeAccountUsage,
+  decodeAgentModelOptions,
+  decodeAgentStatus,
+  decodeBotSummaries,
+  decodeBotSummary,
+  decodeInstalledSkills,
+  decodeQueuedMessageReceipt,
+  decodeQueueSnapshot,
+  decodeSidebarLayoutSnapshot,
+  decodeVoid,
+  type RemoteServerManager,
+} from "../remote-server-manager";
+import type { SkillMarketplaceService } from "../skill-marketplace-service";
+import { handleTrusted } from "../trusted-ipc";
+import {
+  parseAcknowledgeFailedTurn,
+  parseAgentRequest,
+  parseApprovalResponse,
+  parseBrowserTakeoverResponse,
+  parseCancelQueuedMessage,
+  parseCreateBot,
+  parseInterrupt,
+  parseMarkConversationRead,
+  parseMessageReaction,
+  parsePromptResponse,
+  parseReadConversationPage,
+  parseReorderQueue,
+  parseSearchConversationMessages,
+  parseSendMessage,
+  parseSetAgentAvatar,
+  parseSidebarLayoutAction,
+  parseSteerQueuedMessage,
+  parseUpdateBot,
+  parseUpdateQueuedMessage,
+} from "./agent-inputs";
+import { requireString } from "./validation";
+
+export interface AgentIpcDependencies {
+  service: AgentService;
+  sidebarLayout: SidebarLayoutStore;
+  host: HostService;
+  remoteServers: RemoteServerManager;
+  skills: SkillMarketplaceService;
+}
+
+export function registerAgentIpcHandlers({
+  service,
+  sidebarLayout,
+  host,
+  remoteServers,
+  skills,
+}: AgentIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.agentGetStatus, (input: unknown) => {
+    const { serverId } = parseAgentRequest(input);
+    return serverId === "local"
+      ? service.getStatus()
+      : remoteServers.request("/v1/agents/status", {}, serverId, decodeAgentStatus);
+  });
+  handleTrusted(IPC_CHANNELS.agentGetUsage, (input: unknown) => {
+    const { serverId } = parseAgentRequest(input);
+    return serverId === "local"
+      ? service.getUsage()
+      : remoteServers.request("/v1/agents/usage", {}, serverId, decodeAccountUsage);
+  });
+  handleTrusted(IPC_CHANNELS.agentListModels, (input: unknown) => {
+    const { serverId } = parseAgentRequest(input);
+    return serverId === "local"
+      ? service.listModels()
+      : remoteServers.request("/v1/agents/models", {}, serverId, decodeAgentModelOptions);
+  });
+  handleTrusted(IPC_CHANNELS.agentListBots, (input: unknown) => {
+    const { serverId } = parseAgentRequest(input);
+    return serverId === "local"
+      ? service.listBots()
+      : remoteServers.request("/v1/agents", {}, serverId, decodeBotSummaries);
+  });
+  handleTrusted(IPC_CHANNELS.agentListInstalledSkills, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
+    return scoped.serverId === "local"
+      ? skills.listInstalledForChatTags(botId)
+      : remoteServers
+            .list()
+            .find((server) => server.id === scoped.serverId)
+            ?.compatibility?.capabilities.includes("installed-skills")
+        ? remoteServers.request(
+            `/v1/agents/${encodeURIComponent(botId)}/skills`,
+            {},
+            scoped.serverId,
+            decodeInstalledSkills,
+          )
+        : Promise.resolve([]);
+  });
+  handleTrusted(IPC_CHANNELS.agentGetSidebarLayout, (input: unknown): Promise<SidebarLayoutSnapshot> => {
+    const { serverId } = parseAgentRequest(input);
+    return serverId === "local"
+      ? Promise.resolve(sidebarLayout.getSnapshot())
+      : remoteServers.request("/v1/sidebar-layout", {}, serverId, decodeSidebarLayoutSnapshot);
+  });
+  handleTrusted(IPC_CHANNELS.agentMutateSidebarLayout, (input: unknown): Promise<SidebarLayoutSnapshot> => {
+    const scoped = parseAgentRequest(input);
+    const action = parseSidebarLayoutAction(scoped.payload);
+    return scoped.serverId === "local"
+      ? sidebarLayout.mutate(action, new Set(service.listBots().map((bot) => bot.id)))
+      : remoteServers.request(
+          "/v1/sidebar-layout/actions",
+          { method: "POST", body: action },
+          scoped.serverId,
+          decodeSidebarLayoutSnapshot,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentCreateBot, (input: unknown) => {
+    const { serverId, payload } = parseAgentRequest(input);
+    const parsed = parseCreateBot(payload);
+    return serverId === "local"
+      ? service.createBot(parsed)
+      : remoteServers.request("/v1/agents", { method: "POST", body: parsed }, serverId, decodeBotSummary);
+  });
+  handleTrusted(IPC_CHANNELS.agentDuplicateBot, (input: unknown): Promise<DuplicateBotResult> => {
+    const scoped = parseAgentRequest(input);
+    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
+    return routeDuplicateBot(service, sidebarLayout, remoteServers, scoped.serverId, botId);
+  });
+  handleTrusted(IPC_CHANNELS.agentUpdateBot, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    return routeUpdateBot(service, remoteServers, scoped.serverId, parseUpdateBot(scoped.payload));
+  });
+  handleTrusted(IPC_CHANNELS.agentSetAvatar, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseSetAgentAvatar(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.setAvatar(parsed.botId, parsed.image)
+      : remoteServers.setAgentAvatar(parsed.botId, parsed.image, scoped.serverId);
+  });
+  handleTrusted(IPC_CHANNELS.agentDeleteBot, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const botId = requireString(scoped.payload, "botId");
+    return routeDeleteBot(service, sidebarLayout, remoteServers, scoped.serverId, botId);
+  });
+  handleTrusted(IPC_CHANNELS.agentReadConversation, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    return routeReadConversation(host, remoteServers, scoped.serverId, requireString(scoped.payload, "botId"));
+  });
+  handleTrusted(IPC_CHANNELS.agentReadConversationPage, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseReadConversationPage(scoped.payload);
+    return scoped.serverId === "local"
+      ? host.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit)
+      : remoteServers.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit, scoped.serverId);
+  });
+  handleTrusted(IPC_CHANNELS.agentSearchConversationMessages, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseSearchConversationMessages(scoped.payload);
+    return scoped.serverId === "local"
+      ? host.searchAgentConversationMessages(parsed.query, parsed.botId, parsed.cursor, parsed.limit)
+      : remoteServers.searchAgentConversationMessages(
+          parsed.query,
+          parsed.botId,
+          parsed.cursor,
+          parsed.limit,
+          scoped.serverId,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentListConversationReads, (input: unknown) => {
+    const { serverId } = parseAgentRequest(input);
+    return serverId === "local"
+      ? host.listAgentConversationReads()
+      : remoteServers.listAgentConversationReads(serverId);
+  });
+  handleTrusted(IPC_CHANNELS.agentMarkConversationRead, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseMarkConversationRead(scoped.payload);
+    return scoped.serverId === "local"
+      ? host.markAgentConversationRead(parsed)
+      : remoteServers.markAgentConversationRead(parsed, scoped.serverId);
+  });
+  handleTrusted(IPC_CHANNELS.agentSendMessage, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    return routeSendMessage(service, remoteServers, scoped.serverId, parseSendMessage(scoped.payload));
+  });
+  handleTrusted(IPC_CHANNELS.agentSetMessageReaction, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseMessageReaction(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.setMessageReaction(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/reactions`,
+          {
+            method: "POST",
+            body: parsed,
+          },
+          scoped.serverId,
+          decodeVoid,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentListQueue, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    return routeListQueue(service, remoteServers, scoped.serverId, requireString(scoped.payload, "botId"));
+  });
+  handleTrusted(IPC_CHANNELS.agentAcknowledgeFailedTurn, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseAcknowledgeFailedTurn(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.acknowledgeFailedTurn(parsed.botId, parsed.turnId)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/failures/acknowledge`,
+          { method: "POST", body: { turnId: parsed.turnId } },
+          scoped.serverId,
+          decodeVoid,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentCancelQueuedMessage, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseCancelQueuedMessage(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.cancelQueuedMessage(parsed.botId, parsed.deliveryId)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/cancel`,
+          {
+            method: "POST",
+            body: { deliveryId: parsed.deliveryId },
+          },
+          scoped.serverId,
+          decodeVoid,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentSteerQueuedMessage, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseSteerQueuedMessage(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.steerQueuedMessage(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/steer`,
+          {
+            method: "POST",
+            body: { deliveryId: parsed.deliveryId, expectedTurnId: parsed.expectedTurnId },
+          },
+          scoped.serverId,
+          decodeVoid,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentUpdateQueuedMessage, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseUpdateQueuedMessage(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.updateQueuedMessage(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/update`,
+          {
+            method: "POST",
+            body: {
+              deliveryId: parsed.deliveryId,
+              text: parsed.text,
+              keepAttachmentIds: parsed.keepAttachmentIds,
+              attachmentDraftIds: parsed.attachmentDraftIds,
+            },
+          },
+          scoped.serverId,
+          decodeVoid,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentReorderQueue, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseReorderQueue(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.reorderQueue(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/reorder`,
+          { method: "POST", body: { deliveryIds: parsed.deliveryIds } },
+          scoped.serverId,
+          decodeVoid,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentInterrupt, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseInterrupt(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.interrupt(parsed.botId, parsed.turnId)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/interrupt`,
+          {
+            method: "POST",
+            body: { turnId: parsed.turnId },
+          },
+          scoped.serverId,
+          decodeVoid,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentRespondToPrompt, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parsePromptResponse(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.respondToPrompt(parsed)
+      : remoteServers.request("/v1/prompts/respond", { method: "POST", body: parsed }, scoped.serverId, decodeVoid);
+  });
+  handleTrusted(IPC_CHANNELS.agentRespondToApproval, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseApprovalResponse(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.respondToApproval(parsed)
+      : remoteServers.request("/v1/approvals/respond", { method: "POST", body: parsed }, scoped.serverId, decodeVoid);
+  });
+  handleTrusted(IPC_CHANNELS.agentRespondToBrowserTakeover, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseBrowserTakeoverResponse(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.respondToBrowserTakeover(parsed)
+      : remoteServers.request(
+          "/v1/browser-takeovers/respond",
+          { method: "POST", body: parsed },
+          scoped.serverId,
+          decodeVoid,
+        );
+  });
+}
+
+function routeUpdateBot(
+  service: AgentService,
+  remoteServers: RemoteServerManager,
+  serverId: string,
+  input: UpdateBotInput,
+) {
+  return serverId === "local"
+    ? service.updateBot(input)
+    : remoteServers.request(
+        `/v1/agents/${encodeURIComponent(input.botId)}`,
+        {
+          method: "PATCH",
+          body: input,
+        },
+        serverId,
+        decodeBotSummary,
+      );
+}
+
+async function routeDeleteBot(
+  service: AgentService,
+  sidebarLayout: SidebarLayoutStore,
+  remoteServers: RemoteServerManager,
+  serverId: string,
+  botId: string,
+): Promise<void> {
+  if (serverId === "local") {
+    await service.deleteBot(botId);
+    await sidebarLayout.removeAgent(botId);
+    return;
+  }
+  await remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}`, { method: "DELETE" }, serverId, decodeVoid);
+}
+
+async function routeDuplicateBot(
+  service: AgentService,
+  sidebarLayout: SidebarLayoutStore,
+  remoteServers: RemoteServerManager,
+  serverId: string,
+  botId: string,
+): Promise<DuplicateBotResult> {
+  if (serverId !== "local") {
+    return remoteServers.duplicateBot(botId, serverId);
+  }
+  const bot = await service.duplicateBot(botId);
+  try {
+    const layout = await sidebarLayout.placeDuplicateAfter(botId, bot.id, [
+      ...service.listBots().map((candidate) => candidate.id),
+      bot.id,
+    ]);
+    return service.commitBotDuplication(bot.id, layout);
+  } catch (error) {
+    const rollbackResults = await Promise.allSettled([service.deleteBot(bot.id), sidebarLayout.removeAgent(bot.id)]);
+    const rollbackErrors = rollbackResults.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+    if (rollbackErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...rollbackErrors],
+        "Agent duplication failed and the incomplete copy could not be removed.",
+      );
+    }
+    throw error;
+  }
+}
+
+function routeReadConversation(host: HostService, remoteServers: RemoteServerManager, serverId: string, botId: string) {
+  return serverId === "local"
+    ? host.readAgentConversation(botId)
+    : remoteServers.readAgentConversation(botId, serverId);
+}
+
+function routeSendMessage(
+  service: AgentService,
+  remoteServers: RemoteServerManager,
+  serverId: string,
+  input: SendMessageInput,
+) {
+  return serverId === "local"
+    ? service.sendMessage(input)
+    : remoteServers.request(
+        `/v1/agents/${encodeURIComponent(input.botId)}/messages`,
+        {
+          method: "POST",
+          body: input,
+        },
+        serverId,
+        decodeQueuedMessageReceipt,
+      );
+}
+
+function routeListQueue(service: AgentService, remoteServers: RemoteServerManager, serverId: string, botId: string) {
+  return serverId === "local"
+    ? service.listQueue(botId)
+    : remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}/queue`, {}, serverId, decodeQueueSnapshot);
+}

--- a/src/main/ipc/register-app-handlers.ts
+++ b/src/main/ipc/register-app-handlers.ts
@@ -1,0 +1,98 @@
+// App identity, first-run setup, the analytics preference, external links and the data and
+// diagnostics exports.
+
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import {
+  type AppInfo,
+  type AppSetupState,
+  type AppVariant,
+  type ExternalDestination,
+  IPC_CHANNELS,
+} from "@openbot/contracts/ipc";
+import { app, type BrowserWindow, shell } from "electron";
+import type { AgentService } from "../../backend/agent-service";
+import type { BrowserHost } from "../../backend/browser-host";
+import type { MailboxStore } from "../../backend/mailbox-store";
+import { readAnalyticsPreference, writeAnalyticsPreference } from "../analytics-preference-store";
+import { exportDiagnostics, exportOpenBotData } from "../maintenance-service";
+import { readSetupState, writeSetupState } from "../setup-store";
+import { handleTrusted } from "../trusted-ipc";
+import type { UpdateService } from "../update-service";
+import { parseAnalyticsPreference, parseExternalDestination, parseProvider } from "./app-inputs";
+import { requireString } from "./validation";
+
+const EXTERNAL_DESTINATIONS: Record<ExternalDestination, string> = {
+  "agent-setup": "https://github.com/NorbertBodziony/openbot/blob/main/docs/TROUBLESHOOTING.md",
+  "claude-install": "https://code.claude.com/docs",
+  "claude-sign-in": "https://code.claude.com/docs/en/authentication",
+  feedback: "https://x.com/intent/post?text=Feedback%20for%20OpenBot%20%40norbertbodziony%3A%20",
+  message: "https://x.com/norbertbodziony",
+};
+
+export interface AppIpcDependencies {
+  service: AgentService;
+  mailbox: MailboxStore;
+  browser: BrowserHost;
+  updater: UpdateService;
+  setupFile: string;
+  analyticsPreferenceFile: string;
+  initializeAgent: () => Promise<void>;
+  appVariant: AppVariant;
+  getMainWindow: () => BrowserWindow | null;
+  setAnalyticsTrackingEnabled: (enabled: boolean) => void;
+}
+
+export function registerAppIpcHandlers({
+  service,
+  mailbox,
+  browser,
+  updater,
+  setupFile,
+  analyticsPreferenceFile,
+  initializeAgent,
+  appVariant,
+  getMainWindow,
+  setAnalyticsTrackingEnabled,
+}: AppIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.getAppInfo, (): AppInfo => {
+    const platform = process.platform;
+    if (platform !== "darwin" && platform !== "win32" && platform !== "linux") {
+      throw new Error(`Unsupported desktop platform: ${platform}`);
+    }
+    return { name: app.getName(), version: app.getVersion(), platform, variant: appVariant };
+  });
+  handleTrusted(IPC_CHANNELS.getSetupState, () => readSetupState(setupFile));
+  handleTrusted(IPC_CHANNELS.getAnalyticsPreference, () => readAnalyticsPreference(analyticsPreferenceFile));
+  handleTrusted(IPC_CHANNELS.setAnalyticsPreference, async (input: unknown) => {
+    const preference = await writeAnalyticsPreference(analyticsPreferenceFile, parseAnalyticsPreference(input).enabled);
+    setAnalyticsTrackingEnabled(preference.enabled);
+    return preference;
+  });
+
+  handleTrusted(IPC_CHANNELS.saveSetup, async (input: unknown): Promise<AppSetupState> => {
+    const preferredProvider = parseProvider(input);
+    const state = await writeSetupState(setupFile, preferredProvider);
+    await service.setPreferredProvider(preferredProvider);
+    await initializeAgent();
+    return state;
+  });
+
+  handleTrusted(IPC_CHANNELS.openExternal, (destination: unknown) => {
+    return shell.openExternal(EXTERNAL_DESTINATIONS[parseExternalDestination(destination)]);
+  });
+
+  handleTrusted(IPC_CHANNELS.openUrl, (value: unknown) => {
+    const url = new URL(requireString(value, "URL", INPUT_LIMITS.browserUrl));
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error("Only HTTP(S) links can open in the external browser.");
+    }
+    return shell.openExternal(url.toString());
+  });
+
+  handleTrusted(IPC_CHANNELS.maintenanceExportData, () =>
+    exportOpenBotData({ service, mailbox, parentWindow: getMainWindow() }),
+  );
+  handleTrusted(IPC_CHANNELS.maintenanceExportDiagnostics, () =>
+    exportDiagnostics({ service, browser, updater, parentWindow: getMainWindow() }),
+  );
+}

--- a/src/main/ipc/register-attachment-handlers.ts
+++ b/src/main/ipc/register-attachment-handlers.ts
@@ -1,0 +1,263 @@
+// Attachments, and the shared and workspace files an agent can open or preview.
+// Every path here crosses to the local filesystem, so the parsers are the boundary.
+
+import { createHash } from "node:crypto";
+import { chmod, copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import {
+  ATTACHMENT_FILE_EXTENSIONS,
+  IMAGE_ATTACHMENT_EXTENSIONS,
+  isSupportedAttachmentName,
+  SUPPORTED_ATTACHMENT_DESCRIPTION,
+} from "@openbot/contracts/attachment-files";
+import { ATTACHMENT_LIMITS, INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import type { FilePreview, ImportAttachmentsInput } from "@openbot/contracts/ipc";
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { app, type BrowserWindow, dialog, type OpenDialogOptions, shell } from "electron";
+import type { AgentService } from "../../backend/agent-service";
+import type { MailboxStore } from "../../backend/mailbox-store";
+import { filePreviewFromBytes, localFilePreview, mimeTypeForName } from "../file-preview";
+import { decodeVoid, type RemoteServerManager } from "../remote-server-manager";
+import { handleTrusted } from "../trusted-ipc";
+import {
+  parseAgentRequest,
+  parseChooseAttachments,
+  parseImportAttachments,
+  parseOpenAttachment,
+  parseOpenSharedFile,
+  parseOpenWorkspaceFile,
+} from "./agent-inputs";
+import { requireString } from "./validation";
+
+interface AttachmentIpcDependencies {
+  service: AgentService;
+  mailbox: MailboxStore;
+  remoteServers: RemoteServerManager;
+  getMainWindow: () => BrowserWindow | null;
+}
+
+export function registerAttachmentIpcHandlers({
+  service,
+  mailbox,
+  remoteServers,
+  getMainWindow,
+}: AttachmentIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.agentChooseAttachments, async (input: unknown) => {
+    const { serverId, payload } = parseAgentRequest(input);
+    const { filter } = parseChooseAttachments(payload);
+    const options: OpenDialogOptions = {
+      properties: ["openFile", "multiSelections"],
+      filters:
+        filter === "images"
+          ? [{ name: "Images", extensions: [...IMAGE_ATTACHMENT_EXTENSIONS] }]
+          : [{ name: "Supported files", extensions: [...ATTACHMENT_FILE_EXTENSIONS] }],
+    };
+    const mainWindow = getMainWindow();
+    const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
+    if (result.canceled) return [];
+    if (serverId === "local") return service.prepareAttachments(result.filePaths);
+    return uploadRemotePaths(remoteServers, serverId, result.filePaths);
+  });
+  handleTrusted(IPC_CHANNELS.agentImportAttachments, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseImportAttachments(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.prepareImportedAttachments(parsed.paths, parsed.data)
+      : uploadRemoteImports(remoteServers, scoped.serverId, parsed);
+  });
+  handleTrusted(IPC_CHANNELS.agentDiscardDraftAttachment, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const attachmentId = requireString(scoped.payload, "attachmentId");
+    return scoped.serverId === "local"
+      ? service.discardDraftAttachment(attachmentId)
+      : remoteServers.request(
+          `/v1/attachments/${encodeURIComponent(attachmentId)}`,
+          { method: "DELETE" },
+          scoped.serverId,
+          decodeVoid,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentOpenAttachment, async (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseOpenAttachment(scoped.payload);
+    if (scoped.serverId !== "local") {
+      const downloaded = await remoteServers.downloadAttachment(parsed.attachmentId, scoped.serverId);
+      const suggestedName = basename(downloaded.name) || `attachment-${parsed.attachmentId}`;
+      if (parsed.action === "download") {
+        const extension = extname(suggestedName).slice(1).toLowerCase();
+        const saveOptions: Electron.SaveDialogOptions = {
+          defaultPath: join(app.getPath("downloads"), suggestedName),
+          filters: [{ name: "Attachment", extensions: extension ? [extension] : ["*"] }],
+          showsTagField: false,
+        };
+        const mainWindow = getMainWindow();
+        const result =
+          mainWindow && !mainWindow.isDestroyed()
+            ? await dialog.showSaveDialog(mainWindow, saveOptions)
+            : await dialog.showSaveDialog(saveOptions);
+        if (result.canceled || !result.filePath) return;
+        await writeFile(result.filePath, downloaded.bytes, { mode: 0o600 });
+        return;
+      }
+      const cacheRoot = join(app.getPath("userData"), "remote-attachments");
+      await mkdir(cacheRoot, { recursive: true });
+      const safeName = `${parsed.attachmentId}-${suggestedName}`;
+      const target = join(cacheRoot, safeName);
+      await writeFile(target, downloaded.bytes, { mode: 0o600 });
+      if (parsed.action === "reveal") shell.showItemInFolder(target);
+      else {
+        const openError = await shell.openPath(target);
+        if (openError) throw new Error(openError);
+      }
+      return;
+    }
+    const attachment = await mailbox.resolveAttachment(parsed.attachmentId);
+    if (!attachment) throw new Error("Attachment was not found.");
+    if (parsed.action === "download") {
+      const safeId = basename(parsed.attachmentId).replace(/[^a-z0-9_-]/gi, "-") || "attachment";
+      const mimeExtension = attachment.mimeType.split("/")[1]?.replace(/[^a-z0-9]/gi, "");
+      const suggestedName = `attachment-${safeId}${mimeExtension ? `.${mimeExtension}` : ""}`;
+      const extension = extname(suggestedName).slice(1).toLowerCase();
+      const saveOptions: Electron.SaveDialogOptions = {
+        defaultPath: join(app.getPath("downloads"), suggestedName),
+        filters: [{ name: "Attachment", extensions: extension ? [extension] : ["*"] }],
+        showsTagField: false,
+      };
+      const mainWindow = getMainWindow();
+      const result =
+        mainWindow && !mainWindow.isDestroyed()
+          ? await dialog.showSaveDialog(mainWindow, saveOptions)
+          : await dialog.showSaveDialog(saveOptions);
+      if (result.canceled || !result.filePath) return;
+      await copyFile(attachment.path, result.filePath);
+      return;
+    }
+    if (parsed.action === "reveal") {
+      shell.showItemInFolder(attachment.path);
+      return;
+    }
+    const error = await shell.openPath(attachment.path);
+    if (error) throw new Error(error);
+  });
+  handleTrusted(IPC_CHANNELS.agentOpenSharedFile, async (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseOpenSharedFile(scoped.payload);
+    if (scoped.serverId !== "local") {
+      const downloaded = await remoteServers.downloadSharedFile(parsed.path, scoped.serverId);
+      const cacheRoot = join(app.getPath("userData"), "remote-shared-files");
+      await mkdir(cacheRoot, { recursive: true, mode: 0o700 });
+      const cacheKey = createHash("sha256").update(`${scoped.serverId}:${parsed.path}`).digest("hex");
+      const target = join(cacheRoot, `${cacheKey}-${basename(downloaded.name)}`);
+      await writeFile(target, downloaded.bytes, { mode: 0o600 });
+      await chmod(target, 0o600);
+      const openError = await shell.openPath(target);
+      if (openError) throw new Error(openError);
+      return;
+    }
+    const sharedFile = await service.resolveSharedFile(parsed.path);
+    const openError = await shell.openPath(sharedFile.path);
+    if (openError) throw new Error(openError);
+  });
+  handleTrusted(IPC_CHANNELS.agentOpenWorkspaceFile, async (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseOpenWorkspaceFile(scoped.payload);
+    if (scoped.serverId !== "local") {
+      const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, scoped.serverId);
+      const cacheRoot = join(app.getPath("userData"), "remote-workspace-files");
+      await mkdir(cacheRoot, { recursive: true, mode: 0o700 });
+      const cacheKey = createHash("sha256").update(`${scoped.serverId}:${parsed.botId}:${parsed.path}`).digest("hex");
+      const target = join(cacheRoot, `${cacheKey}-${basename(downloaded.name)}`);
+      await writeFile(target, downloaded.bytes, { mode: 0o600 });
+      await chmod(target, 0o600);
+      const openError = await shell.openPath(target);
+      if (openError) throw new Error(openError);
+      return;
+    }
+    const workspaceFile = await service.resolveWorkspaceFile(parsed.botId, parsed.path);
+    const openError = await shell.openPath(workspaceFile.path);
+    if (openError) throw new Error(openError);
+  });
+  handleTrusted(IPC_CHANNELS.agentPreviewSharedFile, async (input: unknown): Promise<FilePreview> => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseOpenSharedFile(scoped.payload);
+    if (scoped.serverId !== "local") {
+      const downloaded = await remoteServers.downloadSharedFile(parsed.path, scoped.serverId);
+      return filePreviewFromBytes(downloaded.name, downloaded.bytes);
+    }
+    const sharedFile = await service.resolveSharedFile(parsed.path);
+    return localFilePreview(sharedFile.path, sharedFile.name, sharedFile.size);
+  });
+  handleTrusted(IPC_CHANNELS.agentPreviewWorkspaceFile, async (input: unknown): Promise<FilePreview> => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseOpenWorkspaceFile(scoped.payload);
+    if (scoped.serverId !== "local") {
+      const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, scoped.serverId);
+      return filePreviewFromBytes(downloaded.name, downloaded.bytes);
+    }
+    const workspaceFile = await service.resolveWorkspaceFile(parsed.botId, parsed.path);
+    return localFilePreview(workspaceFile.path, workspaceFile.name, workspaceFile.size);
+  });
+}
+
+async function uploadRemotePaths(remoteServers: RemoteServerManager, serverId: string, paths: string[]) {
+  if (paths.length > INPUT_LIMITS.attachments) {
+    throw new Error(`Choose at most ${INPUT_LIMITS.attachments} files.`);
+  }
+  for (const path of paths) assertSupportedAttachmentName(basename(path));
+  const files = await Promise.all(
+    paths.map(async (path) => ({
+      name: basename(path),
+      bytes: new Uint8Array(await readFile(path)),
+    })),
+  );
+  const total = files.reduce((sum, file) => sum + file.bytes.byteLength, 0);
+  if (files.some((file) => file.bytes.byteLength > ATTACHMENT_LIMITS.fileBytes)) {
+    throw new Error("A file exceeds the 100 MB limit.");
+  }
+  if (total > ATTACHMENT_LIMITS.totalBytes) {
+    throw new Error("Attachments exceed the 250 MB total limit.");
+  }
+  return Promise.all(
+    files.map((file) => remoteServers.uploadAttachment(file.name, mimeTypeForName(file.name), file.bytes, serverId)),
+  );
+}
+
+async function uploadRemoteImports(
+  remoteServers: RemoteServerManager,
+  serverId: string,
+  input: ImportAttachmentsInput,
+) {
+  if (input.paths.length + input.data.length > INPUT_LIMITS.attachments) {
+    throw new Error(`Choose at most ${INPUT_LIMITS.attachments} files.`);
+  }
+  const pathFiles = await Promise.all(
+    input.paths.map(async (path) => ({
+      name: basename(path),
+      mimeType: mimeTypeForName(path),
+      bytes: new Uint8Array(await readFile(path)),
+    })),
+  );
+  const files = [
+    ...pathFiles,
+    ...input.data.map((item) => ({
+      name: basename(item.name),
+      mimeType: item.mimeType,
+      bytes: item.bytes,
+    })),
+  ];
+  for (const file of files) assertSupportedAttachmentName(file.name);
+  if (files.some((file) => file.bytes.byteLength > ATTACHMENT_LIMITS.fileBytes)) {
+    throw new Error("A file exceeds the 100 MB limit.");
+  }
+  if (files.reduce((sum, file) => sum + file.bytes.byteLength, 0) > ATTACHMENT_LIMITS.totalBytes) {
+    throw new Error("Attachments exceed the 250 MB total limit.");
+  }
+  return Promise.all(
+    files.map((file) => remoteServers.uploadAttachment(file.name, file.mimeType, file.bytes, serverId)),
+  );
+}
+
+function assertSupportedAttachmentName(name: string): void {
+  if (isSupportedAttachmentName(name)) return;
+  throw new Error(`${name} is not supported. Attach ${SUPPORTED_ATTACHMENT_DESCRIPTION}.`);
+}

--- a/src/main/ipc/register-browser-handlers.ts
+++ b/src/main/ipc/register-browser-handlers.ts
@@ -1,0 +1,106 @@
+// The embedded browser and its picture-in-picture window.
+
+import { type BrowserDisplayState, IPC_CHANNELS } from "@openbot/contracts/ipc";
+import type { BrowserHost } from "../../backend/browser-host";
+import type { BrowserPictureInPicture } from "../browser-picture-in-picture";
+import {
+  decodeBrowserControlState,
+  decodeBrowserPreview,
+  decodeBrowserTab,
+  decodeBrowserTabs,
+  decodeVoid,
+  type RemoteServerManager,
+} from "../remote-server-manager";
+import { handleTrusted } from "../trusted-ipc";
+import { parseBrowserBounds, parseBrowserNavigate, parseBrowserOpen, parseVisibility } from "./browser-inputs";
+import { requireString } from "./validation";
+
+export interface BrowserIpcDependencies {
+  browserPictureInPicture: BrowserPictureInPicture;
+  browser: BrowserHost;
+  remoteServers: RemoteServerManager;
+}
+
+export function registerBrowserIpcHandlers({
+  browserPictureInPicture,
+  browser,
+  remoteServers,
+}: BrowserIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.browserOpen, (input: unknown) => {
+    const parsed = parseBrowserOpen(input);
+    return remoteServers.activeServerId === "local"
+      ? browser.open(parsed.url, parsed.ownerThreadId ?? null, parsed.ownerBotId ?? null, parsed.focus)
+      : remoteServers.request("/v1/browser/open", { method: "POST", body: parsed }, undefined, decodeBrowserTab);
+  });
+  handleTrusted(IPC_CHANNELS.browserActivate, (tabId: unknown) =>
+    remoteServers.activeServerId === "local"
+      ? browser.activate(requireString(tabId, "tabId"))
+      : remoteServers.request(
+          "/v1/browser/activate",
+          { method: "POST", body: { tabId: requireString(tabId, "tabId") } },
+          undefined,
+          decodeVoid,
+        ),
+  );
+  handleTrusted(IPC_CHANNELS.browserNavigate, (input: unknown) => {
+    const parsed = parseBrowserNavigate(input);
+    return remoteServers.activeServerId === "local"
+      ? browser.navigate(parsed.tabId, parsed.direction)
+      : remoteServers.request("/v1/browser/navigate", { method: "POST", body: parsed }, undefined, decodeVoid);
+  });
+  handleTrusted(IPC_CHANNELS.browserReload, (tabId: unknown) =>
+    remoteServers.activeServerId === "local"
+      ? browser.reload(requireString(tabId, "tabId"))
+      : remoteServers.request(
+          "/v1/browser/reload",
+          { method: "POST", body: { tabId: requireString(tabId, "tabId") } },
+          undefined,
+          decodeVoid,
+        ),
+  );
+  handleTrusted(IPC_CHANNELS.browserClose, (tabId: unknown) =>
+    remoteServers.activeServerId === "local"
+      ? browser.close(requireString(tabId, "tabId"))
+      : remoteServers.request(
+          "/v1/browser/close",
+          { method: "POST", body: { tabId: requireString(tabId, "tabId") } },
+          undefined,
+          decodeVoid,
+        ),
+  );
+  handleTrusted(IPC_CHANNELS.browserListTabs, () =>
+    remoteServers.activeServerId === "local"
+      ? browser.listTabs()
+      : remoteServers.request("/v1/browser/tabs", {}, undefined, decodeBrowserTabs),
+  );
+  handleTrusted(IPC_CHANNELS.browserGetDisplayState, (): BrowserDisplayState => browser.getDisplayState());
+  handleTrusted(IPC_CHANNELS.browserGetControlState, () =>
+    remoteServers.activeServerId === "local"
+      ? browser.getControlState()
+      : remoteServers.request("/v1/browser/control", {}, undefined, decodeBrowserControlState),
+  );
+  handleTrusted(IPC_CHANNELS.browserCapturePreview, (tabId: unknown) => {
+    const parsedTabId = requireString(tabId, "tabId");
+    return remoteServers.activeServerId === "local"
+      ? browser.capturePreview(parsedTabId)
+      : remoteServers.request(
+          "/v1/browser/preview",
+          { method: "POST", body: { tabId: parsedTabId } },
+          undefined,
+          decodeBrowserPreview,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.browserSetVisible, async (input: unknown) => {
+    const parsed = parseVisibility(input);
+    if (remoteServers.activeServerId === "local") await browser.setVisible(parsed);
+    else {
+      await remoteServers.request("/v1/browser/visible", { method: "POST", body: parsed }, undefined, decodeVoid);
+    }
+  });
+  handleTrusted(IPC_CHANNELS.browserPictureInPictureOpen, (input: unknown) =>
+    browserPictureInPicture.open(input === undefined ? undefined : parseBrowserBounds(input)),
+  );
+  handleTrusted(IPC_CHANNELS.browserPictureInPictureClose, () => browserPictureInPicture.close());
+  handleTrusted(IPC_CHANNELS.browserPictureInPictureDock, () => browserPictureInPicture.dock());
+  handleTrusted(IPC_CHANNELS.browserPictureInPictureHide, () => browserPictureInPicture.hide());
+}

--- a/src/main/ipc/register-computer-use-handlers.ts
+++ b/src/main/ipc/register-computer-use-handlers.ts
@@ -1,0 +1,22 @@
+// The macOS screen-recording and accessibility permission flow.
+
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import type { ComputerUseMacSetupWindowController } from "../computer-use-mac-setup-window";
+import { handleTrusted, handleTrustedWithEvent } from "../trusted-ipc";
+import { parseMacPermission } from "./app-inputs";
+
+export interface ComputerUseIpcDependencies {
+  computerUseMacSetup: ComputerUseMacSetupWindowController;
+}
+
+export function registerComputerUseIpcHandlers({ computerUseMacSetup }: ComputerUseIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.computerUseGetMacSetupState, () => computerUseMacSetup.getState());
+  handleTrusted(IPC_CHANNELS.computerUseOpenMacPermissionSetup, (permission: unknown) =>
+    computerUseMacSetup.open(parseMacPermission(permission)),
+  );
+  handleTrustedWithEvent(IPC_CHANNELS.computerUseStartHelperDrag, (event) =>
+    computerUseMacSetup.startDrag(event.sender),
+  );
+  handleTrusted(IPC_CHANNELS.computerUseRevealHelper, () => computerUseMacSetup.revealHelper());
+  handleTrusted(IPC_CHANNELS.computerUseCloseMacPermissionSetup, () => computerUseMacSetup.close());
+}

--- a/src/main/ipc/register-dynamic-island-handlers.ts
+++ b/src/main/ipc/register-dynamic-island-handlers.ts
@@ -1,0 +1,51 @@
+// The always-on-top island window: its preference, its presentation, and the actions and
+// haptics it sends back.
+
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { type DynamicIslandWindowController, requireDynamicIslandSender } from "../dynamic-island-window";
+import { handleTrustedWithEvent } from "../trusted-ipc";
+import {
+  parseDynamicIslandAction,
+  parseDynamicIslandInteractive,
+  parseDynamicIslandPreference,
+  parseDynamicIslandPresentation,
+} from "./app-inputs";
+
+export interface DynamicIslandIpcDependencies {
+  dynamicIsland: DynamicIslandWindowController;
+}
+
+export function registerDynamicIslandIpcHandlers({ dynamicIsland }: DynamicIslandIpcDependencies): void {
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandGetPreference, (event) => {
+    requireDynamicIslandSender(
+      event.sender.id,
+      new Set([...dynamicIsland.mainRendererIds, ...dynamicIsland.overlayRendererIds]),
+      "main or Dynamic Island renderer",
+    );
+    return dynamicIsland.preference;
+  });
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetPreference, (event, input: unknown) => {
+    requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer");
+    return dynamicIsland.setPreference(parseDynamicIslandPreference(input));
+  });
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPublishPresentation, (event, input: unknown) => {
+    requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer");
+    dynamicIsland.publish(parseDynamicIslandPresentation(input));
+  });
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandGetPresentation, (event) => {
+    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
+    return dynamicIsland.presentation;
+  });
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPerformAction, (event, input: unknown) => {
+    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
+    return dynamicIsland.performAction(parseDynamicIslandAction(input));
+  });
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPerformHaptic, (event) => {
+    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
+    dynamicIsland.performHaptic();
+  });
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetInteractive, (event, input: unknown) => {
+    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
+    dynamicIsland.setInteractive(event.sender.id, parseDynamicIslandInteractive(input).interactive);
+  });
+}

--- a/src/main/ipc/register-hosted-site-handlers.ts
+++ b/src/main/ipc/register-hosted-site-handlers.ts
@@ -1,0 +1,51 @@
+// Publishing a local directory to a hosted site.
+
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { type BrowserWindow, dialog, type OpenDialogOptions } from "electron";
+import type { HostedSiteDesktopService } from "../hosted-site-service";
+import { handleTrusted } from "../trusted-ipc";
+import { isObject, optionalBoolean, requireString } from "./validation";
+
+export interface HostedSiteIpcDependencies {
+  hostedSites: HostedSiteDesktopService;
+  getMainWindow: () => BrowserWindow | null;
+}
+
+export function registerHostedSiteIpcHandlers({ hostedSites, getMainWindow }: HostedSiteIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.hostedSitesList, () => hostedSites.list());
+  handleTrusted(IPC_CHANNELS.hostedSitesChooseDirectory, async () => {
+    const options: OpenDialogOptions = {
+      title: "Choose a static site directory",
+      properties: ["openDirectory"],
+    };
+    const mainWindow = getMainWindow();
+    const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
+    return result.canceled ? null : (result.filePaths[0] ?? null);
+  });
+  handleTrusted(IPC_CHANNELS.hostedSitesPublish, (input: unknown) => {
+    if (!isObject(input)) throw new Error("Invalid site publication.");
+    const spaFallback = optionalBoolean(input.spaFallback, "spaFallback");
+    return hostedSites.publish({
+      sourcePath: requireString(input.sourcePath, "sourcePath", INPUT_LIMITS.path),
+      title: requireString(input.title, "title", 120),
+      description: requireString(input.description, "description", 500),
+      ...(spaFallback !== undefined ? { spaFallback } : {}),
+    });
+  });
+  handleTrusted(IPC_CHANNELS.hostedSitesReplace, (input: unknown) => {
+    if (!isObject(input)) throw new Error("Invalid site replacement.");
+    const spaFallback = optionalBoolean(input.spaFallback, "spaFallback");
+    return hostedSites.replace({
+      siteId: requireString(input.siteId, "siteId", INPUT_LIMITS.identifier),
+      sourcePath: requireString(input.sourcePath, "sourcePath", INPUT_LIMITS.path),
+      title: requireString(input.title, "title", 120),
+      description: requireString(input.description, "description", 500),
+      ...(spaFallback !== undefined ? { spaFallback } : {}),
+    });
+  });
+  handleTrusted(IPC_CHANNELS.hostedSitesDelete, (input: unknown) => {
+    if (!isObject(input)) throw new Error("Invalid site deletion.");
+    return hostedSites.delete(requireString(input.siteId, "siteId", INPUT_LIMITS.identifier));
+  });
+}

--- a/src/main/ipc/register-marketplace-agent-handlers.ts
+++ b/src/main/ipc/register-marketplace-agent-handlers.ts
@@ -1,0 +1,50 @@
+// The agent marketplace: browsing, submitting and installing a published agent.
+
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { isNumber, isString } from "@openbot/contracts/runtime-values";
+import type { AgentMarketplaceService } from "../agent-marketplace-service";
+import { handleTrusted } from "../trusted-ipc";
+import { isObject, requireString } from "./validation";
+
+export interface MarketplaceAgentIpcDependencies {
+  marketplaceAgents: AgentMarketplaceService;
+}
+
+export function registerMarketplaceAgentIpcHandlers({ marketplaceAgents }: MarketplaceAgentIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsList, (input: unknown) => {
+    if (input === null || input === undefined) return marketplaceAgents.list();
+    if (!isObject(input)) throw new Error("Invalid agent marketplace query.");
+    if (input.sort !== undefined && input.sort !== "installs") throw new Error("Unknown agent sort order.");
+    return marketplaceAgents.list({
+      ...(isString(input.query) ? { query: input.query.slice(0, 100) } : {}),
+      ...(input.featured === true ? { featured: true } : {}),
+      ...(input.sort === "installs" ? { sort: "installs" as const } : {}),
+      ...(isString(input.cursor) ? { cursor: input.cursor } : {}),
+      ...(isNumber(input.limit) ? { limit: input.limit } : {}),
+    });
+  });
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsGet, (input: unknown) =>
+    marketplaceAgents.get(requireString(input, "agentId")),
+  );
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsListMine, () => marketplaceAgents.listMine());
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsPreview, (input: unknown) =>
+    marketplaceAgents.preview(requireString(input, "botId")),
+  );
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsSubmit, (input: unknown) => {
+    if (!isObject(input)) throw new Error("Invalid agent submission.");
+    return marketplaceAgents.submit({
+      botId: requireString(input.botId, "botId"),
+      ...(input.agentId === undefined ? {} : { agentId: requireString(input.agentId, "agentId") }),
+    });
+  });
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsInstall, (input: unknown) => {
+    if (!isObject(input)) throw new Error("Invalid agent installation.");
+    return marketplaceAgents.install({
+      agentId: requireString(input.agentId, "agentId"),
+      ...(input.botId === undefined ? {} : { botId: requireString(input.botId, "botId", INPUT_LIMITS.identifier) }),
+      timezone: requireString(input.timezone, "timezone", 255),
+      receiptId: requireString(input.receiptId, "receiptId", INPUT_LIMITS.identifier),
+    });
+  });
+}

--- a/src/main/ipc/register-memory-handlers.ts
+++ b/src/main/ipc/register-memory-handlers.ts
@@ -1,0 +1,75 @@
+// An agent's long-lived memories: the notes it carries between threads.
+
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import type { AgentService } from "../../backend/agent-service";
+import { decodeBotMemories, decodeBotMemory, decodeVoid, type RemoteServerManager } from "../remote-server-manager";
+import { handleTrusted } from "../trusted-ipc";
+import { parseAgentRequest, parseCreateBotMemory, parseDeleteBotMemory, parseUpdateBotMemory } from "./agent-inputs";
+import { requireString } from "./validation";
+
+interface MemoryIpcDependencies {
+  service: AgentService;
+  remoteServers: RemoteServerManager;
+}
+
+export function registerMemoryIpcHandlers({ service, remoteServers }: MemoryIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.agentListMemories, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
+    return scoped.serverId === "local"
+      ? service.listMemories(botId)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(botId)}/memories`,
+          {},
+          scoped.serverId,
+          decodeBotMemories,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentCreateMemory, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseCreateBotMemory(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.createMemory(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/memories`,
+          { method: "POST", body: { text: parsed.text } },
+          scoped.serverId,
+          decodeBotMemory,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentUpdateMemory, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseUpdateBotMemory(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.updateMemory(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/memories/${encodeURIComponent(parsed.memoryId)}`,
+          { method: "PATCH", body: { text: parsed.text } },
+          scoped.serverId,
+          decodeBotMemory,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentDeleteMemory, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseDeleteBotMemory(scoped.payload);
+    if (scoped.serverId === "local") return service.deleteMemory(parsed);
+    return remoteServers.request(
+      `/v1/agents/${encodeURIComponent(parsed.botId)}/memories/${encodeURIComponent(parsed.memoryId)}`,
+      { method: "DELETE" },
+      scoped.serverId,
+      decodeVoid,
+    );
+  });
+  handleTrusted(IPC_CHANNELS.agentClearMemories, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
+    if (scoped.serverId === "local") return service.clearMemories(botId);
+    return remoteServers.request(
+      `/v1/agents/${encodeURIComponent(botId)}/memories`,
+      { method: "DELETE" },
+      scoped.serverId,
+      decodeVoid,
+    );
+  });
+}

--- a/src/main/ipc/register-provider-handlers.ts
+++ b/src/main/ipc/register-provider-handlers.ts
@@ -1,0 +1,33 @@
+// Signing in to Codex, Claude and Grok, and downloading the CLI runtimes they need.
+
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { shell } from "electron";
+import type { AgentService } from "../../backend/agent-service";
+import type { ProviderRuntimeManager } from "../provider-runtime-manager";
+import { handleTrusted } from "../trusted-ipc";
+import { parseProviderId } from "./app-inputs";
+
+export interface ProviderIpcDependencies {
+  service: AgentService;
+  providerRuntimes: ProviderRuntimeManager;
+}
+
+export function registerProviderIpcHandlers({ service, providerRuntimes }: ProviderIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.connectChatGPT, () =>
+    service.connectChatGPT(async (value) => {
+      const url = new URL(value);
+      if (url.protocol !== "https:") throw new Error("Only HTTPS ChatGPT login links can open in the browser.");
+      await shell.openExternal(url.toString());
+    }),
+  );
+  handleTrusted(IPC_CHANNELS.connectClaude, () => service.connectClaude());
+  handleTrusted(IPC_CHANNELS.connectGrok, () => service.connectGrok());
+  handleTrusted(IPC_CHANNELS.refreshAgentProviders, () => service.refreshProviders());
+  handleTrusted(IPC_CHANNELS.providerRuntimesGetStatus, () => providerRuntimes.getStatus());
+  handleTrusted(IPC_CHANNELS.providerRuntimesDownload, (provider: unknown) =>
+    providerRuntimes.download(parseProviderId(provider)),
+  );
+  handleTrusted(IPC_CHANNELS.providerRuntimesCancel, (provider: unknown) =>
+    providerRuntimes.cancel(parseProviderId(provider)),
+  );
+}

--- a/src/main/ipc/register-routine-handlers.ts
+++ b/src/main/ipc/register-routine-handlers.ts
@@ -1,0 +1,97 @@
+// Routines: the scheduled standing instructions attached to one agent.
+
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import type { AgentService } from "../../backend/agent-service";
+import {
+  decodeRoutine,
+  decodeRoutineRun,
+  decodeRoutineRuns,
+  decodeRoutines,
+  decodeVoid,
+  type RemoteServerManager,
+} from "../remote-server-manager";
+import { handleTrusted } from "../trusted-ipc";
+import {
+  parseAgentRequest,
+  parseCreateRoutine,
+  parseDeleteRoutine,
+  parseListRoutineRuns,
+  parseTestRoutine,
+  parseUpdateRoutine,
+} from "./agent-inputs";
+import { requireString } from "./validation";
+
+interface RoutineIpcDependencies {
+  service: AgentService;
+  remoteServers: RemoteServerManager;
+}
+
+export function registerRoutineIpcHandlers({ service, remoteServers }: RoutineIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.agentListRoutines, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
+    return scoped.serverId === "local"
+      ? service.listRoutines(botId)
+      : remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}/routines`, {}, scoped.serverId, decodeRoutines);
+  });
+  handleTrusted(IPC_CHANNELS.agentCreateRoutine, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseCreateRoutine(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.createRoutine(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines`,
+          { method: "POST", body: parsed },
+          scoped.serverId,
+          decodeRoutine,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentUpdateRoutine, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseUpdateRoutine(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.updateRoutine(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}`,
+          { method: "PATCH", body: parsed },
+          scoped.serverId,
+          decodeRoutine,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentDeleteRoutine, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseDeleteRoutine(scoped.payload);
+    if (scoped.serverId === "local") return service.deleteRoutine(parsed);
+    return remoteServers.request(
+      `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}`,
+      { method: "DELETE" },
+      scoped.serverId,
+      decodeVoid,
+    );
+  });
+  handleTrusted(IPC_CHANNELS.agentTestRoutine, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseTestRoutine(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.testRoutine(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}/test`,
+          { method: "POST" },
+          scoped.serverId,
+          decodeRoutineRun,
+        );
+  });
+  handleTrusted(IPC_CHANNELS.agentListRoutineRuns, (input: unknown) => {
+    const scoped = parseAgentRequest(input);
+    const parsed = parseListRoutineRuns(scoped.payload);
+    return scoped.serverId === "local"
+      ? service.listRoutineRuns(parsed)
+      : remoteServers.request(
+          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}/runs?limit=${parsed.limit}`,
+          {},
+          scoped.serverId,
+          decodeRoutineRuns,
+        );
+  });
+}

--- a/src/main/ipc/register-skill-handlers.ts
+++ b/src/main/ipc/register-skill-handlers.ts
@@ -1,0 +1,72 @@
+// The skill marketplace, and the skills installed into a workspace.
+
+import { IPC_CHANNELS, isSkillCategory } from "@openbot/contracts/ipc";
+import { isNumber, isString } from "@openbot/contracts/runtime-values";
+import { type BrowserWindow, dialog, type OpenDialogOptions } from "electron";
+import type { SkillMarketplaceService } from "../skill-marketplace-service";
+import { handleTrusted } from "../trusted-ipc";
+import { parseAvatarImage } from "./avatar-inputs";
+import { isObject, requireString } from "./validation";
+
+export interface SkillIpcDependencies {
+  skills: SkillMarketplaceService;
+  getMainWindow: () => BrowserWindow | null;
+}
+
+export function registerSkillIpcHandlers({ skills, getMainWindow }: SkillIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.skillsList, (input: unknown) => {
+    if (input === null || input === undefined) return skills.list();
+    if (!isObject(input)) throw new Error("Invalid marketplace query.");
+    const category = input.category;
+    if (category !== undefined && !isSkillCategory(category)) throw new Error("Unknown skill category.");
+    if (input.sort !== undefined && input.sort !== "installs") throw new Error("Unknown skill sort order.");
+    return skills.list({
+      ...(isString(input.query) ? { query: input.query.slice(0, 100) } : {}),
+      ...(category ? { category } : {}),
+      ...(input.featured === true ? { featured: true } : {}),
+      ...(input.sort === "installs" ? { sort: "installs" as const } : {}),
+      ...(isString(input.cursor) ? { cursor: input.cursor } : {}),
+      ...(isNumber(input.limit) ? { limit: input.limit } : {}),
+    });
+  });
+  handleTrusted(IPC_CHANNELS.skillsGet, (input: unknown) => skills.get(requireString(input, "skillId")));
+  handleTrusted(IPC_CHANNELS.skillsListMine, () => skills.listMine());
+  handleTrusted(IPC_CHANNELS.skillsChoosePackage, async () => {
+    const options: OpenDialogOptions = {
+      title: "Choose a skill folder or ZIP",
+      properties: ["openFile", "openDirectory"],
+      filters: [{ name: "Skill packages", extensions: ["zip"] }],
+    };
+    const mainWindow = getMainWindow();
+    const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
+    return result.canceled || !result.filePaths[0] ? null : skills.stage(result.filePaths[0]);
+  });
+  handleTrusted(IPC_CHANNELS.skillsSubmit, (input: unknown) => {
+    if (!isObject(input) || !isSkillCategory(input.category)) throw new Error("Invalid skill submission.");
+    return skills.submit({
+      draftId: requireString(input.draftId, "draftId"),
+      category: input.category,
+      icon: parseAvatarImage(input.icon),
+      ...(input.skillId === undefined ? {} : { skillId: requireString(input.skillId, "skillId") }),
+    });
+  });
+  handleTrusted(IPC_CHANNELS.skillsListInstalled, (input: unknown) =>
+    skills.listInstalled(requireString(input, "botId")),
+  );
+  handleTrusted(IPC_CHANNELS.skillsInstall, (input: unknown) => {
+    if (!isObject(input)) throw new Error("Invalid skill installation.");
+    return skills.install({
+      botId: requireString(input.botId, "botId"),
+      skillId: requireString(input.skillId, "skillId"),
+      ...(input.replaceModified === true ? { replaceModified: true } : {}),
+    });
+  });
+  handleTrusted(IPC_CHANNELS.skillsUninstall, (input: unknown) => {
+    if (!isObject(input)) throw new Error("Invalid skill removal.");
+    return skills.uninstall({
+      botId: requireString(input.botId, "botId"),
+      skillId: requireString(input.skillId, "skillId"),
+      ...(input.removeModified === true ? { removeModified: true } : {}),
+    });
+  });
+}

--- a/src/main/ipc/register-update-handlers.ts
+++ b/src/main/ipc/register-update-handlers.ts
@@ -1,0 +1,25 @@
+// The application updater and its auto-download preference.
+
+import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { handleTrusted } from "../trusted-ipc";
+import { readUpdatePreference, writeUpdatePreference } from "../update-preference-store";
+import type { UpdateService } from "../update-service";
+import { parseUpdatePreference } from "./app-inputs";
+
+export interface UpdateIpcDependencies {
+  updater: UpdateService;
+  updatePreferenceFile: string;
+}
+
+export function registerUpdateIpcHandlers({ updater, updatePreferenceFile }: UpdateIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.updateGetStatus, () => updater.getStatus());
+  handleTrusted(IPC_CHANNELS.updateCheck, () => updater.checkForUpdates());
+  handleTrusted(IPC_CHANNELS.updateDownload, () => updater.downloadUpdate());
+  handleTrusted(IPC_CHANNELS.updateInstall, () => updater.installUpdate());
+  handleTrusted(IPC_CHANNELS.updateGetPreference, () => readUpdatePreference(updatePreferenceFile));
+  handleTrusted(IPC_CHANNELS.updateSetPreference, async (input: unknown) => {
+    const preference = await writeUpdatePreference(updatePreferenceFile, parseUpdatePreference(input).autoDownload);
+    updater.setAutoDownload(preference.autoDownload);
+    return preference;
+  });
+}

--- a/src/main/ipc/register-voice-handlers.ts
+++ b/src/main/ipc/register-voice-handlers.ts
@@ -1,0 +1,19 @@
+// The local Whisper model and dictation.
+
+import { IPC_CHANNELS, type VoiceModelStatus, type VoiceTranscriptionResult } from "@openbot/contracts/ipc";
+import { handleTrusted } from "../trusted-ipc";
+import type { VoiceTranscriptionService } from "../voice-transcription-service";
+import { parseVoiceTranscription } from "./voice-inputs";
+
+export interface VoiceIpcDependencies {
+  voice: VoiceTranscriptionService;
+}
+
+export function registerVoiceIpcHandlers({ voice }: VoiceIpcDependencies): void {
+  handleTrusted(IPC_CHANNELS.voiceGetModelStatus, (): Promise<VoiceModelStatus> => voice.getModelStatus());
+  handleTrusted(IPC_CHANNELS.voicePrepareModel, (): Promise<VoiceModelStatus> => voice.prepareModel());
+  handleTrusted(
+    IPC_CHANNELS.voiceTranscribe,
+    (input: unknown): Promise<VoiceTranscriptionResult> => voice.transcribe(parseVoiceTranscription(input).audio),
+  );
+}

--- a/src/renderer/AGENTS.md
+++ b/src/renderer/AGENTS.md
@@ -1,0 +1,77 @@
+# `src/renderer`
+
+The UI stack sits on prerelease channels your training data does not cover: `solid-js@2.0.0-rc.0`
+with `@solidjs/signals` and `@solidjs/web` at the same RC, `@kobalte/core@2.0.0-alpha.0` (patched
+here), plus patched `lucide-solid` and `solid-sonner`. Do not trust your memory of these APIs: check
+`package.json`, then read `.agents/skills/react-to-solid/docs/` (`kobalte-patterns.md`,
+`corvu-patterns.md`, `base-ui-mapping.md`, `third-party-deps.md`) and
+`.agents/skills/zaidan/references/`. Those two skills are vendored and re-synced from upstream, so
+their code samples are 1.x-era and cannot be corrected here — `node_modules/solid-js/CHEATSHEET.md`
+is the source of truth for core APIs, and where they disagree the cheatsheet wins. Read the skills
+for the component patterns, not the imports.
+
+- `bun run dev` for integrated work — it starts the local Auth API and the Electron dev app
+  together. `bun run dev:api` is for API-only debugging.
+- `bun run storybook` verifies isolated components. CI builds it; do not run `build-storybook`.
+- Never verify UI with `dist/`, a packaged `.app`, a production build, or an ad-hoc preview — those
+  are for release verification the user asked for. If the dev app will not start, report the blocker
+  instead of falling back to one.
+
+## Reactive state shape
+
+**Prefer one `createStore` per concern over a row of `createSignal` calls.** Fields that change
+together are one record — a saved-and-draft form pair, a `data`/`loaded`/`loading`/`error` quad, a
+phase plus the numbers only one phase uses, several `Record`s keyed by the same `botId`. Declare the
+shape up front, so replacing one field re-renders only what read that field; `FirstBotSetup.tsx` is
+the form version. Keep the setter private behind named mutations where the store *is* a module's or
+a hook's exported surface, as `app-stored-values.ts` and `createAsyncPanel.ts` do. Inside a
+component, write the field where it changes — `setPanels((state) => { state.x = value; })` at the
+call site, as `SettingsModal.tsx` does — and let a named mutation there earn its name: more than one
+field, a guard or a side effect, or enough call sites that the name deduplicates something. A
+function whose whole body is `state.x = value` is the signal wall one layer down. Ten keyed
+`Record` signals are one row type shredded into ten columns, every write spreads the whole map so
+every consumer of every key re-runs, and parallel signals let a screen hold states
+the product does not have. `createSignal` still fits an element ref, a single measurement, a one-off
+boolean, and a record you always replace whole. Stores come from `"solid-js"` — there is no
+`solid-js/store` in this RC — hold plain values rather than accessors, and are never destructured.
+A `Map` or `Set` never becomes a store — `isWrappable` rejects platform objects — so the
+reference is the reactive unit: write a collection held in a signal by copying
+(`new Set(current).add(id)`), and keep one you never read reactively in a closure.
+
+## Component reuse
+
+Search for an existing component, hook, style, utility or story first, and prefer reuse, composition
+or a small extension. The shared layer is `src/renderer/src/components/ui` over patched Kobalte:
+extend a primitive there rather than copying one into a feature, and update its story when it gains
+a visual or interactive state. Build from scratch only after the search comes up empty, and keep it
+reusable. The [Zaidan catalog](https://zaidan.carere.dev/docs/components) is a source of reference
+*patterns*, not a dependency — it is not installed here; adapt its source to this repository's
+SolidJS conventions, tokens, typography, spacing, icons and accessibility requirements.
+
+## Design system
+
+Use `lucide-solid` icons, and reuse a suitable one before adding an inline SVG or a local icon
+component — document the exception next to any custom icon. The `:root` properties in
+`src/renderer/src/styles.css` are the palette: use the closest semantic `--openbot-*` token,
+including opacity variants, instead of a colour literal, and add a token only for a new semantic
+role. Keep compatibility aliases that are in use, and isolate fixed integration, generated-asset,
+SVG and platform colours at their boundaries.
+
+## Waiting in a renderer test
+
+`*.test.tsx` renders JSX in jsdom; `*.dom.test.ts` is the narrow case of needing a DOM without a
+component. Needing either for logic means the logic is not separable from the DOM yet.
+
+| Barrier | Use it for |
+| --- | --- |
+| `await screen.findByRole(role, { name })` | The normal case. It retries until the element exists, so it *is* the wait — a `getBy*` after a manual wait is the same query with a worse failure message. |
+| `await screen.findByText(...)` | Copy that is a product contract and has no accessible role of its own. |
+| `emitAgentEvent(...)` and the other `emit*` bridges — `app-test-harness.ts` | Driving a main-process event into the renderer. Await a `findBy*` after it; do not wait on the clock. |
+| `subscriberCounts()` — same file | Asserting a screen actually unsubscribed. This is how a leaked bridge subscription is caught. |
+| `installOpenbotStub()` | The whole `window.openbot` surface. Extend the stub rather than reaching around it. |
+| `vi.waitFor(() => expect(spy)...)` | A call that produces no visible change — an analytics event, an IPC invoke. |
+| `vi.useFakeTimers()` + `vi.advanceTimersByTime(n)` | A debounce or a poll interval. Advancing the clock is input, not waiting. |
+
+Never raise a `vi.waitFor` timeout to make a test pass: that is the sleep the `no-sleep-in-tests`
+rule rejected, one layer down. Find the barrier, or add one. Animation timing is not a barrier and
+not a subject — it belongs in a Storybook story.


### PR DESCRIPTION
Closes the remaining CI and structure items from #174.

## `ci: set up Bun and Node through one composite action`

Ten call sites across `ci.yml` and `release.yml` each carried their own `oven-sh/setup-bun`, `actions/setup-node` and `bun install` lines. `.github/actions/setup-bun` is now the one copy: `install` is `frozen` / `ignore-scripts` / `none`, `node` takes an expression so a job can set Node up on one platform only, and both are validated in the action because a typo would otherwise silently drop `--ignore-scripts`. Node always comes from `.nvmrc` — there is no version input, since an overridable one is the same drift one level down. Net −98/+80.

`remote-desktop-runtime.yml` is deliberately **not** converted. Its toolchain is part of a versioned build recipe: the workflow makes a change to itself require a `remoteDesktop.recipeVersion` bump, so routing it through a shared action would move the Bun and Node versions somewhere that check cannot see, and a later edit to the action would change the recipe silently. The issue counted four workflows; three is the right number, and the fourth is now documented as an exemption rather than an oversight.

## `refactor(main): register IPC per domain, and move guidance next to what it guards`

`src/main/index.ts` was 2,697 lines with 120 `handleTrusted` registrations inline, interleaved with window and lifecycle code. It is now 1,627, and `registerIpcHandlers` is a dispatcher — sixteen `register*IpcHandlers` calls against fifteen new files under `src/main/ipc/`, following the shape `register-team-handlers.ts` established for one domain and stopped at. Registrations, input parsers and route helpers moved unchanged.

The largest is `register-agent-handlers.ts` at 431 lines: bots, the conversation and the queue, which are one surface. Memories, routines and attachments came out into their own registrars — each a closed sub-surface with its own parsers and no shared state with the rest.

`registerIpcHandlers` now takes a named `IpcHandlerDependencies` object instead of 21 positional parameters. Three were `setupFile`, `analyticsPreferenceFile` and `updatePreferenceFile` — same type, so swapping two compiles cleanly and writes one preference into another's file.

Root `AGENTS.md` went 279 lines to 202. Renderer UI, migrations and Team API compatibility moved to `src/renderer/`, `src/backend/` and `packages/contracts/`, which load when you open a file under them. The D1 deploy-race rule went to a new `apps/auth-api/AGENTS.md` — `src/backend` is not an ancestor of `apps/auth-api/migrations/` and would not have loaded for the change it governs. `src/main/AGENTS.md` is new and carries the rule the fifteen module headers cite.

Each of the five gains a **waiting table**, which is what Tests rule 4 has been missing: the rule says a test needing a timeout is wrong but never said what to use instead, so a rejected `setTimeout` becomes a longer `vi.waitFor` timeout rather than a real barrier.

## Tests

**No test was added.** Four properties that look like they need one are already mechanical, and Tests rule 2 was run on each — every one was watched failing:

| Property | What catches it | Observed failure |
| --- | --- | --- |
| A moved block left behind in both files | `ipc-channel-coverage.test.ts` | duplicated one `agentListMemories` registration → `1 failed \| 10 passed`, naming both paths |
| A bare `ipcMain` outside the wrapper | same file | pre-existing assertion, unchanged |
| A registrar never called from `index.ts` | `tsc` | `TS6133` — the call site is the import's only use |
| A method missing from / extra in `mock-openbot.ts` | `tsc` | `TS2741` / `TS2353`, both annotated `: OpenBotDesktopApi` |

The first is what makes this refactor safe: 47 agent channels moved across four files and the coverage test proves each is still registered exactly once through the trusted wrappers.

The fourth is #174 item 6 — the issue itself files generating that mirror as a separate decision, and under Tests rule 3 `tsc` covering both directions is the end of it. What the type checker cannot cover is the *behaviour*, and that is written down in `packages/contracts/AGENTS.md`.

## Surfaces touched

Main process and the IPC registration surface only. **No contract changed** — no channel added, removed or renamed, no parser altered — so `packages/contracts`, `src/preload`, `src/renderer` and `mock-openbot.ts` are untouched. Mobile, public web, the three palettes, migrations and `PRIVACY.md` are not involved. Documentation is the AGENTS.md set; the `README.md` command table and `docs/ARCHITECTURE.md` needed no change.

## Verification

`bun run typecheck:node` clean. `bun run test:desktop -- src/main` → 43 files, 339 tests passed. `biome check` clean on every touched path. Repo-wide checks left to CI.

Model: Claude Opus 5, via Claude Code.