### PR TITLE
refactor(renderer): extract mock sidebar layout helper with tests

### DIFF
--- a/src/renderer/src/preview/mock-openbot.ts
+++ b/src/renderer/src/preview/mock-openbot.ts
@@ -47,7 +47,6 @@ import type {
   SetAgentAvatarInput,
   SetMessageReactionInput,
   SetTeamTypingInput,
-  SidebarLayoutAction,
   SidebarLayoutSnapshot,
   SteerQueuedMessageInput,
   TeamInviteSummary,
@@ -85,6 +84,7 @@ import {
   STORY_UPDATE_STATUS,
   STORY_USAGE,
 } from "./fixtures";
+import { applySidebarLayoutAction } from "./mock-sidebar-layout";
 
 type Listener<T> = (value: T) => void;
 
@@ -1395,65 +1395,4 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
       void appInfo;
     },
   };
-}
-
-function applySidebarLayoutAction(layout: SidebarLayoutSnapshot, action: SidebarLayoutAction): SidebarLayoutSnapshot {
-  const revision = layout.revision + 1;
-  if (action.type === "create") {
-    const id = crypto.randomUUID();
-    return {
-      ...layout,
-      revision,
-      sections: [...layout.sections, { id, name: action.name.trim() }],
-      order: [...layout.order, id],
-      agentAssignments: action.agentId
-        ? { ...layout.agentAssignments, [action.agentId]: id }
-        : { ...layout.agentAssignments },
-      agentOrder: [...layout.agentOrder],
-    };
-  }
-  if (action.type === "rename") {
-    return {
-      ...layout,
-      revision,
-      sections: layout.sections.map((section) =>
-        section.id === action.sectionId ? { ...section, name: action.name.trim() } : section,
-      ),
-    };
-  }
-  if (action.type === "delete") {
-    return {
-      ...layout,
-      revision,
-      sections: layout.sections.filter((section) => section.id !== action.sectionId),
-      order: layout.order.filter((sectionId) => sectionId !== action.sectionId),
-      agentAssignments: Object.fromEntries(
-        Object.entries(layout.agentAssignments).filter(([, sectionId]) => sectionId !== action.sectionId),
-      ),
-      agentOrder: [...layout.agentOrder],
-    };
-  }
-  if (action.type === "move") {
-    const order = [...layout.order];
-    const index = order.indexOf(action.sectionId);
-    const target = index + (action.direction === "up" ? -1 : 1) * (action.steps ?? 1);
-    if (index >= 0 && target >= 0 && target < order.length) {
-      const [movedSectionId] = order.splice(index, 1);
-      if (movedSectionId) order.splice(target, 0, movedSectionId);
-    }
-    return { ...layout, revision, order };
-  }
-  if (action.type === "move-agent") {
-    const agentOrder = layout.agentOrder.filter((agentId) => agentId !== action.agentId);
-    const insertionIndex = action.beforeAgentId === null ? agentOrder.length : agentOrder.indexOf(action.beforeAgentId);
-    agentOrder.splice(insertionIndex < 0 ? agentOrder.length : insertionIndex, 0, action.agentId);
-    const agentAssignments = { ...layout.agentAssignments };
-    if (action.sectionId === null) delete agentAssignments[action.agentId];
-    else agentAssignments[action.agentId] = action.sectionId;
-    return { ...layout, revision, agentAssignments, agentOrder };
-  }
-  const agentAssignments = { ...layout.agentAssignments };
-  if (action.sectionId === null) delete agentAssignments[action.agentId];
-  else agentAssignments[action.agentId] = action.sectionId;
-  return { ...layout, revision, agentAssignments };
 }

--- a/src/renderer/src/preview/mock-sidebar-layout.test.ts
+++ b/src/renderer/src/preview/mock-sidebar-layout.test.ts
@@ -1,0 +1,65 @@
+import type { SidebarLayoutSnapshot } from "@openbot/contracts/ipc";
+import { describe, expect, it } from "vitest";
+import { applySidebarLayoutAction } from "./mock-sidebar-layout";
+
+const layout: SidebarLayoutSnapshot = {
+  revision: 3,
+  sections: [
+    { id: "s1", name: "First" },
+    { id: "s2", name: "Second" },
+  ],
+  order: ["s1", "s2"],
+  agentAssignments: { "bot-1": "s1" },
+  agentOrder: ["bot-1"],
+};
+
+describe("mock sidebar layout", () => {
+  it("bumps the revision on every action without mutating the input", () => {
+    const next = applySidebarLayoutAction(layout, { type: "rename", sectionId: "s1", name: "Renamed" });
+    expect(next.revision).toBe(4);
+    expect(next.sections[0]?.name).toBe("Renamed");
+    expect(layout.revision).toBe(3);
+    expect(layout.sections[0]?.name).toBe("First");
+  });
+
+  it("creates sections and optionally assigns the new agent", () => {
+    const next = applySidebarLayoutAction(layout, { type: "create", name: "  Third  ", agentId: "bot-2" });
+    expect(next.sections).toHaveLength(3);
+    const created = next.sections[2];
+    expect(created?.name).toBe("Third");
+    expect(next.order).toEqual(["s1", "s2", created?.id]);
+    expect(next.agentAssignments["bot-2"]).toBe(created?.id);
+  });
+
+  it("deletes sections and drops their assignments", () => {
+    const next = applySidebarLayoutAction(layout, { type: "delete", sectionId: "s1" });
+    expect(next.sections.map((section) => section.id)).toEqual(["s2"]);
+    expect(next.order).toEqual(["s2"]);
+    expect(next.agentAssignments).toEqual({});
+  });
+
+  it("moves sections within bounds and ignores out-of-range moves", () => {
+    const moved = applySidebarLayoutAction(layout, { type: "move", sectionId: "s1", direction: "down" });
+    expect(moved.order).toEqual(["s2", "s1"]);
+    const stayed = applySidebarLayoutAction(layout, { type: "move", sectionId: "s1", direction: "up" });
+    expect(stayed.order).toEqual(["s1", "s2"]);
+  });
+
+  it("orders agents and assigns or unassigns sections", () => {
+    const ordered = applySidebarLayoutAction(layout, {
+      type: "move-agent",
+      agentId: "bot-2",
+      sectionId: "s2",
+      beforeAgentId: "bot-1",
+    });
+    expect(ordered.agentOrder).toEqual(["bot-2", "bot-1"]);
+    expect(ordered.agentAssignments["bot-2"]).toBe("s2");
+    const unassigned = applySidebarLayoutAction(ordered, {
+      type: "assign",
+      agentId: "bot-1",
+      sectionId: null,
+    });
+    expect(unassigned.agentAssignments["bot-1"]).toBeUndefined();
+    expect(unassigned.agentOrder).toContain("bot-1");
+  });
+});

