### PR TITLE
Fix sidebar searchbox focus highlighting

### DIFF
--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -1765,6 +1765,7 @@ textarea {
   transition:
     border-color var(--openbot-duration-hover) ease,
     background-color var(--openbot-duration-hover) ease,
+    box-shadow var(--openbot-duration-hover) ease,
     opacity var(--openbot-duration-fast) ease,
     transform var(--openbot-duration-slow) cubic-bezier(0.32, 0.72, 0, 1);
 }
@@ -1772,6 +1773,7 @@ textarea {
 .search-field:focus-within {
   border-color: var(--openbot-text-dim);
   background: var(--openbot-bg-surface);
+  box-shadow: var(--openbot-focus-ring);
 }
 
 .search-field input {
@@ -1780,6 +1782,7 @@ textarea {
   border: 0;
   outline: 0;
   background: transparent;
+  box-shadow: none;
   color: var(--openbot-text-primary);
   font-size: var(--openbot-text-md);
   line-height: 18px;

--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -1773,6 +1773,9 @@ textarea {
 .search-field:focus-within {
   border-color: var(--openbot-text-dim);
   background: var(--openbot-bg-surface);
+}
+
+.search-field:has(input:focus-visible) {
   box-shadow: var(--openbot-focus-ring);
 }
 


### PR DESCRIPTION
Closes #162

## Summary

- move the sidebar search focus ring from the nested input to the full search wrapper
- transition the wrapper ring with the existing focused border and background
- preserve the searchbox dimensions and native label-wide click target

## Surfaces

- Desktop renderer only
- No mobile, public web, IPC, database, or palette changes

## Verification

- `bunx biome check src/renderer/src/styles/app-shell.css`
- `bun run typecheck:renderer`
- The commit hook also completed staged Biome checks and all repository typecheck projects
- Storybook served `Navigation/Sidebar/AgentLongLabels` successfully from the isolated worktree

## Visual comparison

**Before:** [issue reference screenshot](https://github.com/nightly-labs/openbot/blob/8fee2a71b19f88926b535d15f44da00d06551ecd/.github/issue-assets/7dfd46b62b3e/searchbox-focus-offset.png?raw=1)

**After:** Focus the **Search chats** field in `Navigation/Sidebar/AgentLongLabels`; the semantic focus ring now follows the outer wrapper while the inner input has no separate inset shadow. An after screenshot could not be captured because no in-app browser connection was available in this session.

Model: OpenAI Codex (GPT-5)
Harness: Storybook `Navigation/Sidebar/AgentLongLabels`, resizable 240–400 px sidebar container