### PR TITLE
Fix table layout in assistant messages

### DIFF
--- a/src/renderer/src/components/ConversationView.tsx
+++ b/src/renderer/src/components/ConversationView.tsx
@@ -131,9 +131,9 @@ const QuestionPromptBubble = lazy(() =>
 function conversationBubbleVariant(message: BotMessage): BubbleVariant {
   if (message.author === "you") return "secondary";
   if (message.imageGeneration || (!message.body.trim() && message.attachments?.length)) return "ghost";
-  return messageContentBlocks(message.body, message.streaming === true).some((block) => block.type !== "text")
-    ? "ghost"
-    : "muted";
+  const contentBlocks = messageContentBlocks(message.body, message.streaming === true);
+  if (contentBlocks.some((block) => block.type === "table" || block.type === "comparison-table")) return "muted";
+  return contentBlocks.some((block) => block.type !== "text") ? "ghost" : "muted";
 }
 
 interface RenderedAgentActivity {

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -4910,6 +4910,10 @@ button.chat-action-target:active,
   max-width: min(720px, calc(100% - var(--message-actions-inline-size) - 5px));
 }
 
+.message-entry-bot .message-shell:has(.message-data-table-scroll) {
+  align-items: flex-end;
+}
+
 .message-code-block {
   width: 100%;
   min-width: 0;
@@ -5148,26 +5152,15 @@ button.chat-action-target:active,
 }
 
 .message-data-table {
-  width: 100%;
+  width: max-content;
   min-width: max(100%, calc(var(--message-data-table-columns) * 112px));
-  display: flex;
-  flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--openbot-data-table-outer-border);
   border-radius: var(--openbot-radius-lg);
+  border-spacing: 0;
   background: var(--openbot-data-table-header-bg);
   box-shadow: 0 0 0 0.5px var(--openbot-data-table-ring);
   font-size: var(--openbot-text-md);
-}
-
-.message-data-table thead,
-.message-data-table thead tr,
-.message-data-table tbody tr {
-  display: flex;
-}
-
-.message-data-table thead tr {
-  width: 100%;
 }
 
 .message-data-table thead {
@@ -5176,23 +5169,15 @@ button.chat-action-target:active,
 }
 
 .message-data-table tbody {
-  display: flex;
-  flex-direction: column;
-  border-top: 1px solid var(--openbot-data-table-border);
   background: var(--openbot-data-table-body-bg);
 }
 
