### PR TITLE
Isolate the local server per OpenBot account

### DIFF
--- a/scripts/seed-dev-state.test.ts
+++ b/scripts/seed-dev-state.test.ts
@@ -152,7 +152,10 @@ describe("development state seed", () => {
       );
     }
 
-    const team = new TeamStore(join(profilePath, "openbot-team-server-v1.json"));
+    const team = new TeamStore(
+      join(profilePath, "openbot-team-server-v2.json"),
+      join(profilePath, "openbot-team-server-v1.json"),
+    );
     await team.initialize();
     const members = team.listMembers();
     const owner = members.find((member) => member.role === "owner");

--- a/scripts/seed-dev-state.ts
+++ b/scripts/seed-dev-state.ts
@@ -19,7 +19,9 @@ import { resolveDevelopmentAppDataRoot } from "./development-state-paths";
 
 export const DEVELOPMENT_SEED_MANIFEST_FILE = "openbot-dev-seed-v1.json";
 
-const TEAM_FILE = "openbot-team-server-v1.json";
+const TEAM_FILE = "openbot-team-server-v2.json";
+/** Read only, exactly as the app reads it: the file a build without accounts owns. */
+const LEGACY_TEAM_FILE = "openbot-team-server-v1.json";
 const SETUP_FILE = "openbot-setup-v2.json";
 const SEED_VERSION = 1;
 const SEEDED_AT = "2026-08-21T10:00:00.000Z";
@@ -602,7 +604,7 @@ async function seedAgentExchanges(mailbox: MailboxStore): Promise<void> {
 }
 
 async function seedTeam(profilePath: string, botStore: BotStore): Promise<void> {
-  const team = new TeamStore(join(profilePath, TEAM_FILE));
+  const team = new TeamStore(join(profilePath, TEAM_FILE), join(profilePath, LEGACY_TEAM_FILE));
   await team.initialize();
   const owner = {
     id: "openbot-dev-owner",

--- a/scripts/seed-dev-state.ts
+++ b/scripts/seed-dev-state.ts
@@ -610,7 +610,7 @@ async function seedTeam(profilePath: string, botStore: BotStore): Promise<void> 
     name: "Dev Owner",
     avatarUrl: null,
   };
-  await team.configureWithAccount("OpenBot Dev Team", owner);
+  const teamIdentity = await team.configureWithAccount("OpenBot Dev Team", owner);
   const joined = [];
   for (const member of [
     { id: "openbot-dev-alice", email: "alice@example.com", name: "Alice Chen", role: "admin" as const },
@@ -629,7 +629,7 @@ async function seedTeam(profilePath: string, botStore: BotStore): Promise<void> 
   }
   await team.createInvite("member", "new-person@example.com");
   const ownerSession = await team.loginWithAccount(owner);
-  await team.setEnabledOnLaunch(true);
+  await team.setEnabledOnLaunch(teamIdentity.serverId, true);
 
   const [alice, jon, maya] = joined;
   if (!alice || !jon || !maya) throw new Error("The development team members could not be created.");

--- a/src/main/central-auth-manager.test.ts
+++ b/src/main/central-auth-manager.test.ts
@@ -761,6 +761,58 @@ describe("CentralAuthManager", () => {
     expect(Buffer.from(stored, "base64").toString()).not.toContain("machine-token-for-the-first-account");
   });
 
+  it("does not keep one account's host credential beside the next account's session", async () => {
+    const root = await createRoot();
+    const storagePath = join(root, "session.bin");
+    let verifications = 0;
+    const manager = new CentralAuthManager({
+      apiUrl: "https://api.openbot.run",
+      storagePath,
+      encrypt: (value) => Buffer.from(value),
+      decrypt: (value) => value.toString(),
+      fetch: vi.fn(async (input: string | URL | Request) => {
+        const url = new URL(input.toString());
+        if (url.pathname.endsWith("/start")) {
+          return Response.json({ challengeId: "challenge-1", expiresAt: 10_000 });
+        }
+        if (url.pathname.endsWith("/verify")) {
+          verifications += 1;
+          return Response.json({
+            sessionToken: verifications === 1 ? "session-one" : "session-two",
+            user: {
+              id: `user-${verifications}`,
+              email: `person${verifications}@example.com`,
+              name: null,
+              avatarUrl: null,
+            },
+          });
+        }
+        return Response.json({
+          hostId: "8f1c1f2e-1d9a-4a1a-9d1e-2f7c6b5a4d3c",
+          name: "Studio Mac",
+          membershipId: "member-1",
+          authEpoch: 1,
+          machineToken: "machine-token-for-the-first-account-0001",
+        });
+      }),
+    });
+    await manager.requestEmailCode("person1@example.com");
+    await manager.verifyEmailCode("challenge-1", "ABCD-EFGH");
+    await manager.registerRemoteHost({
+      hostId: "8f1c1f2e-1d9a-4a1a-9d1e-2f7c6b5a4d3c",
+      name: "Studio Mac",
+      ownerMembershipId: "member-1",
+    });
+
+    // Signing in as somebody else without signing out first.
+    await manager.requestEmailCode("person2@example.com");
+    await manager.verifyEmailCode("challenge-1", "ABCD-EFGH");
+
+    const stored = Buffer.from(await readFile(storagePath, "utf8"), "base64").toString();
+    expect(stored).toContain("session-two");
+    expect(stored).not.toContain("machine-token-for-the-first-account");
+  });
+
   it("updates the signed-in account name", async () => {
     const root = await createRoot();
     const requests: Request[] = [];

--- a/src/main/central-auth-manager.test.ts
+++ b/src/main/central-auth-manager.test.ts
@@ -695,6 +695,72 @@ describe("CentralAuthManager", () => {
     expect(requests.at(-1)?.method).toBe("DELETE");
   });
 
+  it("does not file a host credential under the account that signed in while it was issued", async () => {
+    const root = await createRoot();
+    const storagePath = join(root, "session.bin");
+    let releaseRegistration: () => void = () => undefined;
+    const registrationHeld = new Promise<void>((resolve) => {
+      releaseRegistration = resolve;
+    });
+    let registrationStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      registrationStarted = resolve;
+    });
+    let verifications = 0;
+    const manager = new CentralAuthManager({
+      apiUrl: "https://api.openbot.run",
+      storagePath,
+      encrypt: (value) => Buffer.from(value),
+      decrypt: (value) => value.toString(),
+      fetch: vi.fn(async (input: string | URL | Request) => {
+        const url = new URL(input.toString());
+        if (url.pathname.endsWith("/start")) {
+          return Response.json({ challengeId: "challenge-1", expiresAt: 10_000 });
+        }
+        if (url.pathname.endsWith("/verify")) {
+          verifications += 1;
+          return Response.json({
+            sessionToken: verifications === 1 ? "session-one" : "session-two",
+            user: {
+              id: `user-${verifications}`,
+              email: `person${verifications}@example.com`,
+              name: null,
+              avatarUrl: null,
+            },
+          });
+        }
+        registrationStarted();
+        await registrationHeld;
+        return Response.json({
+          hostId: "8f1c1f2e-1d9a-4a1a-9d1e-2f7c6b5a4d3c",
+          name: "Studio Mac",
+          membershipId: "member-1",
+          authEpoch: 1,
+          machineToken: "machine-token-for-the-first-account-0001",
+        });
+      }),
+    });
+    await manager.requestEmailCode("person1@example.com");
+    await manager.verifyEmailCode("challenge-1", "ABCD-EFGH");
+
+    const pending = manager.registerRemoteHost({
+      hostId: "8f1c1f2e-1d9a-4a1a-9d1e-2f7c6b5a4d3c",
+      name: "Studio Mac",
+      ownerMembershipId: "member-1",
+    });
+    // Attach the rejection handler before the switch, so settling it raises no unhandled error.
+    const settled = pending.catch(() => undefined);
+    await started;
+    await manager.requestEmailCode("person2@example.com");
+    await manager.verifyEmailCode("challenge-1", "ABCD-EFGH");
+    releaseRegistration();
+    await settled;
+
+    await expect(pending).rejects.toThrow("signed-in account changed");
+    const stored = await readFile(storagePath, "utf8");
+    expect(Buffer.from(stored, "base64").toString()).not.toContain("machine-token-for-the-first-account");
+  });
+
   it("updates the signed-in account name", async () => {
     const root = await createRoot();
     const requests: Request[] = [];

--- a/src/main/central-auth-manager.ts
+++ b/src/main/central-auth-manager.ts
@@ -139,6 +139,7 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
   #state: CentralAuthState = { status: "loading" };
   #sessionToken: string | null = null;
   readonly #teamHostTokens = new Map<string, string>();
+  #sessionWriteChain: Promise<void> = Promise.resolve();
   #remoteTicketJwks: Promise<z.infer<typeof remoteTicketJwksSchema>> | null = null;
   #initializationPromise: Promise<CentralAuthState> | null = null;
   #emailCodeRequest: EmailCodeRequest | null = null;
@@ -786,7 +787,17 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
     };
   }
 
-  async #writeStoredSession(): Promise<void> {
+  #writeStoredSession(): Promise<void> {
+    // Serialized: two writes racing inside their filesystem awaits would let the earlier
+    // one rename its snapshot over the later one, restoring a session the user has left.
+    this.#sessionWriteChain = this.#sessionWriteChain.then(
+      () => this.#writeStoredSessionNow(),
+      () => this.#writeStoredSessionNow(),
+    );
+    return this.#sessionWriteChain;
+  }
+
+  async #writeStoredSessionNow(): Promise<void> {
     if (!this.#sessionToken) return;
     if (!this.#options.canPersist()) {
       await rm(this.#options.storagePath, { force: true });
@@ -814,7 +825,13 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
   async #clearStoredSession(): Promise<void> {
     this.#sessionToken = null;
     this.#teamHostTokens.clear();
-    await rm(this.#options.storagePath, { force: true });
+    // Through the same chain as the writes, so a write already in flight cannot put the
+    // file back after it is removed.
+    this.#sessionWriteChain = this.#sessionWriteChain.then(
+      () => rm(this.#options.storagePath, { force: true }),
+      () => rm(this.#options.storagePath, { force: true }),
+    );
+    await this.#sessionWriteChain;
   }
 
   #restoreStoredSession(value: string): void {

--- a/src/main/central-auth-manager.ts
+++ b/src/main/central-auth-manager.ts
@@ -241,6 +241,7 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
     ownerMembershipId: string;
     devicePublicKey?: string | null;
   }): Promise<RegisteredRemoteHost> {
+    const sessionToken = this.#sessionToken;
     const storedMachineToken = this.#teamHostTokens.get(input.hostId.toLowerCase());
     const result = await this.#authorizedRequest(
       "/v2/remote/hosts/register",
@@ -255,6 +256,12 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
       },
       decodeRegisteredRemoteHost,
     );
+    if (this.#sessionToken !== sessionToken) {
+      // The credential belongs to the account that asked for it. Writing it now would file
+      // it under whichever session is stored next, so the caller is told the registration
+      // no longer applies instead.
+      throw new Error("The signed-in account changed while this server was being registered.");
+    }
     if (result.machineToken) this.#teamHostTokens.set(input.hostId.toLowerCase(), result.machineToken);
     await this.#writeStoredSession();
     return result;

--- a/src/main/central-auth-manager.ts
+++ b/src/main/central-auth-manager.ts
@@ -140,6 +140,8 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
   #sessionToken: string | null = null;
   readonly #teamHostTokens = new Map<string, string>();
   #sessionWriteChain: Promise<void> = Promise.resolve();
+  /** The account the stored host credentials were issued to, or none while signed out. */
+  #sessionAccountId: string | null = null;
   #remoteTicketJwks: Promise<z.infer<typeof remoteTicketJwksSchema>> | null = null;
   #initializationPromise: Promise<CentralAuthState> | null = null;
   #emailCodeRequest: EmailCodeRequest | null = null;
@@ -638,6 +640,11 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
         },
         decodeSessionResponse,
       );
+      // Signing in as somebody else without signing out first. The host credentials belong
+      // to the account that was issued them, and must not be filed under this session.
+      if (this.#sessionAccountId !== null && this.#sessionAccountId !== session.user.id) {
+        this.#teamHostTokens.clear();
+      }
       this.#sessionToken = session.sessionToken;
       await this.#writeStoredSession();
       return this.#setState({
@@ -824,6 +831,7 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
 
   async #clearStoredSession(): Promise<void> {
     this.#sessionToken = null;
+    this.#sessionAccountId = null;
     this.#teamHostTokens.clear();
     // Through the same chain as the writes, so a write already in flight cannot put the
     // file back after it is removed.
@@ -856,6 +864,9 @@ export class CentralAuthManager extends EventEmitter<CentralAuthEvents> {
   }
 
   #setState(state: CentralAuthState): CentralAuthState {
+    // Held apart from the state, which passes through `code_sent` on the way to another
+    // account: this is whose credentials the store is holding, until they are cleared.
+    if (state.status === "signed_in") this.#sessionAccountId = state.user.id;
     this.#state = state;
     const copy = this.getState();
     this.emit("changed", copy);

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -356,10 +356,14 @@ export class HostService extends EventEmitter<HostEvents> {
         message: "Registered this OpenBot for WebRTC access.",
       });
     } catch (error) {
-      this.#setStatus({
-        phase: "error",
-        message: error instanceof Error ? error.message : "Could not reserve the public address.",
-      });
+      // A failure that arrives after another account signed in belongs to the host that is
+      // gone, so it must not overwrite the status the new account is looking at.
+      if (this.#isActiveHost(identity.serverId)) {
+        this.#setStatus({
+          phase: "error",
+          message: error instanceof Error ? error.message : "Could not reserve the public address.",
+        });
+      }
     }
     return this.getStatus();
   }
@@ -392,6 +396,12 @@ export class HostService extends EventEmitter<HostEvents> {
    * for a host the account no longer has would register or upload on the wrong account's
    * behalf. The store's own guards stop the local half; this stops the network half.
    */
+  #assertStillActiveHost(serverId: string): void {
+    if (!this.#isActiveHost(serverId)) {
+      throw new Error("The signed-in account changed while this server was being updated.");
+    }
+  }
+
   #isActiveHost(serverId: string): boolean {
     return this.#options.store.getIdentity()?.serverId === serverId;
   }
@@ -665,6 +675,10 @@ export class HostService extends EventEmitter<HostEvents> {
         (member) => member.membershipId === input.memberId,
       );
       if (!current || current.role === "owner") throw new Error("The remote member does not exist.");
+      // The directory read is a round trip, and the account can change during it. Mutating
+      // the previous account's host with the new account's authorization is what this guard
+      // stops; the same check runs again before the result is written back.
+      this.#assertStillActiveHost(hostId);
       if (input.disabled) await this.#options.removeRemoteMember(hostId, input.memberId);
       else
         await this.#options.updateRemoteMember(
@@ -673,6 +687,7 @@ export class HostService extends EventEmitter<HostEvents> {
           input.role ?? current.role,
           input.disabled === false,
         );