--- a/src/renderer/src/preview/mock-sidebar-layout.ts
+++ b/src/renderer/src/preview/mock-sidebar-layout.ts
@@ -1,0 +1,65 @@
+import type { SidebarLayoutAction, SidebarLayoutSnapshot } from "@openbot/contracts/ipc";
+
+export function applySidebarLayoutAction(
+  layout: SidebarLayoutSnapshot,
+  action: SidebarLayoutAction,
+): SidebarLayoutSnapshot {
+  const revision = layout.revision + 1;
+  if (action.type === "create") {
+    const id = crypto.randomUUID();
+    return {
+      ...layout,
+      revision,
+      sections: [...layout.sections, { id, name: action.name.trim() }],
+      order: [...layout.order, id],
+      agentAssignments: action.agentId
+        ? { ...layout.agentAssignments, [action.agentId]: id }
+        : { ...layout.agentAssignments },
+      agentOrder: [...layout.agentOrder],
+    };
+  }
+  if (action.type === "rename") {
+    return {
+      ...layout,
+      revision,
+      sections: layout.sections.map((section) =>
+        section.id === action.sectionId ? { ...section, name: action.name.trim() } : section,
+      ),
+    };
+  }
+  if (action.type === "delete") {
+    return {
+      ...layout,
+      revision,
+      sections: layout.sections.filter((section) => section.id !== action.sectionId),
+      order: layout.order.filter((sectionId) => sectionId !== action.sectionId),
+      agentAssignments: Object.fromEntries(
+        Object.entries(layout.agentAssignments).filter(([, sectionId]) => sectionId !== action.sectionId),
+      ),
+      agentOrder: [...layout.agentOrder],
+    };
+  }
+  if (action.type === "move") {
+    const order = [...layout.order];
+    const index = order.indexOf(action.sectionId);
+    const target = index + (action.direction === "up" ? -1 : 1) * (action.steps ?? 1);
+    if (index >= 0 && target >= 0 && target < order.length) {
+      const [movedSectionId] = order.splice(index, 1);
+      if (movedSectionId) order.splice(target, 0, movedSectionId);
+    }
+    return { ...layout, revision, order };
+  }
+  if (action.type === "move-agent") {
+    const agentOrder = layout.agentOrder.filter((agentId) => agentId !== action.agentId);
+    const insertionIndex = action.beforeAgentId === null ? agentOrder.length : agentOrder.indexOf(action.beforeAgentId);
+    agentOrder.splice(insertionIndex < 0 ? agentOrder.length : insertionIndex, 0, action.agentId);
+    const agentAssignments = { ...layout.agentAssignments };
+    if (action.sectionId === null) delete agentAssignments[action.agentId];
+    else agentAssignments[action.agentId] = action.sectionId;
+    return { ...layout, revision, agentAssignments, agentOrder };
+  }
+  const agentAssignments = { ...layout.agentAssignments };
+  if (action.sectionId === null) delete agentAssignments[action.agentId];
+  else agentAssignments[action.agentId] = action.sectionId;
+  return { ...layout, revision, agentAssignments };
+}


### PR DESCRIPTION
Stacked on #204. Smallest slice of the mock split.

- Pure applySidebarLayoutAction moves from mock-openbot.ts to preview/mock-sidebar-layout.ts.
- New mock-sidebar-layout.test.ts: 5 tests (revision bump, input immutability, create/rename/delete/move/agent ordering). Fail-watched (revision +2, went red, restored).
- The mock closure stays whole deliberately: its completeness is already enforced by the OpenBotDesktopApi type, it is stories/test-harness-only fake code, and threading 40 closure vars through builders risks more than it saves.

Verification: preview suite green (14 tests), biome clean, typecheck:renderer clean. No biome-ignore, ts-expect-error, or any-widening added.