-.message-data-table tbody tr:not(:last-child) {
+.message-data-table tbody tr:not(:last-child) td {
   border-bottom: 1px solid var(--openbot-data-table-border);
 }
 
 .message-data-table th,
 .message-data-table td {
-  min-width: 0;
-  display: flex;
-  flex: 1 1 0;
-  align-items: center;
-  overflow: hidden;
   padding: 9px 12px;
   color: var(--openbot-data-table-text);
   font-weight: inherit;
@@ -5201,6 +5186,7 @@ button.chat-action-target:active,
 }
 
 .message-data-table thead th {
+  border-bottom: 1px solid var(--openbot-data-table-border);
   padding-top: 7px;
   padding-bottom: 7px;
   color: var(--openbot-data-table-header-text);
@@ -5212,19 +5198,14 @@ button.chat-action-target:active,
 }
 
 .message-data-table-cell-text {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .message-data-table [data-align="center"] {
-  justify-content: center;
   text-align: center;
 }
 
 .message-data-table [data-align="right"] {
-  justify-content: flex-end;
   text-align: right;
 }
 

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -4910,6 +4910,10 @@ button.chat-action-target:active,
   max-width: min(720px, calc(100% - var(--message-actions-inline-size) - 5px));
 }
 
+.message-entry-bot .ui-bubble:has(.message-data-table-scroll) > .ui-bubble-content {
+  width: 100%;
+}
+
 .message-entry-bot .message-shell:has(.message-data-table-scroll) {
   align-items: flex-end;
 }

--- a/src/renderer/stories/Conversation.stories.tsx
+++ b/src/renderer/stories/Conversation.stories.tsx
@@ -1157,6 +1157,7 @@ export const DataTableInChat: Story = {
     const bubble = table.closest<HTMLElement>(".ui-bubble");
     const actions = canvas.getByRole("toolbar", { name: "Agent message actions" });
     if (!bubble) throw new Error("The data table message bubble is missing.");
+    await expect(bubble).toHaveAttribute("data-variant", "muted");
     await expect(
       Math.abs(actions.getBoundingClientRect().bottom - bubble.getBoundingClientRect().bottom),
     ).toBeLessThanOrEqual(2);

--- a/src/renderer/stories/Conversation.stories.tsx
+++ b/src/renderer/stories/Conversation.stories.tsx
@@ -408,7 +408,7 @@ const dataTableMessages: RendererBotMessage[] = [
   {
     id: "data-table-user",
     author: "you",
-    body: "Compare the available models by context window and input price.",
+    body: "Compare the upcoming Premier League fixtures.",
     time: "10:02",
     kind: "text",
   },
@@ -416,13 +416,15 @@ const dataTableMessages: RendererBotMessage[] = [
     id: "data-table-agent",
     author: "bot",
     body: [
-      "Here’s a compact comparison:",
+      "Here’s a compact comparison based on the current market:",
       "",
-      "| Model | Context | $/1M in |",
-      "| --- | --- | ---: |",
-      "| gpt-4o | 128k | $5.00 |",
-      "| claude-3.5 | 200k | $3.00 |",
-      "| llama-3.1 | 128k | $0.90 |",
+      "| Fixture | Market odds H/D/A | Implied H/D/A | Scenario | Pick |",
+      "| --- | ---: | ---: | ---: | --- |",
+      "| Ipswich–Liverpool | 5.25 / 4.60 / 1.57 | 18% / 21% / 61% | 20% / 22% / 58% | Liverpool win |",
+      "| Newcastle–Bournemouth | 2.20 / 3.70 / 3.00 | 43% / 26% / 32% | 45% / 27% / 28% | Newcastle, cautiously |",
+      "| Brighton–Leeds | 1.90 / 3.60 / 4.00 | 50% / 26% / 24% | 48% / 27% / 25% | Brighton win |",
+      "",
+      "Long values should remain readable by scrolling the table, and the message actions should stay aligned with the bottom of the response.",
     ].join("\n"),
     time: "10:03",
     kind: "text",
@@ -1148,9 +1150,16 @@ export const DataTableInChat: Story = {
     messages: dataTableMessages,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Compare the available models by context window and input price.")).toBeVisible();
-    await expect(canvas.getByRole("table")).toBeVisible();
-    await expect(canvas.getAllByRole("columnheader")).toHaveLength(3);
+    await expect(canvas.getByText("Compare the upcoming Premier League fixtures.")).toBeVisible();
+    const table = canvas.getByRole("table");
+    await expect(table).toBeVisible();
+    await expect(canvas.getAllByRole("columnheader")).toHaveLength(5);
+    const bubble = table.closest<HTMLElement>(".ui-bubble");
+    const actions = canvas.getByRole("toolbar", { name: "Agent message actions" });
+    if (!bubble) throw new Error("The data table message bubble is missing.");
+    await expect(
+      Math.abs(actions.getBoundingClientRect().bottom - bubble.getBoundingClientRect().bottom),
+    ).toBeLessThanOrEqual(2);
   },
 };
 

--- a/src/renderer/stories/MessageBody.stories.tsx
+++ b/src/renderer/stories/MessageBody.stories.tsx
@@ -248,10 +248,10 @@ export const DataTableNarrow: Story = {
       ...message,
       id: "message-data-table-narrow",
       body: [
-        "| Model | Provider | Context | Input | Output | Released |",
-        "| --- | --- | ---: | ---: | ---: | --- |",
-        "| gpt-4o | OpenAI | 128k | $5.00 | $15.00 | May 2024 |",
-        "| claude-3.5 | Anthropic | 200k | $3.00 | $15.00 | June 2024 |",
+        "| Fixture | Market odds H/D/A | Implied H/D/A | Scenario | Pick |",
+        "| --- | ---: | ---: | ---: | --- |",
+        "| Ipswich–Liverpool | 5.25 / 4.60 / 1.57 | 18% / 21% / 61% | 20% / 22% / 58% | Liverpool win |",
+        "| Newcastle–Bournemouth | 2.20 / 3.70 / 3.00 | 43% / 26% / 32% | 45% / 27% / 28% | Newcastle, cautiously |",
       ].join("\n"),
       status: undefined,
       attachments: [],
@@ -261,6 +261,8 @@ export const DataTableNarrow: Story = {
   play: async ({ canvas }) => {
     const region = canvas.getByRole("region", { name: "Data table" });
     await expect(region.scrollWidth).toBeGreaterThan(region.clientWidth);
+    const longFixture = canvas.getByText("Newcastle–Bournemouth");
+    await expect(getComputedStyle(longFixture).textOverflow).toBe("clip");
   },
 };
 


### PR DESCRIPTION
## Summary

- Render complete table responses inside the normal muted assistant Bubble, including surrounding prose.
- Keep complete data-table values readable by sizing columns to their content inside the existing horizontal scroller.
- Bottom-align message actions for assistant responses containing data or comparison tables.
- Extend the existing narrow and in-chat Storybook scenarios with the reported long-table shape.

## Surface

Desktop renderer only. Mobile, public web, IPC contracts, persistence, and network behavior are unchanged.

## Testing

- `bunx biome check src/renderer/src/components/ConversationView.tsx src/renderer/src/styles/conversation.css src/renderer/stories/Conversation.stories.tsx src/renderer/stories/MessageBody.stories.tsx`
- `bun run typecheck:storybook`
- `bun run typecheck:renderer`
- `bun run test:desktop -- src/renderer/src/components/conversation/MessageRendering.test.tsx` (59 tests)
- `git diff --check`

The commit hook repo-wide `bun run typecheck` was not used as validation: its unrelated Auth API and site projects could not resolve `@cloudflare/workers-types` in the isolated worktree. Their targeted surfaces were not changed.

## Visual evidence

Before: the reported screenshots show long fixture and pick values permanently ellipsized, the action toolbar centered beside the table, and surrounding prose outside the assistant Bubble.

After: the regression is represented in the existing `MessageBody/DataTableNarrow` and `Conversation/DataTableInChat` Storybook stories and is available in the isolated Electron profile `OpenBot Dev 5271`. A fresh automated screenshot could not be captured because no in-app browser connection was available.

## Implementation

Model: Codex (GPT-5)
Harness: Electron development app, Storybook 10.5.10, focused Vitest, and TypeScript checks