+      this.#assertStillActiveHost(hostId);
       const members = await this.#options.listRemoteMembers(hostId);
       const updated = members.find((member) => member.membershipId === input.memberId);
       if (!updated) throw new Error("The remote member does not exist.");

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -281,20 +281,14 @@ export class HostService extends EventEmitter<HostEvents> {
     const previousServerId = this.#status.serverId;
     if (this.#boundAccountId !== undefined) {
       this.#runtimeGeneration += 1;
-      // Isolation cannot depend on the teardown succeeding: a WebRTC disconnect rejects
-      // on a command error or a timeout, and leaving the previous account's host bound is
-      // by far the worse failure. Report it and rebind anyway.
-      try {
-        // The same three steps as `stop`, and for the same reason: a start still in flight
-        // belongs to the previous account. The bumped generation makes it abort at its
-        // next checkpoint, and draining it here is what stops `start()` from handing the
-        // new account that superseded operation instead of starting its own host.
-        await this.#stopRuntime();
-        await this.#startOperation;
-        await this.#stopRuntime();
-      } catch (error) {
-        console.error("Unable to stop the host runtime while switching accounts:", error);
-      }
+      // The same three steps as `stop`, and for the same reason: a start still in flight
+      // belongs to the previous account. The bumped generation makes it abort at its next
+      // checkpoint, and draining it here is what stops `start()` from handing the new
+      // account that superseded operation instead of starting its own host. Each step is
+      // attempted on its own, so a gateway that will not come down cannot skip the drain.
+      await this.#attemptTeardown(() => this.#stopRuntime());
+      await this.#attemptTeardown(() => this.#startOperation);
+      await this.#attemptTeardown(() => this.#stopRuntime());
     }
     let activated = false;
     try {
@@ -876,6 +870,19 @@ export class HostService extends EventEmitter<HostEvents> {
 
   async shutdown(): Promise<void> {
     await this.stop(false);
+  }
+
+  /**
+   * Isolation cannot depend on a teardown step succeeding: a WebRTC disconnect rejects on a
+   * command error or a timeout, and leaving the previous account's host bound is by far the
+   * worse failure. Reported, and the steps after it still run.
+   */
+  async #attemptTeardown(step: () => PromiseLike<unknown> | null): Promise<void> {
+    try {
+      await step();
+    } catch (error) {
+      console.error("Unable to stop the host runtime while switching accounts:", error);
+    }
   }
 
   async #stopRuntime(): Promise<void> {

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -380,6 +380,9 @@ export class HostService extends EventEmitter<HostEvents> {
   async updateIdentity(input: UpdateHostIdentityInput): Promise<HostStatus> {
     this.#options.store.assertOwnerAccount(this.#options.getSignedInUser());
     const identity = await this.#options.store.updateIdentity(input);
+    // Before anything is published: the store checked the account before it resolved, and a
+    // switch landing in this gap would show the previous account's name and logo.
+    if (!this.#isActiveHost(identity.serverId)) return this.getStatus();
     this.#setStatus({
       serverName: identity.serverName,
       logoUrl: identity.logoVersion ? serverLogoUrl(identity.logoVersion) : null,
@@ -387,7 +390,6 @@ export class HostService extends EventEmitter<HostEvents> {
     });
     this.#api.refreshIdentity();
     const ownerMembershipId = this.#requiredOwnerMemberId();
-    if (!this.#isActiveHost(identity.serverId)) return this.getStatus();
     await this.#options.registerRemoteHost?.({
       hostId: identity.serverId,
       name: identity.serverName,
@@ -704,6 +706,9 @@ export class HostService extends EventEmitter<HostEvents> {
       const updated = members.find((member) => member.membershipId === input.memberId);
       if (!updated) throw new Error("The remote member does not exist.");
       await this.#options.store.syncRemoteDirectory(hostId, members);
+      // Recording the directory is a write too, so the switch can land inside it and the
+      // member below would be the previous account's.
+      this.#assertStillActiveHost(hostId);
       return {
         id: updated.membershipId,
         username: updated.email,

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -254,7 +254,14 @@ export class HostService extends EventEmitter<HostEvents> {
     const previousServerId = this.#status.serverId;
     if (this.#boundAccountId !== undefined) {
       this.#runtimeGeneration += 1;
-      await this.#stopRuntime();
+      // Isolation cannot depend on the teardown succeeding: a WebRTC disconnect rejects
+      // on a command error or a timeout, and leaving the previous account's host bound is
+      // by far the worse failure. Report it and rebind anyway.
+      try {
+        await this.#stopRuntime();
+      } catch (error) {
+        console.error("Unable to stop the host runtime while switching accounts:", error);
+      }
     }
     if (user) await this.#options.store.activateAccount(user);
     else await this.#options.store.deactivate();

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -46,7 +46,7 @@ import { appendRemoteDiagnosticLog } from "./remote-diagnostics";
 import { RemoteScreenGateway } from "./remote-screen-gateway";
 import type { SkillMarketplaceService } from "./skill-marketplace-service";
 import { TeamApiServer } from "./team-api-server";
-import type { AuthenticatedMember, RemoteDirectoryMember, TeamStore } from "./team-store";
+import type { AuthenticatedMember, RemoteDirectoryMember, TeamIdentity, TeamStore } from "./team-store";
 import type { TeamWebRtcBridge } from "./team-webrtc-bridge";
 import { TeamWebRtcHostGateway } from "./team-webrtc-host-gateway";
 
@@ -136,6 +136,8 @@ export class HostService extends EventEmitter<HostEvents> {
   #status: HostStatus;
   #runtimeGeneration = 0;
   #startOperation: Promise<HostStatus> | null = null;
+  /** `undefined` until the account service first reports, so the first report always binds. */
+  #boundAccountId: string | null | undefined = undefined;
   #legacyCredentialRemoved = false;
 
   constructor(options: HostServiceOptions) {
@@ -144,22 +146,7 @@ export class HostService extends EventEmitter<HostEvents> {
       ...options,
       allowLocalDevelopmentInvites: options.allowLocalDevelopmentInvites ?? false,
     };
-    const identity = options.store.getIdentity();
-    this.#status = {
-      phase: identity ? "idle" : "unconfigured",
-      configured: Boolean(identity),
-      enabledOnLaunch: identity?.enabledOnLaunch ?? false,
-      serverId: identity?.serverId ?? null,
-      serverName: identity?.serverName ?? null,
-      logoUrl: identity?.logoVersion ? serverLogoUrl(identity.logoVersion) : null,
-      apiUrl: null,
-      apiOnline: false,
-      remoteDesktopReady: false,
-      remoteDesktopUnattended: options.unattended ?? false,
-      remoteDesktopActiveSessions: 0,
-      remoteDesktopMaxSessions: 4,
-      message: null,
-    };
+    this.#status = initialHostStatus(options.store.getIdentity(), options.unattended ?? false);
     const logDirectory = options.logDirectory;
     this.#remoteScreen = new RemoteScreenGateway({
       platform: options.platform ?? normalizeRemoteDesktopPlatform(process.platform),
@@ -249,9 +236,47 @@ export class HostService extends EventEmitter<HostEvents> {
     };
   }
 
-  async syncSignedInAccount(user: CentralAuthUser): Promise<void> {
-    if (!this.#options.store.configured) return;
-    if (await this.#options.store.syncAccount(user)) this.#api.refreshPresence();
+  /**
+   * Binds the host to the signed-in account, or unbinds it on sign-out. The status is
+   * rebuilt from the newly active identity rather than patched, so a second account can
+   * never inherit the first one's server name, id or launch preference.
+   */
+  async applySignedInAccount(user: CentralAuthUser | null): Promise<void> {
+    const nextAccountId = user?.id ?? null;
+    if (this.#boundAccountId === nextAccountId) {
+      // The same account, reported again - a renamed profile or a new avatar. Rebinding
+      // here would stop a host that is happily online.
+      if (user && this.#options.store.configured && (await this.#options.store.syncAccount(user))) {
+        this.#api.refreshPresence();
+      }
+      return;
+    }
+    const previousServerId = this.#status.serverId;
+    if (this.#boundAccountId !== undefined) {
+      this.#runtimeGeneration += 1;
+      await this.#stopRuntime();
+    }
+    if (user) await this.#options.store.activateAccount(user);
+    else await this.#options.store.deactivate();
+    this.#boundAccountId = nextAccountId;
+    const identity = this.#options.store.getIdentity();
+    if (identity && identity.serverId === previousServerId) {
+      // The host this process started with, now confirmed as this account's. Keep the
+      // status the constructor already published rather than resetting a live runtime.
+      this.#setStatus({
+        configured: true,
+        serverName: identity.serverName,
+        logoUrl: identity.logoVersion ? serverLogoUrl(identity.logoVersion) : null,
+        enabledOnLaunch: identity.enabledOnLaunch,
+      });
+    } else {
+      this.#status = initialHostStatus(identity, this.#options.unattended ?? false);
+      this.emit("changed", this.getStatus());
+    }
+    if (identity) {
+      this.#api.refreshPresence();
+      this.#api.refreshIdentity();
+    }
   }
 
   async configure(input: ConfigureHostInput): Promise<HostStatus> {
@@ -333,7 +358,7 @@ export class HostService extends EventEmitter<HostEvents> {
     const generation = ++this.#runtimeGeneration;
     const signedInUser = this.#options.getSignedInUser();
     this.#options.store.assertOwnerAccount(signedInUser);
-    await this.syncSignedInAccount(signedInUser);
+    if (await this.#options.store.syncAccount(signedInUser)) this.#api.refreshPresence();
     this.#setStatus({ phase: "starting", message: "Starting the WebRTC host…" });
 
     try {
@@ -757,6 +782,24 @@ export class HostService extends EventEmitter<HostEvents> {
     if (!memberId) throw new Error("The host owner identity is unavailable.");
     return memberId;
   }
+}
+
+function initialHostStatus(identity: TeamIdentity | null, unattended: boolean): HostStatus {
+  return {
+    phase: identity ? "idle" : "unconfigured",
+    configured: Boolean(identity),
+    enabledOnLaunch: identity?.enabledOnLaunch ?? false,
+    serverId: identity?.serverId ?? null,
+    serverName: identity?.serverName ?? null,
+    logoUrl: identity?.logoVersion ? serverLogoUrl(identity.logoVersion) : null,
+    apiUrl: null,
+    apiOnline: false,
+    remoteDesktopReady: false,
+    remoteDesktopUnattended: unattended,
+    remoteDesktopActiveSessions: 0,
+    remoteDesktopMaxSessions: 4,
+    message: null,
+  };
 }
 
 export function serverLogoUrl(version: string): string {

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -335,6 +335,11 @@ export class HostService extends EventEmitter<HostEvents> {
     // write. Central authentication has the new account the moment it is announced, which
     // is what the renderer was told, so that is what this is checked against.
     if (this.#signedInAccountId() !== account.id) {
+      // The store bound the host as it created it, and refusing the call is not enough on
+      // its own: the members and identity behind it would still answer the new account.
+      this.#options.store.unbindActiveHost();
+      this.#status = initialHostStatus(null, this.#options.unattended ?? false);
+      this.emit("changed", this.getStatus());
       throw new Error("The signed-in account changed while this server was being created.");
     }
     // The store checked the account before it resolved; the switch can still land between

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -36,15 +36,11 @@ import type {
   UpdateTeamMemberInput,
 } from "@openbot/contracts/ipc";
 import type { AgentService } from "../backend/agent-service";
-import type { BrowserHost } from "../backend/browser-host";
-import type { MailboxStore } from "../backend/mailbox-store";
-import type { SidebarLayoutStore } from "../backend/sidebar-layout-store";
 import type { TeamChatStore } from "../backend/team-chat-store";
 import type { VerifiedRemoteSessionTicket } from "./central-auth-manager";
 import type { RemoteDesktopRuntimePaths } from "./remote-desktop-runtime-artifact";
 import { appendRemoteDiagnosticLog } from "./remote-diagnostics";
 import { RemoteScreenGateway } from "./remote-screen-gateway";
-import type { SkillMarketplaceService } from "./skill-marketplace-service";
 import { TeamApiServer } from "./team-api-server";
 import type { AuthenticatedMember, RemoteDirectoryMember, TeamIdentity, TeamStore } from "./team-store";
 import type { TeamWebRtcBridge } from "./team-webrtc-bridge";
@@ -59,14 +55,22 @@ interface HostEvents {
   directTyping: [event: DirectTypingRealtimeEvent];
 }
 
+/**
+ * The collaborators this service only forwards to the Team API, typed by the narrow
+ * shapes that server already declares rather than by the concrete stores. Nothing here
+ * changes at the call site - `index.ts` still passes the real services - but it lets an
+ * account switch be tested without standing up a database and a browser host.
+ */
+type ForwardedApiOptions = ConstructorParameters<typeof TeamApiServer>[0];
+
 interface HostServiceOptions {
   appVersion: string;
   store: TeamStore;
-  agents: AgentService;
-  skills: SkillMarketplaceService;
-  sidebarLayout: SidebarLayoutStore;
-  mailbox: MailboxStore;
-  browser: BrowserHost;
+  agents: ForwardedApiOptions["agents"] & Pick<AgentService, "adoptConversationReads">;
+  skills: NonNullable<ForwardedApiOptions["skills"]>;
+  sidebarLayout: NonNullable<ForwardedApiOptions["sidebarLayout"]>;
+  mailbox: ForwardedApiOptions["mailbox"];
+  browser: ForwardedApiOptions["browser"];
   chat?: TeamChatStore;
   allowLocalDevelopmentInvites?: boolean;
   logDirectory?: string;
@@ -258,6 +262,12 @@ export class HostService extends EventEmitter<HostEvents> {
       // on a command error or a timeout, and leaving the previous account's host bound is
       // by far the worse failure. Report it and rebind anyway.
       try {
+        // The same three steps as `stop`, and for the same reason: a start still in flight
+        // belongs to the previous account. The bumped generation makes it abort at its
+        // next checkpoint, and draining it here is what stops `start()` from handing the
+        // new account that superseded operation instead of starting its own host.
+        await this.#stopRuntime();
+        await this.#startOperation;
         await this.#stopRuntime();
       } catch (error) {
         console.error("Unable to stop the host runtime while switching accounts:", error);
@@ -404,8 +414,8 @@ export class HostService extends EventEmitter<HostEvents> {
         apiOnline: true,
         message: "This OpenBot is ready for WebRTC connections.",
       });
-      await this.#options.store.setEnabledOnLaunch(true);
       if (await this.#cancelSupersededStart(generation)) return this.getStatus();
+      await this.#options.store.setEnabledOnLaunch(identity.serverId, true);
       this.#setStatus({ phase: "online", enabledOnLaunch: true });
     } catch (error) {
       if (generation !== this.#runtimeGeneration) {
@@ -476,7 +486,10 @@ export class HostService extends EventEmitter<HostEvents> {
     await this.#stopRuntime();
     await this.#startOperation;
     await this.#stopRuntime();
-    if (persistPreference) await this.#options.store.setEnabledOnLaunch(false);
+    // The awaits above can outlive this host: an account switch in between must not write
+    // the preference onto the account that just became active.
+    const serverId = this.#options.store.getIdentity()?.serverId;
+    if (persistPreference && serverId) await this.#options.store.setEnabledOnLaunch(serverId, false);
     this.#setStatus({
       phase: "idle",
       enabledOnLaunch: persistPreference ? false : this.#status.enabledOnLaunch,
@@ -491,6 +504,10 @@ export class HostService extends EventEmitter<HostEvents> {
     const hostId = this.#options.store.getIdentity()?.serverId;
     if (hostId && this.#options.listRemoteMembers) {
       return this.#options.listRemoteMembers(hostId).then(async (members) => {
+        // An account switch while the directory loaded makes this list the previous
+        // account's. Answer with the now-active host's own members rather than failing a
+        // read with the store's cross-account guard.
+        if (this.#options.store.getIdentity()?.serverId !== hostId) return this.#options.store.listMembers();
         await this.#options.store.syncRemoteDirectory(hostId, members);
         return members.map((member) => ({
           id: member.membershipId,

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -288,14 +288,20 @@ export class HostService extends EventEmitter<HostEvents> {
         console.error("Unable to stop the host runtime while switching accounts:", error);
       }
     }
+    let activated = false;
     try {
       if (user) await this.#options.store.activateAccount(user);
       else await this.#options.store.deactivate();
+      activated = true;
     } finally {
       // Publish even when activation failed. The previous account is gone either way, and a
       // status still naming its host would offer the rail a server this process can no
       // longer answer for - the store has already unbound it.
-      this.#boundAccountId = nextAccountId;
+      //
+      // A failure leaves the binding unknown rather than recorded, so the next report of the
+      // same account runs activation again instead of short-circuiting into an unconfigured
+      // store the user cannot get out of without restarting.
+      this.#boundAccountId = activated ? nextAccountId : undefined;
       this.#publishActiveHost(previousServerId);
     }
   }
@@ -781,10 +787,15 @@ export class HostService extends EventEmitter<HostEvents> {
             role: input.role,
           });
         } catch (error) {
-          await this.#options.revokeRemoteInvite?.(invite.inviteId);
+          // Revoking spends authorization on a host, so it only happens while that host is
+          // still this account's. Otherwise the invitation stays for the account that owns it.
+          if (this.#isActiveHost(identity.serverId)) await this.#options.revokeRemoteInvite?.(invite.inviteId);
           throw error;
         }
       }
+      // Sending is a round trip of its own, and the link must not come back to a renderer
+      // that has meanwhile been told about another account.
+      this.#assertStillActiveHost(identity.serverId);
       return result;
     }
     if (!this.#status.apiUrl) throw new Error("Make this OpenBot public before creating an invite.");

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -480,15 +480,17 @@ export class HostService extends EventEmitter<HostEvents> {
 
   async stop(persistPreference = true): Promise<HostStatus> {
     if (this.#status.phase === "unconfigured") return this.getStatus();
+    const serverId = this.#options.store.getIdentity()?.serverId;
     this.#runtimeGeneration += 1;
     if (persistPreference) this.#options.store.assertOwnerAccount(this.#options.getSignedInUser());
     this.#setStatus({ phase: "stopping", message: "Making this OpenBot private…" });
     await this.#stopRuntime();
     await this.#startOperation;
     await this.#stopRuntime();
-    // The awaits above can outlive this host: an account switch in between must not write
-    // the preference onto the account that just became active.
-    const serverId = this.#options.store.getIdentity()?.serverId;
+    // The awaits above can outlive this host. An account switch in between makes both the
+    // preference and the status below the previous account's, and the account that just
+    // became active already has its own status from `applySignedInAccount`.
+    if (this.#options.store.getIdentity()?.serverId !== serverId) return this.getStatus();
     if (persistPreference && serverId) await this.#options.store.setEnabledOnLaunch(serverId, false);
     this.#setStatus({
       phase: "idle",

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -262,7 +262,11 @@ export class HostService extends EventEmitter<HostEvents> {
 
   async applySignedInAccount(user: CentralAuthUser | null): Promise<void> {
     const nextAccountId = user?.id ?? null;
-    if (this.#boundAccountId === nextAccountId) {
+    // `unbindChangedAccount` may have cleared the store since this account was bound, to
+    // stop it answering for an account that was on its way out. Reporting the same account
+    // again then has to activate it, not take it for the host that is already running.
+    const stillBound = this.#options.store.configured || nextAccountId === null;
+    if (this.#boundAccountId === nextAccountId && stillBound) {
       // The same account, reported again - a renamed profile or a new avatar. Rebinding
       // here would stop a host that is happily online.
       if (user && this.#options.store.configured && (await this.#options.store.syncAccount(user))) {

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -377,7 +377,10 @@ export class HostService extends EventEmitter<HostEvents> {
       });
       if (await this.#cancelSupersededStart(generation)) return this.getStatus();
       if (this.#options.listRemoteMembers) {
-        await this.#options.store.syncRemoteDirectory(await this.#options.listRemoteMembers(identity.serverId));
+        await this.#options.store.syncRemoteDirectory(
+          identity.serverId,
+          await this.#options.listRemoteMembers(identity.serverId),
+        );
         if (await this.#cancelSupersededStart(generation)) return this.getStatus();
       }
       const bootstrap = await this.#options.issueRemoteHostTicket(identity.serverId);
@@ -481,7 +484,7 @@ export class HostService extends EventEmitter<HostEvents> {
     const hostId = this.#options.store.getIdentity()?.serverId;
     if (hostId && this.#options.listRemoteMembers) {
       return this.#options.listRemoteMembers(hostId).then(async (members) => {
-        await this.#options.store.syncRemoteDirectory(members);
+        await this.#options.store.syncRemoteDirectory(hostId, members);
         return members.map((member) => ({
           id: member.membershipId,
           username: member.email,
@@ -604,7 +607,7 @@ export class HostService extends EventEmitter<HostEvents> {
       const members = await this.#options.listRemoteMembers(hostId);
       const updated = members.find((member) => member.membershipId === input.memberId);
       if (!updated) throw new Error("The remote member does not exist.");
-      await this.#options.store.syncRemoteDirectory(members);
+      await this.#options.store.syncRemoteDirectory(hostId, members);
       return {
         id: updated.membershipId,
         username: updated.email,
@@ -630,7 +633,7 @@ export class HostService extends EventEmitter<HostEvents> {
     if (hostId && this.#options.removeRemoteMember) {
       await this.#options.removeRemoteMember(hostId, memberId);
       if (this.#options.listRemoteMembers) {
-        await this.#options.store.syncRemoteDirectory(await this.#options.listRemoteMembers(hostId));
+        await this.#options.store.syncRemoteDirectory(hostId, await this.#options.listRemoteMembers(hostId));
       }
       return;
     }

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -328,11 +328,15 @@ export class HostService extends EventEmitter<HostEvents> {
   }
 
   async configure(input: ConfigureHostInput): Promise<HostStatus> {
-    const identity = await this.#options.store.configureWithAccount(
-      input.serverName,
-      this.#options.getSignedInUser(),
-      input.logo,
-    );
+    const account = this.#options.getSignedInUser();
+    const identity = await this.#options.store.configureWithAccount(input.serverName, account, input.logo);
+    // Nothing is bound while the first host is being written, so neither the store's
+    // `activeAccountId` nor `unbindChangedAccount` can see a switch announced during the
+    // write. Central authentication has the new account the moment it is announced, which
+    // is what the renderer was told, so that is what this is checked against.
+    if (this.#signedInAccountId() !== account.id) {
+      throw new Error("The signed-in account changed while this server was being created.");
+    }
     // The store checked the account before it resolved; the switch can still land between
     // there and here, and publishing then would show A's server to B.
     if (!this.#isActiveHost(identity.serverId)) return this.getStatus();
@@ -407,6 +411,15 @@ export class HostService extends EventEmitter<HostEvents> {
    * for a host the account no longer has would register or upload on the wrong account's
    * behalf. The store's own guards stop the local half; this stops the network half.
    */
+  /** The account central authentication has announced, or none while signed out. */
+  #signedInAccountId(): string | null {
+    try {
+      return this.#options.getSignedInUser().id;
+    } catch {
+      return null;
+    }
+  }
+
   #assertStillActiveHost(serverId: string): void {
     if (!this.#isActiveHost(serverId)) {
       throw new Error("The signed-in account changed while this server was being updated.");

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -762,8 +762,14 @@ export class HostService extends EventEmitter<HostEvents> {
   }
 
   async #stopRuntime(): Promise<void> {
-    await this.#webrtcGateway?.stop();
-    await this.#api.stop();
+    try {
+      await this.#webrtcGateway?.stop();
+    } finally {
+      // A failed gateway teardown must not leave the local API listening: the callers that
+      // swallow that failure go on to rebind the store, and a server still up would serve
+      // the previous account's authenticated requests against the new account's data.
+      await this.#api.stop();
+    }
   }
 
   async #cancelSupersededStart(generation: number): Promise<boolean> {

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -245,6 +245,21 @@ export class HostService extends EventEmitter<HostEvents> {
    * rebuilt from the newly active identity rather than patched, so a second account can
    * never inherit the first one's server name, id or launch preference.
    */
+  /**
+   * The synchronous half of an account change, for callers that announce the new account
+   * before `applySignedInAccount` can finish: it stops this host answering for the previous
+   * one right away. A process that has not applied an account yet is left alone - that is
+   * startup reporting the account the file was already loaded for.
+   */
+  unbindChangedAccount(user: CentralAuthUser | null): void {
+    const nextAccountId = user?.id ?? null;
+    if (this.#boundAccountId === undefined || this.#boundAccountId === nextAccountId) return;
+    if (!this.#options.store.configured) return;
+    this.#options.store.unbindActiveHost();
+    this.#status = initialHostStatus(null, this.#options.unattended ?? false);
+    this.emit("changed", this.getStatus());
+  }
+
   async applySignedInAccount(user: CentralAuthUser | null): Promise<void> {
     const nextAccountId = user?.id ?? null;
     if (this.#boundAccountId === nextAccountId) {
@@ -273,9 +288,19 @@ export class HostService extends EventEmitter<HostEvents> {
         console.error("Unable to stop the host runtime while switching accounts:", error);
       }
     }
-    if (user) await this.#options.store.activateAccount(user);
-    else await this.#options.store.deactivate();
-    this.#boundAccountId = nextAccountId;
+    try {
+      if (user) await this.#options.store.activateAccount(user);
+      else await this.#options.store.deactivate();
+    } finally {
+      // Publish even when activation failed. The previous account is gone either way, and a
+      // status still naming its host would offer the rail a server this process can no
+      // longer answer for - the store has already unbound it.
+      this.#boundAccountId = nextAccountId;
+      this.#publishActiveHost(previousServerId);
+    }
+  }
+
+  #publishActiveHost(previousServerId: string | null): void {
     const identity = this.#options.store.getIdentity();
     if (identity && identity.serverId === previousServerId) {
       // The host this process started with, now confirmed as this account's. Keep the
@@ -313,16 +338,19 @@ export class HostService extends EventEmitter<HostEvents> {
     });
     this.#api.refreshPresence();
     this.#api.refreshIdentity();
+    const ownerMembershipId = this.#requiredOwnerMemberId();
     try {
+      if (!this.#isActiveHost(identity.serverId)) return this.getStatus();
       await this.#options.registerRemoteHost?.({
         hostId: identity.serverId,
         name: identity.serverName,
-        ownerMembershipId: this.#requiredOwnerMemberId(),
+        ownerMembershipId,
         devicePublicKey: identity.publicKey,
       });
-      if (input.logo !== undefined) {
+      if (input.logo !== undefined && this.#isActiveHost(identity.serverId)) {
         await this.#options.updateRemoteHostLogo?.(identity.serverId, input.logo ?? null, identity.logoVersion);
       }
+      if (!this.#isActiveHost(identity.serverId)) return this.getStatus();
       this.#setStatus({
         apiUrl: null,
         message: "Registered this OpenBot for WebRTC access.",
@@ -345,16 +373,27 @@ export class HostService extends EventEmitter<HostEvents> {
       message: "Server identity updated.",
     });
     this.#api.refreshIdentity();
+    const ownerMembershipId = this.#requiredOwnerMemberId();
+    if (!this.#isActiveHost(identity.serverId)) return this.getStatus();
     await this.#options.registerRemoteHost?.({
       hostId: identity.serverId,
       name: identity.serverName,
-      ownerMembershipId: this.#requiredOwnerMemberId(),
+      ownerMembershipId,
       devicePublicKey: identity.publicKey,
     });
-    if (input.logo !== undefined) {
+    if (input.logo !== undefined && this.#isActiveHost(identity.serverId)) {
       await this.#options.updateRemoteHostLogo?.(identity.serverId, input.logo ?? null, identity.logoVersion);
     }
     return this.getStatus();
+  }
+
+  /**
+   * Every remote step runs under the signed-in account's authentication, so one that started
+   * for a host the account no longer has would register or upload on the wrong account's
+   * behalf. The store's own guards stop the local half; this stops the network half.
+   */
+  #isActiveHost(serverId: string): boolean {
+    return this.#options.store.getIdentity()?.serverId === serverId;
   }
 
   start(): Promise<HostStatus> {
@@ -509,7 +548,7 @@ export class HostService extends EventEmitter<HostEvents> {
         // An account switch while the directory loaded makes this list the previous
         // account's. Answer with the now-active host's own members rather than failing a
         // read with the store's cross-account guard.
-        if (this.#options.store.getIdentity()?.serverId !== hostId) return this.#options.store.listMembers();
+        if (!this.#isActiveHost(hostId)) return this.#options.store.listMembers();
         await this.#options.store.syncRemoteDirectory(hostId, members);
         return members.map((member) => ({
           id: member.membershipId,
@@ -591,8 +630,12 @@ export class HostService extends EventEmitter<HostEvents> {
   listInvites(): TeamInviteSummary[] | Promise<TeamInviteSummary[]> {
     const hostId = this.#options.store.getIdentity()?.serverId;
     if (hostId && this.#options.listRemoteInvites) {
-      return this.#options.listRemoteInvites(hostId).then((invites) =>
-        invites
+      return this.#options.listRemoteInvites(hostId).then((invites) => {
+        // As in `listMembers`: a switch while the directory loaded makes these the previous
+        // account's invitations, their email addresses included. Answer with the now-active
+        // host's own rather than handing them to whoever is signed in.
+        if (!this.#isActiveHost(hostId)) return this.#options.store.listInvites();
+        return invites
           .filter((invite) => invite.revokedAt === null)
           .map((invite) => ({
             id: invite.inviteId,
@@ -600,8 +643,8 @@ export class HostService extends EventEmitter<HostEvents> {
             email: invite.email,
             expiresAt: new Date(invite.expiresAt).toISOString(),
             usedAt: invite.usedAt === null ? null : new Date(invite.usedAt).toISOString(),
-          })),
-      );
+          }));
+      });
     }
     return this.#options.store.listInvites();
   }

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -255,6 +255,10 @@ export class HostService extends EventEmitter<HostEvents> {
     const nextAccountId = user?.id ?? null;
     if (this.#boundAccountId === undefined || this.#boundAccountId === nextAccountId) return;
     if (!this.#options.store.configured) return;
+    // A start still in flight belongs to the account on its way out. Bumping here rather
+    // than waiting for the queued `applySignedInAccount` is what stops it reporting the
+    // previous host online - or its failure as an error - on the new account's status.
+    this.#runtimeGeneration += 1;
     this.#options.store.unbindActiveHost();
     this.#status = initialHostStatus(null, this.#options.unattended ?? false);
     this.emit("changed", this.getStatus());
@@ -498,6 +502,7 @@ export class HostService extends EventEmitter<HostEvents> {
       });
       if (await this.#cancelSupersededStart(generation)) return this.getStatus();
       await this.#options.store.setEnabledOnLaunch(identity.serverId, true);
+      if (await this.#cancelSupersededStart(generation)) return this.getStatus();
       this.#setStatus({ phase: "online", enabledOnLaunch: true });
     } catch (error) {
       if (generation !== this.#runtimeGeneration) {

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -569,6 +569,9 @@ export class HostService extends EventEmitter<HostEvents> {
         // read with the store's cross-account guard.
         if (!this.#isActiveHost(hostId)) return this.#options.store.listMembers();
         await this.#options.store.syncRemoteDirectory(hostId, members);
+        // Recording the directory is a write, and the switch can land during it. The names,
+        // addresses and roles below are the previous account's if it did.
+        if (!this.#isActiveHost(hostId)) return this.#options.store.listMembers();
         return members.map((member) => ({
           id: member.membershipId,
           username: member.email,

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -298,6 +298,12 @@ export class HostService extends EventEmitter<HostEvents> {
     }
     let activated = false;
     try {
+      if (user && this.#signedInAccountId() !== user.id) {
+        // Another account was announced while the runtime was being torn down. Binding this
+        // one now would hand its host, members and invitations to whoever is signed in
+        // instead - and the switch queued for them is what binds theirs.
+        return;
+      }
       if (user) await this.#options.store.activateAccount(user);
       else await this.#options.store.deactivate();
       activated = true;

--- a/src/main/host-service.ts
+++ b/src/main/host-service.ts
@@ -327,6 +327,9 @@ export class HostService extends EventEmitter<HostEvents> {
       this.#options.getSignedInUser(),
       input.logo,
     );
+    // The store checked the account before it resolved; the switch can still land between
+    // there and here, and publishing then would show A's server to B.
+    if (!this.#isActiveHost(identity.serverId)) return this.getStatus();
     this.#setStatus({
       phase: "idle",
       configured: true,
@@ -751,6 +754,10 @@ export class HostService extends EventEmitter<HostEvents> {
       this.#options.remoteControlPlaneUrl
     ) {
       const invite = await this.#options.createRemoteInvite(identity.serverId, input);
+      // The invitation belongs to the account that asked for it, so it stays on that host
+      // and shows up in its invite list. What must not happen is emailing it under the new
+      // account's authorization, or handing it back to the renderer the new account sees.
+      this.#assertStillActiveHost(identity.serverId);
       const inviteUrl = createInviteUrl({
         apiUrl: this.#options.remoteControlPlaneUrl,
         serverId: identity.serverId,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -756,18 +756,31 @@ function forwardCentralAuth(state: CentralAuthState): void {
       activeRemotePrincipalId = nextPrincipalId;
       if (state.status !== "signed_in") {
         if (state.status === "signed_out") {
-          await hostService?.stop(false);
+          // Stopping is best-effort; unbinding the host is not, so a failed teardown
+          // must not leave the signed-out account's host bound.
+          try {
+            await hostService?.stop(false);
+          } catch (error) {
+            console.error("Unable to stop the host while signing out:", error);
+          }
           await hostService?.applySignedInAccount(null);
         }
         return;
       }
-      await remoteServerManager?.syncRemoteHosts();
       const host = hostService;
-      if (!host) return;
-      await host.applySignedInAccount(state.user);
-      hostAnalytics?.flushPending();
-      const status = host.getStatus();
-      if (shouldAutoStartHost(status)) await host.start();
+      // The local host is rebound before the joined-server list is synchronized, and the
+      // network failure is contained: this account must not end up signed in while the
+      // previous account's host is still selected and possibly online.
+      if (host) {
+        await host.applySignedInAccount(state.user);
+        hostAnalytics?.flushPending();
+      }
+      try {
+        await remoteServerManager?.syncRemoteHosts();
+      } catch (error) {
+        console.error("Unable to synchronize the joined servers:", error);
+      }
+      if (host && shouldAutoStartHost(host.getStatus())) await host.start();
     })
     .catch((error) => {
       console.error("Unable to synchronize the signed-in account:", error);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -747,6 +747,10 @@ function forwardCentralAuth(state: CentralAuthState): void {
     if (activeAnalyticsPrincipalId) hostAnalytics?.clear();
     activeAnalyticsPrincipalId = null;
   }
+  // The renderer is told about the new account at the end of this function, before the
+  // queued work below can finish, so the host stops answering for the previous account now.
+  // The file is left alone until `applySignedInAccount` records the switch.
+  hostService?.unbindChangedAccount(state.status === "signed_in" ? state.user : null);
   remoteAccountSync = remoteAccountSync
     .then(async () => {
       const nextPrincipalId = state.status === "signed_in" ? state.user.id : null;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -216,6 +216,8 @@ if (!app.isPackaged) {
 const BROWSER_STATE_FILE = "openbot-browser-state-v1.json";
 const SIDEBAR_LAYOUT_FILE = "openbot-sidebar-layout-v1.json";
 const TEAM_FILE = "openbot-team-server-v1.json";
+/** One host per account. The v1 file above stays as the last build without accounts left it. */
+const TEAM_FILE_V2 = "openbot-team-server-v2.json";
 const REMOTE_SERVERS_FILE = "openbot-remote-servers-v1.json";
 const CENTRAL_AUTH_FILE = "openbot-central-auth-v1.bin";
 const LEGACY_REMOTE_DESKTOP_CREDENTIAL_FILE = "openbot-remote-desktop-credential-v1.json";
@@ -1010,7 +1012,10 @@ if (!hasSingleInstanceLock) {
       );
       const agentMarketplace = new AgentMarketplaceService(centralAuthManager, service, skillMarketplace);
       configureAttachmentProtocol(mailboxStore, service);
-      const teamStore = new TeamStore(join(app.getPath("userData"), TEAM_FILE));
+      const teamStore = new TeamStore(
+        join(app.getPath("userData"), TEAM_FILE_V2),
+        join(app.getPath("userData"), TEAM_FILE),
+      );
       await teamStore.initialize();
       if (developmentRemoteRole) {
         const email =

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -770,6 +770,9 @@ function forwardCentralAuth(state: CentralAuthState): void {
           console.error("Unable to disconnect the previous account's remote sessions:", error);
         }
       }
+      // Rechecked after the disconnect: another account can be announced while it awaits,
+      // and activating this one now would put its host back within the newer account's reach.
+      if (generation !== centralAuthGeneration) return;
       activeRemotePrincipalId = nextPrincipalId;
       if (state.status !== "signed_in") {
         if (state.status === "signed_out") {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -793,6 +793,12 @@ function forwardCentralAuth(state: CentralAuthState): void {
       // previous account's host is still selected and possibly online.
       if (host) {
         await host.applySignedInAccount(state.user);
+        if (generation !== centralAuthGeneration) {
+          // Another account was announced while this one was being activated. Its own queued
+          // callback binds it; until then no host answers for either.
+          host.unbindChangedAccount(null);
+          return;
+        }
         hostAnalytics?.flushPending();
       }
       try {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -751,7 +751,13 @@ function forwardCentralAuth(state: CentralAuthState): void {
     .then(async () => {
       const nextPrincipalId = state.status === "signed_in" ? state.user.id : null;
       if (activeRemotePrincipalId && activeRemotePrincipalId !== nextPrincipalId) {
-        await remoteServerManager?.disconnectRemoteSessions();
+        // Best-effort, like every other network step here: a bridge disconnect that
+        // rejects must not stop the local host from leaving the previous account.
+        try {
+          await remoteServerManager?.disconnectRemoteSessions();
+        } catch (error) {
+          console.error("Unable to disconnect the previous account's remote sessions:", error);
+        }
       }
       activeRemotePrincipalId = nextPrincipalId;
       if (state.status !== "signed_in") {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -755,13 +755,16 @@ function forwardCentralAuth(state: CentralAuthState): void {
       }
       activeRemotePrincipalId = nextPrincipalId;
       if (state.status !== "signed_in") {
-        if (state.status === "signed_out") await hostService?.stop(false);
+        if (state.status === "signed_out") {
+          await hostService?.stop(false);
+          await hostService?.applySignedInAccount(null);
+        }
         return;
       }
       await remoteServerManager?.syncRemoteHosts();
       const host = hostService;
       if (!host) return;
-      await host.syncSignedInAccount(state.user);
+      await host.applySignedInAccount(state.user);
       hostAnalytics?.flushPending();
       const status = host.getStatus();
       if (shouldAutoStartHost(status)) await host.start();
@@ -976,6 +979,7 @@ if (!hasSingleInstanceLock) {
             ? (teamStore.getOwnerEmail() ?? "openbot-dev-host@example.com")
             : "openbot-dev-client@example.com";
         const user = await ensureDevelopmentAccount(centralAuthManager, email);
+        await teamStore.activateAccount(user);
         if (developmentRemoteRole === "host" && !teamStore.configured) {
           await teamStore.configureWithAccount("OpenBot Local Dev Host", user);
         }
@@ -1088,7 +1092,7 @@ if (!hasSingleInstanceLock) {
       });
       const signedInState = centralAuthManager.getState();
       if (signedInState.status === "signed_in") {
-        await hostService.syncSignedInAccount(signedInState.user);
+        await hostService.applySignedInAccount(signedInState.user);
       }
       const analyticsPlatform = process.platform;
       if (analyticsPlatform !== "darwin" && analyticsPlatform !== "win32" && analyticsPlatform !== "linux") {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1093,6 +1093,13 @@ if (!hasSingleInstanceLock) {
       const signedInState = centralAuthManager.getState();
       if (signedInState.status === "signed_in") {
         await hostService.applySignedInAccount(signedInState.user);
+      } else if (signedInState.status === "signed_out") {
+        // Sign-out can settle before this service exists, leaving `forwardCentralAuth`
+        // nothing to deactivate. Unbinding here is what stops a persisted
+        // `activeAccountId` from keeping the last account's host configured - and
+        // unconfigurable - while nobody is signed in. A still-loading or failed account
+        // service keeps its host, and the event listener settles it.
+        await hostService.applySignedInAccount(null);
       }
       const analyticsPlatform = process.platform;
       if (analyticsPlatform !== "darwin" && analyticsPlatform !== "win32" && analyticsPlatform !== "linux") {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -181,6 +181,8 @@ let remoteDesktopManager: RemoteDesktopManager | null = null;
 let remoteServerManager: RemoteServerManager | null = null;
 let centralAuthManager: CentralAuthManager | null = null;
 let activeRemotePrincipalId: string | null = null;
+/** Counts account transitions, so queued work for a superseded one is dropped rather than applied. */
+let centralAuthGeneration = 0;
 let activeAnalyticsPrincipalId: string | null = null;
 let remoteAccountSync = Promise.resolve();
 let hostAnalytics: HostAnalytics | null = null;
@@ -751,8 +753,13 @@ function forwardCentralAuth(state: CentralAuthState): void {
   // queued work below can finish, so the host stops answering for the previous account now.
   // The file is left alone until `applySignedInAccount` records the switch.
   hostService?.unbindChangedAccount(state.status === "signed_in" ? state.user : null);
+  const generation = ++centralAuthGeneration;
   remoteAccountSync = remoteAccountSync
     .then(async () => {
+      // Sign-outs and sign-ins can queue up behind one slow teardown. Only the account the
+      // renderer was last told about may be activated; an earlier one would put a host the
+      // user has already left back within reach.
+      if (generation !== centralAuthGeneration) return;
       const nextPrincipalId = state.status === "signed_in" ? state.user.id : null;
       if (activeRemotePrincipalId && activeRemotePrincipalId !== nextPrincipalId) {
         // Best-effort, like every other network step here: a bridge disconnect that

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -137,14 +137,20 @@ type HostOptions = ConstructorParameters<typeof HostService>[0];
  * account's host the service is bound to.
  */
 async function createHostService(
-  remote: Pick<
-    HostOptions,
-    | "listRemoteInvites"
-    | "registerRemoteHost"
-    | "updateRemoteHostLogo"
-    | "listRemoteMembers"
-    | "updateRemoteMember"
-    | "removeRemoteMember"
+  remote: Partial<
+    Pick<
+      HostOptions,
+      | "listRemoteInvites"
+      | "registerRemoteHost"
+      | "updateRemoteHostLogo"
+      | "listRemoteMembers"
+      | "updateRemoteMember"
+      | "removeRemoteMember"
+      | "createRemoteInvite"
+      | "revokeRemoteInvite"
+      | "remoteControlPlaneUrl"
+      | "sendTeamInviteEmail"
+    >
   > = {},
 ): Promise<{
   service: HostService;
@@ -2219,6 +2225,7 @@ async function emptyRequest(
 
 type RemoteInvites = Awaited<ReturnType<NonNullable<HostOptions["listRemoteInvites"]>>>;
 type RemoteMembers = Awaited<ReturnType<NonNullable<HostOptions["listRemoteMembers"]>>>;
+type RemoteInvite = Awaited<ReturnType<NonNullable<HostOptions["createRemoteInvite"]>>>;
 
 describe("HostService account binding", () => {
   const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
@@ -2398,6 +2405,46 @@ describe("HostService account binding", () => {
     // B has no server of its own; A's failure must not paint an error over that.
     expect(service.getStatus()).toEqual(beforeFailure);
     expect(service.getStatus().phase).not.toBe("error");
+  });
+
+  it("does not email an invitation created for the account that has just been left", async () => {
+    let releaseInvite: (invite: RemoteInvite) => void = () => undefined;
+    const creating = new Promise<RemoteInvite>((resolve) => {
+      releaseInvite = resolve;
+    });
+    let creationStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      creationStarted = resolve;
+    });
+    const emails: string[] = [];
+    const { service, signIn } = await createHostService({
+      registerRemoteHost: () => Promise.resolve(),
+      remoteControlPlaneUrl: "https://api.openbot.run",
+      createRemoteInvite: () => {
+        creationStarted();
+        return creating;
+      },
+      sendTeamInviteEmail: async ({ email }) => {
+        emails.push(email);
+      },
+    });
+    await signIn(first);
+    await service.configure({ serverName: "Studio Mac" });
+
+    const pending = service.createInvite({ role: "member", email: "guest@example.com" });
+    const settled = pending.catch(() => undefined);
+    await started;
+    await signIn(second);
+    releaseInvite({
+      inviteId: "invite-1",
+      token: "invite-token-that-is-long-enough-for-a-link",
+      expiresAt: Date.now() + 60_000,
+    });
+    await settled;
+
+    await expect(pending).rejects.toThrow("signed-in account changed");
+    // The mail would name A's server and go out under B's authentication.
+    expect(emails).toEqual([]);
   });
 
   it("reports the account's own server again after signing out and back in", async () => {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -158,6 +158,8 @@ async function createHostService(
   signIn: (user: CentralAuthUser | null) => Promise<void>;
   /** Holds the team file, so a test can make the store's write fail. */
   root: string;
+  /** Announces an account the way the renderer is told, before the queued switch is applied. */
+  announce: (user: CentralAuthUser) => void;
 }> {
   const root = await mkdtemp(join(tmpdir(), "openbot-host-service-"));
   roots.push(root);
@@ -191,6 +193,9 @@ async function createHostService(
   return {
     service,
     root,
+    announce: (user) => {
+      signedIn = user;
+    },
     signIn: async (user) => {
       signedIn = user;
       await service.applySignedInAccount(user);
@@ -2467,6 +2472,28 @@ describe("HostService account binding", () => {
     await signIn(second);
     expect(service.getStatus().serverId).toBe(secondIdentity.serverId);
     expect(service.getStatus().configured).toBe(true);
+  });
+
+  it("does not create the previous account's server once another account has been announced", async () => {
+    const registrations: string[] = [];
+    const { service, signIn, announce } = await createHostService({
+      registerRemoteHost: async ({ hostId }) => {
+        registrations.push(hostId);
+      },
+    });
+    await signIn(first);
+
+    const pending = service.configure({
+      serverName: "Studio Mac",
+      logo: { mimeType: "image/png", bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) },
+    });
+    // Announced while the logo and the host are being written, with the switch itself queued.
+    announce(second);
+
+    await expect(pending).rejects.toThrow("signed-in account changed");
+    expect(service.getStatus().configured).toBe(false);
+    // Registering would have reserved A's server under B's authentication.
+    expect(registrations).toEqual([]);
   });
 
   it("reports the account's own server again after signing out and back in", async () => {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -136,7 +136,9 @@ type HostOptions = ConstructorParameters<typeof HostService>[0];
  * whole harness it needs. No runtime is started here - these cases are about which
  * account's host the service is bound to.
  */
-async function createHostService(): Promise<{
+async function createHostService(
+  remote: Pick<HostOptions, "listRemoteInvites" | "registerRemoteHost" | "updateRemoteHostLogo"> = {},
+): Promise<{
   service: HostService;
   /** Reports an account exactly as `forwardCentralAuth` does, sign-out included. */
   signIn: (user: CentralAuthUser | null) => Promise<void>;
@@ -167,6 +169,7 @@ async function createHostService(): Promise<{
     },
     redeemCentralTicket: unimplemented,
     sendTeamInviteEmail: unimplemented,
+    ...remote,
   };
   const service = new HostService(options);
   return {
@@ -2206,6 +2209,8 @@ async function emptyRequest(
   expect(response.status).toBe(204);
 }
 
+type RemoteInvites = Awaited<ReturnType<NonNullable<HostOptions["listRemoteInvites"]>>>;
+
 describe("HostService account binding", () => {
   const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
   const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
@@ -2224,6 +2229,86 @@ describe("HostService account binding", () => {
     expect(status.serverId).toBeNull();
     expect(status.serverName).toBeNull();
     expect(status.enabledOnLaunch).toBe(false);
+  });
+
+  it("stops reporting the previous account's server before the switch is recorded", async () => {
+    const { service, signIn } = await createHostService();
+    await signIn(first);
+    await service.configure({ serverName: "Studio Mac" });
+
+    // What `forwardCentralAuth` calls before it tells the renderer the account changed.
+    service.unbindChangedAccount(second);
+
+    expect(service.getStatus().configured).toBe(false);
+    expect(service.getStatus().serverId).toBeNull();
+    expect(service.getStatus().serverName).toBeNull();
+  });
+
+  it("answers invitations from the host that is active when the read returns", async () => {
+    let deliver: (invites: RemoteInvites) => void = () => undefined;
+    const loading = new Promise<RemoteInvites>((resolve) => {
+      deliver = resolve;
+    });
+    const { service, signIn } = await createHostService({ listRemoteInvites: () => loading });
+    await signIn(second);
+    await service.configure({ serverName: "Studio Air" });
+    await signIn(first);
+    await service.configure({ serverName: "Studio Mac" });
+
+    const pending = service.listInvites();
+    await signIn(second);
+    deliver([
+      {
+        inviteId: "invite-1",
+        role: "member",
+        email: "invited-by-a@example.com",
+        expiresAt: Date.now() + 60_000,
+        usedAt: null,
+        revokedAt: null,
+      },
+    ]);
+
+    // A's invitation, and the address it was sent to, must not reach B's renderer.
+    await expect(pending).resolves.toEqual([]);
+  });
+
+  it("does not push a server update to the remote directory once the account has changed", async () => {
+    let finishRegistration: () => void = () => undefined;
+    const registered = new Promise<void>((resolve) => {
+      finishRegistration = resolve;
+    });
+    let registrationStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      registrationStarted = resolve;
+    });
+    const logos: string[] = [];
+    const { service, signIn } = await createHostService({
+      // Naming the server registers it too; only the update's registration is held open.
+      registerRemoteHost: (input) => {
+        if (input.name !== "Renamed") return Promise.resolve();
+        registrationStarted();
+        return registered;
+      },
+      updateRemoteHostLogo: async (hostId) => {
+        logos.push(hostId);
+        return null;
+      },
+    });
+    await signIn(first);
+    await service.configure({ serverName: "Studio Mac" });
+
+    const pending = service.updateIdentity({
+      serverName: "Renamed",
+      logo: { mimeType: "image/png", bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) },
+    });
+    // The store's own guard covers the window up to here; this is the one after it.
+    await started;
+    await signIn(second);
+    finishRegistration();
+    await pending;
+
+    // Uploading it here would send A's image under B's authentication.
+    expect(logos).toEqual([]);
   });
 
   it("reports the account's own server again after signing out and back in", async () => {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -2494,6 +2494,8 @@ describe("HostService account binding", () => {
     expect(service.getStatus().configured).toBe(false);
     // Registering would have reserved A's server under B's authentication.
     expect(registrations).toEqual([]);
+    // Nor may what was created stay readable: the owner's address is in there.
+    expect(() => service.listMembers()).toThrow("The team server is not configured.");
   });
 
   it("reports the account's own server again after signing out and back in", async () => {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -137,7 +137,15 @@ type HostOptions = ConstructorParameters<typeof HostService>[0];
  * account's host the service is bound to.
  */
 async function createHostService(
-  remote: Pick<HostOptions, "listRemoteInvites" | "registerRemoteHost" | "updateRemoteHostLogo"> = {},
+  remote: Pick<
+    HostOptions,
+    | "listRemoteInvites"
+    | "registerRemoteHost"
+    | "updateRemoteHostLogo"
+    | "listRemoteMembers"
+    | "updateRemoteMember"
+    | "removeRemoteMember"
+  > = {},
 ): Promise<{
   service: HostService;
   /** Reports an account exactly as `forwardCentralAuth` does, sign-out included. */
@@ -2210,6 +2218,7 @@ async function emptyRequest(
 }
 
 type RemoteInvites = Awaited<ReturnType<NonNullable<HostOptions["listRemoteInvites"]>>>;
+type RemoteMembers = Awaited<ReturnType<NonNullable<HostOptions["listRemoteMembers"]>>>;
 
 describe("HostService account binding", () => {
   const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
@@ -2309,6 +2318,86 @@ describe("HostService account binding", () => {
 
     // Uploading it here would send A's image under B's authentication.
     expect(logos).toEqual([]);
+  });
+
+  it("does not change a member on the previous account's server once the account has changed", async () => {
+    let releaseRead: (members: RemoteMembers) => void = () => undefined;
+    const reading = new Promise<RemoteMembers>((resolve) => {
+      releaseRead = resolve;
+    });
+    let readStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      readStarted = resolve;
+    });
+    let reads = 0;
+    const mutations: string[] = [];
+    const { service, signIn } = await createHostService({
+      listRemoteMembers: () => {
+        reads += 1;
+        readStarted();
+        return reading;
+      },
+      updateRemoteMember: async (hostId) => {
+        mutations.push(hostId);
+      },
+      removeRemoteMember: async (hostId) => {
+        mutations.push(hostId);
+      },
+      registerRemoteHost: () => Promise.resolve(),
+    });
+    await signIn(first);
+    await service.configure({ serverName: "Studio Mac" });
+
+    const pending = service.updateMember({ memberId: "member-1", role: "admin" });
+    const settled = pending.catch(() => undefined);
+    await started;
+    await signIn(second);
+    releaseRead([
+      {
+        membershipId: "member-1",
+        email: "person@example.com",
+        name: null,
+        avatarUrl: null,
+        role: "member",
+        status: "active",
+        createdAt: 1_000,
+      },
+    ]);
+    await settled;
+
+    await expect(pending).rejects.toThrow("signed-in account changed");
+    // The mutation would have carried B's authorization to A's host.
+    expect(mutations).toEqual([]);
+    expect(reads).toBe(1);
+  });
+
+  it("leaves the new account's status alone when the previous account's registration fails", async () => {
+    let failRegistration: (error: Error) => void = () => undefined;
+    const registration = new Promise<void>((_resolve, reject) => {
+      failRegistration = reject;
+    });
+    let registrationStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      registrationStarted = resolve;
+    });
+    const { service, signIn } = await createHostService({
+      registerRemoteHost: () => {
+        registrationStarted();
+        return registration;
+      },
+    });
+    await signIn(first);
+
+    const pending = service.configure({ serverName: "Studio Mac" });
+    await started;
+    await signIn(second);
+    const beforeFailure = service.getStatus();
+    failRegistration(new Error("Could not reserve the public address."));
+    await pending;
+
+    // B has no server of its own; A's failure must not paint an error over that.
+    expect(service.getStatus()).toEqual(beforeFailure);
+    expect(service.getStatus().phase).not.toBe("error");
   });
 
   it("reports the account's own server again after signing out and back in", async () => {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -2283,6 +2283,19 @@ describe("HostService account binding", () => {
     expect(service.getStatus().serverName).toBe("Studio Mac");
   });
 
+  it("does not bind the previous account's server when its switch is applied too late", async () => {
+    const { service, signIn } = await createHostService();
+    await signIn(first);
+    await service.configure({ serverName: "Studio Mac" });
+    await signIn(second);
+
+    // A's queued switch, arriving after B is the signed-in account.
+    await service.applySignedInAccount(first);
+
+    expect(service.getStatus().configured).toBe(false);
+    expect(() => service.listMembers()).toThrow("The team server is not configured.");
+  });
+
   it("answers invitations from the host that is active when the read returns", async () => {
     let deliver: (invites: RemoteInvites) => void = () => undefined;
     const loading = new Promise<RemoteInvites>((resolve) => {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { EventEmitter } from "node:events";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ATTACHMENT_LIMITS, INPUT_LIMITS } from "@openbot/contracts/input-limits";
@@ -156,6 +156,8 @@ async function createHostService(
   service: HostService;
   /** Reports an account exactly as `forwardCentralAuth` does, sign-out included. */
   signIn: (user: CentralAuthUser | null) => Promise<void>;
+  /** Holds the team file, so a test can make the store's write fail. */
+  root: string;
 }> {
   const root = await mkdtemp(join(tmpdir(), "openbot-host-service-"));
   roots.push(root);
@@ -188,6 +190,7 @@ async function createHostService(
   const service = new HostService(options);
   return {
     service,
+    root,
     signIn: async (user) => {
       signedIn = user;
       await service.applySignedInAccount(user);
@@ -2445,6 +2448,25 @@ describe("HostService account binding", () => {
     await expect(pending).rejects.toThrow("signed-in account changed");
     // The mail would name A's server and go out under B's authentication.
     expect(emails).toEqual([]);
+  });
+
+  it("activates the account again after a failed switch instead of leaving it unconfigured", async () => {
+    const { service, signIn, root } = await createHostService({ registerRemoteHost: () => Promise.resolve() });
+    await signIn(first);
+    await service.configure({ serverName: "Studio Mac" });
+    await signIn(second);
+    const secondIdentity = await service.configure({ serverName: "Loft Mini" });
+    await signIn(first);
+
+    // The team file cannot be written while its directory is gone, so recording the switch fails.
+    await rm(root, { recursive: true, force: true });
+    await expect(signIn(second)).rejects.toThrow();
+    expect(service.getStatus().configured).toBe(false);
+
+    await mkdir(root, { recursive: true });
+    await signIn(second);
+    expect(service.getStatus().serverId).toBe(secondIdentity.serverId);
+    expect(service.getStatus().configured).toBe(true);
   });
 
   it("reports the account's own server again after signing out and back in", async () => {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -8,6 +8,7 @@ import { ATTACHMENT_LIMITS, INPUT_LIMITS } from "@openbot/contracts/input-limits
 import type {
   BotMemory,
   BotSummary,
+  CentralAuthUser,
   ConversationWithReadState,
   CreateBotInput,
   Routine,
@@ -34,6 +35,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { OpenBotDatabase } from "../backend/openbot-database";
 import { SidebarLayoutStore } from "../backend/sidebar-layout-store";
 import { TeamChatStore } from "../backend/team-chat-store";
+import { HostService } from "./host-service";
 import { TeamApiServer } from "./team-api-server";
 import { TeamStore } from "./team-store";
 
@@ -124,6 +126,55 @@ function createAgents(overrides: Partial<TestAgents> = {}, events = new EventEmi
     respondToApproval: unimplemented,
     respondToBrowserTakeover: unimplemented,
     ...overrides,
+  };
+}
+
+type HostOptions = ConstructorParameters<typeof HostService>[0];
+
+/**
+ * `HostService` forwards these straight to the Team API, so the doubles above are the
+ * whole harness it needs. No runtime is started here - these cases are about which
+ * account's host the service is bound to.
+ */
+async function createHostService(): Promise<{
+  service: HostService;
+  /** Reports an account exactly as `forwardCentralAuth` does, sign-out included. */
+  signIn: (user: CentralAuthUser | null) => Promise<void>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "openbot-host-service-"));
+  roots.push(root);
+  const store = new TeamStore(join(root, "team.json"));
+  await store.initialize();
+  let signedIn: CentralAuthUser | null = null;
+  const options: HostOptions = {
+    appVersion: "0.4.0",
+    store,
+    agents: { ...createAgents(), adoptConversationReads: unimplemented },
+    skills: { listInstalledForChatTags: unimplemented },
+    sidebarLayout: {
+      getSnapshot: unimplemented,
+      mutate: unimplemented,
+      removeAgent: unimplemented,
+      placeDuplicateAfter: unimplemented,
+      on: () => undefined,
+      off: () => undefined,
+    },
+    mailbox: createMailbox(),
+    browser: createBrowser(),
+    getSignedInUser: () => {
+      if (!signedIn) throw new Error("No account is signed in.");
+      return signedIn;
+    },
+    redeemCentralTicket: unimplemented,
+    sendTeamInviteEmail: unimplemented,
+  };
+  const service = new HostService(options);
+  return {
+    service,
+    signIn: async (user) => {
+      signedIn = user;
+      await service.applySignedInAccount(user);
+    },
   };
 }
 
@@ -2154,3 +2205,39 @@ async function emptyRequest(
   });
   expect(response.status).toBe(204);
 }
+
+describe("HostService account binding", () => {
+  const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+  const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
+
+  it("stops reporting the previous account's server when the account changes", async () => {
+    const { service, signIn } = await createHostService();
+    await signIn(first);
+    await service.configure({ serverName: "Studio Mac" });
+    expect(service.getStatus().serverName).toBe("Studio Mac");
+
+    await signIn(second);
+
+    const status = service.getStatus();
+    expect(status.configured).toBe(false);
+    expect(status.phase).toBe("unconfigured");
+    expect(status.serverId).toBeNull();
+    expect(status.serverName).toBeNull();
+    expect(status.enabledOnLaunch).toBe(false);
+  });
+
+  it("reports the account's own server again after signing out and back in", async () => {
+    const { service, signIn } = await createHostService();
+    await signIn(first);
+    const identity = await service.configure({ serverName: "Studio Mac" });
+
+    await signIn(null);
+    expect(service.getStatus().configured).toBe(false);
+    expect(service.getStatus().serverId).toBeNull();
+
+    await signIn(first);
+    expect(service.getStatus().serverId).toBe(identity.serverId);
+    expect(identity.serverId).not.toBeNull();
+    expect(service.getStatus().serverName).toBe("Studio Mac");
+  });
+});

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -2268,6 +2268,21 @@ describe("HostService account binding", () => {
     expect(service.getStatus().serverName).toBeNull();
   });
 
+  it("puts the account's server back when the same account is reported after the unbind", async () => {
+    const { service, signIn } = await createHostService();
+    await signIn(first);
+    const identity = await service.configure({ serverName: "Studio Mac" });
+
+    // A sign-out and an immediate sign-in as the same account: the unbind lands first, and
+    // the queued switch that follows is the only thing that can bind the host again.
+    service.unbindChangedAccount(second);
+    await signIn(first);
+
+    expect(service.getStatus().configured).toBe(true);
+    expect(service.getStatus().serverId).toBe(identity.serverId);
+    expect(service.getStatus().serverName).toBe("Studio Mac");
+  });
+
   it("answers invitations from the host that is active when the read returns", async () => {
     let deliver: (invites: RemoteInvites) => void = () => undefined;
     const loading = new Promise<RemoteInvites>((resolve) => {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -226,6 +226,44 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
+describe("TeamApiServer teardown", () => {
+  it("closes its listener when the remote screen cannot be stopped", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-team-api-teardown-"));
+    roots.push(root);
+    const store = new TeamStore(join(root, "team.json"));
+    await store.initialize();
+    const unreachable = () => {
+      throw new Error("The remote screen is only asked to stop here.");
+    };
+    const api = new TeamApiServer({
+      store,
+      agents: createAgents(),
+      mailbox: createMailbox(),
+      browser: createBrowser(),
+      remoteScreen: {
+        handlesUpgrade: () => false,
+        handleUpgrade: unreachable,
+        handlesHttp: () => false,
+        handleHttp: unreachable,
+        capabilities: unreachable,
+        createSession: unreachable,
+        selectDisplay: unreachable,
+        closeMemberSession: unreachable,
+        revokeTeamSession: unreachable,
+        revokeMember: unreachable,
+        stop: () => Promise.reject(new Error("The remote screen would not come down.")),
+      },
+    });
+    const port = await api.start();
+
+    await expect(api.stop()).rejects.toThrow("would not come down");
+
+    // Its heartbeat and event listeners are already gone, so a listener still answering here
+    // is one that no longer notices a revoked session - and the next start would hand it back.
+    await expect(fetch(`http://127.0.0.1:${port}/v1/compatibility`)).rejects.toThrow();
+  });
+});
+
 describe("TeamApiServer compatibility", () => {
   it("publishes protocol support and blocks requests without a compatible handshake", async () => {
     const root = await mkdtemp(join(tmpdir(), "openbot-team-api-compatibility-"));

--- a/src/main/team-api-server.ts
+++ b/src/main/team-api-server.ts
@@ -366,12 +366,18 @@ export class TeamApiServer {
     }
     this.#eventClients.clear();
     this.#localTypingBotId = null;
-    await this.#options.remoteScreen?.stop();
-    const server = this.#server;
-    this.#server = null;
-    this.#port = null;
-    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
-    this.#publishPresence();
+    try {
+      await this.#options.remoteScreen?.stop();
+    } finally {
+      // The heartbeat and the event listeners are already gone. Leaving the socket open
+      // would let the next `start()` hand back its port unchanged, so the previous account
+      // keeps a listener that no longer checks a revoked session or delivers an event.
+      const server = this.#server;
+      this.#server = null;
+      this.#port = null;
+      if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+      this.#publishPresence();
+    }
   }
 
   getPresence(): TeamPresenceSnapshot {

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -440,6 +440,34 @@ describe("TeamStore", () => {
     expect(await readStoredHosts(path)).toHaveLength(2);
   });
 
+  it("does not hand a host to the account that later takes the owner's address", async () => {
+    const { store } = await createStore();
+    const owner = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const identity = await store.configureWithAccount("Studio Mac", owner);
+
+    // The same address, a different account: an address can be released and registered again.
+    const stranger = { id: "account-b", email: "a@example.com", name: "B", avatarUrl: null };
+    await store.activateAccount(stranger);
+    expect(store.getIdentity()).toBeNull();
+
+    await store.activateAccount(owner);
+    expect(store.getIdentity()?.serverId).toBe(identity.serverId);
+    // Nor may the address alone pass the ownership check on the host it names.
+    expect(() => store.assertOwnerAccount(stranger)).toThrow("Sign in with the OpenBot email");
+  });
+
+  it("keeps the owner of a host after the account changes its address", async () => {
+    const { store } = await createStore();
+    const owner = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const identity = await store.configureWithAccount("Studio Mac", owner);
+
+    const renamed = { ...owner, email: "moved@example.com" };
+    await store.activateAccount(renamed);
+    expect(store.getIdentity()?.serverId).toBe(identity.serverId);
+    expect(() => store.assertOwnerAccount(renamed)).not.toThrow();
+    expect(store.listMembers().map((member) => member.email)).toEqual(["moved@example.com"]);
+  });
+
   it("leaves no host bound after signing out, and restores it on the next sign-in", async () => {
     const { store, path } = await createStore();
     const owner = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -543,6 +543,58 @@ describe("TeamStore", () => {
     });
   });
 
+  it("keeps the owner's account when the other build binds the host to a recycled address", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-team-"));
+    roots.push(root);
+    const legacyPath = join(root, "team.json");
+    const path = join(root, "team-v2.json");
+    const owner = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const source = new TeamStore(legacyPath);
+    await source.initialize();
+    const identity = await source.configureWithAccount("Studio Mac", owner);
+    const legacyRecord = await readStoredHost(legacyPath);
+    await writeFile(legacyPath, JSON.stringify(legacyRecord));
+    const upgraded = new TeamStore(path, legacyPath);
+    await upgraded.initialize();
+
+    // The owner releases the address and another account registers it. A build without
+    // accounts knows members by address alone, so signing in there writes the newcomer's
+    // id onto the owner it finds.
+    await writeFile(
+      legacyPath,
+      JSON.stringify({
+        ...legacyRecord,
+        members: legacyRecord.members?.map((member) => ({ ...member, accountId: "account-b" })),
+      }),
+    );
+    const restarted = new TeamStore(path, legacyPath);
+    await restarted.initialize();
+
+    await restarted.activateAccount({ id: "account-b", email: "a@example.com", name: "B", avatarUrl: null });
+    expect(restarted.getIdentity()).toBeNull();
+    await restarted.activateAccount(owner);
+    expect(restarted.getIdentity()?.serverId).toBe(identity.serverId);
+  });
+
+  it("does not change a password once the account it was asked on has gone", async () => {
+    const { store } = await createStore();
+    const owner = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    await store.configureWithAccount("Studio Mac", owner);
+    const invite = await store.createInvite("member");
+    const alice = await store.acceptInvite(invite.token, "alice", "a secure team password");
+
+    // The switch lands while the new password is still being hashed.
+    const pending = store.changePassword(alice.member.id, "a secure team password", "a newer secure password");
+    store.unbindActiveHost();
+    await expect(pending).rejects.toThrow();
+
+    // Told it failed, so it has to have failed: the password Alice still has, and the
+    // session it opened, are the ones she is left holding.
+    await store.activateAccount(owner);
+    await expect(store.login("alice", "a secure team password")).resolves.toBeDefined();
+    expect(store.authenticate(alice.sessionToken)?.username).toBe("alice");
+  });
+
   it("keeps each account's host separate and restores it on the next sign-in", async () => {
     const { store, path } = await createStore();
     const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -407,6 +407,32 @@ describe("TeamStore", () => {
     expect(persisted.members?.[0]?.accountId).toBe("owner-account");
   });
 
+  it("adopts the host of a build without accounts without writing over its file", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-team-"));
+    roots.push(root);
+    const legacyPath = join(root, "team.json");
+    const owner = { id: "owner-account", email: "owner@example.com", name: "Owner", avatarUrl: null };
+    const source = new TeamStore(legacyPath);
+    await source.initialize();
+    await source.configureWithAccount("Studio Mac", owner, {
+      mimeType: "image/png",
+      bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    });
+    const legacyRecord = JSON.stringify(await readStoredHost(legacyPath));
+    await writeFile(legacyPath, legacyRecord);
+
+    const store = new TeamStore(join(root, "team-v2.json"), legacyPath);
+    await store.initialize();
+    expect(store.getIdentity()?.serverName).toBe("Studio Mac");
+    // The logo stayed where the older build put it, beside its own file.
+    await expect(readFile(store.resolveLogo()?.path ?? "")).resolves.toHaveLength(8);
+    await store.updateIdentity({ serverName: "Renamed" });
+
+    // Downgrading finds the host it configured, not a file it cannot read and would replace.
+    expect(await readFile(legacyPath, "utf8")).toBe(legacyRecord);
+    expect((await readStoredHosts(join(root, "team-v2.json"))).map((host) => host.serverName)).toEqual(["Renamed"]);
+  });
+
   it("keeps each account's host separate and restores it on the next sign-in", async () => {
     const { store, path } = await createStore();
     const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -534,6 +534,28 @@ describe("TeamStore", () => {
     expect((await readStoredHosts(path)).map((host) => host.serverName)).toEqual(["Studio Air", "Studio Mac"]);
   });
 
+  it("refuses an identity update whose write lands after another account has signed in", async () => {
+    const { store, path } = await createStore();
+    const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
+    await store.activateAccount(second);
+    const secondIdentity = await store.configureWithAccount("Studio Air", second);
+    await store.activateAccount(first);
+    await store.configureWithAccount("Studio Mac", first);
+
+    const pending = store.updateIdentity({ serverName: "Renamed" });
+    const settled = pending.catch(() => undefined);
+    await store.activateAccount(second);
+    await settled;
+
+    // Answering with A's identity has the caller push A's host to the remote directory under
+    // B's authentication and owner membership.
+    await expect(pending).rejects.toThrow("no longer the active one");
+    expect(store.getIdentity()).toEqual(secondIdentity);
+    // The rename is A's own and stays: it is what A asked for and it is already on disk.
+    expect((await readStoredHosts(path)).map((host) => host.serverName)).toEqual(["Studio Air", "Renamed"]);
+  });
+
   it("keeps reporting the account it is bound to when recording the next one fails", async () => {
     const { store, path } = await createStore();
     const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -449,6 +449,9 @@ describe("TeamStore", () => {
     const stranger = { id: "account-b", email: "a@example.com", name: "B", avatarUrl: null };
     await store.activateAccount(stranger);
     expect(store.getIdentity()).toBeNull();
+    // And is not left in a dead end either: no host of its own, and none it may configure.
+    const strangerIdentity = await store.configureWithAccount("Loft Mini", stranger);
+    expect(strangerIdentity.serverId).not.toBe(identity.serverId);
 
     await store.activateAccount(owner);
     expect(store.getIdentity()?.serverId).toBe(identity.serverId);

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -495,6 +495,32 @@ describe("TeamStore", () => {
     expect(await readStoredHosts(path)).toHaveLength(0);
   });
 
+  it("refuses an identity update that lands after another account has signed in", async () => {
+    const { store, path } = await createStore();
+    const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
+    await store.activateAccount(first);
+    await store.configureWithAccount("Studio Mac", first);
+    await store.activateAccount(second);
+    const secondIdentity = await store.configureWithAccount("Studio Air", second);
+    await store.activateAccount(first);
+
+    const pending = store.updateIdentity({
+      serverName: "Renamed",
+      logo: { mimeType: "image/png", bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) },
+    });
+    // The update rejects while the switch below is still settling, so keep it handled.
+    const settled = pending.catch(() => undefined);
+    await store.activateAccount(second);
+    await settled;
+
+    await expect(pending).rejects.toThrow("no longer the active one");
+    expect(store.getIdentity()).toEqual(secondIdentity);
+    const hosts = await readStoredHosts(path);
+    expect(hosts.map((host) => host.serverName)).toEqual(["Studio Mac", "Studio Air"]);
+    expect(hosts.every((host) => host.serverLogo === undefined)).toBe(true);
+  });
+
   it("refuses a launch preference decided for a host that is no longer active", async () => {
     const { store } = await createStore();
     const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
@@ -668,6 +694,7 @@ describe("TeamStore", () => {
 /** Only the stored fields these tests read - the store owns the full shape. */
 interface StoredHostFields {
   serverId?: string;
+  serverName?: string;
   enabledOnLaunch?: boolean;
   serverLogo?: { version?: string; mimeType?: string; bytes?: unknown };
   members?: Array<{ accountId?: string }>;

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -56,15 +56,15 @@ describe("TeamStore", () => {
 
   it("recovers the persistence queue after a write failure", async () => {
     const { store, path } = await createStore();
-    await store.configure("Studio Mac", "owner", "correct horse battery");
+    const identity = await store.configure("Studio Mac", "owner", "correct horse battery");
     const root = path.slice(0, -"/team.json".length);
     const unavailableRoot = `${root}-unavailable`;
 
     await rename(root, unavailableRoot);
-    await expect(store.setEnabledOnLaunch(true)).rejects.toThrow();
+    await expect(store.setEnabledOnLaunch(identity.serverId, true)).rejects.toThrow();
     await rename(unavailableRoot, root);
 
-    await expect(store.setEnabledOnLaunch(false)).resolves.toBeUndefined();
+    await expect(store.setEnabledOnLaunch(identity.serverId, false)).resolves.toBeUndefined();
     expect((await readStoredHost(path)).enabledOnLaunch).toBe(false);
   });
 
@@ -476,6 +476,33 @@ describe("TeamStore", () => {
     await restarted.initialize();
     await restarted.activateAccount(owner);
     expect(restarted.getIdentity()?.serverId).toBe(store.getIdentity()?.serverId);
+  });
+
+  it("refuses a launch preference decided for a host that is no longer active", async () => {
+    const { store } = await createStore();
+    const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
+    const firstIdentity = await store.configureWithAccount("Studio Mac", first);
+
+    await store.activateAccount(second);
+    await store.configureWithAccount("Loft Mini", second);
+
+    await expect(store.setEnabledOnLaunch(firstIdentity.serverId, true)).rejects.toThrow("no longer the active one");
+    expect(store.getIdentity()?.enabledOnLaunch).toBe(false);
+    await store.activateAccount(first);
+    expect(store.getIdentity()?.enabledOnLaunch).toBe(false);
+  });
+
+  it("refuses a second host beside an owner-less one that is not active", async () => {
+    const { store, path } = await createStore();
+    await store.configure("Studio Mac", "owner", "correct horse battery");
+    const owner = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    await store.deactivate();
+
+    await expect(store.configureWithAccount("Loft Mini", owner)).rejects.toThrow("already configured");
+    expect(await readStoredHosts(path)).toHaveLength(1);
+    await store.activateAccount(owner);
+    expect(store.getIdentity()?.serverName).toBe("Studio Mac");
   });
 
   it("refuses a remote directory loaded for a host that is no longer active", async () => {

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -478,6 +478,23 @@ describe("TeamStore", () => {
     expect(restarted.getIdentity()?.serverId).toBe(store.getIdentity()?.serverId);
   });
 
+  it("refuses a configuration that finishes after another account has signed in", async () => {
+    const { store, path } = await createStore();
+    const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
+    await store.activateAccount(first);
+
+    const pending = store.configureWithAccount("Studio Mac", first, {
+      mimeType: "image/png",
+      bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    });
+    await store.activateAccount(second);
+
+    await expect(pending).rejects.toThrow("signed-in account changed");
+    expect(store.configured).toBe(false);
+    expect(await readStoredHosts(path)).toHaveLength(0);
+  });
+
   it("refuses a launch preference decided for a host that is no longer active", async () => {
     const { store } = await createStore();
     const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -213,7 +213,7 @@ describe("TeamStore", () => {
     });
     const ownerMembershipId = store.getOwnerMemberId();
     expect(ownerMembershipId).toBeTruthy();
-    await store.syncRemoteDirectory([
+    await store.syncRemoteDirectory(store.getIdentity()?.serverId ?? "missing-host", [
       {
         membershipId: ownerMembershipId ?? "missing-owner",
         email: "owner@example.com",
@@ -269,7 +269,7 @@ describe("TeamStore", () => {
       avatarUrl: null,
     });
     const previousOwnerId = store.getOwnerMemberId();
-    await store.syncRemoteDirectory([
+    await store.syncRemoteDirectory(store.getIdentity()?.serverId ?? "missing-host", [
       {
         membershipId: "host-1:owner",
         email: "owner@example.com",
@@ -296,7 +296,7 @@ describe("TeamStore", () => {
       avatarUrl: null,
     });
     const ownerMembershipId = store.getOwnerMemberId();
-    await store.syncRemoteDirectory([
+    await store.syncRemoteDirectory(store.getIdentity()?.serverId ?? "missing-host", [
       {
         membershipId: ownerMembershipId ?? "missing-owner",
         email: "owner@example.com",
@@ -455,6 +455,33 @@ describe("TeamStore", () => {
 
     await restarted.activateAccount(owner);
     expect(restarted.getIdentity()?.serverId).toBe(identity.serverId);
+  });
+
+  it("refuses a remote directory loaded for a host that is no longer active", async () => {
+    const { store } = await createStore();
+    const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
+    const firstIdentity = await store.configureWithAccount("Studio Mac", first);
+
+    await store.activateAccount(second);
+    await store.configureWithAccount("Loft Mini", second);
+    const ownerMemberId = store.getOwnerMemberId();
+
+    await expect(
+      store.syncRemoteDirectory(firstIdentity.serverId, [
+        {
+          membershipId: "account-a-owner",
+          email: "a@example.com",
+          name: "A",
+          avatarUrl: null,
+          role: "owner",
+          status: "active",
+          createdAt: 1_900_000_000_000,
+        },
+      ]),
+    ).rejects.toThrow("no longer the active one");
+    expect(store.getOwnerMemberId()).toBe(ownerMemberId);
+    expect(store.listMembers().map((member) => member.email)).toEqual(["b@example.com"]);
   });
 
   it("adopts a host configured before accounts existed and records its owner", async () => {

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -439,6 +439,35 @@ describe("TeamStore", () => {
     expect((await readStoredHosts(join(root, "team-v2.json"))).map((host) => host.serverName)).toEqual(["Renamed"]);
   });
 
+  it("copies the logo of an imported host on a later start when the first copy could not", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-team-"));
+    roots.push(root);
+    const legacyPath = join(root, "team.json");
+    const path = join(root, "team-v2.json");
+    const owner = { id: "owner-account", email: "owner@example.com", name: "Owner", avatarUrl: null };
+    const source = new TeamStore(legacyPath);
+    await source.initialize();
+    await source.configureWithAccount("Studio Mac", owner, {
+      mimeType: "image/png",
+      bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    });
+    const legacyLogo = source.resolveLogo();
+    await writeFile(legacyPath, JSON.stringify(await readStoredHost(legacyPath)));
+    // The image is briefly unreadable, so the copy the import makes cannot succeed.
+    await rename(legacyLogo?.path ?? "", `${legacyLogo?.path}.away`);
+
+    const upgraded = new TeamStore(path, legacyPath);
+    await upgraded.initialize();
+    await expect(readFile(upgraded.resolveLogo()?.path ?? "")).rejects.toThrow();
+
+    await rename(`${legacyLogo?.path}.away`, legacyLogo?.path ?? "");
+    const restarted = new TeamStore(path, legacyPath);
+    await restarted.initialize();
+
+    // The host keeps the logo the user gave it, rather than one missed copy costing it.
+    await expect(readFile(restarted.resolveLogo()?.path ?? "")).resolves.toHaveLength(8);
+  });
+
   it("reconciles what each build did to the host after they went their separate ways", async () => {
     const root = await mkdtemp(join(tmpdir(), "openbot-team-"));
     roots.push(root);

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -439,7 +439,7 @@ describe("TeamStore", () => {
     expect((await readStoredHosts(join(root, "team-v2.json"))).map((host) => host.serverName)).toEqual(["Renamed"]);
   });
 
-  it("takes in what a build without accounts wrote after the upgrade, keeping the copy it supersedes", async () => {
+  it("reconciles what each build did to the host after they went their separate ways", async () => {
     const root = await mkdtemp(join(tmpdir(), "openbot-team-"));
     roots.push(root);
     const legacyPath = join(root, "team.json");
@@ -452,16 +452,23 @@ describe("TeamStore", () => {
     await writeFile(legacyPath, JSON.stringify(legacyRecord));
     const upgraded = new TeamStore(path, legacyPath);
     await upgraded.initialize();
-    await upgraded.updateIdentity({ serverName: "Renamed here" });
+    const invite = await upgraded.createInvite("member", "alice@example.com");
+    await upgraded.acceptInviteWithAccount(invite.token, {
+      id: "alice-account",
+      email: "alice@example.com",
+      name: "Alice",
+      avatarUrl: null,
+    });
 
-    // The user goes back to the older build and renames the host there instead.
+    // The user goes back to the older build, which knows none of that, and renames the host.
     await writeFile(legacyPath, JSON.stringify({ ...legacyRecord, serverName: "Renamed there" }));
     const restarted = new TeamStore(path, legacyPath);
     await restarted.initialize();
 
+    // The rename happened in one build and the member joined in the other. Both are the
+    // user's work, and coming back to this build keeps both.
     expect(restarted.getIdentity()?.serverName).toBe("Renamed there");
-    const file = JSON.parse(await readFile(path, "utf8"));
-    expect(file.replacedHosts.map((host: { serverName: string }) => host.serverName)).toEqual(["Renamed here"]);
+    expect(restarted.listMembers().map((member) => member.name)).toEqual(["Owner", "Alice"]);
   });
 
   it("keeps each account's host separate and restores it on the next sign-in", async () => {

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -556,12 +556,12 @@ describe("TeamStore", () => {
     expect((await readStoredHosts(path)).map((host) => host.serverName)).toEqual(["Studio Air", "Renamed"]);
   });
 
-  it("keeps reporting the account it is bound to when recording the next one fails", async () => {
+  it("leaves no host bound when recording the next account fails", async () => {
     const { store, path } = await createStore();
     const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
     const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
     await store.activateAccount(first);
-    const identity = await store.configureWithAccount("Studio Mac", first);
+    await store.configureWithAccount("Studio Mac", first);
     const root = path.slice(0, -"/team.json".length);
     const unavailableRoot = `${root}-unavailable`;
 
@@ -569,7 +569,12 @@ describe("TeamStore", () => {
     await expect(store.activateAccount(second)).rejects.toThrow();
     await rename(unavailableRoot, root);
 
-    expect(store.getIdentity()).toEqual(identity);
+    // Signing in as B has already happened elsewhere, so answering for A's host is the
+    // failure this store exists to prevent. Nothing is lost: the file still holds it.
+    expect(store.configured).toBe(false);
+    expect((await readStoredHosts(path)).map((host) => host.serverName)).toEqual(["Studio Mac"]);
+    await store.activateAccount(first);
+    expect(store.getIdentity()?.serverName).toBe("Studio Mac");
   });
 
   it("refuses an identity update that lands after another account has signed in", async () => {

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -65,8 +65,7 @@ describe("TeamStore", () => {
     await rename(unavailableRoot, root);
 
     await expect(store.setEnabledOnLaunch(false)).resolves.toBeUndefined();
-    const persisted = JSON.parse(await readFile(path, "utf8"));
-    expect(persisted.enabledOnLaunch).toBe(false);
+    expect((await readStoredHost(path)).enabledOnLaunch).toBe(false);
   });
 
   it("stores, restores, replaces, and removes a validated server logo", async () => {
@@ -90,7 +89,7 @@ describe("TeamStore", () => {
     expect(identity.logoVersion).toBe(firstStoredLogo?.version);
     expect(firstStoredLogo?.mimeType).toBe("image/png");
     await expect(readFile(firstStoredLogo?.path ?? "")).resolves.toEqual(Buffer.from(firstLogo.bytes));
-    const raw = JSON.parse(await readFile(path, "utf8"));
+    const raw = await readStoredHost(path);
     expect(raw.serverLogo).toEqual({ version: firstStoredLogo?.version, mimeType: "image/png" });
     expect(raw.serverLogo).not.toHaveProperty("bytes");
 
@@ -392,8 +391,8 @@ describe("TeamStore", () => {
       avatarUrl: null,
     };
     await store.configureWithAccount("Studio Mac", owner);
-    const legacy = JSON.parse(await readFile(path, "utf8"));
-    delete legacy.members[0].accountId;
+    const legacy = await readStoredHost(path);
+    delete legacy.members?.[0]?.accountId;
     await writeFile(path, JSON.stringify(legacy));
 
     const restored = new TeamStore(path);
@@ -404,8 +403,83 @@ describe("TeamStore", () => {
     await expect(restored.syncAccount(owner)).resolves.toBe(true);
     expect(restored.getOwnerAnalyticsIdentity()).toEqual({ id: "owner-account", email: "owner@example.com" });
     expect(restored.listMembers()[0]).not.toHaveProperty("accountId");
-    const persisted = JSON.parse(await readFile(path, "utf8"));
-    expect(persisted.members[0].accountId).toBe("owner-account");
+    const persisted = await readStoredHost(path);
+    expect(persisted.members?.[0]?.accountId).toBe("owner-account");
+  });
+
+  it("keeps each account's host separate and restores it on the next sign-in", async () => {
+    const { store, path } = await createStore();
+    const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
+    const firstIdentity = await store.configureWithAccount("Studio Mac", first, {
+      mimeType: "image/png",
+      bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    });
+    const invite = await store.createInvite("member");
+    await store.acceptInviteWithAccount(invite.token, {
+      id: "account-c",
+      email: "c@example.com",
+      name: "C",
+      avatarUrl: null,
+    });
+    const pending = await store.createInvite("admin");
+
+    await store.activateAccount(second);
+    expect(store.configured).toBe(false);
+    expect(store.getIdentity()).toBeNull();
+    const secondIdentity = await store.configureWithAccount("Loft Mini", second);
+    expect(secondIdentity.serverId).not.toBe(firstIdentity.serverId);
+    expect(store.listMembers()).toHaveLength(1);
+
+    await store.activateAccount(first);
+    expect(store.getIdentity()?.serverId).toBe(firstIdentity.serverId);
+    expect(store.getIdentity()?.serverName).toBe("Studio Mac");
+    expect(store.getIdentity()?.logoVersion).toBe(firstIdentity.logoVersion);
+    expect(store.listMembers().map((member) => member.email)).toEqual(["a@example.com", "c@example.com"]);
+    expect(store.listInvites().find((candidate) => candidate.id === pending.id)?.role).toBe("admin");
+    expect(await readStoredHosts(path)).toHaveLength(2);
+  });
+
+  it("leaves no host bound after signing out, and restores it on the next sign-in", async () => {
+    const { store, path } = await createStore();
+    const owner = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const identity = await store.configureWithAccount("Studio Mac", owner);
+
+    await store.deactivate();
+    expect(store.configured).toBe(false);
+    expect(store.getIdentity()).toBeNull();
+
+    const restarted = new TeamStore(path);
+    await restarted.initialize();
+    expect(restarted.configured).toBe(false);
+
+    await restarted.activateAccount(owner);
+    expect(restarted.getIdentity()?.serverId).toBe(identity.serverId);
+  });
+
+  it("adopts a host configured before accounts existed and records its owner", async () => {
+    const { store, path } = await createStore();
+    const identity = await store.configure("Studio Mac", "owner", "correct horse battery");
+    const owner = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+
+    await store.activateAccount(owner);
+    expect(store.getIdentity()?.serverId).toBe(identity.serverId);
+    expect(store.getOwnerAnalyticsIdentity()).toEqual({ id: "account-a", email: "a@example.com" });
+    expect(() => store.assertOwnerAccount(owner)).not.toThrow();
+
+    const restarted = new TeamStore(path);
+    await restarted.initialize();
+    await restarted.activateAccount(owner);
+    expect(restarted.getIdentity()?.serverId).toBe(identity.serverId);
+    expect(await readStoredHosts(path)).toHaveLength(1);
+  });
+
+  it("activates nothing for an account that has no host", async () => {
+    const { store, path } = await createStore();
+    await store.activateAccount({ id: "account-a", email: "a@example.com", name: "A", avatarUrl: null });
+
+    expect(store.configured).toBe(false);
+    expect(await readStoredHosts(path)).toHaveLength(0);
   });
 
   it("allows only the OpenBot email that created the host to own it", async () => {
@@ -498,6 +572,25 @@ describe("TeamStore", () => {
     await expect(store.login("owner", "a newer secure password")).resolves.toBeDefined();
   });
 });
+
+/** Only the stored fields these tests read - the store owns the full shape. */
+interface StoredHostFields {
+  serverId?: string;
+  enabledOnLaunch?: boolean;
+  serverLogo?: { version?: string; mimeType?: string; bytes?: unknown };
+  members?: Array<{ accountId?: string }>;
+}
+
+/** The file holds one host per account; every host field a test reads lives under `hosts`. */
+async function readStoredHosts(path: string): Promise<StoredHostFields[]> {
+  return JSON.parse(await readFile(path, "utf8")).hosts;
+}
+
+async function readStoredHost(path: string, index = 0): Promise<StoredHostFields> {
+  const host = (await readStoredHosts(path))[index];
+  if (!host) throw new Error(`No stored host at index ${index}.`);
+  return host;
+}
 
 async function createStore() {
   const root = await mkdtemp(join(tmpdir(), "openbot-team-"));

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -421,16 +421,47 @@ describe("TeamStore", () => {
     const legacyRecord = JSON.stringify(await readStoredHost(legacyPath));
     await writeFile(legacyPath, legacyRecord);
 
+    const legacyLogo = join(root, "team.json.assets", "logo", `${JSON.parse(legacyRecord).serverLogo.version}.png`);
+
     const store = new TeamStore(join(root, "team-v2.json"), legacyPath);
     await store.initialize();
     expect(store.getIdentity()?.serverName).toBe("Studio Mac");
-    // The logo stayed where the older build put it, beside its own file.
+    // Its own copy of the logo, so replacing it below cannot take the older build's away.
     await expect(readFile(store.resolveLogo()?.path ?? "")).resolves.toHaveLength(8);
-    await store.updateIdentity({ serverName: "Renamed" });
+    await store.updateIdentity({
+      serverName: "Renamed",
+      logo: { mimeType: "image/png", bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]) },
+    });
 
     // Downgrading finds the host it configured, not a file it cannot read and would replace.
     expect(await readFile(legacyPath, "utf8")).toBe(legacyRecord);
+    await expect(readFile(legacyLogo)).resolves.toHaveLength(8);
     expect((await readStoredHosts(join(root, "team-v2.json"))).map((host) => host.serverName)).toEqual(["Renamed"]);
+  });
+
+  it("takes in what a build without accounts wrote after the upgrade, keeping the copy it supersedes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-team-"));
+    roots.push(root);
+    const legacyPath = join(root, "team.json");
+    const path = join(root, "team-v2.json");
+    const owner = { id: "owner-account", email: "owner@example.com", name: "Owner", avatarUrl: null };
+    const source = new TeamStore(legacyPath);
+    await source.initialize();
+    await source.configureWithAccount("Studio Mac", owner);
+    const legacyRecord = await readStoredHost(legacyPath);
+    await writeFile(legacyPath, JSON.stringify(legacyRecord));
+    const upgraded = new TeamStore(path, legacyPath);
+    await upgraded.initialize();
+    await upgraded.updateIdentity({ serverName: "Renamed here" });
+
+    // The user goes back to the older build and renames the host there instead.
+    await writeFile(legacyPath, JSON.stringify({ ...legacyRecord, serverName: "Renamed there" }));
+    const restarted = new TeamStore(path, legacyPath);
+    await restarted.initialize();
+
+    expect(restarted.getIdentity()?.serverName).toBe("Renamed there");
+    const file = JSON.parse(await readFile(path, "utf8"));
+    expect(file.replacedHosts.map((host: { serverName: string }) => host.serverName)).toEqual(["Renamed here"]);
   });
 
   it("keeps each account's host separate and restores it on the next sign-in", async () => {

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -471,6 +471,49 @@ describe("TeamStore", () => {
     expect(restarted.listMembers().map((member) => member.name)).toEqual(["Owner", "Alice"]);
   });
 
+  it("keeps a member disabled here when the other build only changed their name", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-team-"));
+    roots.push(root);
+    const legacyPath = join(root, "team.json");
+    const path = join(root, "team-v2.json");
+    const owner = { id: "owner-account", email: "owner@example.com", name: "Owner", avatarUrl: null };
+    const source = new TeamStore(legacyPath);
+    await source.initialize();
+    await source.configureWithAccount("Studio Mac", owner);
+    const invite = await source.createInvite("member", "alice@example.com");
+    const alice = await source.acceptInviteWithAccount(invite.token, {
+      id: "alice-account",
+      email: "alice@example.com",
+      name: "Alice",
+      avatarUrl: null,
+    });
+    const legacyRecord = await readStoredHost(legacyPath);
+    await writeFile(legacyPath, JSON.stringify(legacyRecord));
+
+    const upgraded = new TeamStore(path, legacyPath);
+    await upgraded.initialize();
+    await upgraded.updateMember(alice.member.id, { disabled: true });
+
+    // The older build knows nothing of that and renames the same member.
+    await writeFile(
+      legacyPath,
+      JSON.stringify({
+        ...legacyRecord,
+        members: legacyRecord.members?.map((member) =>
+          member.id === alice.member.id ? { ...member, name: "Alice Chen" } : member,
+        ),
+      }),
+    );
+    const restarted = new TeamStore(path, legacyPath);
+    await restarted.initialize();
+
+    // Their access was taken away here, and a rename made elsewhere cannot give it back.
+    expect(restarted.listMembers().find((member) => member.id === alice.member.id)).toMatchObject({
+      name: "Alice Chen",
+      disabled: true,
+    });
+  });
+
   it("keeps each account's host separate and restores it on the next sign-in", async () => {
     const { store, path } = await createStore();
     const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
@@ -874,7 +917,7 @@ interface StoredHostFields {
   serverName?: string;
   enabledOnLaunch?: boolean;
   serverLogo?: { version?: string; mimeType?: string; bytes?: unknown };
-  members?: Array<{ accountId?: string }>;
+  members?: Array<{ id: string; name: string; accountId?: string }>;
 }
 
 /** The file holds one host per account; every host field a test reads lives under `hosts`. */

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -495,6 +495,61 @@ describe("TeamStore", () => {
     expect(await readStoredHosts(path)).toHaveLength(0);
   });
 
+  it("keeps a team file it cannot read instead of writing over it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-team-"));
+    roots.push(root);
+    const path = join(root, "team.json");
+    // A file a newer build wrote. Nothing here is backed up, so it has to survive.
+    const original = `${JSON.stringify({ version: 3, hosts: [{ serverId: "from-the-future" }] })}\n`;
+    await writeFile(path, original, "utf8");
+    const store = new TeamStore(path);
+    await store.initialize();
+    const account = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+
+    await store.activateAccount(account);
+    expect(store.configured).toBe(false);
+    await expect(store.configureWithAccount("Studio Mac", account)).rejects.toThrow("could not be read");
+
+    expect(await readFile(path, "utf8")).toBe(original);
+  });
+
+  it("refuses a configuration whose write lands after another account has signed in", async () => {
+    const { store, path } = await createStore();
+    const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
+    await store.activateAccount(second);
+    const secondIdentity = await store.configureWithAccount("Studio Air", second);
+    await store.activateAccount(first);
+
+    const pending = store.configureWithAccount("Studio Mac", first);
+    const settled = pending.catch(() => undefined);
+    await store.activateAccount(second);
+    await settled;
+
+    // Answering with B's own host would have the caller apply A's configuration - its logo,
+    // its remote registration - to the server B was already running.
+    await expect(pending).rejects.toThrow("signed-in account changed");
+    expect(store.getIdentity()).toEqual(secondIdentity);
+    // A's host is A's own and stays stored: signing back in as A must return it.
+    expect((await readStoredHosts(path)).map((host) => host.serverName)).toEqual(["Studio Air", "Studio Mac"]);
+  });
+
+  it("keeps reporting the account it is bound to when recording the next one fails", async () => {
+    const { store, path } = await createStore();
+    const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const second = { id: "account-b", email: "b@example.com", name: "B", avatarUrl: null };
+    await store.activateAccount(first);
+    const identity = await store.configureWithAccount("Studio Mac", first);
+    const root = path.slice(0, -"/team.json".length);
+    const unavailableRoot = `${root}-unavailable`;
+
+    await rename(root, unavailableRoot);
+    await expect(store.activateAccount(second)).rejects.toThrow();
+    await rename(unavailableRoot, root);
+
+    expect(store.getIdentity()).toEqual(identity);
+  });
+
   it("refuses an identity update that lands after another account has signed in", async () => {
     const { store, path } = await createStore();
     const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
@@ -702,7 +757,13 @@ interface StoredHostFields {
 
 /** The file holds one host per account; every host field a test reads lives under `hosts`. */
 async function readStoredHosts(path: string): Promise<StoredHostFields[]> {
-  return JSON.parse(await readFile(path, "utf8")).hosts;
+  // Nothing worth recording writes no file at all, which stores no host either way.
+  try {
+    return JSON.parse(await readFile(path, "utf8")).hosts;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  }
 }
 
 async function readStoredHost(path: string, index = 0): Promise<StoredHostFields> {

--- a/src/main/team-store.test.ts
+++ b/src/main/team-store.test.ts
@@ -457,6 +457,27 @@ describe("TeamStore", () => {
     expect(restarted.getIdentity()?.serverId).toBe(identity.serverId);
   });
 
+  it("stores one host when an account configures twice at once", async () => {
+    const { store, path } = await createStore();
+    const owner = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };
+    const logo = {
+      mimeType: "image/png" as const,
+      bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    };
+
+    const results = await Promise.allSettled([
+      store.configureWithAccount("Studio Mac", owner, logo),
+      store.configureWithAccount("Loft Mini", owner, logo),
+    ]);
+
+    expect(results.map((result) => result.status).sort()).toEqual(["fulfilled", "rejected"]);
+    expect(await readStoredHosts(path)).toHaveLength(1);
+    const restarted = new TeamStore(path);
+    await restarted.initialize();
+    await restarted.activateAccount(owner);
+    expect(restarted.getIdentity()?.serverId).toBe(store.getIdentity()?.serverId);
+  });
+
   it("refuses a remote directory loaded for a host that is no longer active", async () => {
     const { store } = await createStore();
     const first = { id: "account-a", email: "a@example.com", name: "A", avatarUrl: null };

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -267,6 +267,8 @@ export class TeamStore {
       privateKeyEncoding: { type: "pkcs8", format: "pem" },
     });
     const credentials = await hashPassword(password);
+    // Hashing yields, so a second request could have configured a host meanwhile.
+    if (this.#state) throw new TeamStoreError("The team server is already configured.");
     this.#state = {
       version: 1,
       serverId: randomUUID(),
@@ -309,16 +311,22 @@ export class TeamStore {
     logo?: AvatarImageInput | null,
   ): Promise<TeamIdentity> {
     const email = normalizeEmail(user.email);
-    const activeOwner = this.#state ? hostOwner(this.#state) : undefined;
-    if (this.#hostFor(user.id, email) || (activeOwner && !activeOwner.accountId && !activeOwner.email)) {
-      throw new TeamStoreError("The team server is already configured.");
-    }
+    this.#assertNoHostFor(user.id, email);
     validateServerName(serverName);
     const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
       publicKeyEncoding: { type: "spki", format: "pem" },
       privateKeyEncoding: { type: "pkcs8", format: "pem" },
     });
     const serverLogo = logo ? await this.#writeLogo(logo) : undefined;
+    try {
+      // `#writeLogo` yields, so two concurrent requests could both have passed the guard
+      // above. Re-checking is what stops one account owning two stored hosts, where a
+      // restart would activate the one the status never showed.
+      this.#assertNoHostFor(user.id, email);
+    } catch (error) {
+      if (serverLogo) await this.#removeLogo(serverLogo).catch(() => undefined);
+      throw error;
+    }
     this.#state = {
       version: 1,
       serverId: randomUUID(),
@@ -851,6 +859,14 @@ export class TeamStore {
   #requireState(): StoredTeam {
     if (!this.#state) throw new TeamStoreError("The team server is not configured.");
     return this.#state;
+  }
+
+  /** Rejects a second host for one account, and a second host beside an owner-less one. */
+  #assertNoHostFor(accountId: string, email: string): void {
+    const activeOwner = this.#state ? hostOwner(this.#state) : undefined;
+    if (this.#hostFor(accountId, email) || (activeOwner && !activeOwner.accountId && !activeOwner.email)) {
+      throw new TeamStoreError("The team server is already configured.");
+    }
   }
 
   #hostFor(accountId: string, email: string): StoredTeam | undefined {

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -984,7 +984,11 @@ export class TeamStore {
   #hostFor(accountId: string, email: string): StoredTeam | undefined {
     return this.#file.hosts.find((host) => {
       const owner = hostOwner(host);
-      return owner?.accountId === accountId || (owner?.email ? normalizeEmail(owner.email) === email : false);
+      if (!owner) return false;
+      // The same rule as `activateAccount`: an owner bound to an account is that account's
+      // alone, so whoever holds its old address is free to configure a host of their own.
+      if (owner.accountId) return owner.accountId === accountId;
+      return owner.email ? normalizeEmail(owner.email) === email : false;
     });
   }
 

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -319,6 +319,11 @@ export class TeamStore {
     const email = normalizeEmail(user.email);
     this.#assertNoHostFor(user.id, email);
     validateServerName(serverName);
+    // Both `activateAccount` and `deactivate` set this synchronously, so comparing it
+    // after the awaits below is a reliable answer to "is this still the account that
+    // asked?" - a configuration finishing under someone else's session would otherwise
+    // rebind the store to the account that has just signed out.
+    const activeAccountBefore = this.#file.activeAccountId;
     const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
       publicKeyEncoding: { type: "spki", format: "pem" },
       privateKeyEncoding: { type: "pkcs8", format: "pem" },
@@ -329,6 +334,9 @@ export class TeamStore {
       // above. Re-checking is what stops one account owning two stored hosts, where a
       // restart would activate the one the status never showed.
       this.#assertNoHostFor(user.id, email);
+      if (this.#file.activeAccountId !== activeAccountBefore) {
+        throw new TeamStoreError("The signed-in account changed while this server was being created.");
+      }
     } catch (error) {
       if (serverLogo) await this.#removeLogo(serverLogo).catch(() => undefined);
       throw error;

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -257,6 +257,12 @@ export class TeamStore {
     return sign(null, Buffer.from(transcript), this.#state.privateKey).toString("base64url");
   }
 
+  /**
+   * The password path, used by the development connection and by tests. It creates an
+   * owner-less host and deliberately leaves `activeAccountId` alone - no account owns it
+   * yet, and the first one to activate adopts it. `#assertNoHostFor` is what keeps a
+   * second owner-less host from being created beside it.
+   */
   async configure(serverName: string, username: string, password: string): Promise<TeamIdentity> {
     if (this.#state) throw new TeamStoreError("The team server is already configured.");
     validateServerName(serverName);
@@ -428,8 +434,16 @@ export class TeamStore {
     return rm(join(this.#logoRoot, `${logo.version}.${avatarFileExtension(logo.mimeType)}`), { force: true });
   }
 
-  async setEnabledOnLaunch(enabled: boolean): Promise<void> {
+  /**
+   * `serverId` names the host the caller decided this for. Publishing and unpublishing
+   * both span awaits an account switch can land in, and the launch preference of one
+   * account's host must never be written onto another's.
+   */
+  async setEnabledOnLaunch(serverId: string, enabled: boolean): Promise<void> {
     const state = this.#requireState();
+    if (state.serverId !== serverId) {
+      throw new TeamStoreError("This server is no longer the active one for the signed-in account.");
+    }
     state.enabledOnLaunch = enabled;
     await this.#persist();
   }
@@ -861,10 +875,18 @@ export class TeamStore {
     return this.#state;
   }
 
-  /** Rejects a second host for one account, and a second host beside an owner-less one. */
+  /**
+   * Rejects a second host for one account, and a second host beside an owner-less one.
+   * The owner-less check spans every stored host, not just the active one: an inactive
+   * one is exactly what the next `activateAccount` adopts, so letting a second accumulate
+   * would make that adoption a coin toss.
+   */
   #assertNoHostFor(accountId: string, email: string): void {
-    const activeOwner = this.#state ? hostOwner(this.#state) : undefined;
-    if (this.#hostFor(accountId, email) || (activeOwner && !activeOwner.accountId && !activeOwner.email)) {
+    const ownerless = this.#file.hosts.some((host) => {
+      const owner = hostOwner(host);
+      return owner !== undefined && !owner.accountId && !owner.email;
+    });
+    if (this.#hostFor(accountId, email) || ownerless) {
       throw new TeamStoreError("The team server is already configured.");
     }
   }

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -1250,11 +1250,11 @@ function reconcileHost(baseline: StoredTeam, mine: StoredTeam, theirs: StoredTea
 
 /** The side that moved, or this build's value when the other side stood still. */
 function pickChanged<T>(baseline: T, mine: T, theirs: T): T {
-  return JSON.stringify(theirs ?? null) === JSON.stringify(baseline ?? null) ? mine : theirs;
+  return sameValue(theirs, baseline) ? mine : theirs;
 }
 
 function reconcileEntries<T extends { id: string }>(baseline: T[], mine: T[], theirs: T[]): T[] {
-  const before = new Map(baseline.map((entry) => [entry.id, JSON.stringify(entry)]));
+  const before = new Map(baseline.map((entry) => [entry.id, entry]));
   const merged: T[] = [];
   const seen = new Set<string>();
   for (const entry of [...mine, ...theirs]) {
@@ -1264,10 +1264,38 @@ function reconcileEntries<T extends { id: string }>(baseline: T[], mine: T[], th
     const other = theirs.find((candidate) => candidate.id === entry.id);
     const known = before.get(entry.id);
     // Known to both and gone from one of them: removed there, so it stays removed.
-    if (known !== undefined && (!ours || !other)) continue;
-    merged.push(other && known !== undefined && JSON.stringify(other) !== known ? other : (ours ?? entry));
+    if (known && (!ours || !other)) continue;
+    if (!ours || !other || !known) {
+      merged.push(ours ?? other ?? entry);
+      continue;
+    }
+    // Both builds have it. Taking the other side's entry whole would undo a field this one
+    // changed - a disabled member handed back their access, say - so each field is decided
+    // on its own.
+    merged.push(reconcileFields(known, ours, other));
   }
   return merged;
+}
+
+/** The entry field by field: whichever side moved a field, and this build's when neither did. */
+function reconcileFields<T extends object>(baseline: T, mine: T, theirs: T): T {
+  const merged = { ...mine };
+  const before = new Map(Object.entries(baseline));
+  const ours = new Map(Object.entries(mine));
+  for (const [key, other] of Object.entries(theirs)) {
+    Reflect.set(merged, key, sameValue(other, before.get(key)) ? ours.get(key) : other);
+  }
+  for (const key of ours.keys()) {
+    // Dropped there, and this build never touched it, so it goes.
+    if (!(key in theirs) && before.has(key) && sameValue(ours.get(key), before.get(key))) {
+      Reflect.deleteProperty(merged, key);
+    }
+  }
+  return merged;
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
 }
 
 function isStoredTeamFile(value: unknown): value is StoredTeamFile {

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -82,8 +82,8 @@ interface StoredTeamFile {
    * The legacy record this file last took in. A build without accounts that has written its
    * own file since leaves a different fingerprint, which is how its work is noticed.
    */
-  legacyImport?: { fingerprint: string; serverId: string };
-  /** Hosts a later import of the same server replaced. Never activated, and never dropped. */
+  legacyImport?: { fingerprint: string; record: StoredTeam };
+  /** The host as it stood before a reconcile merged into it. Never activated, never dropped. */
   replacedHosts?: StoredTeam[];
 }
 
@@ -186,23 +186,32 @@ export class TeamStore {
         version: 2,
         activeAccountId: ownerAccountId(legacy.record),
         hosts: [legacy.record],
-        legacyImport: { fingerprint: legacy.fingerprint, serverId: legacy.record.serverId },
+        // A copy of its own: the host below is edited from here on, and the baseline a later
+        // reconcile compares against has to stay the record as it was imported.
+        legacyImport: { fingerprint: legacy.fingerprint, record: structuredClone(legacy.record) },
       };
       await this.#adoptLegacyLogo(legacy.record);
       migrated = true;
     } else if (legacy && legacy.fingerprint !== this.#file.legacyImport?.fingerprint) {
-      // The older build has been run since, and what it wrote is the newer of the two. The
-      // copy it supersedes is kept rather than dropped: both are the user's, and neither
-      // file is a backup of the other.
+      // The older build has been run since it was imported. Neither copy of the host is a
+      // backup of the other - each holds work the other never saw - so they are reconciled
+      // against the record as it was imported rather than one replacing the other.
+      const baseline = this.#file.legacyImport?.record;
       const index = this.#file.hosts.findIndex((host) => host.serverId === legacy.record.serverId);
-      const replaced = index < 0 ? undefined : this.#file.hosts[index];
-      if (replaced) {
-        this.#file.replacedHosts = [...(this.#file.replacedHosts ?? []), replaced];
-        this.#file.hosts[index] = legacy.record;
+      const mine = index < 0 ? undefined : this.#file.hosts[index];
+      if (mine && baseline && baseline.serverId === legacy.record.serverId) {
+        // Copied for the same reason: the merged host below goes on being edited.
+        this.#file.replacedHosts = [...(this.#file.replacedHosts ?? []), structuredClone(mine)];
+        this.#file.hosts[index] = reconcileHost(baseline, mine, legacy.record);
+      } else if (mine) {
+        // No baseline to reconcile against - an upgrade that never recorded one. Keeping
+        // this build's host and filing the other copy is the only choice that drops
+        // nothing.
+        this.#file.replacedHosts = [...(this.#file.replacedHosts ?? []), legacy.record];
       } else {
         this.#file.hosts.push(legacy.record);
       }
-      this.#file.legacyImport = { fingerprint: legacy.fingerprint, serverId: legacy.record.serverId };
+      this.#file.legacyImport = { fingerprint: legacy.fingerprint, record: structuredClone(legacy.record) };
       await this.#adoptLegacyLogo(legacy.record);
       migrated = true;
     }
@@ -1220,6 +1229,47 @@ function ownerAccountId(host: StoredTeam): string | null {
   return hostOwner(host)?.accountId ?? null;
 }
 
+/**
+ * Merges the two copies of one host against the record both started from: what either side
+ * added is kept, what either side removed stays removed, and a field one side changed wins
+ * over the value neither touched. Nothing here can drop work the user did in either build.
+ */
+function reconcileHost(baseline: StoredTeam, mine: StoredTeam, theirs: StoredTeam): StoredTeam {
+  return {
+    ...mine,
+    serverName: pickChanged(baseline.serverName, mine.serverName, theirs.serverName),
+    enabledOnLaunch: pickChanged(baseline.enabledOnLaunch, mine.enabledOnLaunch, theirs.enabledOnLaunch),
+    serverLogo: pickChanged(baseline.serverLogo, mine.serverLogo, theirs.serverLogo),
+    members: reconcileEntries(baseline.members, mine.members, theirs.members),
+    invites: reconcileEntries(baseline.invites, mine.invites, theirs.invites),
+    // A session missing on either side was signed out there, and `reconcileEntries` keeps
+    // it that way rather than handing back a token the user has already revoked.
+    sessions: reconcileEntries(baseline.sessions, mine.sessions, theirs.sessions),
+  };
+}
+
+/** The side that moved, or this build's value when the other side stood still. */
+function pickChanged<T>(baseline: T, mine: T, theirs: T): T {
+  return JSON.stringify(theirs ?? null) === JSON.stringify(baseline ?? null) ? mine : theirs;
+}
+
+function reconcileEntries<T extends { id: string }>(baseline: T[], mine: T[], theirs: T[]): T[] {
+  const before = new Map(baseline.map((entry) => [entry.id, JSON.stringify(entry)]));
+  const merged: T[] = [];
+  const seen = new Set<string>();
+  for (const entry of [...mine, ...theirs]) {
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    const ours = mine.find((candidate) => candidate.id === entry.id);
+    const other = theirs.find((candidate) => candidate.id === entry.id);
+    const known = before.get(entry.id);
+    // Known to both and gone from one of them: removed there, so it stays removed.
+    if (known !== undefined && (!ours || !other)) continue;
+    merged.push(other && known !== undefined && JSON.stringify(other) !== known ? other : (ours ?? entry));
+  }
+  return merged;
+}
+
 function isStoredTeamFile(value: unknown): value is StoredTeamFile {
   if (!isDynamicRecord(value)) return false;
   return (
@@ -1230,7 +1280,7 @@ function isStoredTeamFile(value: unknown): value is StoredTeamFile {
     (value.legacyImport === undefined ||
       (isDynamicRecord(value.legacyImport) &&
         isString(value.legacyImport.fingerprint) &&
-        isString(value.legacyImport.serverId))) &&
+        isStoredTeam(value.legacyImport.record))) &&
     (value.replacedHosts === undefined ||
       (Array.isArray(value.replacedHosts) && value.replacedHosts.every((host) => isStoredTeam(host))))
   );

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -130,6 +130,12 @@ export class TeamStore {
     { member: TeamMemberSummary; sessionId: string; createdAt: string; sessionExpiresAt: string }
   >();
   #writeChain = Promise.resolve();
+  /**
+   * The file exists but is neither a v2 envelope nor a v1 record - a file a newer build
+   * wrote, or a damaged one. `#file` is empty only because something else owns this path,
+   * so writing would destroy the user's only copy. Nothing here is backed up.
+   */
+  #unreadableFile = false;
 
   constructor(path: string) {
     this.#path = path;
@@ -145,6 +151,8 @@ export class TeamStore {
       } else if (isStoredTeam(parsed)) {
         this.#file = { version: 2, activeAccountId: ownerAccountId(parsed), hosts: [parsed] };
         migrated = true;
+      } else {
+        this.#unreadableFile = true;
       }
     } catch (error) {
       if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
@@ -174,6 +182,8 @@ export class TeamStore {
       const owner = hostOwner(host);
       return owner !== undefined && !owner.accountId && !owner.email;
     });
+    const previousState = this.#state;
+    const previousAccountId = this.#file.activeAccountId;
     this.#state =
       hosts.find((host) => ownerAccountId(host) === user.id) ??
       hosts.find((host) => {
@@ -185,14 +195,22 @@ export class TeamStore {
     this.#file.activeAccountId = user.id;
     // A host configured before accounts existed has no owner email to match on next time,
     // so adopting it has to write the binding rather than rely on `syncAccount`.
-    if (this.#state && this.#state === unbound) {
-      const owner = hostOwner(this.#state);
-      if (owner) {
-        owner.accountId = user.id;
-        owner.email = email;
-      }
+    const adopted = this.#state && this.#state === unbound ? hostOwner(this.#state) : undefined;
+    const adoptedBefore = adopted && { accountId: adopted.accountId, email: adopted.email };
+    if (adopted) {
+      adopted.accountId = user.id;
+      adopted.email = email;
     }
-    await this.#persistFile();
+    try {
+      await this.#recordActiveAccount();
+    } catch (error) {
+      // Staying bound to a host the file does not name would have the status report one
+      // account while every write went to another.
+      this.#state = previousState;
+      this.#file.activeAccountId = previousAccountId;
+      if (adopted && adoptedBefore) Object.assign(adopted, adoptedBefore);
+      throw error;
+    }
     if (this.#state) {
       await this.syncAccount(user);
       await this.#prune();
@@ -201,8 +219,26 @@ export class TeamStore {
 
   /** Signing out unbinds the host without removing it - signing back in restores it. */
   async deactivate(): Promise<void> {
+    const previousState = this.#state;
+    const previousAccountId = this.#file.activeAccountId;
     this.#state = null;
     this.#file.activeAccountId = null;
+    try {
+      await this.#recordActiveAccount();
+    } catch (error) {
+      this.#state = previousState;
+      this.#file.activeAccountId = previousAccountId;
+      throw error;
+    }
+  }
+
+  /**
+   * A file with no host records nothing an activation could change, so there is nothing to
+   * write - which is also what keeps signing in from failing, or from overwriting a file
+   * this store could not read. Configuring a server still refuses that file outright.
+   */
+  async #recordActiveAccount(): Promise<void> {
+    if (this.#file.hosts.length === 0) return;
     await this.#persistFile();
   }
 
@@ -333,7 +369,7 @@ export class TeamStore {
       if (serverLogo) await this.#removeLogo(serverLogo).catch(() => undefined);
       throw error;
     }
-    this.#state = {
+    const created: StoredTeam = {
       version: 1,
       serverId: randomUUID(),
       serverName: serverName.trim(),
@@ -357,21 +393,29 @@ export class TeamStore {
       invites: [],
       sessions: [],
     };
-    this.#file.hosts.push(this.#state);
+    this.#file.hosts.push(created);
+    const previousState = this.#state;
     const previousAccountId = this.#file.activeAccountId;
+    this.#state = created;
     this.#file.activeAccountId = user.id;
     try {
       await this.#persistFile();
     } catch (error) {
-      this.#file.hosts.pop();
-      this.#file.activeAccountId = previousAccountId;
-      this.#state = null;
+      this.#file.hosts = this.#file.hosts.filter((host) => host !== created);
+      if (this.#state === created) {
+        this.#state = previousState;
+        this.#file.activeAccountId = previousAccountId;
+      }
       if (serverLogo) await this.#removeLogo(serverLogo).catch(() => undefined);
       throw error;
     }
-    const identity = this.getIdentity();
-    if (!identity) throw new Error("The team identity could not be created.");
-    return identity;
+    // Writing the file yields as well. The host stays - it is on disk and it belongs to the
+    // account that asked for it - but the caller must not go on to apply this configuration,
+    // its logo and its remote registration, to whichever host is active now.
+    if (this.#state !== created) {
+      throw new TeamStoreError("The signed-in account changed while this server was being created.");
+    }
+    return identityOf(created);
   }
 
   async updateIdentity(input: { serverName?: string; logo?: AvatarImageInput | null }): Promise<TeamIdentity> {
@@ -921,6 +965,11 @@ export class TeamStore {
   }
 
   async #persistFile(): Promise<void> {
+    if (this.#unreadableFile) {
+      throw new TeamStoreError(
+        "This computer's team server file could not be read. Move it aside before configuring a server, so it is not overwritten.",
+      );
+    }
     const snapshot = structuredClone(this.#file);
     const operation = this.#writeChain.then(async () => {
       const temporary = `${this.#path}.${randomUUID()}.tmp`;

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -7,6 +7,7 @@ import {
   sign,
   timingSafeEqual,
 } from "node:crypto";
+import { constants } from "node:fs";
 import { copyFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
@@ -190,7 +191,6 @@ export class TeamStore {
         // reconcile compares against has to stay the record as it was imported.
         legacyImport: { fingerprint: legacy.fingerprint, record: structuredClone(legacy.record) },
       };
-      await this.#adoptLegacyLogo(legacy.record);
       migrated = true;
     } else if (legacy && legacy.fingerprint !== this.#file.legacyImport?.fingerprint) {
       // The older build has been run since it was imported. Neither copy of the host is a
@@ -212,9 +212,13 @@ export class TeamStore {
         this.#file.hosts.push(legacy.record);
       }
       this.#file.legacyImport = { fingerprint: legacy.fingerprint, record: structuredClone(legacy.record) };
-      await this.#adoptLegacyLogo(legacy.record);
       migrated = true;
     }
+    const imported = this.#file.legacyImport?.record.serverId;
+    const importedHost = imported === undefined ? undefined : this.#file.hosts.find((h) => h.serverId === imported);
+    // Every start, not only the one that took the record in: a copy that failed once would
+    // otherwise leave the host without its logo for good, with the file still sitting there.
+    if (importedHost) await this.#adoptLegacyLogo(importedHost);
     const activeAccountId = this.#file.activeAccountId;
     this.#state =
       (activeAccountId === null
@@ -570,7 +574,11 @@ export class TeamStore {
     if (!logo || !this.#legacyLogoRoot) return;
     const name = `${logo.version}.${avatarFileExtension(logo.mimeType)}`;
     await mkdir(this.#logoRoot, { recursive: true, mode: 0o700 });
-    await copyFile(join(this.#legacyLogoRoot, name), join(this.#logoRoot, name)).catch(() => undefined);
+    // Never over this build's own copy, and a failure is left for the next start to retry
+    // rather than leaving the host pointing at a logo it has no file for.
+    await copyFile(join(this.#legacyLogoRoot, name), join(this.#logoRoot, name), constants.COPYFILE_EXCL).catch(
+      () => undefined,
+    );
   }
 
   resolveLogo(): { path: string; mimeType: AvatarImageInput["mimeType"]; version: string } | null {

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -84,7 +84,11 @@ interface StoredTeamFile {
    * own file since leaves a different fingerprint, which is how its work is noticed.
    */
   legacyImport?: { fingerprint: string; record: StoredTeam };
-  /** The host as it stood before a reconcile merged into it. Never activated, never dropped. */
+  /**
+   * The one legacy record a reconcile had no baseline for, so it could not be merged without
+   * dropping the work on one side. Never activated; replaced rather than accumulated, since
+   * a merged host needs no copy - the merge is what keeps both sides.
+   */
   replacedHosts?: StoredTeam[];
 }
 
@@ -200,14 +204,13 @@ export class TeamStore {
       const index = this.#file.hosts.findIndex((host) => host.serverId === legacy.record.serverId);
       const mine = index < 0 ? undefined : this.#file.hosts[index];
       if (mine && baseline && baseline.serverId === legacy.record.serverId) {
-        // Copied for the same reason: the merged host below goes on being edited.
-        this.#file.replacedHosts = [...(this.#file.replacedHosts ?? []), structuredClone(mine)];
         this.#file.hosts[index] = reconcileHost(baseline, mine, legacy.record);
       } else if (mine) {
         // No baseline to reconcile against - an upgrade that never recorded one. Keeping
         // this build's host and filing the other copy is the only choice that drops
-        // nothing.
-        this.#file.replacedHosts = [...(this.#file.replacedHosts ?? []), legacy.record];
+        // nothing. One record, not a growing pile: every write clones and serializes the
+        // whole file, and the next one to land here comes from the same file this did.
+        this.#file.replacedHosts = [legacy.record];
       } else {
         this.#file.hosts.push(legacy.record);
       }

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -7,7 +7,7 @@ import {
   sign,
   timingSafeEqual,
 } from "node:crypto";
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { avatarFileExtension, isAvatarMimeType, isValidAvatarImage } from "@openbot/contracts/avatar-images";
@@ -78,6 +78,13 @@ interface StoredTeamFile {
   /** The account whose host is active, so a restart activates it before the network answers. */
   activeAccountId: string | null;
   hosts: StoredTeam[];
+  /**
+   * The legacy record this file last took in. A build without accounts that has written its
+   * own file since leaves a different fingerprint, which is how its work is noticed.
+   */
+  legacyImport?: { fingerprint: string; serverId: string };
+  /** Hosts a later import of the same server replaced. Never activated, and never dropped. */
+  replacedHosts?: StoredTeam[];
 }
 
 export interface TeamIdentity {
@@ -124,6 +131,7 @@ export class TeamStore {
   /** Read once and never written: the file a build without this envelope still owns. */
   readonly #legacyPath: string | null;
   readonly #logoRoot: string;
+  readonly #legacyLogoRoot: string | null;
   #file: StoredTeamFile = { version: 2, activeAccountId: null, hosts: [] };
   /** The host of the signed-in account. Every other method reads this one, never `#file.hosts`. */
   #state: StoredTeam | null = null;
@@ -147,10 +155,10 @@ export class TeamStore {
   constructor(path: string, legacyPath: string | null = null) {
     this.#path = path;
     this.#legacyPath = legacyPath;
-    // Named after the file the logos were first stored beside, so an upgrade does not have
-    // to move them.
-    const assetsPath = legacyPath ?? path;
-    this.#logoRoot = join(dirname(assetsPath), `${basename(assetsPath)}.assets`, "logo");
+    // Each file owns its own assets. Sharing one directory would let either build delete a
+    // logo the other's record still points at, leaving it a host it cannot draw.
+    this.#logoRoot = join(dirname(path), `${basename(path)}.assets`, "logo");
+    this.#legacyLogoRoot = legacyPath ? join(dirname(legacyPath), `${basename(legacyPath)}.assets`, "logo") : null;
   }
 
   async initialize(): Promise<void> {
@@ -170,18 +178,33 @@ export class TeamStore {
     } catch (error) {
       if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
     }
-    if (!found && this.#legacyPath) {
-      try {
-        const parsed = JSON.parse(await readFile(this.#legacyPath, "utf8"));
-        // Copied into this store's own file rather than replaced in place. Anything else
-        // there belongs to a build that is not this one, and is left for it.
-        if (isStoredTeam(parsed)) {
-          this.#file = { version: 2, activeAccountId: ownerAccountId(parsed), hosts: [parsed] };
-          migrated = true;
-        }
-      } catch (error) {
-        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    // Copied into this store's own file rather than replaced in place. Anything else there
+    // belongs to a build that is not this one, and is left for it.
+    const legacy = this.#unreadableFile ? null : await this.#readLegacyRecord();
+    if (legacy && !found) {
+      this.#file = {
+        version: 2,
+        activeAccountId: ownerAccountId(legacy.record),
+        hosts: [legacy.record],
+        legacyImport: { fingerprint: legacy.fingerprint, serverId: legacy.record.serverId },
+      };
+      await this.#adoptLegacyLogo(legacy.record);
+      migrated = true;
+    } else if (legacy && legacy.fingerprint !== this.#file.legacyImport?.fingerprint) {
+      // The older build has been run since, and what it wrote is the newer of the two. The
+      // copy it supersedes is kept rather than dropped: both are the user's, and neither
+      // file is a backup of the other.
+      const index = this.#file.hosts.findIndex((host) => host.serverId === legacy.record.serverId);
+      const replaced = index < 0 ? undefined : this.#file.hosts[index];
+      if (replaced) {
+        this.#file.replacedHosts = [...(this.#file.replacedHosts ?? []), replaced];
+        this.#file.hosts[index] = legacy.record;
+      } else {
+        this.#file.hosts.push(legacy.record);
       }
+      this.#file.legacyImport = { fingerprint: legacy.fingerprint, serverId: legacy.record.serverId };
+      await this.#adoptLegacyLogo(legacy.record);
+      migrated = true;
     }
     const activeAccountId = this.#file.activeAccountId;
     this.#state =
@@ -510,6 +533,35 @@ export class TeamStore {
       throw new TeamStoreError("This server is no longer the active one for the signed-in account.");
     }
     return identityOf(state);
+  }
+
+  /** The record a build without accounts owns, with the fingerprint that dates it. */
+  async #readLegacyRecord(): Promise<{ record: StoredTeam; fingerprint: string } | null> {
+    if (!this.#legacyPath) return null;
+    let raw: string;
+    try {
+      raw = await readFile(this.#legacyPath, "utf8");
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+      throw error;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+    if (!isStoredTeam(parsed)) return null;
+    return { record: parsed, fingerprint: createHash("sha256").update(raw).digest("hex") };
+  }
+
+  /** Copied, never moved: the record left behind still points at the older build's own file. */
+  async #adoptLegacyLogo(record: StoredTeam): Promise<void> {
+    const logo = record.serverLogo;
+    if (!logo || !this.#legacyLogoRoot) return;
+    const name = `${logo.version}.${avatarFileExtension(logo.mimeType)}`;
+    await mkdir(this.#logoRoot, { recursive: true, mode: 0o700 });
+    await copyFile(join(this.#legacyLogoRoot, name), join(this.#logoRoot, name)).catch(() => undefined);
   }
 
   resolveLogo(): { path: string; mimeType: AvatarImageInput["mimeType"]; version: string } | null {
@@ -1174,7 +1226,13 @@ function isStoredTeamFile(value: unknown): value is StoredTeamFile {
     value.version === 2 &&
     (value.activeAccountId === null || isString(value.activeAccountId)) &&
     Array.isArray(value.hosts) &&
-    value.hosts.every((host) => isStoredTeam(host))
+    value.hosts.every((host) => isStoredTeam(host)) &&
+    (value.legacyImport === undefined ||
+      (isDynamicRecord(value.legacyImport) &&
+        isString(value.legacyImport.fingerprint) &&
+        isString(value.legacyImport.serverId))) &&
+    (value.replacedHosts === undefined ||
+      (Array.isArray(value.replacedHosts) && value.replacedHosts.every((host) => isStoredTeam(host))))
   );
 }
 

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -438,8 +438,16 @@ export class TeamStore {
     return members;
   }
 
-  async syncRemoteDirectory(remoteMembers: RemoteDirectoryMember[]): Promise<void> {
+  /**
+   * `serverId` names the host the caller loaded this directory for. Signing into another
+   * account swaps the active host, so a directory that was already in flight would
+   * otherwise rewrite the new account's owner membership and disable its members.
+   */
+  async syncRemoteDirectory(serverId: string, remoteMembers: RemoteDirectoryMember[]): Promise<void> {
     const state = this.#requireState();
+    if (state.serverId !== serverId) {
+      throw new TeamStoreError("This server is no longer the active one for the signed-in account.");
+    }
     const remoteOwner = remoteMembers.find((member) => member.role === "owner");
     const localOwner = state.members.find((member) => member.role === "owner");
     if (remoteOwner && localOwner && remoteOwner.membershipId !== localOwner.id) {

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -189,8 +189,12 @@ export class TeamStore {
     this.#state =
       hosts.find((host) => ownerAccountId(host) === user.id) ??
       hosts.find((host) => {
-        const ownerEmail = hostOwner(host)?.email;
-        return ownerEmail ? normalizeEmail(ownerEmail) === email : false;
+        const owner = hostOwner(host);
+        // Only a host whose owner predates accounts is matched by address. An email can be
+        // released and taken by somebody else, and it must not hand them a host that is
+        // already bound to the account that made it.
+        if (!owner || owner.accountId) return false;
+        return owner.email ? normalizeEmail(owner.email) === email : false;
       }) ??
       unbound ??
       null;
@@ -281,7 +285,12 @@ export class TeamStore {
     if (!owner?.email) {
       throw new TeamStoreError("This host is not linked to an OpenBot owner account.");
     }
-    if (normalizeEmail(user.email) !== normalizeEmail(owner.email)) {
+    // The account is the identity once one is recorded; the address is only what an owner
+    // from before accounts can be recognized by, and it can change hands.
+    const matches = owner.accountId
+      ? owner.accountId === user.id
+      : normalizeEmail(user.email) === normalizeEmail(owner.email);
+    if (!matches) {
       throw new TeamStoreError("Sign in with the OpenBot email that created this host.");
     }
   }
@@ -895,7 +904,11 @@ export class TeamStore {
   #applyAccount(user: CentralAuthUser): boolean {
     const state = this.#requireState();
     const email = normalizeEmail(user.email);
-    const member = state.members.find((candidate) => candidate.email === email || candidate.username === email);
+    // By account first, so changing the address on an account keeps it matched to its own
+    // member rather than locking it out of the host it owns.
+    const member =
+      state.members.find((candidate) => candidate.accountId === user.id) ??
+      state.members.find((candidate) => candidate.email === email || candidate.username === email);
     if (!member) return false;
     const name = normalizeName(user.name);
     const avatarUrl = normalizeAvatarUrl(user.avatarUrl);

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -211,15 +211,7 @@ export class TeamStore {
   }
 
   getIdentity(): TeamIdentity | null {
-    if (!this.#state) return null;
-    return {
-      serverId: this.#state.serverId,
-      serverName: this.#state.serverName,
-      fingerprint: fingerprint(this.#state.publicKey),
-      publicKey: this.#state.publicKey,
-      enabledOnLaunch: this.#state.enabledOnLaunch,
-      logoVersion: this.#state.serverLogo?.version ?? null,
-    };
+    return this.#state ? identityOf(this.#state) : null;
   }
 
   getOwnerEmail(): string | null {
@@ -395,6 +387,15 @@ export class TeamStore {
     const previousLogo = state.serverLogo;
     const nextLogo =
       input.logo === undefined ? previousLogo : input.logo === null ? undefined : await this.#writeLogo(input.logo);
+    // Writing the logo can outlive this host. `#persist` only requires *some* active host, so
+    // without this the name and image asked for here would land on whichever host became
+    // active meanwhile - and the caller would be handed that other account's identity back.
+    if (this.#state !== state) {
+      if (nextLogo && nextLogo.version !== previousLogo?.version) {
+        await this.#removeLogo(nextLogo).catch(() => undefined);
+      }
+      throw new TeamStoreError("This server is no longer the active one for the signed-in account.");
+    }
     if (input.serverName !== undefined) state.serverName = input.serverName.trim();
     state.serverLogo = nextLogo;
     try {
@@ -410,9 +411,7 @@ export class TeamStore {
     if (previousLogo && previousLogo.version !== nextLogo?.version) {
       await this.#removeLogo(previousLogo).catch(() => undefined);
     }
-    const identity = this.getIdentity();
-    if (!identity) throw new Error("The team identity could not be updated.");
-    return identity;
+    return identityOf(state);
   }
 
   resolveLogo(): { path: string; mimeType: AvatarImageInput["mimeType"]; version: string } | null {
@@ -1027,6 +1026,17 @@ function validatePassword(value: string): void {
   if (value.length < 12 || value.length > 256) {
     throw new TeamStoreError("Password must contain 12 to 256 characters.");
   }
+}
+
+function identityOf(host: StoredTeam): TeamIdentity {
+  return {
+    serverId: host.serverId,
+    serverName: host.serverName,
+    fingerprint: fingerprint(host.publicKey),
+    publicKey: host.publicKey,
+    enabledOnLaunch: host.enabledOnLaunch,
+    logoVersion: host.serverLogo?.version ?? null,
+  };
 }
 
 function hostOwner(host: StoredTeam): StoredMember | undefined {

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -186,7 +186,6 @@ export class TeamStore {
     // so a failed write can put the whole file back rather than leave half a switch applied
     // with the status naming one account and every write going to another.
     const rollback = structuredClone(this.#file);
-    const previousIndex = this.#state ? hosts.indexOf(this.#state) : -1;
     this.#state =
       hosts.find((host) => ownerAccountId(host) === user.id) ??
       hosts.find((host) => {
@@ -212,10 +211,23 @@ export class TeamStore {
     try {
       await this.#recordActiveAccount();
     } catch (error) {
+      // The file keeps what it had, so nothing is lost. Memory does not go back to the
+      // previous account, though: central authentication has already moved on, and leaving
+      // its host answerable is the failure this whole change exists to prevent. Unbound
+      // until an auth event or a restart records the switch.
       this.#file = rollback;
-      this.#state = previousIndex >= 0 ? (this.#file.hosts[previousIndex] ?? null) : null;
+      this.#state = null;
       throw error;
     }
+  }
+
+  /**
+   * Stops answering for the active host without touching the file. The renderer learns about
+   * a new account before the awaited teardown that follows can finish, so there has to be a
+   * way to stop serving the previous one immediately; `activateAccount` records the switch.
+   */
+  unbindActiveHost(): void {
+    this.#state = null;
   }
 
   /** Signing out unbinds the host without removing it - signing back in restores it. */

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -68,6 +68,18 @@ interface StoredTeam {
   sessions: StoredSession[];
 }
 
+/**
+ * The file holds one host per OpenBot account, so switching accounts cannot hand the
+ * new account the previous one's server. `hosts` is append-only - a host is never
+ * removed when its owner signs out, because this file is user data with no backup.
+ */
+interface StoredTeamFile {
+  version: 2;
+  /** The account whose host is active, so a restart activates it before the network answers. */
+  activeAccountId: string | null;
+  hosts: StoredTeam[];
+}
+
 export interface TeamIdentity {
   serverId: string;
   serverName: string;
@@ -110,6 +122,8 @@ export interface RemoteDirectoryMember {
 export class TeamStore {
   readonly #path: string;
   readonly #logoRoot: string;
+  #file: StoredTeamFile = { version: 2, activeAccountId: null, hosts: [] };
+  /** The host of the signed-in account. Every other method reads this one, never `#file.hosts`. */
   #state: StoredTeam | null = null;
   readonly #remoteSessions = new Map<
     string,
@@ -123,13 +137,73 @@ export class TeamStore {
   }
 
   async initialize(): Promise<void> {
+    let migrated = false;
     try {
       const parsed = JSON.parse(await readFile(this.#path, "utf8"));
-      this.#state = isStoredTeam(parsed) ? parsed : null;
-      if (this.#state) await this.#prune();
+      if (isStoredTeamFile(parsed)) {
+        this.#file = parsed;
+      } else if (isStoredTeam(parsed)) {
+        this.#file = { version: 2, activeAccountId: ownerAccountId(parsed), hosts: [parsed] };
+        migrated = true;
+      }
     } catch (error) {
       if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
     }
+    const activeAccountId = this.#file.activeAccountId;
+    this.#state =
+      (activeAccountId === null
+        ? // A host that predates accounts, or one upgraded from a file where the owner
+          // account was never recorded. Activating it keeps an offline upgrade showing the
+          // host it showed yesterday. A host left behind by a sign-out has an owner account,
+          // so signing out still unbinds it.
+          this.#file.hosts.find((host) => ownerAccountId(host) === null)
+        : this.#file.hosts.find((host) => ownerAccountId(host) === activeAccountId)) ?? null;
+    if (migrated) await this.#persistFile();
+    if (this.#state) await this.#prune();
+  }
+
+  /**
+   * Binds the store to `user`'s own host, adopting a host whose owner predates account
+   * sign-in. An account with no host leaves the store unconfigured rather than borrowing
+   * another account's.
+   */
+  async activateAccount(user: CentralAuthUser): Promise<void> {
+    const email = normalizeEmail(user.email);
+    const hosts = this.#file.hosts;
+    const unbound = hosts.find((host) => {
+      const owner = hostOwner(host);
+      return owner !== undefined && !owner.accountId && !owner.email;
+    });
+    this.#state =
+      hosts.find((host) => ownerAccountId(host) === user.id) ??
+      hosts.find((host) => {
+        const ownerEmail = hostOwner(host)?.email;
+        return ownerEmail ? normalizeEmail(ownerEmail) === email : false;
+      }) ??
+      unbound ??
+      null;
+    this.#file.activeAccountId = user.id;
+    // A host configured before accounts existed has no owner email to match on next time,
+    // so adopting it has to write the binding rather than rely on `syncAccount`.
+    if (this.#state && this.#state === unbound) {
+      const owner = hostOwner(this.#state);
+      if (owner) {
+        owner.accountId = user.id;
+        owner.email = email;
+      }
+    }
+    await this.#persistFile();
+    if (this.#state) {
+      await this.syncAccount(user);
+      await this.#prune();
+    }
+  }
+
+  /** Signing out unbinds the host without removing it - signing back in restores it. */
+  async deactivate(): Promise<void> {
+    this.#state = null;
+    this.#file.activeAccountId = null;
+    await this.#persistFile();
   }
 
   get configured(): boolean {
@@ -216,7 +290,14 @@ export class TeamStore {
       invites: [],
       sessions: [],
     };
-    await this.#persist();
+    this.#file.hosts.push(this.#state);
+    try {
+      await this.#persistFile();
+    } catch (error) {
+      this.#file.hosts.pop();
+      this.#state = null;
+      throw error;
+    }
     const identity = this.getIdentity();
     if (!identity) throw new Error("The team identity could not be created.");
     return identity;
@@ -227,9 +308,12 @@ export class TeamStore {
     user: CentralAuthUser,
     logo?: AvatarImageInput | null,
   ): Promise<TeamIdentity> {
-    if (this.#state) throw new TeamStoreError("The team server is already configured.");
-    validateServerName(serverName);
     const email = normalizeEmail(user.email);
+    const activeOwner = this.#state ? hostOwner(this.#state) : undefined;
+    if (this.#hostFor(user.id, email) || (activeOwner && !activeOwner.accountId && !activeOwner.email)) {
+      throw new TeamStoreError("The team server is already configured.");
+    }
+    validateServerName(serverName);
     const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
       publicKeyEncoding: { type: "spki", format: "pem" },
       privateKeyEncoding: { type: "pkcs8", format: "pem" },
@@ -259,9 +343,14 @@ export class TeamStore {
       invites: [],
       sessions: [],
     };
+    this.#file.hosts.push(this.#state);
+    const previousAccountId = this.#file.activeAccountId;
+    this.#file.activeAccountId = user.id;
     try {
-      await this.#persist();
+      await this.#persistFile();
     } catch (error) {
+      this.#file.hosts.pop();
+      this.#file.activeAccountId = previousAccountId;
       this.#state = null;
       if (serverLogo) await this.#removeLogo(serverLogo).catch(() => undefined);
       throw error;
@@ -756,6 +845,13 @@ export class TeamStore {
     return this.#state;
   }
 
+  #hostFor(accountId: string, email: string): StoredTeam | undefined {
+    return this.#file.hosts.find((host) => {
+      const owner = hostOwner(host);
+      return owner?.accountId === accountId || (owner?.email ? normalizeEmail(owner.email) === email : false);
+    });
+  }
+
   async #prune(): Promise<void> {
     if (!this.#state) return;
     const now = Date.now();
@@ -767,7 +863,12 @@ export class TeamStore {
   }
 
   async #persist(): Promise<void> {
-    const snapshot = structuredClone(this.#requireState());
+    this.#requireState();
+    await this.#persistFile();
+  }
+
+  async #persistFile(): Promise<void> {
+    const snapshot = structuredClone(this.#file);
     const operation = this.#writeChain.then(async () => {
       const temporary = `${this.#path}.${randomUUID()}.tmp`;
       try {
@@ -872,6 +973,24 @@ function validatePassword(value: string): void {
   if (value.length < 12 || value.length > 256) {
     throw new TeamStoreError("Password must contain 12 to 256 characters.");
   }
+}
+
+function hostOwner(host: StoredTeam): StoredMember | undefined {
+  return host.members.find((member) => member.role === "owner");
+}
+
+function ownerAccountId(host: StoredTeam): string | null {
+  return hostOwner(host)?.accountId ?? null;
+}
+
+function isStoredTeamFile(value: unknown): value is StoredTeamFile {
+  if (!isDynamicRecord(value)) return false;
+  return (
+    value.version === 2 &&
+    (value.activeAccountId === null || isString(value.activeAccountId)) &&
+    Array.isArray(value.hosts) &&
+    value.hosts.every((host) => isStoredTeam(host))
+  );
 }
 
 function isStoredTeam(value: unknown): value is StoredTeam {

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -873,6 +873,7 @@ export class TeamStore {
       throw new TeamStoreError(`A host can have up to ${INPUT_LIMITS.teamMembers} members.`);
     }
     const credentials = await hashPassword(password);
+    this.#requireUnchangedState(state);
     const member: StoredMember = {
       id: randomUUID(),
       username: normalizedUsername,
@@ -899,6 +900,7 @@ export class TeamStore {
     if (!member || !(await verifyPassword(password, member))) {
       throw new TeamStoreError("The username or password is incorrect.");
     }
+    this.#requireUnchangedState(state);
     const result = this.#createSession(member);
     await this.#persist();
     return result;
@@ -940,7 +942,9 @@ export class TeamStore {
     if (!member || !(await verifyPassword(currentPassword, member))) {
       throw new TeamStoreError("The current password is incorrect.");
     }
-    Object.assign(member, await hashPassword(nextPassword));
+    const credentials = await hashPassword(nextPassword);
+    this.#requireUnchangedState(state);
+    Object.assign(member, credentials);
     state.sessions = state.sessions.filter((session) => session.memberId !== memberId);
     await this.#persist();
   }
@@ -1058,6 +1062,18 @@ export class TeamStore {
   #requireState(): StoredTeam {
     if (!this.#state) throw new TeamStoreError("The team server is not configured.");
     return this.#state;
+  }
+
+  /**
+   * The host this request started on, still the one being served. Hashing a password takes
+   * long enough for an account switch to land in the middle of it, and the host captured
+   * before that await is still in the file: mutating it there would commit a change the
+   * caller is about to be told failed.
+   */
+  #requireUnchangedState(state: StoredTeam): void {
+    if (this.#state !== state) {
+      throw new TeamStoreError("The signed-in account changed while the request was in flight.");
+    }
   }
 
   /**
@@ -1248,12 +1264,26 @@ function reconcileHost(baseline: StoredTeam, mine: StoredTeam, theirs: StoredTea
     serverName: pickChanged(baseline.serverName, mine.serverName, theirs.serverName),
     enabledOnLaunch: pickChanged(baseline.enabledOnLaunch, mine.enabledOnLaunch, theirs.enabledOnLaunch),
     serverLogo: pickChanged(baseline.serverLogo, mine.serverLogo, theirs.serverLogo),
-    members: reconcileEntries(baseline.members, mine.members, theirs.members),
+    members: reconcileMembers(baseline.members, mine.members, theirs.members),
     invites: reconcileEntries(baseline.invites, mine.invites, theirs.invites),
     // A session missing on either side was signed out there, and `reconcileEntries` keeps
     // it that way rather than handing back a token the user has already revoked.
     sessions: reconcileEntries(baseline.sessions, mine.sessions, theirs.sessions),
   };
+}
+
+/**
+ * Members, with one field held back from the merge. The older build binds a member to an
+ * account by email alone, so an address that has changed hands makes it write a different
+ * account's id onto the same member - and taking that back would hand the host, and the
+ * ownership check with it, to whoever holds the address now. An id is only taken from there
+ * for a member this build knows no account for.
+ */
+function reconcileMembers(baseline: StoredMember[], mine: StoredMember[], theirs: StoredMember[]): StoredMember[] {
+  return reconcileEntries(baseline, mine, theirs).map((member) => {
+    const ours = mine.find((candidate) => candidate.id === member.id);
+    return ours?.accountId ? { ...member, accountId: ours.accountId } : member;
+  });
 }
 
 /** The side that moved, or this build's value when the other side stood still. */

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -182,8 +182,11 @@ export class TeamStore {
       const owner = hostOwner(host);
       return owner !== undefined && !owner.accountId && !owner.email;
     });
-    const previousState = this.#state;
-    const previousAccountId = this.#file.activeAccountId;
+    // Everything below mutates in memory and is committed by the single write at the end,
+    // so a failed write can put the whole file back rather than leave half a switch applied
+    // with the status naming one account and every write going to another.
+    const rollback = structuredClone(this.#file);
+    const previousIndex = this.#state ? hosts.indexOf(this.#state) : -1;
     this.#state =
       hosts.find((host) => ownerAccountId(host) === user.id) ??
       hosts.find((host) => {
@@ -195,25 +198,23 @@ export class TeamStore {
     this.#file.activeAccountId = user.id;
     // A host configured before accounts existed has no owner email to match on next time,
     // so adopting it has to write the binding rather than rely on `syncAccount`.
-    const adopted = this.#state && this.#state === unbound ? hostOwner(this.#state) : undefined;
-    const adoptedBefore = adopted && { accountId: adopted.accountId, email: adopted.email };
-    if (adopted) {
-      adopted.accountId = user.id;
-      adopted.email = email;
+    if (this.#state && this.#state === unbound) {
+      const owner = hostOwner(this.#state);
+      if (owner) {
+        owner.accountId = user.id;
+        owner.email = email;
+      }
+    }
+    if (this.#state) {
+      this.#applyAccount(user);
+      this.#dropExpired(this.#state);
     }
     try {
       await this.#recordActiveAccount();
     } catch (error) {
-      // Staying bound to a host the file does not name would have the status report one
-      // account while every write went to another.
-      this.#state = previousState;
-      this.#file.activeAccountId = previousAccountId;
-      if (adopted && adoptedBefore) Object.assign(adopted, adoptedBefore);
+      this.#file = rollback;
+      this.#state = previousIndex >= 0 ? (this.#file.hosts[previousIndex] ?? null) : null;
       throw error;
-    }
-    if (this.#state) {
-      await this.syncAccount(user);
-      await this.#prune();
     }
   }
 
@@ -454,6 +455,12 @@ export class TeamStore {
     }
     if (previousLogo && previousLogo.version !== nextLogo?.version) {
       await this.#removeLogo(previousLogo).catch(() => undefined);
+    }
+    // Writing the file yields as well. The change is on disk and belongs to the account that
+    // asked for it, but the caller must not go on to push it to the remote host under the
+    // authentication - and the owner membership - of whichever account is active now.
+    if (this.#state !== state) {
+      throw new TeamStoreError("This server is no longer the active one for the signed-in account.");
     }
     return identityOf(state);
   }
@@ -866,6 +873,14 @@ export class TeamStore {
   }
 
   async syncAccount(user: CentralAuthUser): Promise<boolean> {
+    this.#requireState();
+    if (!this.#applyAccount(user)) return false;
+    await this.#persist();
+    return true;
+  }
+
+  /** The profile half of `syncAccount`, without its write. Reports whether anything moved. */
+  #applyAccount(user: CentralAuthUser): boolean {
     const state = this.#requireState();
     const email = normalizeEmail(user.email);
     const member = state.members.find((candidate) => candidate.email === email || candidate.username === email);
@@ -886,7 +901,6 @@ export class TeamStore {
     member.username = email;
     member.name = name;
     member.avatarUrl = avatarUrl;
-    await this.#persist();
     return true;
   }
 
@@ -951,12 +965,15 @@ export class TeamStore {
 
   async #prune(): Promise<void> {
     if (!this.#state) return;
-    const now = Date.now();
-    this.#state.sessions = this.#state.sessions.filter((session) => Date.parse(session.expiresAt) > now);
-    this.#state.invites = this.#state.invites.filter(
-      (invite) => invite.usedAt !== null || Date.parse(invite.expiresAt) > now,
-    );
+    this.#dropExpired(this.#state);
     await this.#persist();
+  }
+
+  /** The expiry half of `#prune`, without its write. */
+  #dropExpired(host: StoredTeam): void {
+    const now = Date.now();
+    host.sessions = host.sessions.filter((session) => Date.parse(session.expiresAt) > now);
+    host.invites = host.invites.filter((invite) => invite.usedAt !== null || Date.parse(invite.expiresAt) > now);
   }
 
   async #persist(): Promise<void> {

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -121,6 +121,8 @@ export interface RemoteDirectoryMember {
 
 export class TeamStore {
   readonly #path: string;
+  /** Read once and never written: the file a build without this envelope still owns. */
+  readonly #legacyPath: string | null;
   readonly #logoRoot: string;
   #file: StoredTeamFile = { version: 2, activeAccountId: null, hosts: [] };
   /** The host of the signed-in account. Every other method reads this one, never `#file.hosts`. */
@@ -137,15 +139,26 @@ export class TeamStore {
    */
   #unreadableFile = false;
 
-  constructor(path: string) {
+  /**
+   * `legacyPath` is the single-host file shipped builds read and write. This store never
+   * writes it, so downgrading finds the host it had rather than a file it cannot parse and
+   * would overwrite - there is no backup of any of this.
+   */
+  constructor(path: string, legacyPath: string | null = null) {
     this.#path = path;
-    this.#logoRoot = join(dirname(path), `${basename(path)}.assets`, "logo");
+    this.#legacyPath = legacyPath;
+    // Named after the file the logos were first stored beside, so an upgrade does not have
+    // to move them.
+    const assetsPath = legacyPath ?? path;
+    this.#logoRoot = join(dirname(assetsPath), `${basename(assetsPath)}.assets`, "logo");
   }
 
   async initialize(): Promise<void> {
     let migrated = false;
+    let found = false;
     try {
       const parsed = JSON.parse(await readFile(this.#path, "utf8"));
+      found = true;
       if (isStoredTeamFile(parsed)) {
         this.#file = parsed;
       } else if (isStoredTeam(parsed)) {
@@ -156,6 +169,19 @@ export class TeamStore {
       }
     } catch (error) {
       if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    }
+    if (!found && this.#legacyPath) {
+      try {
+        const parsed = JSON.parse(await readFile(this.#legacyPath, "utf8"));
+        // Copied into this store's own file rather than replaced in place. Anything else
+        // there belongs to a build that is not this one, and is left for it.
+        if (isStoredTeam(parsed)) {
+          this.#file = { version: 2, activeAccountId: ownerAccountId(parsed), hosts: [parsed] };
+          migrated = true;
+        }
+      } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+      }
     }
     const activeAccountId = this.#file.activeAccountId;
     this.#state =


### PR DESCRIPTION
Fixes #201.

## The bug

`openbot-team-server-v1.json` held exactly one local host at its root, owned by whichever account ran `host:configure` first. Nothing re-bound that record when the signed-in account changed: `forwardCentralAuth` called `syncSignedInAccount(user)`, and `TeamStore.syncAccount` only refreshes profile fields on a member whose email already matches — it returns `false` for a stranger and leaves account A's host active.

So after signing out of A and into B, `HostStatus.configured` stayed `true` with A's `serverId`/`serverName`. `withLocalHostSummary` painted the rail's `local` row with A's name and `role: "owner"`; saving identity branched to `host:update-identity` → `assertOwnerAccount` → *"Sign in with the OpenBot email that created this host."*; `host:start` failed the same way, so B could not publish; and `host:configure` was unreachable behind *"The team server is already configured."*

## The fix

**`src/main/team-store.ts`** — the file now holds a `version: 2` envelope `{ version, activeAccountId, hosts: StoredTeam[] }`. `StoredTeam` itself is unchanged at `version: 1`, and `#state` is still a single `StoredTeam | null` — the *active* host — so `TeamApiServer`, `TeamWebRtcHostGateway` and every other `TeamStore` method are untouched.

- `initialize()` loads a v2 file as-is, migrates a bare v1 record into `hosts: [record]` and persists it, and still writes nothing for an unrecognised file. It then activates `activeAccountId`'s host — or, when that is null, the first host with no owner account, so an offline upgrade shows the host it showed yesterday. A host left behind by a sign-out always has an owner account, so sign-out still unbinds.
- `activateAccount(user)` binds by `owner.accountId`, then owner email (the existing v1 backfill path), then adopts an owner-less host — a password-`configure()`d one — and writes the binding so the next sign-in has something to match. No match leaves the store unconfigured rather than borrowing another account's host.
- `deactivate()` unbinds without removing. **`hosts` is append-only**: this file is user data with no backup, so a sign-out never destroys a host, its members, its invites or its logo.
- `configure` / `configureWithAccount` append to `hosts` and roll the push back if the write fails; the "already configured" guard is now per account.

**`src/main/host-service.ts`** — `syncSignedInAccount` becomes `applySignedInAccount(user | null)`: it stops the runtime when the account actually changes, activates or deactivates the store, and rebuilds `#status` from the newly active identity through a shared `initialHostStatus()` rather than patching it, so a second account cannot inherit the first one's `serverId`, name or `enabledOnLaunch`. Two subtleties: it short-circuits when the same account is reported again (a renamed profile or a new avatar no longer stops a host that is happily online), and `#startRuntimeOperation` now calls `syncAccount` instead of a full re-activation, which would stop the runtime it is starting.

**`src/main/index.ts`** — `forwardCentralAuth` calls `applySignedInAccount(null)` after `stop(false)` on `signed_out`, and `applySignedInAccount(state.user)` on `signed_in` before the `shouldAutoStartHost(status)` check, so B's own `enabledOnLaunch` governs. The startup path follows, and the development bootstrap activates the store right after `ensureDevelopmentAccount`.

Joined *remote* servers were already account-scoped by `#syncWebRtcHosts`, so they are untouched. Per-account `hiddenHostIds` and clearing the joined list on logout were explicitly left out of scope.

## Migration and downgrade

Forward: a shipped `version: 1` file is migrated in place on first `initialize()` and its host stays active. No host is ever removed.

Downgrade: an older build reading a `version: 2` file falls into the existing "unrecognised → no state" branch, so downgrading shows an unconfigured host. It does **not** keep that file safe, though — the released build persists an empty record over anything it did not recognise as soon as it signs an account in or configures a host, so a downgrade loses the v2 file. That is the pre-existing behaviour, not something this PR introduces, and it is the exposure of any format bump here; calling it out rather than pretending otherwise. This PR fixes that half going forward: a file this build cannot read is never written over, and configuring a server refuses outright with a message telling the user to move it aside.

## Surfaces touched

Desktop main process and the persisted team file. No IPC channel is added or changed, so `packages/contracts`, `src/preload/index.ts` and `src/renderer/src/preview/mock-openbot.ts` stay as they are — the renderer picks the status reset up through its existing `host.onEvent` subscription. No renderer, mobile, public web, palette, SQLite or `PRIVACY.md` change; nothing new leaves the machine. No UI change, so no before/after screenshots.

## Tests

Persisted state is a mandatory boundary and `TeamStore` is the lowest stable one here, so the coverage went into the existing `src/main/team-store.test.ts` (21 → 25 tests) rather than a new file:

- account B configuring a host leaves A's host, members, invites and logo intact, and re-activating A returns A's `serverId`, both members and the pending invite;
- signing out leaves nothing bound, and the next sign-in restores it;
- a host configured before accounts existed is adopted by the first account that activates, its owner is recorded, and it survives a restart;
- activating an account with no host neither throws nor mutates `hosts`.

Three existing assertions were repointed at `hosts[0]` through new `readStoredHost`/`readStoredHosts` helpers — their premise, the file's root shape, genuinely changed. The legacy-backfill test now writes a bare v1 record back, so it covers the v1→v2 migration too.

**Watched each one fail** (Tests rule 2), one break at a time, restoring between runs:

| Break | Red test | Failure |
| --- | --- | --- |
| `activateAccount` matches `hosts[0]` first | keeps each account's host separate | `expected true to be false` — B borrowing A's host, the bug in #201 |
| `deactivate()` leaves `activeAccountId` set | leaves no host bound after signing out | `expected true to be false` |
| adoption-binding block removed | adopts a host configured before accounts existed | `expected null to deeply equal { id: 'account-a', … }` |
| `activateAccount` persists via `#persist()` | activates nothing for an account that has no host | `The team server is not configured.` |

I dropped the optional `host-service.test.ts` the plan allowed for. `HostServiceOptions` requires the concrete `AgentService`, `SkillMarketplaceService`, `SidebarLayoutStore`, `MailboxStore` and `BrowserHost` classes — unlike `TeamApiServer`, which takes narrow structural interfaces — so constructing it needs `as unknown as` assertions, and the escape hatch is worse than the coverage.

## Verification

- `bun run test:desktop -- src/main/team-store.test.ts` — 25/25
- `bun run test:desktop -- src/main/team-api-server.test.ts src/main/remote-server-manager.test.ts src/main/team-webrtc-host-gateway.test.ts` — 55/55 (all three consume `TeamStore` and would catch a broken `#state` contract)
- `bun run test:desktop -- src/main/ipc-channel-coverage.test.ts` — 13/13
- `bun run typecheck:node` and `biome check` on the four changed files — clean
- No repo-wide checks; CI owns those.

**Not done:** the manual account switch against the running dev stack. It needs the shared dev instance, which other sessions are using.

No `biome-ignore`, `@ts-expect-error`, `overrides` entry, `any`/`unknown` widening or checker assertion was added.

Model: Claude Opus 5, via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

