### PR TITLE
feat(ipc): a main-process handler cannot be registered without a payload decoder

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -384,34 +384,38 @@ function registerIpcHandlers(
     );
     return dynamicIsland.preference;
   });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetPreference, parseDynamicIslandPreference, (event, preference) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer");
-    return dynamicIsland.setPreference(preference);
-  });
+  handleTrustedWithEvent(
+    IPC_CHANNELS.dynamicIslandSetPreference,
+    (event) => requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer"),
+    parseDynamicIslandPreference,
+    (_event, preference) => dynamicIsland.setPreference(preference),
+  );
   handleTrustedWithEvent(
     IPC_CHANNELS.dynamicIslandPublishPresentation,
+    (event) => requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer"),
     parseDynamicIslandPresentation,
-    (event, presentation) => {
-      requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer");
-      dynamicIsland.publish(presentation);
-    },
+    (_event, presentation) => dynamicIsland.publish(presentation),
   );
   handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandGetPresentation, (event) => {
     requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
     return dynamicIsland.presentation;
   });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPerformAction, parseDynamicIslandAction, (event, action) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
-    return dynamicIsland.performAction(action);
-  });
+  handleTrustedWithEvent(
+    IPC_CHANNELS.dynamicIslandPerformAction,
+    (event) => requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer"),
+    parseDynamicIslandAction,
+    (_event, action) => dynamicIsland.performAction(action),
+  );
   handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPerformHaptic, (event) => {
     requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
     dynamicIsland.performHaptic();
   });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetInteractive, parseDynamicIslandInteractive, (event, state) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
-    dynamicIsland.setInteractive(event.sender.id, state.interactive);
-  });
+  handleTrustedWithEvent(
+    IPC_CHANNELS.dynamicIslandSetInteractive,
+    (event) => requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer"),
+    parseDynamicIslandInteractive,
+    (event, state) => dynamicIsland.setInteractive(event.sender.id, state.interactive),
+  );
   handleTrusted(IPC_CHANNELS.saveSetup, parseProvider, async (preferredProvider): Promise<AppSetupState> => {
     const state = await writeSetupState(setupFile, preferredProvider);
     await service.setPreferredProvider(preferredProvider);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -143,7 +143,7 @@ import {
 import { parseAvatarImage } from "./ipc/avatar-inputs";
 import { parseBrowserBounds, parseBrowserNavigate, parseBrowserOpen, parseVisibility } from "./ipc/browser-inputs";
 import { registerTeamIpcHandlers, withLocalHostSummary } from "./ipc/register-team-handlers";
-import { optionalPayload, requireString, stringPayload } from "./ipc/validation";
+import { nullishPayload, optionalPayload, requireString, stringPayload } from "./ipc/validation";
 import { parseVoiceTranscription } from "./ipc/voice-inputs";
 import { MacHapticFeedback } from "./mac-haptic-feedback";
 import { readMainWindowBounds, resolveMainWindowBounds, writeMainWindowBounds } from "./main-window-state";
@@ -475,7 +475,7 @@ function registerIpcHandlers(
     (sessionId) => centralAuth.revokeMobileConnectedDevice(sessionId),
   );
   handleTrusted(IPC_CHANNELS.authLogout, () => centralAuth.logout());
-  handleTrusted(IPC_CHANNELS.skillsList, optionalPayload(parseMarketplaceSkillQuery), (query) => skills.list(query));
+  handleTrusted(IPC_CHANNELS.skillsList, nullishPayload(parseMarketplaceSkillQuery), (query) => skills.list(query));
   handleTrusted(IPC_CHANNELS.skillsGet, stringPayload("skillId"), (skillId) => skills.get(skillId));
   handleTrusted(IPC_CHANNELS.skillsListMine, () => skills.listMine());
   handleTrusted(IPC_CHANNELS.skillsChoosePackage, async () => {
@@ -503,7 +503,7 @@ function registerIpcHandlers(
   handleTrusted(IPC_CHANNELS.hostedSitesPublish, parsePublishHostedSite, (site) => hostedSites.publish(site));
   handleTrusted(IPC_CHANNELS.hostedSitesReplace, parseReplaceHostedSite, (site) => hostedSites.replace(site));
   handleTrusted(IPC_CHANNELS.hostedSitesDelete, parseDeleteHostedSite, (siteId) => hostedSites.delete(siteId));
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsList, optionalPayload(parseMarketplaceAgentQuery), (query) =>
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsList, nullishPayload(parseMarketplaceAgentQuery), (query) =>
     marketplaceAgents.list(query),
   );
   handleTrusted(IPC_CHANNELS.marketplaceAgentsGet, stringPayload("agentId"), (agentId) =>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,7 +22,6 @@ import {
   type FilePreview,
   type ImportAttachmentsInput,
   IPC_CHANNELS,
-  isSkillCategory,
   type MacPermissionId,
   type SendMessageInput,
   type SidebarLayoutSnapshot,
@@ -30,8 +29,6 @@ import {
   type VoiceModelStatus,
   type VoiceTranscriptionResult,
 } from "@openbot/contracts/ipc";
-import { isNumber, isString } from "@openbot/contracts/runtime-values";
-import { validateProfileName } from "@openbot/contracts/validation";
 import {
   app,
   BrowserWindow,
@@ -121,20 +118,32 @@ import {
 } from "./ipc/agent-inputs";
 import {
   parseAnalyticsPreference,
+  parseDeleteHostedSite,
   parseDynamicIslandAction,
   parseDynamicIslandInteractive,
   parseDynamicIslandPreference,
   parseDynamicIslandPresentation,
+  parseEmailCodeVerification,
   parseExternalDestination,
+  parseInstallMarketplaceAgent,
+  parseInstallSkill,
   parseMacPermission,
+  parseMarketplaceAgentQuery,
+  parseMarketplaceSkillQuery,
+  parseProfileName,
   parseProvider,
   parseProviderId,
+  parsePublishHostedSite,
+  parseReplaceHostedSite,
+  parseSubmitMarketplaceAgent,
+  parseSubmitSkill,
+  parseUninstallSkill,
   parseUpdatePreference,
 } from "./ipc/app-inputs";
 import { parseAvatarImage } from "./ipc/avatar-inputs";
 import { parseBrowserBounds, parseBrowserNavigate, parseBrowserOpen, parseVisibility } from "./ipc/browser-inputs";
 import { registerTeamIpcHandlers, withLocalHostSummary } from "./ipc/register-team-handlers";
-import { isObject, optionalBoolean, requireString } from "./ipc/validation";
+import { optionalPayload, requireString, stringPayload } from "./ipc/validation";
 import { parseVoiceTranscription } from "./ipc/voice-inputs";
 import { MacHapticFeedback } from "./mac-haptic-feedback";
 import { readMainWindowBounds, resolveMainWindowBounds, writeMainWindowBounds } from "./main-window-state";
@@ -362,8 +371,8 @@ function registerIpcHandlers(
   });
   handleTrusted(IPC_CHANNELS.getSetupState, () => readSetupState(setupFile));
   handleTrusted(IPC_CHANNELS.getAnalyticsPreference, () => readAnalyticsPreference(analyticsPreferenceFile));
-  handleTrusted(IPC_CHANNELS.setAnalyticsPreference, async (input: unknown) => {
-    const preference = await writeAnalyticsPreference(analyticsPreferenceFile, parseAnalyticsPreference(input).enabled);
+  handleTrusted(IPC_CHANNELS.setAnalyticsPreference, parseAnalyticsPreference, async (parsed) => {
+    const preference = await writeAnalyticsPreference(analyticsPreferenceFile, parsed.enabled);
     hostAnalytics?.setTrackingEnabled(preference.enabled);
     return preference;
   });
@@ -375,48 +384,51 @@ function registerIpcHandlers(
     );
     return dynamicIsland.preference;
   });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetPreference, (event, input: unknown) => {
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetPreference, parseDynamicIslandPreference, (event, preference) => {
     requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer");
-    return dynamicIsland.setPreference(parseDynamicIslandPreference(input));
+    return dynamicIsland.setPreference(preference);
   });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPublishPresentation, (event, input: unknown) => {
-    requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer");
-    dynamicIsland.publish(parseDynamicIslandPresentation(input));
-  });
+  handleTrustedWithEvent(
+    IPC_CHANNELS.dynamicIslandPublishPresentation,
+    parseDynamicIslandPresentation,
+    (event, presentation) => {
+      requireDynamicIslandSender(event.sender.id, dynamicIsland.mainRendererIds, "main renderer");
+      dynamicIsland.publish(presentation);
+    },
+  );
   handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandGetPresentation, (event) => {
     requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
     return dynamicIsland.presentation;
   });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPerformAction, (event, input: unknown) => {
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPerformAction, parseDynamicIslandAction, (event, action) => {
     requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
-    return dynamicIsland.performAction(parseDynamicIslandAction(input));
+    return dynamicIsland.performAction(action);
   });
   handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandPerformHaptic, (event) => {
     requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
     dynamicIsland.performHaptic();
   });
-  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetInteractive, (event, input: unknown) => {
+  handleTrustedWithEvent(IPC_CHANNELS.dynamicIslandSetInteractive, parseDynamicIslandInteractive, (event, state) => {
     requireDynamicIslandSender(event.sender.id, dynamicIsland.overlayRendererIds, "Dynamic Island renderer");
-    dynamicIsland.setInteractive(event.sender.id, parseDynamicIslandInteractive(input).interactive);
+    dynamicIsland.setInteractive(event.sender.id, state.interactive);
   });
-  handleTrusted(IPC_CHANNELS.saveSetup, async (input: unknown): Promise<AppSetupState> => {
-    const preferredProvider = parseProvider(input);
+  handleTrusted(IPC_CHANNELS.saveSetup, parseProvider, async (preferredProvider): Promise<AppSetupState> => {
     const state = await writeSetupState(setupFile, preferredProvider);
     await service.setPreferredProvider(preferredProvider);
     await initializeAgent();
     return state;
   });
   handleTrusted(IPC_CHANNELS.computerUseGetMacSetupState, () => computerUseMacSetup.getState());
-  handleTrusted(IPC_CHANNELS.computerUseOpenMacPermissionSetup, (permission: unknown) =>
-    computerUseMacSetup.open(parseMacPermission(permission)),
+  handleTrusted(IPC_CHANNELS.computerUseOpenMacPermissionSetup, parseMacPermission, (parsed) =>
+    computerUseMacSetup.open(parsed),
   );
   handleTrustedWithEvent(IPC_CHANNELS.computerUseStartHelperDrag, (event) =>
     computerUseMacSetup.startDrag(event.sender),
   );
   handleTrusted(IPC_CHANNELS.computerUseRevealHelper, () => computerUseMacSetup.revealHelper());
   handleTrusted(IPC_CHANNELS.computerUseCloseMacPermissionSetup, () => computerUseMacSetup.close());
-  handleTrusted(IPC_CHANNELS.openExternal, (destination: unknown) => {
-    return shell.openExternal(EXTERNAL_DESTINATIONS[parseExternalDestination(destination)]);
+  handleTrusted(IPC_CHANNELS.openExternal, parseExternalDestination, (parsed) => {
+    return shell.openExternal(EXTERNAL_DESTINATIONS[parsed]);
   });
   handleTrusted(IPC_CHANNELS.connectChatGPT, () =>
     service.connectChatGPT(async (value) => {
@@ -429,70 +441,42 @@ function registerIpcHandlers(
   handleTrusted(IPC_CHANNELS.connectGrok, () => service.connectGrok());
   handleTrusted(IPC_CHANNELS.refreshAgentProviders, () => service.refreshProviders());
   handleTrusted(IPC_CHANNELS.providerRuntimesGetStatus, () => providerRuntimes.getStatus());
-  handleTrusted(IPC_CHANNELS.providerRuntimesDownload, (provider: unknown) =>
-    providerRuntimes.download(parseProviderId(provider)),
-  );
-  handleTrusted(IPC_CHANNELS.providerRuntimesCancel, (provider: unknown) =>
-    providerRuntimes.cancel(parseProviderId(provider)),
-  );
-  handleTrusted(IPC_CHANNELS.openUrl, (value: unknown) => {
-    const url = new URL(requireString(value, "URL", INPUT_LIMITS.browserUrl));
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
+  handleTrusted(IPC_CHANNELS.providerRuntimesDownload, parseProviderId, (parsed) => providerRuntimes.download(parsed));
+  handleTrusted(IPC_CHANNELS.providerRuntimesCancel, parseProviderId, (parsed) => providerRuntimes.cancel(parsed));
+  handleTrusted(IPC_CHANNELS.openUrl, stringPayload("URL", INPUT_LIMITS.browserUrl), (url) => {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       throw new Error("Only HTTP(S) links can open in the external browser.");
     }
-    return shell.openExternal(url.toString());
+    return shell.openExternal(parsed.toString());
   });
   handleTrusted(IPC_CHANNELS.voiceGetModelStatus, (): Promise<VoiceModelStatus> => voice.getModelStatus());
   handleTrusted(IPC_CHANNELS.voicePrepareModel, (): Promise<VoiceModelStatus> => voice.prepareModel());
   handleTrusted(
     IPC_CHANNELS.voiceTranscribe,
-    (input: unknown): Promise<VoiceTranscriptionResult> => voice.transcribe(parseVoiceTranscription(input).audio),
+    parseVoiceTranscription,
+    (transcription): Promise<VoiceTranscriptionResult> => voice.transcribe(transcription.audio),
   );
   handleTrusted(IPC_CHANNELS.authGetState, () => centralAuth.getState());
   handleTrusted(IPC_CHANNELS.authRetry, () => centralAuth.retry());
-  handleTrusted(IPC_CHANNELS.authRequestEmailCode, (email: unknown) =>
-    centralAuth.requestEmailCode(requireString(email, "email", INPUT_LIMITS.email)),
+  handleTrusted(IPC_CHANNELS.authRequestEmailCode, stringPayload("email", INPUT_LIMITS.email), (email) =>
+    centralAuth.requestEmailCode(email),
   );
-  handleTrusted(IPC_CHANNELS.authVerifyEmailCode, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Sign-in code details are required.");
-    return centralAuth.verifyEmailCode(
-      requireString(input.challengeId, "challengeId", INPUT_LIMITS.identifier),
-      requireString(input.code, "code", 32),
-    );
-  });
-  handleTrusted(IPC_CHANNELS.authUpdateName, (input: unknown) => {
-    const rawName = requireString(input, "name", INPUT_LIMITS.accountName);
-    const validation = validateProfileName(rawName);
-    if (validation.error) {
-      throw new Error(
-        `name must contain ${INPUT_LIMITS.profileNameMin} to ${INPUT_LIMITS.profileName} safe characters.`,
-      );
-    }
-    return centralAuth.updateName(validation.name);
-  });
-  handleTrusted(IPC_CHANNELS.authUpdateAvatar, (input: unknown) => centralAuth.updateAvatar(parseAvatarImage(input)));
+  handleTrusted(IPC_CHANNELS.authVerifyEmailCode, parseEmailCodeVerification, (verification) =>
+    centralAuth.verifyEmailCode(verification.challengeId, verification.code),
+  );
+  handleTrusted(IPC_CHANNELS.authUpdateName, parseProfileName, (name) => centralAuth.updateName(name));
+  handleTrusted(IPC_CHANNELS.authUpdateAvatar, parseAvatarImage, (parsed) => centralAuth.updateAvatar(parsed));
   handleTrusted(IPC_CHANNELS.authCreateMobileConnect, () => centralAuth.createMobileConnect());
   handleTrusted(IPC_CHANNELS.authListMobileConnectedDevices, () => centralAuth.listMobileConnectedDevices());
-  handleTrusted(IPC_CHANNELS.authRevokeMobileConnectedDevice, (input: unknown) =>
-    centralAuth.revokeMobileConnectedDevice(requireString(input, "sessionId", INPUT_LIMITS.identifier)),
+  handleTrusted(
+    IPC_CHANNELS.authRevokeMobileConnectedDevice,
+    stringPayload("sessionId", INPUT_LIMITS.identifier),
+    (sessionId) => centralAuth.revokeMobileConnectedDevice(sessionId),
   );
   handleTrusted(IPC_CHANNELS.authLogout, () => centralAuth.logout());
-  handleTrusted(IPC_CHANNELS.skillsList, (input: unknown) => {
-    if (input === null || input === undefined) return skills.list();
-    if (!isObject(input)) throw new Error("Invalid marketplace query.");
-    const category = input.category;
-    if (category !== undefined && !isSkillCategory(category)) throw new Error("Unknown skill category.");
-    if (input.sort !== undefined && input.sort !== "installs") throw new Error("Unknown skill sort order.");
-    return skills.list({
-      ...(isString(input.query) ? { query: input.query.slice(0, 100) } : {}),
-      ...(category ? { category } : {}),
-      ...(input.featured === true ? { featured: true } : {}),
-      ...(input.sort === "installs" ? { sort: "installs" as const } : {}),
-      ...(isString(input.cursor) ? { cursor: input.cursor } : {}),
-      ...(isNumber(input.limit) ? { limit: input.limit } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.skillsGet, (input: unknown) => skills.get(requireString(input, "skillId")));
+  handleTrusted(IPC_CHANNELS.skillsList, optionalPayload(parseMarketplaceSkillQuery), (query) => skills.list(query));
+  handleTrusted(IPC_CHANNELS.skillsGet, stringPayload("skillId"), (skillId) => skills.get(skillId));
   handleTrusted(IPC_CHANNELS.skillsListMine, () => skills.listMine());
   handleTrusted(IPC_CHANNELS.skillsChoosePackage, async () => {
     const options: OpenDialogOptions = {
@@ -503,34 +487,10 @@ function registerIpcHandlers(
     const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
     return result.canceled || !result.filePaths[0] ? null : skills.stage(result.filePaths[0]);
   });
-  handleTrusted(IPC_CHANNELS.skillsSubmit, (input: unknown) => {
-    if (!isObject(input) || !isSkillCategory(input.category)) throw new Error("Invalid skill submission.");
-    return skills.submit({
-      draftId: requireString(input.draftId, "draftId"),
-      category: input.category,
-      icon: parseAvatarImage(input.icon),
-      ...(input.skillId === undefined ? {} : { skillId: requireString(input.skillId, "skillId") }),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.skillsListInstalled, (input: unknown) =>
-    skills.listInstalled(requireString(input, "botId")),
-  );
-  handleTrusted(IPC_CHANNELS.skillsInstall, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid skill installation.");
-    return skills.install({
-      botId: requireString(input.botId, "botId"),
-      skillId: requireString(input.skillId, "skillId"),
-      ...(input.replaceModified === true ? { replaceModified: true } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.skillsUninstall, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid skill removal.");
-    return skills.uninstall({
-      botId: requireString(input.botId, "botId"),
-      skillId: requireString(input.skillId, "skillId"),
-      ...(input.removeModified === true ? { removeModified: true } : {}),
-    });
-  });
+  handleTrusted(IPC_CHANNELS.skillsSubmit, parseSubmitSkill, (submission) => skills.submit(submission));
+  handleTrusted(IPC_CHANNELS.skillsListInstalled, stringPayload("botId"), (botId) => skills.listInstalled(botId));
+  handleTrusted(IPC_CHANNELS.skillsInstall, parseInstallSkill, (installation) => skills.install(installation));
+  handleTrusted(IPC_CHANNELS.skillsUninstall, parseUninstallSkill, (removal) => skills.uninstall(removal));
   handleTrusted(IPC_CHANNELS.hostedSitesList, () => hostedSites.list());
   handleTrusted(IPC_CHANNELS.hostedSitesChooseDirectory, async () => {
     const options: OpenDialogOptions = {
@@ -540,73 +500,32 @@ function registerIpcHandlers(
     const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
     return result.canceled ? null : (result.filePaths[0] ?? null);
   });
-  handleTrusted(IPC_CHANNELS.hostedSitesPublish, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid site publication.");
-    const spaFallback = optionalBoolean(input.spaFallback, "spaFallback");
-    return hostedSites.publish({
-      sourcePath: requireString(input.sourcePath, "sourcePath", INPUT_LIMITS.path),
-      title: requireString(input.title, "title", 120),
-      description: requireString(input.description, "description", 500),
-      ...(spaFallback !== undefined ? { spaFallback } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.hostedSitesReplace, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid site replacement.");
-    const spaFallback = optionalBoolean(input.spaFallback, "spaFallback");
-    return hostedSites.replace({
-      siteId: requireString(input.siteId, "siteId", INPUT_LIMITS.identifier),
-      sourcePath: requireString(input.sourcePath, "sourcePath", INPUT_LIMITS.path),
-      title: requireString(input.title, "title", 120),
-      description: requireString(input.description, "description", 500),
-      ...(spaFallback !== undefined ? { spaFallback } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.hostedSitesDelete, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid site deletion.");
-    return hostedSites.delete(requireString(input.siteId, "siteId", INPUT_LIMITS.identifier));
-  });
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsList, (input: unknown) => {
-    if (input === null || input === undefined) return marketplaceAgents.list();
-    if (!isObject(input)) throw new Error("Invalid agent marketplace query.");
-    if (input.sort !== undefined && input.sort !== "installs") throw new Error("Unknown agent sort order.");
-    return marketplaceAgents.list({
-      ...(isString(input.query) ? { query: input.query.slice(0, 100) } : {}),
-      ...(input.featured === true ? { featured: true } : {}),
-      ...(input.sort === "installs" ? { sort: "installs" as const } : {}),
-      ...(isString(input.cursor) ? { cursor: input.cursor } : {}),
-      ...(isNumber(input.limit) ? { limit: input.limit } : {}),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsGet, (input: unknown) =>
-    marketplaceAgents.get(requireString(input, "agentId")),
+  handleTrusted(IPC_CHANNELS.hostedSitesPublish, parsePublishHostedSite, (site) => hostedSites.publish(site));
+  handleTrusted(IPC_CHANNELS.hostedSitesReplace, parseReplaceHostedSite, (site) => hostedSites.replace(site));
+  handleTrusted(IPC_CHANNELS.hostedSitesDelete, parseDeleteHostedSite, (siteId) => hostedSites.delete(siteId));
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsList, optionalPayload(parseMarketplaceAgentQuery), (query) =>
+    marketplaceAgents.list(query),
+  );
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsGet, stringPayload("agentId"), (agentId) =>
+    marketplaceAgents.get(agentId),
   );
   handleTrusted(IPC_CHANNELS.marketplaceAgentsListMine, () => marketplaceAgents.listMine());
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsPreview, (input: unknown) =>
-    marketplaceAgents.preview(requireString(input, "botId")),
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsPreview, stringPayload("botId"), (botId) =>
+    marketplaceAgents.preview(botId),
   );
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsSubmit, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid agent submission.");
-    return marketplaceAgents.submit({
-      botId: requireString(input.botId, "botId"),
-      ...(input.agentId === undefined ? {} : { agentId: requireString(input.agentId, "agentId") }),
-    });
-  });
-  handleTrusted(IPC_CHANNELS.marketplaceAgentsInstall, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Invalid agent installation.");
-    return marketplaceAgents.install({
-      agentId: requireString(input.agentId, "agentId"),
-      ...(input.botId === undefined ? {} : { botId: requireString(input.botId, "botId", INPUT_LIMITS.identifier) }),
-      timezone: requireString(input.timezone, "timezone", 255),
-      receiptId: requireString(input.receiptId, "receiptId", INPUT_LIMITS.identifier),
-    });
-  });
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsSubmit, parseSubmitMarketplaceAgent, (submission) =>
+    marketplaceAgents.submit(submission),
+  );
+  handleTrusted(IPC_CHANNELS.marketplaceAgentsInstall, parseInstallMarketplaceAgent, (installation) =>
+    marketplaceAgents.install(installation),
+  );
   handleTrusted(IPC_CHANNELS.updateGetStatus, () => updater.getStatus());
   handleTrusted(IPC_CHANNELS.updateCheck, () => updater.checkForUpdates());
   handleTrusted(IPC_CHANNELS.updateDownload, () => updater.downloadUpdate());
   handleTrusted(IPC_CHANNELS.updateInstall, () => updater.installUpdate());
   handleTrusted(IPC_CHANNELS.updateGetPreference, () => readUpdatePreference(updatePreferenceFile));
-  handleTrusted(IPC_CHANNELS.updateSetPreference, async (input: unknown) => {
-    const preference = await writeUpdatePreference(updatePreferenceFile, parseUpdatePreference(input).autoDownload);
+  handleTrusted(IPC_CHANNELS.updateSetPreference, parseUpdatePreference, async (parsed) => {
+    const preference = await writeUpdatePreference(updatePreferenceFile, parsed.autoDownload);
     updater.setAutoDownload(preference.autoDownload);
     return preference;
   });
@@ -629,32 +548,31 @@ function registerIpcHandlers(
     },
   });
 
-  handleTrusted(IPC_CHANNELS.agentGetStatus, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentGetStatus, parseAgentRequest, (parsed) => {
+    const { serverId } = parsed;
     return serverId === "local"
       ? service.getStatus()
       : remoteServers.request("/v1/agents/status", {}, serverId, decodeAgentStatus);
   });
-  handleTrusted(IPC_CHANNELS.agentGetUsage, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentGetUsage, parseAgentRequest, (parsed) => {
+    const { serverId } = parsed;
     return serverId === "local"
       ? service.getUsage()
       : remoteServers.request("/v1/agents/usage", {}, serverId, decodeAccountUsage);
   });
-  handleTrusted(IPC_CHANNELS.agentListModels, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentListModels, parseAgentRequest, (parsed) => {
+    const { serverId } = parsed;
     return serverId === "local"
       ? service.listModels()
       : remoteServers.request("/v1/agents/models", {}, serverId, decodeAgentModelOptions);
   });
-  handleTrusted(IPC_CHANNELS.agentListBots, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentListBots, parseAgentRequest, (parsed) => {
+    const { serverId } = parsed;
     return serverId === "local"
       ? service.listBots()
       : remoteServers.request("/v1/agents", {}, serverId, decodeBotSummaries);
   });
-  handleTrusted(IPC_CHANNELS.agentListInstalledSkills, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentListInstalledSkills, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
     return scoped.serverId === "local"
       ? skills.listInstalledForChatTags(botId)
@@ -670,14 +588,16 @@ function registerIpcHandlers(
           )
         : Promise.resolve([]);
   });
-  handleTrusted(IPC_CHANNELS.agentGetSidebarLayout, (input: unknown): Promise<SidebarLayoutSnapshot> => {
-    const { serverId } = parseAgentRequest(input);
-    return serverId === "local"
-      ? Promise.resolve(sidebarLayout.getSnapshot())
-      : remoteServers.request("/v1/sidebar-layout", {}, serverId, decodeSidebarLayoutSnapshot);
-  });
-  handleTrusted(IPC_CHANNELS.agentMutateSidebarLayout, (input: unknown): Promise<SidebarLayoutSnapshot> => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(
+    IPC_CHANNELS.agentGetSidebarLayout,
+    parseAgentRequest,
+    ({ serverId }): Promise<SidebarLayoutSnapshot> => {
+      return serverId === "local"
+        ? Promise.resolve(sidebarLayout.getSnapshot())
+        : remoteServers.request("/v1/sidebar-layout", {}, serverId, decodeSidebarLayoutSnapshot);
+    },
+  );
+  handleTrusted(IPC_CHANNELS.agentMutateSidebarLayout, parseAgentRequest, (scoped): Promise<SidebarLayoutSnapshot> => {
     const action = parseSidebarLayoutAction(scoped.payload);
     return scoped.serverId === "local"
       ? sidebarLayout.mutate(action, new Set(service.listBots().map((bot) => bot.id)))
@@ -688,36 +608,30 @@ function registerIpcHandlers(
           decodeSidebarLayoutSnapshot,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentCreateBot, (input: unknown) => {
-    const { serverId, payload } = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentCreateBot, parseAgentRequest, ({ serverId, payload }) => {
     const parsed = parseCreateBot(payload);
     return serverId === "local"
       ? service.createBot(parsed)
       : remoteServers.request("/v1/agents", { method: "POST", body: parsed }, serverId, decodeBotSummary);
   });
-  handleTrusted(IPC_CHANNELS.agentDuplicateBot, (input: unknown): Promise<DuplicateBotResult> => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentDuplicateBot, parseAgentRequest, (scoped): Promise<DuplicateBotResult> => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
     return routeDuplicateBot(service, sidebarLayout, remoteServers, scoped.serverId, botId);
   });
-  handleTrusted(IPC_CHANNELS.agentUpdateBot, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentUpdateBot, parseAgentRequest, (scoped) => {
     return routeUpdateBot(service, remoteServers, scoped.serverId, parseUpdateBot(scoped.payload));
   });
-  handleTrusted(IPC_CHANNELS.agentSetAvatar, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentSetAvatar, parseAgentRequest, (scoped) => {
     const parsed = parseSetAgentAvatar(scoped.payload);
     return scoped.serverId === "local"
       ? service.setAvatar(parsed.botId, parsed.image)
       : remoteServers.setAgentAvatar(parsed.botId, parsed.image, scoped.serverId);
   });
-  handleTrusted(IPC_CHANNELS.agentDeleteBot, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentDeleteBot, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId");
     return routeDeleteBot(service, sidebarLayout, remoteServers, scoped.serverId, botId);
   });
-  handleTrusted(IPC_CHANNELS.agentListMemories, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentListMemories, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
     return scoped.serverId === "local"
       ? service.listMemories(botId)
@@ -728,8 +642,7 @@ function registerIpcHandlers(
           decodeBotMemories,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentCreateMemory, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentCreateMemory, parseAgentRequest, (scoped) => {
     const parsed = parseCreateBotMemory(scoped.payload);
     return scoped.serverId === "local"
       ? service.createMemory(parsed)
@@ -740,8 +653,7 @@ function registerIpcHandlers(
           decodeBotMemory,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentUpdateMemory, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentUpdateMemory, parseAgentRequest, (scoped) => {
     const parsed = parseUpdateBotMemory(scoped.payload);
     return scoped.serverId === "local"
       ? service.updateMemory(parsed)
@@ -752,8 +664,7 @@ function registerIpcHandlers(
           decodeBotMemory,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentDeleteMemory, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentDeleteMemory, parseAgentRequest, (scoped) => {
     const parsed = parseDeleteBotMemory(scoped.payload);
     if (scoped.serverId === "local") return service.deleteMemory(parsed);
     return remoteServers.request(
@@ -763,8 +674,7 @@ function registerIpcHandlers(
       decodeVoid,
     );
   });
-  handleTrusted(IPC_CHANNELS.agentClearMemories, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentClearMemories, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
     if (scoped.serverId === "local") return service.clearMemories(botId);
     return remoteServers.request(
@@ -774,15 +684,13 @@ function registerIpcHandlers(
       decodeVoid,
     );
   });
-  handleTrusted(IPC_CHANNELS.agentListRoutines, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentListRoutines, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
     return scoped.serverId === "local"
       ? service.listRoutines(botId)
       : remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}/routines`, {}, scoped.serverId, decodeRoutines);
   });
-  handleTrusted(IPC_CHANNELS.agentCreateRoutine, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentCreateRoutine, parseAgentRequest, (scoped) => {
     const parsed = parseCreateRoutine(scoped.payload);
     return scoped.serverId === "local"
       ? service.createRoutine(parsed)
@@ -793,8 +701,7 @@ function registerIpcHandlers(
           decodeRoutine,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentUpdateRoutine, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentUpdateRoutine, parseAgentRequest, (scoped) => {
     const parsed = parseUpdateRoutine(scoped.payload);
     return scoped.serverId === "local"
       ? service.updateRoutine(parsed)
@@ -805,8 +712,7 @@ function registerIpcHandlers(
           decodeRoutine,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentDeleteRoutine, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentDeleteRoutine, parseAgentRequest, (scoped) => {
     const parsed = parseDeleteRoutine(scoped.payload);
     if (scoped.serverId === "local") return service.deleteRoutine(parsed);
     return remoteServers.request(
@@ -816,8 +722,7 @@ function registerIpcHandlers(
       decodeVoid,
     );
   });
-  handleTrusted(IPC_CHANNELS.agentTestRoutine, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentTestRoutine, parseAgentRequest, (scoped) => {
     const parsed = parseTestRoutine(scoped.payload);
     return scoped.serverId === "local"
       ? service.testRoutine(parsed)
@@ -828,8 +733,7 @@ function registerIpcHandlers(
           decodeRoutineRun,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentListRoutineRuns, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentListRoutineRuns, parseAgentRequest, (scoped) => {
     const parsed = parseListRoutineRuns(scoped.payload);
     return scoped.serverId === "local"
       ? service.listRoutineRuns(parsed)
@@ -840,19 +744,16 @@ function registerIpcHandlers(
           decodeRoutineRuns,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentReadConversation, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentReadConversation, parseAgentRequest, (scoped) => {
     return routeReadConversation(host, remoteServers, scoped.serverId, requireString(scoped.payload, "botId"));
   });
-  handleTrusted(IPC_CHANNELS.agentReadConversationPage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentReadConversationPage, parseAgentRequest, (scoped) => {
     const parsed = parseReadConversationPage(scoped.payload);
     return scoped.serverId === "local"
       ? host.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit)
       : remoteServers.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit, scoped.serverId);
   });
-  handleTrusted(IPC_CHANNELS.agentSearchConversationMessages, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentSearchConversationMessages, parseAgentRequest, (scoped) => {
     const parsed = parseSearchConversationMessages(scoped.payload);
     return scoped.serverId === "local"
       ? host.searchAgentConversationMessages(parsed.query, parsed.botId, parsed.cursor, parsed.limit)
@@ -864,25 +765,22 @@ function registerIpcHandlers(
           scoped.serverId,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentListConversationReads, (input: unknown) => {
-    const { serverId } = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentListConversationReads, parseAgentRequest, (parsed) => {
+    const { serverId } = parsed;
     return serverId === "local"
       ? host.listAgentConversationReads()
       : remoteServers.listAgentConversationReads(serverId);
   });
-  handleTrusted(IPC_CHANNELS.agentMarkConversationRead, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentMarkConversationRead, parseAgentRequest, (scoped) => {
     const parsed = parseMarkConversationRead(scoped.payload);
     return scoped.serverId === "local"
       ? host.markAgentConversationRead(parsed)
       : remoteServers.markAgentConversationRead(parsed, scoped.serverId);
   });
-  handleTrusted(IPC_CHANNELS.agentSendMessage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentSendMessage, parseAgentRequest, (scoped) => {
     return routeSendMessage(service, remoteServers, scoped.serverId, parseSendMessage(scoped.payload));
   });
-  handleTrusted(IPC_CHANNELS.agentSetMessageReaction, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentSetMessageReaction, parseAgentRequest, (scoped) => {
     const parsed = parseMessageReaction(scoped.payload);
     return scoped.serverId === "local"
       ? service.setMessageReaction(parsed)
@@ -896,8 +794,8 @@ function registerIpcHandlers(
           decodeVoid,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentChooseAttachments, async (input: unknown) => {
-    const { serverId, payload } = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentChooseAttachments, parseAgentRequest, async (parsed) => {
+    const { serverId, payload } = parsed;
     const { filter } = parseChooseAttachments(payload);
     const options: OpenDialogOptions = {
       properties: ["openFile", "multiSelections"],
@@ -911,15 +809,13 @@ function registerIpcHandlers(
     if (serverId === "local") return service.prepareAttachments(result.filePaths);
     return uploadRemotePaths(remoteServers, serverId, result.filePaths);
   });
-  handleTrusted(IPC_CHANNELS.agentImportAttachments, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentImportAttachments, parseAgentRequest, (scoped) => {
     const parsed = parseImportAttachments(scoped.payload);
     return scoped.serverId === "local"
       ? service.prepareImportedAttachments(parsed.paths, parsed.data)
       : uploadRemoteImports(remoteServers, scoped.serverId, parsed);
   });
-  handleTrusted(IPC_CHANNELS.agentDiscardDraftAttachment, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentDiscardDraftAttachment, parseAgentRequest, (scoped) => {
     const attachmentId = requireString(scoped.payload, "attachmentId");
     return scoped.serverId === "local"
       ? service.discardDraftAttachment(attachmentId)
@@ -930,8 +826,7 @@ function registerIpcHandlers(
           decodeVoid,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentOpenAttachment, async (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentOpenAttachment, parseAgentRequest, async (scoped) => {
     const parsed = parseOpenAttachment(scoped.payload);
     if (scoped.serverId !== "local") {
       const downloaded = await remoteServers.downloadAttachment(parsed.attachmentId, scoped.serverId);
@@ -990,8 +885,7 @@ function registerIpcHandlers(
     const error = await shell.openPath(attachment.path);
     if (error) throw new Error(error);
   });
-  handleTrusted(IPC_CHANNELS.agentOpenSharedFile, async (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentOpenSharedFile, parseAgentRequest, async (scoped) => {
     const parsed = parseOpenSharedFile(scoped.payload);
     if (scoped.serverId !== "local") {
       const downloaded = await remoteServers.downloadSharedFile(parsed.path, scoped.serverId);
@@ -1009,8 +903,7 @@ function registerIpcHandlers(
     const openError = await shell.openPath(sharedFile.path);
     if (openError) throw new Error(openError);
   });
-  handleTrusted(IPC_CHANNELS.agentOpenWorkspaceFile, async (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentOpenWorkspaceFile, parseAgentRequest, async (scoped) => {
     const parsed = parseOpenWorkspaceFile(scoped.payload);
     if (scoped.serverId !== "local") {
       const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, scoped.serverId);
@@ -1028,8 +921,7 @@ function registerIpcHandlers(
     const openError = await shell.openPath(workspaceFile.path);
     if (openError) throw new Error(openError);
   });
-  handleTrusted(IPC_CHANNELS.agentPreviewSharedFile, async (input: unknown): Promise<FilePreview> => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentPreviewSharedFile, parseAgentRequest, async (scoped): Promise<FilePreview> => {
     const parsed = parseOpenSharedFile(scoped.payload);
     if (scoped.serverId !== "local") {
       const downloaded = await remoteServers.downloadSharedFile(parsed.path, scoped.serverId);
@@ -1038,8 +930,7 @@ function registerIpcHandlers(
     const sharedFile = await service.resolveSharedFile(parsed.path);
     return localFilePreview(sharedFile.path, sharedFile.name, sharedFile.size);
   });
-  handleTrusted(IPC_CHANNELS.agentPreviewWorkspaceFile, async (input: unknown): Promise<FilePreview> => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentPreviewWorkspaceFile, parseAgentRequest, async (scoped): Promise<FilePreview> => {
     const parsed = parseOpenWorkspaceFile(scoped.payload);
     if (scoped.serverId !== "local") {
       const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, scoped.serverId);
@@ -1048,12 +939,10 @@ function registerIpcHandlers(
     const workspaceFile = await service.resolveWorkspaceFile(parsed.botId, parsed.path);
     return localFilePreview(workspaceFile.path, workspaceFile.name, workspaceFile.size);
   });
-  handleTrusted(IPC_CHANNELS.agentListQueue, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentListQueue, parseAgentRequest, (scoped) => {
     return routeListQueue(service, remoteServers, scoped.serverId, requireString(scoped.payload, "botId"));
   });
-  handleTrusted(IPC_CHANNELS.agentAcknowledgeFailedTurn, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentAcknowledgeFailedTurn, parseAgentRequest, (scoped) => {
     const parsed = parseAcknowledgeFailedTurn(scoped.payload);
     return scoped.serverId === "local"
       ? service.acknowledgeFailedTurn(parsed.botId, parsed.turnId)
@@ -1064,8 +953,7 @@ function registerIpcHandlers(
           decodeVoid,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentCancelQueuedMessage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentCancelQueuedMessage, parseAgentRequest, (scoped) => {
     const parsed = parseCancelQueuedMessage(scoped.payload);
     return scoped.serverId === "local"
       ? service.cancelQueuedMessage(parsed.botId, parsed.deliveryId)
@@ -1079,8 +967,7 @@ function registerIpcHandlers(
           decodeVoid,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentSteerQueuedMessage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentSteerQueuedMessage, parseAgentRequest, (scoped) => {
     const parsed = parseSteerQueuedMessage(scoped.payload);
     return scoped.serverId === "local"
       ? service.steerQueuedMessage(parsed)
@@ -1094,8 +981,7 @@ function registerIpcHandlers(
           decodeVoid,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentUpdateQueuedMessage, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentUpdateQueuedMessage, parseAgentRequest, (scoped) => {
     const parsed = parseUpdateQueuedMessage(scoped.payload);
     return scoped.serverId === "local"
       ? service.updateQueuedMessage(parsed)
@@ -1114,8 +1000,7 @@ function registerIpcHandlers(
           decodeVoid,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentReorderQueue, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentReorderQueue, parseAgentRequest, (scoped) => {
     const parsed = parseReorderQueue(scoped.payload);
     return scoped.serverId === "local"
       ? service.reorderQueue(parsed)
@@ -1126,8 +1011,7 @@ function registerIpcHandlers(
           decodeVoid,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentInterrupt, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentInterrupt, parseAgentRequest, (scoped) => {
     const parsed = parseInterrupt(scoped.payload);
     return scoped.serverId === "local"
       ? service.interrupt(parsed.botId, parsed.turnId)
@@ -1141,22 +1025,19 @@ function registerIpcHandlers(
           decodeVoid,
         );
   });
-  handleTrusted(IPC_CHANNELS.agentRespondToPrompt, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentRespondToPrompt, parseAgentRequest, (scoped) => {
     const parsed = parsePromptResponse(scoped.payload);
     return scoped.serverId === "local"
       ? service.respondToPrompt(parsed)
       : remoteServers.request("/v1/prompts/respond", { method: "POST", body: parsed }, scoped.serverId, decodeVoid);
   });
-  handleTrusted(IPC_CHANNELS.agentRespondToApproval, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentRespondToApproval, parseAgentRequest, (scoped) => {
     const parsed = parseApprovalResponse(scoped.payload);
     return scoped.serverId === "local"
       ? service.respondToApproval(parsed)
       : remoteServers.request("/v1/approvals/respond", { method: "POST", body: parsed }, scoped.serverId, decodeVoid);
   });
-  handleTrusted(IPC_CHANNELS.agentRespondToBrowserTakeover, (input: unknown) => {
-    const scoped = parseAgentRequest(input);
+  handleTrusted(IPC_CHANNELS.agentRespondToBrowserTakeover, parseAgentRequest, (scoped) => {
     const parsed = parseBrowserTakeoverResponse(scoped.payload);
     return scoped.serverId === "local"
       ? service.respondToBrowserTakeover(parsed)
@@ -1168,47 +1049,30 @@ function registerIpcHandlers(
         );
   });
 
-  handleTrusted(IPC_CHANNELS.browserOpen, (input: unknown) => {
-    const parsed = parseBrowserOpen(input);
+  handleTrusted(IPC_CHANNELS.browserOpen, parseBrowserOpen, (parsed) => {
     return remoteServers.activeServerId === "local"
       ? browser.open(parsed.url, parsed.ownerThreadId ?? null, parsed.ownerBotId ?? null, parsed.focus)
       : remoteServers.request("/v1/browser/open", { method: "POST", body: parsed }, undefined, decodeBrowserTab);
   });
-  handleTrusted(IPC_CHANNELS.browserActivate, (tabId: unknown) =>
+  handleTrusted(IPC_CHANNELS.browserActivate, stringPayload("tabId"), (tabId) =>
     remoteServers.activeServerId === "local"
-      ? browser.activate(requireString(tabId, "tabId"))
-      : remoteServers.request(
-          "/v1/browser/activate",
-          { method: "POST", body: { tabId: requireString(tabId, "tabId") } },
-          undefined,
-          decodeVoid,
-        ),
+      ? browser.activate(tabId)
+      : remoteServers.request("/v1/browser/activate", { method: "POST", body: { tabId } }, undefined, decodeVoid),
   );
-  handleTrusted(IPC_CHANNELS.browserNavigate, (input: unknown) => {
-    const parsed = parseBrowserNavigate(input);
+  handleTrusted(IPC_CHANNELS.browserNavigate, parseBrowserNavigate, (parsed) => {
     return remoteServers.activeServerId === "local"
       ? browser.navigate(parsed.tabId, parsed.direction)
       : remoteServers.request("/v1/browser/navigate", { method: "POST", body: parsed }, undefined, decodeVoid);
   });
-  handleTrusted(IPC_CHANNELS.browserReload, (tabId: unknown) =>
+  handleTrusted(IPC_CHANNELS.browserReload, stringPayload("tabId"), (tabId) =>
     remoteServers.activeServerId === "local"
-      ? browser.reload(requireString(tabId, "tabId"))
-      : remoteServers.request(
-          "/v1/browser/reload",
-          { method: "POST", body: { tabId: requireString(tabId, "tabId") } },
-          undefined,
-          decodeVoid,
-        ),
+      ? browser.reload(tabId)
+      : remoteServers.request("/v1/browser/reload", { method: "POST", body: { tabId } }, undefined, decodeVoid),
   );
-  handleTrusted(IPC_CHANNELS.browserClose, (tabId: unknown) =>
+  handleTrusted(IPC_CHANNELS.browserClose, stringPayload("tabId"), (tabId) =>
     remoteServers.activeServerId === "local"
-      ? browser.close(requireString(tabId, "tabId"))
-      : remoteServers.request(
-          "/v1/browser/close",
-          { method: "POST", body: { tabId: requireString(tabId, "tabId") } },
-          undefined,
-          decodeVoid,
-        ),
+      ? browser.close(tabId)
+      : remoteServers.request("/v1/browser/close", { method: "POST", body: { tabId } }, undefined, decodeVoid),
   );
   handleTrusted(IPC_CHANNELS.browserListTabs, () =>
     remoteServers.activeServerId === "local"
@@ -1221,26 +1085,24 @@ function registerIpcHandlers(
       ? browser.getControlState()
       : remoteServers.request("/v1/browser/control", {}, undefined, decodeBrowserControlState),
   );
-  handleTrusted(IPC_CHANNELS.browserCapturePreview, (tabId: unknown) => {
-    const parsedTabId = requireString(tabId, "tabId");
-    return remoteServers.activeServerId === "local"
-      ? browser.capturePreview(parsedTabId)
+  handleTrusted(IPC_CHANNELS.browserCapturePreview, stringPayload("tabId"), (tabId) =>
+    remoteServers.activeServerId === "local"
+      ? browser.capturePreview(tabId)
       : remoteServers.request(
           "/v1/browser/preview",
-          { method: "POST", body: { tabId: parsedTabId } },
+          { method: "POST", body: { tabId } },
           undefined,
           decodeBrowserPreview,
-        );
-  });
-  handleTrusted(IPC_CHANNELS.browserSetVisible, async (input: unknown) => {
-    const parsed = parseVisibility(input);
+        ),
+  );
+  handleTrusted(IPC_CHANNELS.browserSetVisible, parseVisibility, async (parsed) => {
     if (remoteServers.activeServerId === "local") await browser.setVisible(parsed);
     else {
       await remoteServers.request("/v1/browser/visible", { method: "POST", body: parsed }, undefined, decodeVoid);
     }
   });
-  handleTrusted(IPC_CHANNELS.browserPictureInPictureOpen, (input: unknown) =>
-    browserPictureInPicture.open(input === undefined ? undefined : parseBrowserBounds(input)),
+  handleTrusted(IPC_CHANNELS.browserPictureInPictureOpen, optionalPayload(parseBrowserBounds), (bounds) =>
+    browserPictureInPicture.open(bounds),
   );
   handleTrusted(IPC_CHANNELS.browserPictureInPictureClose, () => browserPictureInPicture.close());
   handleTrusted(IPC_CHANNELS.browserPictureInPictureDock, () => browserPictureInPicture.dock());

--- a/src/main/ipc-channel-coverage.test.ts
+++ b/src/main/ipc-channel-coverage.test.ts
@@ -25,7 +25,9 @@ import { describe, expect, it } from "vitest";
 const repositoryRoot = resolve(import.meta.dirname, "../..");
 
 // The channel is the first argument to each of these, except sendToRenderer,
-// where it follows the target window.
+// where it follows the target window. What comes after the channel varies —
+// handleTrusted takes either a handler alone or a payload decoder and a handler —
+// and the scan reads only the channel position, so it does not care.
 const MAIN_HANDLER_CALLEES = ["handleTrusted", "handleTrustedWithEvent"];
 const MAIN_SEND_CALLEES = ["sendToRenderer"];
 const PRELOAD_INVOKE_CALLEES = ["ipcRenderer.invoke", "invokeAgent", "invokeAgentForServer"];

--- a/src/main/ipc/app-inputs.ts
+++ b/src/main/ipc/app-inputs.ts
@@ -1,11 +1,21 @@
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type {
   AgentProviderId,
   DynamicIslandAction,
   DynamicIslandPreference,
   DynamicIslandPresentation,
   ExternalDestination,
+  InstallMarketplaceAgentInput,
+  InstallSkillInput,
   MacPermissionId,
+  MarketplaceAgentQuery,
+  MarketplaceSkillQuery,
+  PublishHostedSiteInput,
+  ReplaceHostedSiteInput,
   SetAnalyticsPreferenceInput,
+  SubmitMarketplaceAgentInput,
+  SubmitSkillInput,
+  UninstallSkillInput,
   UpdatePreference,
 } from "@openbot/contracts/ipc";
 import {
@@ -13,8 +23,12 @@ import {
   isDynamicIslandInteractive,
   isDynamicIslandPreference,
   isDynamicIslandPresentation,
+  isSkillCategory,
 } from "@openbot/contracts/ipc";
-import { isBoolean, isDynamicRecord } from "@openbot/contracts/runtime-values";
+import { type DynamicRecord, isBoolean, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { validateProfileName } from "@openbot/contracts/validation";
+import { parseAvatarImage } from "./avatar-inputs";
+import { isObject, optionalBoolean, requireString } from "./validation";
 
 export function parseProvider(input: unknown): AgentProviderId {
   if (!isDynamicRecord(input)) throw new Error("Setup input is required.");
@@ -80,4 +94,122 @@ export function parseExternalDestination(input: unknown): ExternalDestination {
     throw new Error("Unknown external destination.");
   }
   return input;
+}
+
+export function parseEmailCodeVerification(input: unknown): { challengeId: string; code: string } {
+  if (!isObject(input)) throw new Error("Sign-in code details are required.");
+  return {
+    challengeId: requireString(input.challengeId, "challengeId", INPUT_LIMITS.identifier),
+    code: requireString(input.code, "code", 32),
+  };
+}
+
+export function parseProfileName(input: unknown): string {
+  const validation = validateProfileName(requireString(input, "name", INPUT_LIMITS.accountName));
+  if (validation.error) {
+    throw new Error(`name must contain ${INPUT_LIMITS.profileNameMin} to ${INPUT_LIMITS.profileName} safe characters.`);
+  }
+  return validation.name;
+}
+
+// The two marketplaces share a query shape; only the category filter and the error wording differ.
+// `query` is truncated rather than rejected, which is the behaviour these channels have always had.
+function parseMarketplaceQueryFields(input: DynamicRecord, sortError: string): MarketplaceAgentQuery {
+  if (input.sort !== undefined && input.sort !== "installs") throw new Error(sortError);
+  return {
+    ...(isString(input.query) ? { query: input.query.slice(0, 100) } : {}),
+    ...(input.featured === true ? { featured: true } : {}),
+    ...(input.sort === "installs" ? { sort: "installs" as const } : {}),
+    ...(isString(input.cursor) ? { cursor: input.cursor } : {}),
+    ...(isNumber(input.limit) ? { limit: input.limit } : {}),
+  };
+}
+
+export function parseMarketplaceSkillQuery(input: unknown): MarketplaceSkillQuery {
+  if (!isObject(input)) throw new Error("Invalid marketplace query.");
+  const category = input.category;
+  if (category !== undefined && !isSkillCategory(category)) throw new Error("Unknown skill category.");
+  return {
+    ...parseMarketplaceQueryFields(input, "Unknown skill sort order."),
+    ...(category ? { category } : {}),
+  };
+}
+
+export function parseMarketplaceAgentQuery(input: unknown): MarketplaceAgentQuery {
+  if (!isObject(input)) throw new Error("Invalid agent marketplace query.");
+  return parseMarketplaceQueryFields(input, "Unknown agent sort order.");
+}
+
+export function parseSubmitSkill(input: unknown): SubmitSkillInput {
+  if (!isObject(input) || !isSkillCategory(input.category)) throw new Error("Invalid skill submission.");
+  return {
+    draftId: requireString(input.draftId, "draftId"),
+    category: input.category,
+    icon: parseAvatarImage(input.icon),
+    ...(input.skillId === undefined ? {} : { skillId: requireString(input.skillId, "skillId") }),
+  };
+}
+
+export function parseInstallSkill(input: unknown): InstallSkillInput {
+  if (!isObject(input)) throw new Error("Invalid skill installation.");
+  return {
+    botId: requireString(input.botId, "botId"),
+    skillId: requireString(input.skillId, "skillId"),
+    ...(input.replaceModified === true ? { replaceModified: true } : {}),
+  };
+}
+
+export function parseUninstallSkill(input: unknown): UninstallSkillInput {
+  if (!isObject(input)) throw new Error("Invalid skill removal.");
+  return {
+    botId: requireString(input.botId, "botId"),
+    skillId: requireString(input.skillId, "skillId"),
+    ...(input.removeModified === true ? { removeModified: true } : {}),
+  };
+}
+
+export function parsePublishHostedSite(input: unknown): PublishHostedSiteInput {
+  if (!isObject(input)) throw new Error("Invalid site publication.");
+  const spaFallback = optionalBoolean(input.spaFallback, "spaFallback");
+  return {
+    sourcePath: requireString(input.sourcePath, "sourcePath", INPUT_LIMITS.path),
+    title: requireString(input.title, "title", 120),
+    description: requireString(input.description, "description", 500),
+    ...(spaFallback !== undefined ? { spaFallback } : {}),
+  };
+}
+
+export function parseReplaceHostedSite(input: unknown): ReplaceHostedSiteInput {
+  if (!isObject(input)) throw new Error("Invalid site replacement.");
+  const spaFallback = optionalBoolean(input.spaFallback, "spaFallback");
+  return {
+    siteId: requireString(input.siteId, "siteId", INPUT_LIMITS.identifier),
+    sourcePath: requireString(input.sourcePath, "sourcePath", INPUT_LIMITS.path),
+    title: requireString(input.title, "title", 120),
+    description: requireString(input.description, "description", 500),
+    ...(spaFallback !== undefined ? { spaFallback } : {}),
+  };
+}
+
+export function parseDeleteHostedSite(input: unknown): string {
+  if (!isObject(input)) throw new Error("Invalid site deletion.");
+  return requireString(input.siteId, "siteId", INPUT_LIMITS.identifier);
+}
+
+export function parseSubmitMarketplaceAgent(input: unknown): SubmitMarketplaceAgentInput {
+  if (!isObject(input)) throw new Error("Invalid agent submission.");
+  return {
+    botId: requireString(input.botId, "botId"),
+    ...(input.agentId === undefined ? {} : { agentId: requireString(input.agentId, "agentId") }),
+  };
+}
+
+export function parseInstallMarketplaceAgent(input: unknown): InstallMarketplaceAgentInput {
+  if (!isObject(input)) throw new Error("Invalid agent installation.");
+  return {
+    agentId: requireString(input.agentId, "agentId"),
+    ...(input.botId === undefined ? {} : { botId: requireString(input.botId, "botId", INPUT_LIMITS.identifier) }),
+    timezone: requireString(input.timezone, "timezone", 255),
+    receiptId: requireString(input.receiptId, "receiptId", INPUT_LIMITS.identifier),
+  };
 }

--- a/src/main/ipc/input-parsers.test.ts
+++ b/src/main/ipc/input-parsers.test.ts
@@ -57,7 +57,7 @@ import {
   parseReorderServers,
   parseUpdateTeamMember,
 } from "./server-inputs";
-import { requireString } from "./validation";
+import { nullishPayload, optionalPayload, requireString } from "./validation";
 import { parseVoiceTranscription } from "./voice-inputs";
 
 describe("app IPC input parsing", () => {
@@ -637,6 +637,18 @@ describe("shared IPC validation", () => {
     expect(() => requireString(" ", "field")).toThrowError("field is required.");
     expect(() => requireString("long", "field", 3)).toThrowError("field is too long.");
     expect(requireString(" value ", "field")).toBe(" value ");
+  });
+
+  // Only the two marketplace queries ever accepted an explicit null as "no query". Collapsing the
+  // two helpers into one would let a null reach a channel like Picture-in-Picture as default bounds,
+  // which is a malformed payload silently succeeding rather than being rejected.
+  it("separates an omitted payload from an explicit null", () => {
+    const decode = (value: unknown) => `decoded:${String(value)}`;
+
+    expect(optionalPayload(decode)(undefined)).toBeUndefined();
+    expect(optionalPayload(decode)(null)).toBe("decoded:null");
+    expect(nullishPayload(decode)(undefined)).toBeUndefined();
+    expect(nullishPayload(decode)(null)).toBeUndefined();
   });
 });
 

--- a/src/main/ipc/input-parsers.test.ts
+++ b/src/main/ipc/input-parsers.test.ts
@@ -40,6 +40,9 @@ import {
   parseDynamicIslandPresentation,
   parseExternalDestination,
   parseMacPermission,
+  parseMarketplaceAgentQuery,
+  parseMarketplaceSkillQuery,
+  parseProfileName,
   parseProvider,
   parseProviderId,
   parseUpdatePreference,
@@ -69,6 +72,41 @@ describe("app IPC input parsing", () => {
     expect(parseAnalyticsPreference({ enabled: false })).toEqual({ enabled: false });
     expect(parseUpdatePreference({ autoDownload: false })).toEqual({ autoDownload: false });
     expect(parseUpdatePreference({ autoDownload: true })).toEqual({ autoDownload: true });
+  });
+
+  // These two channels validated their payload inline until the decoder became a required argument,
+  // so the cases below pin the behaviour that move preserved rather than any new rule. The 100
+  // character cap on `query` is silent truncation, not rejection, and turning it into an error would
+  // be a product change.
+  it("truncates an over-long marketplace search instead of rejecting it", () => {
+    const query = "a".repeat(150);
+    expect(parseMarketplaceSkillQuery({ query })).toEqual({ query: "a".repeat(100) });
+    expect(parseMarketplaceAgentQuery({ query })).toEqual({ query: "a".repeat(100) });
+  });
+
+  it("keeps only the marketplace filters a caller actually sent", () => {
+    expect(parseMarketplaceSkillQuery({})).toEqual({});
+    expect(
+      parseMarketplaceSkillQuery({ featured: true, sort: "installs", cursor: "page-2", limit: 20, category: "coding" }),
+    ).toEqual({ featured: true, sort: "installs", cursor: "page-2", limit: 20, category: "coding" });
+    expect(parseMarketplaceSkillQuery({ featured: false, cursor: 7 })).toEqual({});
+    expect(parseMarketplaceAgentQuery({ featured: true, limit: 5 })).toEqual({ featured: true, limit: 5 });
+  });
+
+  it("separates the two marketplaces by their rejection messages", () => {
+    expect(() => parseMarketplaceSkillQuery(null)).toThrowError("Invalid marketplace query.");
+    expect(() => parseMarketplaceAgentQuery(null)).toThrowError("Invalid agent marketplace query.");
+    expect(() => parseMarketplaceSkillQuery({ sort: "newest" })).toThrowError("Unknown skill sort order.");
+    expect(() => parseMarketplaceAgentQuery({ sort: "newest" })).toThrowError("Unknown agent sort order.");
+    expect(() => parseMarketplaceSkillQuery({ category: "cooking" })).toThrowError("Unknown skill category.");
+  });
+
+  it("applies the profile name rule through one decoder", () => {
+    expect(parseProfileName("  Ada Lovelace  ")).toBe("Ada Lovelace");
+    expect(() => parseProfileName("")).toThrowError("name is required.");
+    expect(() => parseProfileName("a")).toThrowError(
+      `name must contain ${INPUT_LIMITS.profileNameMin} to ${INPUT_LIMITS.profileName} safe characters.`,
+    );
   });
 
   it("keeps setup and permission error messages", () => {

--- a/src/main/ipc/register-team-handlers.ts
+++ b/src/main/ipc/register-team-handlers.ts
@@ -13,12 +13,14 @@ import {
   parseLoginServer,
   parseMarkDirectRead,
   parseReadDirectConversationPage,
+  parseRemoteDesktopConnect,
+  parseRemoteDesktopDisplay,
   parseReorderServers,
   parseSendDirectMessage,
   parseSetTeamTyping,
   parseUpdateTeamMember,
 } from "./server-inputs";
-import { isObject, requireString } from "./validation";
+import { requireString, stringPayload } from "./validation";
 
 interface TeamIpcDependencies {
   host: HostService;
@@ -34,133 +36,101 @@ export function registerTeamIpcHandlers({
   takePendingInvite,
 }: TeamIpcDependencies): void {
   handleTrusted(IPC_CHANNELS.serversList, () => withLocalHostSummary(remoteServers.list(), host.getStatus()));
-  handleTrusted(IPC_CHANNELS.serversSelect, (serverId: unknown) =>
-    remoteServers
-      .select(requireString(serverId, "serverId"))
-      .then((servers) => withLocalHostSummary(servers, host.getStatus())),
+  handleTrusted(IPC_CHANNELS.serversSelect, stringPayload("serverId"), (serverId) =>
+    remoteServers.select(serverId).then((servers) => withLocalHostSummary(servers, host.getStatus())),
   );
-  handleTrusted(IPC_CHANNELS.serversReorder, (input: unknown) =>
-    remoteServers
-      .reorder(parseReorderServers(input).serverIds)
-      .then((servers) => withLocalHostSummary(servers, host.getStatus())),
+  handleTrusted(IPC_CHANNELS.serversReorder, parseReorderServers, (request) =>
+    remoteServers.reorder(request.serverIds).then((servers) => withLocalHostSummary(servers, host.getStatus())),
   );
-  handleTrusted(IPC_CHANNELS.serversJoin, (input: unknown) => remoteServers.join(parseJoinServer(input)));
-  handleTrusted(IPC_CHANNELS.serversPreviewInvite, (input: unknown) =>
-    remoteServers.previewInvite(parseJoinServer(input)),
-  );
+  handleTrusted(IPC_CHANNELS.serversJoin, parseJoinServer, (request) => remoteServers.join(request));
+  handleTrusted(IPC_CHANNELS.serversPreviewInvite, parseJoinServer, (request) => remoteServers.previewInvite(request));
   handleTrusted(IPC_CHANNELS.serversTakePendingInvite, takePendingInvite);
-  handleTrusted(IPC_CHANNELS.serversLogin, (input: unknown) => remoteServers.login(parseLoginServer(input)));
-  handleTrusted(IPC_CHANNELS.serversRetryConnection, (serverId: unknown) =>
-    remoteServers.retryConnection(requireString(serverId, "serverId")),
+  handleTrusted(IPC_CHANNELS.serversLogin, parseLoginServer, (request) => remoteServers.login(request));
+  handleTrusted(IPC_CHANNELS.serversRetryConnection, stringPayload("serverId"), (serverId) =>
+    remoteServers.retryConnection(serverId),
   );
-  handleTrusted(IPC_CHANNELS.serversRemove, (serverId: unknown) =>
-    remoteServers.remove(requireString(serverId, "serverId")),
-  );
+  handleTrusted(IPC_CHANNELS.serversRemove, stringPayload("serverId"), (serverId) => remoteServers.remove(serverId));
   handleTrusted(IPC_CHANNELS.serversGetPresence, () =>
     remoteServers.activeServerId === "local" ? host.getPresence() : remoteServers.getPresence(),
   );
-  handleTrusted(IPC_CHANNELS.serversGetPresenceFor, (serverId: unknown) => {
-    const target = requireString(serverId, "serverId");
-    return target === "local" ? host.getPresence() : remoteServers.getPresenceFor(target);
-  });
-  handleTrusted(IPC_CHANNELS.serversRefreshIdentity, (serverId: unknown) =>
-    remoteServers.refreshIdentity(requireString(serverId, "serverId")),
+  handleTrusted(IPC_CHANNELS.serversGetPresenceFor, stringPayload("serverId"), (serverId) =>
+    serverId === "local" ? host.getPresence() : remoteServers.getPresenceFor(serverId),
   );
-  handleTrusted(IPC_CHANNELS.serversListMembers, (serverId: unknown) =>
-    remoteServers.listMembers(requireString(serverId, "serverId")),
+  handleTrusted(IPC_CHANNELS.serversRefreshIdentity, stringPayload("serverId"), (serverId) =>
+    remoteServers.refreshIdentity(serverId),
   );
-  handleTrusted(IPC_CHANNELS.serversUpdateMember, (input: unknown) => {
-    const request = parseAgentRequest(input);
-    return remoteServers.updateMember(request.serverId, parseUpdateTeamMember(request.payload));
-  });
-  handleTrusted(IPC_CHANNELS.serversRemoveMember, (input: unknown) => {
-    const request = parseAgentRequest(input);
-    return remoteServers.removeMember(request.serverId, requireString(request.payload, "memberId"));
-  });
-  handleTrusted(IPC_CHANNELS.serversListInvites, (serverId: unknown) =>
-    remoteServers.listInvites(requireString(serverId, "serverId")),
+  handleTrusted(IPC_CHANNELS.serversListMembers, stringPayload("serverId"), (serverId) =>
+    remoteServers.listMembers(serverId),
   );
-  handleTrusted(IPC_CHANNELS.serversRevokeInvite, (input: unknown) => {
-    const request = parseAgentRequest(input);
-    return remoteServers.revokeInvite(request.serverId, requireString(request.payload, "inviteId"));
-  });
-  handleTrusted(IPC_CHANNELS.serversCreateInvite, (input: unknown) => {
-    const request = parseAgentRequest(input);
-    return remoteServers.createInvite(request.serverId, parseCreateTeamInvite(request.payload));
-  });
-  handleTrusted(IPC_CHANNELS.serversSetTyping, (input: unknown) => {
-    const parsed = parseSetTeamTyping(input);
+  handleTrusted(IPC_CHANNELS.serversUpdateMember, parseAgentRequest, (request) =>
+    remoteServers.updateMember(request.serverId, parseUpdateTeamMember(request.payload)),
+  );
+  handleTrusted(IPC_CHANNELS.serversRemoveMember, parseAgentRequest, (request) =>
+    remoteServers.removeMember(request.serverId, requireString(request.payload, "memberId")),
+  );
+  handleTrusted(IPC_CHANNELS.serversListInvites, stringPayload("serverId"), (serverId) =>
+    remoteServers.listInvites(serverId),
+  );
+  handleTrusted(IPC_CHANNELS.serversRevokeInvite, parseAgentRequest, (request) =>
+    remoteServers.revokeInvite(request.serverId, requireString(request.payload, "inviteId")),
+  );
+  handleTrusted(IPC_CHANNELS.serversCreateInvite, parseAgentRequest, (request) =>
+    remoteServers.createInvite(request.serverId, parseCreateTeamInvite(request.payload)),
+  );
+  handleTrusted(IPC_CHANNELS.serversSetTyping, parseSetTeamTyping, (parsed) => {
     if (remoteServers.activeServerId === "local") host.setTyping(parsed);
     else remoteServers.setTyping(parsed);
   });
   handleTrusted(IPC_CHANNELS.serversListDirectThreads, () =>
     remoteServers.activeServerId === "local" ? host.listDirectThreads() : remoteServers.listDirectThreads(),
   );
-  handleTrusted(IPC_CHANNELS.serversReadDirectConversation, (memberId: unknown) => {
-    const parsedMemberId = requireString(memberId, "memberId");
-    return remoteServers.activeServerId === "local"
-      ? host.readDirectConversation(parsedMemberId)
-      : remoteServers.readDirectConversation(parsedMemberId);
-  });
-  handleTrusted(IPC_CHANNELS.serversReadDirectConversationPage, (input: unknown) => {
-    const parsed = parseReadDirectConversationPage(input);
-    return remoteServers.activeServerId === "local"
+  handleTrusted(IPC_CHANNELS.serversReadDirectConversation, stringPayload("memberId"), (memberId) =>
+    remoteServers.activeServerId === "local"
+      ? host.readDirectConversation(memberId)
+      : remoteServers.readDirectConversation(memberId),
+  );
+  handleTrusted(IPC_CHANNELS.serversReadDirectConversationPage, parseReadDirectConversationPage, (parsed) =>
+    remoteServers.activeServerId === "local"
       ? host.readDirectConversationPage(parsed.memberId, parsed.anchor, parsed.limit)
-      : remoteServers.readDirectConversationPage(parsed.memberId, parsed.anchor, parsed.limit);
-  });
-  handleTrusted(IPC_CHANNELS.serversSendDirectMessage, (input: unknown) => {
-    const parsed = parseSendDirectMessage(input);
-    return remoteServers.activeServerId === "local"
-      ? host.sendDirectMessage(parsed)
-      : remoteServers.sendDirectMessage(parsed);
-  });
-  handleTrusted(IPC_CHANNELS.serversMarkDirectRead, (input: unknown) => {
-    const parsed = parseMarkDirectRead(input);
-    return remoteServers.activeServerId === "local"
-      ? host.markDirectRead(parsed)
-      : remoteServers.markDirectRead(parsed);
-  });
-  handleTrusted(IPC_CHANNELS.serversSetDirectTyping, (input: unknown) => {
-    const parsed = parseDirectTyping(input);
+      : remoteServers.readDirectConversationPage(parsed.memberId, parsed.anchor, parsed.limit),
+  );
+  handleTrusted(IPC_CHANNELS.serversSendDirectMessage, parseSendDirectMessage, (parsed) =>
+    remoteServers.activeServerId === "local" ? host.sendDirectMessage(parsed) : remoteServers.sendDirectMessage(parsed),
+  );
+  handleTrusted(IPC_CHANNELS.serversMarkDirectRead, parseMarkDirectRead, (parsed) =>
+    remoteServers.activeServerId === "local" ? host.markDirectRead(parsed) : remoteServers.markDirectRead(parsed),
+  );
+  handleTrusted(IPC_CHANNELS.serversSetDirectTyping, parseDirectTyping, (parsed) => {
     if (remoteServers.activeServerId === "local") host.setDirectTyping(parsed);
     else remoteServers.setDirectTyping(parsed);
   });
 
   handleTrusted(IPC_CHANNELS.hostGetStatus, () => host.getStatus());
-  handleTrusted(IPC_CHANNELS.hostConfigure, (input: unknown) => host.configure(parseHostConfig(input)));
-  handleTrusted(IPC_CHANNELS.hostUpdateIdentity, (input: unknown) => host.updateIdentity(parseHostIdentity(input)));
+  handleTrusted(IPC_CHANNELS.hostConfigure, parseHostConfig, (config) => host.configure(config));
+  handleTrusted(IPC_CHANNELS.hostUpdateIdentity, parseHostIdentity, (identity) => host.updateIdentity(identity));
   handleTrusted(IPC_CHANNELS.hostGetPresence, () => host.getPresence());
   handleTrusted(IPC_CHANNELS.hostStart, () => host.start());
   handleTrusted(IPC_CHANNELS.hostStop, () => host.stop());
   handleTrusted(IPC_CHANNELS.hostListMembers, () => host.listMembers());
-  handleTrusted(IPC_CHANNELS.hostUpdateMember, (input: unknown) => host.updateMember(parseUpdateTeamMember(input)));
-  handleTrusted(IPC_CHANNELS.hostRemoveMember, (memberId: unknown) =>
-    host.removeMember(requireString(memberId, "memberId")),
-  );
+  handleTrusted(IPC_CHANNELS.hostUpdateMember, parseUpdateTeamMember, (update) => host.updateMember(update));
+  handleTrusted(IPC_CHANNELS.hostRemoveMember, stringPayload("memberId"), (memberId) => host.removeMember(memberId));
   handleTrusted(IPC_CHANNELS.hostListSessions, () => host.listSessions());
-  handleTrusted(IPC_CHANNELS.hostRevokeSession, (sessionId: unknown) =>
-    host.revokeSession(requireString(sessionId, "sessionId")),
+  handleTrusted(IPC_CHANNELS.hostRevokeSession, stringPayload("sessionId"), (sessionId) =>
+    host.revokeSession(sessionId),
   );
   handleTrusted(IPC_CHANNELS.hostListInvites, () => host.listInvites());
-  handleTrusted(IPC_CHANNELS.hostRevokeInvite, (inviteId: unknown) =>
-    host.revokeInvite(requireString(inviteId, "inviteId")),
-  );
-  handleTrusted(IPC_CHANNELS.hostCreateInvite, (input: unknown) => host.createInvite(parseCreateTeamInvite(input)));
+  handleTrusted(IPC_CHANNELS.hostRevokeInvite, stringPayload("inviteId"), (inviteId) => host.revokeInvite(inviteId));
+  handleTrusted(IPC_CHANNELS.hostCreateInvite, parseCreateTeamInvite, (invite) => host.createInvite(invite));
 
   handleTrusted(IPC_CHANNELS.remoteDesktopList, () => remoteDesktop.list());
-  handleTrusted(IPC_CHANNELS.remoteDesktopConnect, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Remote control details are required.");
-    return remoteDesktop.connect({ serverId: requireString(input.serverId, "serverId") });
-  });
-  handleTrusted(IPC_CHANNELS.remoteDesktopSelectDisplay, (input: unknown) => {
-    if (!isObject(input)) throw new Error("Remote display details are required.");
-    return remoteDesktop.selectDisplay(
-      requireString(input.serverId, "serverId"),
-      requireString(input.displayId, "displayId"),
-    );
-  });
-  handleTrusted(IPC_CHANNELS.remoteDesktopDisconnect, (sessionId: unknown) =>
-    remoteDesktop.disconnect(requireString(sessionId, "sessionId")),
+  handleTrusted(IPC_CHANNELS.remoteDesktopConnect, parseRemoteDesktopConnect, (request) =>
+    remoteDesktop.connect(request),
+  );
+  handleTrusted(IPC_CHANNELS.remoteDesktopSelectDisplay, parseRemoteDesktopDisplay, (request) =>
+    remoteDesktop.selectDisplay(request.serverId, request.displayId),
+  );
+  handleTrusted(IPC_CHANNELS.remoteDesktopDisconnect, stringPayload("sessionId"), (sessionId) =>
+    remoteDesktop.disconnect(sessionId),
   );
 }
 

--- a/src/main/ipc/register-team-handlers.ts
+++ b/src/main/ipc/register-team-handlers.ts
@@ -3,6 +3,7 @@ import type { HostService } from "../host-service";
 import type { RemoteDesktopManager } from "../remote-desktop-manager";
 import type { RemoteServerManager } from "../remote-server-manager";
 import { handleTrusted } from "../trusted-ipc";
+import { parseAgentRequest } from "./agent-inputs";
 import {
   parseCreateTeamInvite,
   parseDirectTyping,
@@ -68,21 +69,25 @@ export function registerTeamIpcHandlers({
   handleTrusted(IPC_CHANNELS.serversListMembers, (serverId: unknown) =>
     remoteServers.listMembers(requireString(serverId, "serverId")),
   );
-  handleTrusted(IPC_CHANNELS.serversUpdateMember, (serverId: unknown, input: unknown) =>
-    remoteServers.updateMember(requireString(serverId, "serverId"), parseUpdateTeamMember(input)),
-  );
-  handleTrusted(IPC_CHANNELS.serversRemoveMember, (serverId: unknown, memberId: unknown) =>
-    remoteServers.removeMember(requireString(serverId, "serverId"), requireString(memberId, "memberId")),
-  );
+  handleTrusted(IPC_CHANNELS.serversUpdateMember, (input: unknown) => {
+    const request = parseAgentRequest(input);
+    return remoteServers.updateMember(request.serverId, parseUpdateTeamMember(request.payload));
+  });
+  handleTrusted(IPC_CHANNELS.serversRemoveMember, (input: unknown) => {
+    const request = parseAgentRequest(input);
+    return remoteServers.removeMember(request.serverId, requireString(request.payload, "memberId"));
+  });
   handleTrusted(IPC_CHANNELS.serversListInvites, (serverId: unknown) =>
     remoteServers.listInvites(requireString(serverId, "serverId")),
   );
-  handleTrusted(IPC_CHANNELS.serversRevokeInvite, (serverId: unknown, inviteId: unknown) =>
-    remoteServers.revokeInvite(requireString(serverId, "serverId"), requireString(inviteId, "inviteId")),
-  );
-  handleTrusted(IPC_CHANNELS.serversCreateInvite, (serverId: unknown, input: unknown) =>
-    remoteServers.createInvite(requireString(serverId, "serverId"), parseCreateTeamInvite(input)),
-  );
+  handleTrusted(IPC_CHANNELS.serversRevokeInvite, (input: unknown) => {
+    const request = parseAgentRequest(input);
+    return remoteServers.revokeInvite(request.serverId, requireString(request.payload, "inviteId"));
+  });
+  handleTrusted(IPC_CHANNELS.serversCreateInvite, (input: unknown) => {
+    const request = parseAgentRequest(input);
+    return remoteServers.createInvite(request.serverId, parseCreateTeamInvite(request.payload));
+  });
   handleTrusted(IPC_CHANNELS.serversSetTyping, (input: unknown) => {
     const parsed = parseSetTeamTyping(input);
     if (remoteServers.activeServerId === "local") host.setTyping(parsed);

--- a/src/main/ipc/server-inputs.ts
+++ b/src/main/ipc/server-inputs.ts
@@ -177,3 +177,16 @@ export function parseDirectTyping(value: unknown): DirectTypingInput {
     typing: value.typing,
   };
 }
+
+export function parseRemoteDesktopConnect(input: unknown): { serverId: string } {
+  if (!isObject(input)) throw new Error("Remote control details are required.");
+  return { serverId: requireString(input.serverId, "serverId") };
+}
+
+export function parseRemoteDesktopDisplay(input: unknown): { serverId: string; displayId: string } {
+  if (!isObject(input)) throw new Error("Remote display details are required.");
+  return {
+    serverId: requireString(input.serverId, "serverId"),
+    displayId: requireString(input.displayId, "displayId"),
+  };
+}

--- a/src/main/ipc/validation.ts
+++ b/src/main/ipc/validation.ts
@@ -7,6 +7,23 @@ export function requireString(value: unknown, field: string, maxLength: number =
   return value;
 }
 
+/**
+ * `requireString` bound to one field name, for the many channels whose whole payload is a single
+ * identifier. `handleTrusted` takes a `(value: unknown) => Payload`, and `requireString` takes three
+ * arguments, so without this each of those channels would need its own one-line named decoder.
+ */
+export function stringPayload(field: string, maxLength: number = INPUT_LIMITS.identifier): (value: unknown) => string {
+  return (value) => requireString(value, field, maxLength);
+}
+
+/**
+ * Wraps a decoder for a channel whose payload may legitimately be absent, so an omitted payload
+ * stays `undefined` rather than being rejected as malformed.
+ */
+export function optionalPayload<Payload>(decode: (value: unknown) => Payload): (value: unknown) => Payload | undefined {
+  return (value) => (value === null || value === undefined ? undefined : decode(value));
+}
+
 export function isObject(value: unknown): value is DynamicRecord {
   return isDynamicRecord(value);
 }

--- a/src/main/ipc/validation.ts
+++ b/src/main/ipc/validation.ts
@@ -18,9 +18,19 @@ export function stringPayload(field: string, maxLength: number = INPUT_LIMITS.id
 
 /**
  * Wraps a decoder for a channel whose payload may legitimately be absent, so an omitted payload
- * stays `undefined` rather than being rejected as malformed.
+ * stays `undefined` rather than being rejected as malformed. An explicit `null` is not an omission
+ * and still goes to the decoder, which is what a caller sending one has always got.
  */
 export function optionalPayload<Payload>(decode: (value: unknown) => Payload): (value: unknown) => Payload | undefined {
+  return (value) => (value === undefined ? undefined : decode(value));
+}
+
+/**
+ * The same, for the two marketplace channels that have shipped treating an explicit `null` as "no
+ * query" alongside an omitted one. Widening `optionalPayload` to cover them instead would make every
+ * other channel newly accept a `null` its decoder used to reject.
+ */
+export function nullishPayload<Payload>(decode: (value: unknown) => Payload): (value: unknown) => Payload | undefined {
   return (value) => (value === null || value === undefined ? undefined : decode(value));
 }
 

--- a/src/main/trusted-ipc.test.ts
+++ b/src/main/trusted-ipc.test.ts
@@ -123,4 +123,29 @@ describe("trusted IPC wrappers", () => {
 
     expect(registrations.get("test:accept-with-event")?.(TRUSTED_EVENT, "one")).toEqual([TRUSTED_EVENT, "decoded:one"]);
   });
+
+  // Ordering again, one level in: every window of the app shares the trusted origin, so a channel
+  // restricted to one of them authorizes by sender identity. That answers "may this caller use this
+  // channel at all", so it has to settle before the decoder runs — otherwise a caller the channel
+  // rejects still gets to choose which payload-validation error comes back.
+  it("authorizes the sender before decoding a payload it sent", () => {
+    const order: string[] = [];
+    handleTrustedWithEvent(
+      "test:authorized",
+      () => {
+        order.push("authorize");
+        throw new Error("Rejected Dynamic Island IPC request outside the main renderer.");
+      },
+      (value) => {
+        order.push("decode");
+        return value;
+      },
+      (_event, payload) => payload,
+    );
+
+    expect(() => registrations.get("test:authorized")?.(TRUSTED_EVENT, "one")).toThrowError(
+      "Rejected Dynamic Island IPC request outside the main renderer.",
+    );
+    expect(order).toEqual(["authorize"]);
+  });
 });

--- a/src/main/trusted-ipc.test.ts
+++ b/src/main/trusted-ipc.test.ts
@@ -57,10 +57,49 @@ describe("trusted IPC wrappers", () => {
     expect(handled).toBe(0);
   });
 
-  it("passes a request from the application origin to the handler with its arguments", () => {
-    handleTrusted("test:accept", (first, second) => [first, second]);
+  it("decodes the payload before the handler sees it", () => {
+    handleTrusted(
+      "test:accept",
+      (value) => `decoded:${String(value)}`,
+      (payload) => [payload],
+    );
 
-    expect(registrations.get("test:accept")?.(TRUSTED_EVENT, "one", 2)).toEqual(["one", 2]);
+    expect(registrations.get("test:accept")?.(TRUSTED_EVENT, "one")).toEqual(["decoded:one"]);
+  });
+
+  it("does not run the handler when the decoder rejects the payload", () => {
+    let handled = 0;
+    handleTrusted(
+      "test:bad-payload",
+      () => {
+        throw new Error("Invalid payload.");
+      },
+      () => {
+        handled += 1;
+      },
+    );
+
+    expect(() => registrations.get("test:bad-payload")?.(TRUSTED_EVENT, "one")).toThrow("Invalid payload.");
+    expect(handled).toBe(0);
+  });
+
+  // Ordering, not just outcome: decoding an untrusted renderer's payload is work done on behalf of
+  // a caller already known to be rejected, so the sender check has to come first.
+  it("rejects an untrusted renderer before decoding anything it sent", () => {
+    let decoded = 0;
+    handleTrusted(
+      "test:reject-before-decode",
+      (value) => {
+        decoded += 1;
+        return value;
+      },
+      (payload) => payload,
+    );
+
+    expect(() => registrations.get("test:reject-before-decode")?.(UNTRUSTED_EVENT, "one")).toThrow(
+      "Rejected IPC request from an untrusted renderer.",
+    );
+    expect(decoded).toBe(0);
   });
 
   it("rejects an untrusted renderer for the event-carrying wrapper too", () => {
@@ -75,9 +114,13 @@ describe("trusted IPC wrappers", () => {
     expect(handled).toBe(0);
   });
 
-  it("hands the event to the handler once the renderer is trusted", () => {
-    handleTrustedWithEvent("test:accept-with-event", (event, first) => [event, first]);
+  it("hands the event and the decoded payload to the handler once the renderer is trusted", () => {
+    handleTrustedWithEvent(
+      "test:accept-with-event",
+      (value) => `decoded:${String(value)}`,
+      (event, payload) => [event, payload],
+    );
 
-    expect(registrations.get("test:accept-with-event")?.(TRUSTED_EVENT, "one")).toEqual([TRUSTED_EVENT, "one"]);
+    expect(registrations.get("test:accept-with-event")?.(TRUSTED_EVENT, "one")).toEqual([TRUSTED_EVENT, "decoded:one"]);
   });
 });

--- a/src/main/trusted-ipc.ts
+++ b/src/main/trusted-ipc.ts
@@ -29,6 +29,14 @@ type TakesNoArguments<Handler> = Handler extends (...args: infer Args) => unknow
     : ArityMessage
   : never;
 
+// Authorization that needs the event — a sender-identity check the trusted-URL gate is not able to
+// make, because every window of the app shares one origin — belongs beside that gate rather than in
+// the handler. Both answer "may this caller use this channel at all", so both have to be settled
+// before the process decodes anything the caller sent. Without the slot the check can only run after
+// the decoder, which hands a caller already known to be rejected a payload-validation error to read
+// and makes it the decoder's allocations that answer first.
+type AuthorizeSender = (event: IpcMainInvokeEvent) => void;
+
 // The event is passed by the wrapper, not the renderer, so a handler may name it or ignore it.
 type TakesEventOnly<Handler> = Handler extends (...args: infer Args) => unknown
   ? Args["length"] extends 0 | 1
@@ -38,7 +46,12 @@ type TakesEventOnly<Handler> = Handler extends (...args: infer Args) => unknown
 
 type TrustedEventRegistration =
   | [handler: (event: IpcMainInvokeEvent) => unknown]
-  | [decode: PayloadDecoder<unknown>, handler: (event: IpcMainInvokeEvent, payload: unknown) => unknown];
+  | [decode: PayloadDecoder<unknown>, handler: (event: IpcMainInvokeEvent, payload: unknown) => unknown]
+  | [
+      authorize: AuthorizeSender,
+      decode: PayloadDecoder<unknown>,
+      handler: (event: IpcMainInvokeEvent, payload: unknown) => unknown,
+    ];
 
 export function handleTrusted<Handler extends () => unknown>(
   channel: string,
@@ -72,13 +85,28 @@ export function handleTrustedWithEvent<Payload, Result>(
   decode: PayloadDecoder<Payload>,
   handler: (event: IpcMainInvokeEvent, payload: Payload) => Result,
 ): void;
+// Only the payload-taking form has an authorizing overload. An authorized channel with nothing to
+// decode has no ordering to fix — its handler is already the first thing that runs — and a three
+// argument `(channel, authorize, handler)` form could not be told apart from `(channel, decode,
+// handler)`, since an `AuthorizeSender` is structurally a decoder that returns nothing.
+export function handleTrustedWithEvent<Payload, Result>(
+  channel: string,
+  authorize: AuthorizeSender,
+  decode: PayloadDecoder<Payload>,
+  handler: (event: IpcMainInvokeEvent, payload: Payload) => Result,
+): void;
 export function handleTrustedWithEvent(channel: string, ...registration: TrustedEventRegistration): void {
   ipcMain.handle(channel, (event, payload: unknown) => {
     if (!isTrustedRendererUrl(event.senderFrame?.url)) {
       throw new Error("Rejected IPC request from an untrusted renderer.");
     }
     if (registration.length === 1) return registration[0](event);
-    const [decode, handler] = registration;
+    if (registration.length === 2) {
+      const [decode, handler] = registration;
+      return handler(event, decode(payload));
+    }
+    const [authorize, decode, handler] = registration;
+    authorize(event);
     return handler(event, decode(payload));
   });
 }

--- a/src/main/trusted-ipc.ts
+++ b/src/main/trusted-ipc.ts
@@ -1,23 +1,57 @@
 import { type IpcMainInvokeEvent, ipcMain } from "electron";
 import { isTrustedRendererUrl } from "./trusted-renderer";
 
-export function handleTrusted<Result>(channel: string, handler: (...arguments_: unknown[]) => Result): void {
-  ipcMain.handle(channel, (event, ...arguments_: unknown[]) => {
+// A handler that takes a payload can only be registered with a decoder for it, because there is no
+// overload that pairs one with a raw `unknown`. That is what keeps validation from being a
+// convention: a registration that does not say how its payload decodes is a compile error, not a
+// hole for review to catch. The decoder is a plain `(value: unknown) => Payload`, so it can be a
+// hand-written parser, a zod `parse`, or anything else, without changing a call site.
+type PayloadDecoder<Payload> = (value: unknown) => Payload;
+
+// The implementation takes the two shapes as a tuple union so its length discriminates them. A
+// plain union of the second parameter would need a type assertion to call either arm, and asserting
+// past the checker inside the trust boundary's own wrapper is the last place worth doing it.
+type TrustedRegistration =
+  | [handler: () => unknown]
+  | [decode: PayloadDecoder<unknown>, handler: (payload: unknown) => unknown];
+
+type TrustedEventRegistration =
+  | [handler: (event: IpcMainInvokeEvent) => unknown]
+  | [decode: PayloadDecoder<unknown>, handler: (event: IpcMainInvokeEvent, payload: unknown) => unknown];
+
+export function handleTrusted<Result>(channel: string, handler: () => Result): void;
+export function handleTrusted<Payload, Result>(
+  channel: string,
+  decode: PayloadDecoder<Payload>,
+  handler: (payload: Payload) => Result,
+): void;
+export function handleTrusted(channel: string, ...registration: TrustedRegistration): void {
+  ipcMain.handle(channel, (event, payload: unknown) => {
+    // The sender check runs first, and inline: an untrusted renderer is rejected before the process
+    // spends any work decoding what it sent, and the static scan in ipc-channel-coverage.test.ts
+    // reads this call's own body for the check, so extracting it into a helper would blind the scan.
     if (!isTrustedRendererUrl(event.senderFrame?.url)) {
       throw new Error("Rejected IPC request from an untrusted renderer.");
     }
-    return handler(...arguments_);
+    if (registration.length === 1) return registration[0]();
+    const [decode, handler] = registration;
+    return handler(decode(payload));
   });
 }
 
-export function handleTrustedWithEvent<Result>(
+export function handleTrustedWithEvent<Result>(channel: string, handler: (event: IpcMainInvokeEvent) => Result): void;
+export function handleTrustedWithEvent<Payload, Result>(
   channel: string,
-  handler: (event: IpcMainInvokeEvent, ...arguments_: unknown[]) => Result,
-): void {
-  ipcMain.handle(channel, (event, ...arguments_: unknown[]) => {
+  decode: PayloadDecoder<Payload>,
+  handler: (event: IpcMainInvokeEvent, payload: Payload) => Result,
+): void;
+export function handleTrustedWithEvent(channel: string, ...registration: TrustedEventRegistration): void {
+  ipcMain.handle(channel, (event, payload: unknown) => {
     if (!isTrustedRendererUrl(event.senderFrame?.url)) {
       throw new Error("Rejected IPC request from an untrusted renderer.");
     }
-    return handler(event, ...arguments_);
+    if (registration.length === 1) return registration[0](event);
+    const [decode, handler] = registration;
+    return handler(event, decode(payload));
   });
 }

--- a/src/main/trusted-ipc.ts
+++ b/src/main/trusted-ipc.ts
@@ -15,11 +15,35 @@ type TrustedRegistration =
   | [handler: () => unknown]
   | [decode: PayloadDecoder<unknown>, handler: (payload: unknown) => unknown];
 
+// `() => Result` alone would not close the hole: a handler declared `(payload?: unknown)`, one with a
+// default, and one taking `...rest` are all assignable to it, so they would bind to the no-payload
+// overload and then be called with nothing. The renderer's payload is dropped rather than passed on,
+// so no unvalidated value reaches a handler either way — but the registration compiles while quietly
+// meaning something else, which is the ambiguity this change exists to remove. Constraining the
+// parameter tuple's own length rejects all three, and says why in the diagnostic.
+type ArityMessage = "this handler takes a payload, so it must be registered with a decoder for it";
+
+type TakesNoArguments<Handler> = Handler extends (...args: infer Args) => unknown
+  ? Args["length"] extends 0
+    ? unknown
+    : ArityMessage
+  : never;
+
+// The event is passed by the wrapper, not the renderer, so a handler may name it or ignore it.
+type TakesEventOnly<Handler> = Handler extends (...args: infer Args) => unknown
+  ? Args["length"] extends 0 | 1
+    ? unknown
+    : ArityMessage
+  : never;
+
 type TrustedEventRegistration =
   | [handler: (event: IpcMainInvokeEvent) => unknown]
   | [decode: PayloadDecoder<unknown>, handler: (event: IpcMainInvokeEvent, payload: unknown) => unknown];
 
-export function handleTrusted<Result>(channel: string, handler: () => Result): void;
+export function handleTrusted<Handler extends () => unknown>(
+  channel: string,
+  handler: Handler & TakesNoArguments<Handler>,
+): void;
 export function handleTrusted<Payload, Result>(
   channel: string,
   decode: PayloadDecoder<Payload>,
@@ -39,7 +63,10 @@ export function handleTrusted(channel: string, ...registration: TrustedRegistrat
   });
 }
 
-export function handleTrustedWithEvent<Result>(channel: string, handler: (event: IpcMainInvokeEvent) => Result): void;
+export function handleTrustedWithEvent<Handler extends (event: IpcMainInvokeEvent) => unknown>(
+  channel: string,
+  handler: Handler & TakesEventOnly<Handler>,
+): void;
 export function handleTrustedWithEvent<Payload, Result>(
   channel: string,
   decode: PayloadDecoder<Payload>,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1116,11 +1116,15 @@ const openbotApi: OpenBotDesktopApi = {
     getPresenceFor: (serverId) => ipcRenderer.invoke(IPC_CHANNELS.serversGetPresenceFor, serverId),
     refreshIdentity: (serverId) => ipcRenderer.invoke(IPC_CHANNELS.serversRefreshIdentity, serverId),
     listMembers: (serverId) => ipcRenderer.invoke(IPC_CHANNELS.serversListMembers, serverId),
-    updateMember: (serverId, input) => ipcRenderer.invoke(IPC_CHANNELS.serversUpdateMember, serverId, input),
-    removeMember: (serverId, memberId) => ipcRenderer.invoke(IPC_CHANNELS.serversRemoveMember, serverId, memberId),
+    updateMember: (serverId, input) =>
+      ipcRenderer.invoke(IPC_CHANNELS.serversUpdateMember, { serverId, payload: input }),
+    removeMember: (serverId, memberId) =>
+      ipcRenderer.invoke(IPC_CHANNELS.serversRemoveMember, { serverId, payload: memberId }),
     listInvites: (serverId) => ipcRenderer.invoke(IPC_CHANNELS.serversListInvites, serverId),
-    revokeInvite: (serverId, inviteId) => ipcRenderer.invoke(IPC_CHANNELS.serversRevokeInvite, serverId, inviteId),
-    createInvite: (serverId, input) => ipcRenderer.invoke(IPC_CHANNELS.serversCreateInvite, serverId, input),
+    revokeInvite: (serverId, inviteId) =>
+      ipcRenderer.invoke(IPC_CHANNELS.serversRevokeInvite, { serverId, payload: inviteId }),
+    createInvite: (serverId, input) =>
+      ipcRenderer.invoke(IPC_CHANNELS.serversCreateInvite, { serverId, payload: input }),
     setTyping: (input) => ipcRenderer.invoke(IPC_CHANNELS.serversSetTyping, input),
     onPresence: (listener) => {
       const handler = (_event: Electron.IpcRendererEvent, payload: ScopedTeamPresenceSnapshot) => {


### PR DESCRIPTION
## The problem

`handleTrusted(channel, handler)` handed the handler a raw `unknown` and left validation to convention. 109 of 111 payload-taking handlers did decode first — but nothing made them, so the two that did not (`skillsList`, `marketplaceAgentsList`) looked exactly like the ones that did, and only review told them apart.

This is the thing that allowed the drift #193 fixed. #193 unified the *validators*; this makes using one non-optional.

## The change

The decoder is now a positional argument, and there is no overload pairing a payload-taking handler with a raw `unknown`. A registration that does not say how its payload decodes is a compile error:

```ts
export function handleTrusted<Result>(channel: string, handler: () => Result): void;
export function handleTrusted<Payload, Result>(
  channel: string,
  decode: (value: unknown) => Payload,
  handler: (payload: Payload) => Result,
): void;
```

Assignability does the enforcement: a handler declaring `(input: unknown)` is not assignable to `() => Result`, so a two-argument call with a payload-taking handler fails to resolve rather than silently matching the zero-payload overload. Adding the overloads produced exactly 92 compile errors, one per unconverted site.

The decoder slot is a plain `(value: unknown) => Payload`, which today's `parseX`, zod's `parse` and `Schema.decodeUnknownSync(S)` all satisfy identically. This does not commit to a schema library; it makes adopting one a mechanical swap of decoder expressions.

**Decoding runs after the sender check**, inside the wrapper — an untrusted renderer is rejected before the process spends work parsing what it sent.

### Two commits

1. `refactor(ipc)` — the last four server-scoped channels (`serversUpdateMember`, `serversRemoveMember`, `serversRevokeInvite`, `serversCreateInvite`) move from positional `(serverId, payload)` to the `{ serverId, payload }` envelope every other server-scoped channel already uses. This is why the wrapper needs two overloads instead of three. The renderer-facing API keeps its signature, so no renderer file and no `mock-openbot.ts` change. **This is internal IPC shape, not the Team API wire protocol** — `packages/contracts/src/team-protocol` is untouched.
2. `feat(ipc)` — the overloads and the conversion of all 171 registrations.

### Two helpers carry the bulk

- `stringPayload(field, maxLength?)` curries the existing three-parameter `requireString` for the 23 channels whose whole payload is one identifier.
- `optionalPayload(decode)` keeps an absent payload `undefined` for the three that allow one.

## The 14 lines that are not mechanical

Everything else is a rename. These handlers gained a named decoder, and are where a reviewer should look:

| decoder | replaces |
| --- | --- |
| `parseEmailCodeVerification` | inline `isObject` + two `requireString` |
| `parseProfileName` | `requireString` **and** the `validateProfileName` message that was hand-rebuilt from `INPUT_LIMITS` at the call site — one rule, one place |
| `parseSubmitSkill`, `parseInstallSkill`, `parseUninstallSkill` | inline field validation |
| `parsePublishHostedSite`, `parseReplaceHostedSite`, `parseDeleteHostedSite` | inline field validation |
| `parseSubmitMarketplaceAgent`, `parseInstallMarketplaceAgent` | inline field validation |
| `parseRemoteDesktopConnect`, `parseRemoteDesktopDisplay` | inline field validation |
| `parseMarketplaceSkillQuery`, `parseMarketplaceAgentQuery` | the two handlers that inspected the raw `unknown` with no decoder at all |

The two marketplace queries were near-identical and now share `parseMarketplaceQueryFields`. **Behaviour is preserved exactly, including `query.slice(0, 100)`** — that is silent truncation, not validation, and turning it into a rejection would be a product change, not a refactor.

## Two judgement calls worth flagging

**The wrapper implementation uses a rest tuple union**, not a union of the second parameter:

```ts
type TrustedRegistration =
  | [handler: () => unknown]
  | [decode: PayloadDecoder<unknown>, handler: (payload: unknown) => unknown];
```

A plain union needs three `as` assertions to call either arm, which `noUnsafeTypeAssertion` flags — and asserting past the checker inside the trust boundary's own wrapper is the last place worth doing it. The tuple discriminates on `.length` with no assertion. No `biome-ignore`, no `@ts-expect-error`, no `any`, no widening at a boundary anywhere in this PR.

**The sender check stays inlined in both wrappers.** I first extracted an `assertTrustedSender` helper; that turned the `validates the sender of every channel it is handed inside the trusted module` scan in `ipc-channel-coverage.test.ts` red, because it reads each `ipcMain.handle` call's own body for `isTrustedRendererUrl`. Inlining restores the scan's teeth rather than loosening it to accept a helper name — a comment now says so, so the next person does not re-extract it.

## Surfaces touched

Desktop main process only. No renderer, no mobile, no public web, no palette token, no migration, no Team API protocol, no reverse state, no `PRIVACY.md` change. Preload changes in commit 1 only, and only the four envelope call sites.

`ipc-channel-coverage.test.ts` reads argument position 0, so inserting a decoder at position 1 leaves every set comparison intact — only its prose comment needed updating.

## Tests

Per AGENTS.md rule 7, at the lowest stable boundary once — the wrapper, not 171 call sites.

`src/main/trusted-ipc.test.ts` (rewritten, its old two-argument shape no longer compiles):

| assertion | broken by | goes red |
| --- | --- | --- |
| the handler receives the decoded value | passing the raw value through | that test + the throwing-decoder one |
| a throwing decoder means the handler never runs | swallowing the throw | that test alone |
| an untrusted sender is rejected **before** the decoder runs | moving decode above the check | that test alone |

`src/main/ipc/input-parsers.test.ts` — the marketplace truncation cap, which filters survive, the two marketplaces' distinct rejection messages, and the profile-name rule. Each goes red alone when its own rule is broken; verified by cutting the cap to 50, deleting the `limit` passthrough, sharing one sort error, and removing the profile-name throw.

**All seven watched fail, for the reason meant, against the final code** — including a re-run after the wrapper was rewritten to the tuple form.

## Verification

```
bun run typecheck:node                                            # clean
bunx biome check <the 9 touched files>                            # clean
bun run test:desktop -- src/main/trusted-ipc.test.ts \
  src/main/ipc/input-parsers.test.ts \
  src/main/ipc-channel-coverage.test.ts                           # 43 passed
```

Per AGENTS.md, no repo-wide checks were run — CI owns those.

## Follow-ups, deliberately not ridden along

- `limit` in both marketplace queries is `isNumber` with no bound.
- `computerUseStartHelperDrag` passes `event.sender` into `startDrag()` with no sender-identity check beyond the trusted-URL gate.

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)