### PR TITLE
refactor(contracts): route the Team API through one shared path table

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -13,6 +13,8 @@
     "./ipc": "./src/ipc.ts",
     "./mobile-connect": "./src/mobile-connect.ts",
     "./runtime-values": "./src/runtime-values.ts",
+    "./ipc-decoding": "./src/ipc-decoding.ts",
+    "./team-api-routes": "./src/team-api-routes.ts",
     "./team-protocol": "./src/team-protocol/index.ts",
     "./team-protocol/current": "./src/team-protocol/current.ts",
     "./team-protocol/v1": "./src/team-protocol/v1.ts",

--- a/packages/contracts/src/ipc-decoding.ts
+++ b/packages/contracts/src/ipc-decoding.ts
@@ -1,0 +1,72 @@
+// The throwing field readers both untrusted-input boundaries need.
+//
+// `src/preload/index.ts` decodes what the main process sends the renderer; `remote-server-manager.ts`
+// decodes what a remote team server sends this machine. They had a hand-written copy each of the same
+// five readers, with identical logic and identical messages, and each was the kind of function whose
+// second copy drifts silently.
+//
+// This is deliberately only the *identical* half. Several decoders share a name across the two files
+// and are not the same function - `decodeAgentStatus` accepts any string phase in the preload and
+// enumerates the phases in the server client - because they guard different boundaries: main is
+// trusted by the renderer, a remote host is trusted by nobody. Merging those on the looser one would
+// weaken the network boundary, so they stay apart and say in their names which side they guard.
+//
+// These throw, which is why they are not in `runtime-values.ts`: that file is pure non-throwing
+// predicates, imported by the renderer, the backend and the preload alike.
+
+import { type DynamicRecord, isBoolean, isDynamicRecord, isNumber, isString } from "./runtime-values";
+
+export function decodeRecord(value: unknown, label: string): DynamicRecord {
+  if (!isDynamicRecord(value)) throw new Error(`Invalid ${label}.`);
+  return value;
+}
+
+export function requiredString(record: DynamicRecord, field: string): string {
+  const value = record[field];
+  if (!isString(value)) throw new Error(`Invalid ${field}.`);
+  return value;
+}
+
+export function requiredNumber(record: DynamicRecord, field: string): number {
+  const value = record[field];
+  if (!isNumber(value)) throw new Error(`Invalid ${field}.`);
+  return value;
+}
+
+export function requiredBoolean(record: DynamicRecord, field: string): boolean {
+  const value = record[field];
+  if (!isBoolean(value)) throw new Error(`Invalid ${field}.`);
+  return value;
+}
+
+export function nullableString(record: DynamicRecord, field: string): string | null {
+  const value = record[field];
+  if (value === null || isString(value)) return value;
+  throw new Error(`Invalid ${field}.`);
+}
+
+// A decoder is a `(value: unknown) => T` callback, so the label cannot be a parameter of the decoder
+// itself without every call site wrapping it in a lambda. These build one instead, which keeps each
+// boundary's own wording - the message is what tells a reader which side rejected the payload.
+export function guardedDecoder<T>(guard: (value: unknown) => value is T, label: string): (value: unknown) => T {
+  return (value) => {
+    if (!guard(value)) throw new Error(`Invalid ${label}.`);
+    return value;
+  };
+}
+
+export function guardedListDecoder<T>(guard: (value: unknown) => value is T, label: string): (value: unknown) => T[] {
+  return (value) => {
+    if (!Array.isArray(value) || !value.every(guard)) throw new Error(`Invalid ${label}.`);
+    return value;
+  };
+}
+
+// A channel that answers with nothing has to reject a payload rather than ignore it: data where none
+// was expected means the two sides disagree about the channel.
+export function emptyDecoder(message: string): (value: unknown) => undefined {
+  return (value) => {
+    if (value !== undefined && value !== null) throw new Error(message);
+    return undefined;
+  };
+}

--- a/packages/contracts/src/ipc-team-host.ts
+++ b/packages/contracts/src/ipc-team-host.ts
@@ -1,5 +1,10 @@
 import type { AvatarImageInput } from "./ipc-conversation";
 
+// The id every IPC payload carries for "this computer" rather than a remote team server. It is a
+// wire value the main process, the preload bridge and the renderer all compare against, so it lives
+// beside the types they share instead of being retyped at each comparison.
+export const LOCAL_SERVER_ID = "local";
+
 export type ServerConnectionState = "online" | "connecting" | "offline" | "error" | "incompatible";
 export type TeamRole = "owner" | "admin" | "member";
 

--- a/packages/contracts/src/team-api-routes.ts
+++ b/packages/contracts/src/team-api-routes.ts
@@ -26,6 +26,13 @@ function segment(value: string): string {
   return encodeURIComponent(value);
 }
 
+// The remote-screen namespace, exposed on the group below as `prefix` because it is rewritten as a
+// *string inside a served body*, not built as a path: `remote-viewer-proxy.ts` prefixes every
+// occurrence in the viewer's HTML and JavaScript with its own server-scoped base, so a rename here
+// that the proxy did not follow would leave those assets pointing outside the proxy and 404. The
+// group's entries are built from it so there is one source, not a fifth copy.
+const REMOTE_SCREEN = "/v1/remote-screen";
+
 export const TEAM_API_ROUTES = {
   compatibility: "/v1/compatibility",
   identity: "/v1/identity",
@@ -84,15 +91,16 @@ export const TEAM_API_ROUTES = {
     visible: "/v1/browser/visible",
   },
   remoteScreen: {
-    capabilities: "/v1/remote-screen/capabilities",
-    sessions: "/v1/remote-screen/sessions",
-    session: (sessionId: string) => `/v1/remote-screen/sessions/${segment(sessionId)}`,
-    display: "/v1/remote-screen/display",
+    prefix: REMOTE_SCREEN,
+    capabilities: `${REMOTE_SCREEN}/capabilities`,
+    sessions: `${REMOTE_SCREEN}/sessions`,
+    session: (sessionId: string) => `${REMOTE_SCREEN}/sessions/${segment(sessionId)}`,
+    display: `${REMOTE_SCREEN}/display`,
     // Served by `remote-screen-gateway.ts`, which the Team API router delegates the whole
     // `sessions/:id/{viewer,authorize,viewer-state,moonlight}` family to. It is here because the
     // client and the gateway's own `viewerUrl` both build it, and it answers 404 for a session that
     // does not exist - so it is not part of the route round-trip case.
-    viewer: (sessionId: string) => `/v1/remote-screen/sessions/${segment(sessionId)}/viewer`,
+    viewer: (sessionId: string) => `${REMOTE_SCREEN}/sessions/${segment(sessionId)}/viewer`,
   },
   sidebarLayout: {
     state: "/v1/sidebar-layout",

--- a/packages/contracts/src/team-api-routes.ts
+++ b/packages/contracts/src/team-api-routes.ts
@@ -1,0 +1,141 @@
+// Every Team API path the desktop builds, in one place.
+//
+// The host router in `src/main/team-api-server.ts` and the client in `src/main/remote-server-manager.ts`
+// are two hand-written halves of one HTTP surface, and until this table every path was a bare string
+// literal on both of them - plus a third copy in the IPC handlers that call through. Nothing linked
+// the copies, so a rename that missed one half broke every remote server silently. The IPC channel
+// version of that mistake is caught by `src/main/ipc-channel-coverage.test.ts`; this had no
+// equivalent, which is why it comes with a round-trip case in `src/main/team-api-server.test.ts`.
+//
+// These are path *builders*, not a matcher, and every entry is exactly what the host compares
+// `url.pathname` against - queries stay at the call site that knows the parameters. The host does not
+// compare full paths for the parametric routes: it regex-matches `/v1/agents/:botId` and switches on
+// an action sub-segment, so a shared matcher would mean rewriting its 404 and 405 semantics. Static
+// entries are for both halves; the host's regex branches stay literal.
+//
+// The frozen artifacts under `./team-protocol` deliberately do not import this table. `v1.ts` keeps
+// its own copy of the route list because it classifies requests for a *released* wire protocol: if a
+// rename here followed into it, the meaning of a shipped protocol would change, and that is the one
+// thing a released adapter may never do. The duplication there is the point - do not "fix" it.
+//
+// The cloud account API in `apps/auth-api` serves `/v1/...` paths of its own. It is an unrelated
+// service reached by `central-auth-manager.ts` and the marketplace services, and its routes do not
+// belong here.
+
+function segment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export const TEAM_API_ROUTES = {
+  compatibility: "/v1/compatibility",
+  identity: "/v1/identity",
+  events: "/v1/events",
+  me: "/v1/me",
+  attachments: "/v1/attachments",
+  attachment: (attachmentId: string) => `/v1/attachments/${segment(attachmentId)}`,
+  sharedFiles: "/v1/shared-files",
+  workspaceFiles: "/v1/workspace-files",
+  // The WebSocket upgrade path, not a JSON endpoint.
+  remoteDesktopUpgrade: "/v1/remote-desktop",
+  join: {
+    server: "/v1/join",
+    account: "/v1/join/account",
+    invitationPreview: "/v1/invitations/preview",
+  },
+  auth: {
+    login: "/v1/auth/login",
+    account: "/v1/auth/account",
+    logout: "/v1/auth/logout",
+    password: "/v1/auth/password",
+  },
+  host: {
+    remoteMac: "/v1/host/remote-mac",
+    remoteDesktopAccess: "/v1/host/remote-desktop-access",
+  },
+  team: {
+    presence: "/v1/team/presence",
+    logo: "/v1/team/logo",
+    members: "/v1/team/members",
+    member: (memberId: string) => `/v1/team/members/${segment(memberId)}`,
+    invites: "/v1/team/invites",
+    invite: (inviteId: string) => `/v1/team/invites/${segment(inviteId)}`,
+    sessions: "/v1/team/sessions",
+    session: (sessionId: string) => `/v1/team/sessions/${segment(sessionId)}`,
+  },
+  direct: {
+    threads: "/v1/direct/threads",
+    messages: "/v1/direct/messages",
+    conversation: (memberId: string) => `/v1/direct/conversations/${segment(memberId)}`,
+    conversationPage: (memberId: string) => `/v1/direct/conversations/${segment(memberId)}/page`,
+    conversationRead: (memberId: string) => `/v1/direct/conversations/${segment(memberId)}/read`,
+  },
+  messages: {
+    search: "/v1/messages/search",
+  },
+  browser: {
+    open: "/v1/browser/open",
+    activate: "/v1/browser/activate",
+    navigate: "/v1/browser/navigate",
+    reload: "/v1/browser/reload",
+    close: "/v1/browser/close",
+    tabs: "/v1/browser/tabs",
+    control: "/v1/browser/control",
+    preview: "/v1/browser/preview",
+    visible: "/v1/browser/visible",
+  },
+  remoteScreen: {
+    capabilities: "/v1/remote-screen/capabilities",
+    sessions: "/v1/remote-screen/sessions",
+    session: (sessionId: string) => `/v1/remote-screen/sessions/${segment(sessionId)}`,
+    display: "/v1/remote-screen/display",
+    // Served by `remote-screen-gateway.ts`, which the Team API router delegates the whole
+    // `sessions/:id/{viewer,authorize,viewer-state,moonlight}` family to. It is here because the
+    // client and the gateway's own `viewerUrl` both build it, and it answers 404 for a session that
+    // does not exist - so it is not part of the route round-trip case.
+    viewer: (sessionId: string) => `/v1/remote-screen/sessions/${segment(sessionId)}/viewer`,
+  },
+  sidebarLayout: {
+    state: "/v1/sidebar-layout",
+    actions: "/v1/sidebar-layout/actions",
+  },
+  respond: {
+    prompt: "/v1/prompts/respond",
+    approval: "/v1/approvals/respond",
+    browserTakeover: "/v1/browser-takeovers/respond",
+  },
+  agents: {
+    // GET lists, POST creates.
+    all: "/v1/agents",
+    status: "/v1/agents/status",
+    usage: "/v1/agents/usage",
+    models: "/v1/agents/models",
+    conversationReads: "/v1/agents/conversation-reads",
+  },
+  agent: {
+    // PATCH updates, DELETE removes.
+    one: (botId: string) => `/v1/agents/${segment(botId)}`,
+    skills: (botId: string) => `/v1/agents/${segment(botId)}/skills`,
+    duplicate: (botId: string) => `/v1/agents/${segment(botId)}/duplicate`,
+    avatar: (botId: string) => `/v1/agents/${segment(botId)}/avatar`,
+    conversation: (botId: string) => `/v1/agents/${segment(botId)}/conversation`,
+    conversationPage: (botId: string) => `/v1/agents/${segment(botId)}/conversation-page`,
+    conversationRead: (botId: string) => `/v1/agents/${segment(botId)}/conversation/read`,
+    messages: (botId: string) => `/v1/agents/${segment(botId)}/messages`,
+    reactions: (botId: string) => `/v1/agents/${segment(botId)}/reactions`,
+    interrupt: (botId: string) => `/v1/agents/${segment(botId)}/interrupt`,
+    failuresAcknowledge: (botId: string) => `/v1/agents/${segment(botId)}/failures/acknowledge`,
+    queue: (botId: string) => `/v1/agents/${segment(botId)}/queue`,
+    queueCancel: (botId: string) => `/v1/agents/${segment(botId)}/queue/cancel`,
+    queueSteer: (botId: string) => `/v1/agents/${segment(botId)}/queue/steer`,
+    queueUpdate: (botId: string) => `/v1/agents/${segment(botId)}/queue/update`,
+    queueReorder: (botId: string) => `/v1/agents/${segment(botId)}/queue/reorder`,
+    memories: (botId: string) => `/v1/agents/${segment(botId)}/memories`,
+    memory: (botId: string, memoryId: string) => `/v1/agents/${segment(botId)}/memories/${segment(memoryId)}`,
+    routines: (botId: string) => `/v1/agents/${segment(botId)}/routines`,
+    routine: (botId: string, routineId: string) => `/v1/agents/${segment(botId)}/routines/${segment(routineId)}`,
+    routineTest: (botId: string, routineId: string) =>
+      `/v1/agents/${segment(botId)}/routines/${segment(routineId)}/test`,
+    routineRuns: (botId: string, routineId: string) =>
+      `/v1/agents/${segment(botId)}/routines/${segment(routineId)}/runs`,
+  },
+} as const;

--- a/packages/contracts/src/team-protocol/v1.ts
+++ b/packages/contracts/src/team-protocol/v1.ts
@@ -1898,7 +1898,11 @@ function projectV1RoutineSchedule(value: DynamicRecord): TeamProtocolV1JsonObjec
   }
 }
 
-function teamProtocolV1HttpRoute(method: string, path: string): TeamProtocolV1HttpRoute | null {
+// Exported for the shared route table's coverage case in `src/main/team-api-server.test.ts`. The host
+// encodes every JSON response through this adapter, so a path `TEAM_API_ROUTES` builds that this
+// frozen list cannot name is a route no client can be answered on. Classification only: it reads the
+// list below and decides nothing, so exporting it leaves every released response meaning what it did.
+export function teamProtocolV1HttpRoute(method: string, path: string): TeamProtocolV1HttpRoute | null {
   const pathname = new URL(path, "http://openbot.invalid").pathname;
   const exact: Record<string, TeamProtocolV1HttpRoute> = {
     "GET /v1/compatibility": "GET compatibility",

--- a/src/main/dynamic-island-actions.ts
+++ b/src/main/dynamic-island-actions.ts
@@ -1,4 +1,6 @@
 import type { DynamicIslandAction } from "@openbot/contracts/ipc";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
+import { routeToServer } from "./ipc/route-to-server";
 
 type CriticalAction = Extract<DynamicIslandAction, { type: "answer-prompt" | "respond-approval" }>;
 
@@ -24,11 +26,17 @@ export async function performDynamicIslandCriticalAction(
 ): Promise<void> {
   if (action.type === "answer-prompt") {
     const input = { requestId: action.requestId, answers: action.answers };
-    if (action.serverId === "local") await local.respondToPrompt(input);
-    else await remote.request("/v1/prompts/respond", { method: "POST", body: input }, action.serverId, decodeVoid);
+    await routeToServer<void>(action.serverId, {
+      local: () => local.respondToPrompt(input),
+      remote: (serverId) =>
+        remote.request(TEAM_API_ROUTES.respond.prompt, { method: "POST", body: input }, serverId, decodeVoid),
+    });
     return;
   }
   const input = { requestId: action.requestId, decision: action.decision };
-  if (action.serverId === "local") await local.respondToApproval(input);
-  else await remote.request("/v1/approvals/respond", { method: "POST", body: input }, action.serverId, decodeVoid);
+  await routeToServer<void>(action.serverId, {
+    local: () => local.respondToApproval(input),
+    remote: (serverId) =>
+      remote.request(TEAM_API_ROUTES.respond.approval, { method: "POST", body: input }, serverId, decodeVoid),
+  });
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -448,7 +448,7 @@ function createWindow(): BrowserWindow {
     }
     const tabId = browserHost?.activeTabId;
     if (
-      remoteServerManager?.activeServerId !== "local" ||
+      remoteServerManager?.activeServerId !== LOCAL_SERVER_ID ||
       !browserHost?.visible ||
       !tabId ||
       !isCloseBrowserTabShortcut(input)
@@ -1588,7 +1588,7 @@ function configureServerLogoProtocols(teamStore: TeamStore): void {
     try {
       const url = new URL(request.url);
       const logo = teamStore.resolveLogo();
-      if (url.hostname !== "local" || !logo || logo.version !== url.searchParams.get("v")) {
+      if (url.hostname !== LOCAL_SERVER_ID || !logo || logo.version !== url.searchParams.get("v")) {
         return new Response("Not found", { status: 404 });
       }
       return new Response(await readFile(logo.path), {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import {
   type BrowserDisplayState,
   type CentralAuthState,
   IPC_CHANNELS,
+  LOCAL_SERVER_ID,
   type MacPermissionId,
   type VoiceModelStatus,
 } from "@openbot/contracts/ipc";
@@ -658,7 +659,7 @@ function configureApplicationMenu(service: AgentService, updater: UpdateService)
 }
 
 function forwardAgentEvent(serverId: string, event: AgentEvent, bufferedLive = false): void {
-  if (serverId === "local") hostAnalytics?.handleAgentEvent(event);
+  if (serverId === LOCAL_SERVER_ID) hostAnalytics?.handleAgentEvent(event);
   if (!mainWindow || mainWindow.isDestroyed()) return;
   sendToRenderer(
     mainWindow,

--- a/src/main/ipc/register-agent-handlers.ts
+++ b/src/main/ipc/register-agent-handlers.ts
@@ -11,16 +11,17 @@ import {
   type SidebarLayoutSnapshot,
   type UpdateBotInput,
 } from "@openbot/contracts/ipc";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import type { AgentService } from "../../backend/agent-service";
 import type { SidebarLayoutStore } from "../../backend/sidebar-layout-store";
 import type { HostService } from "../host-service";
 import {
-  decodeAccountUsage,
+  decodeAccountUsageFromHost,
   decodeAgentModelOptions,
-  decodeAgentStatus,
+  decodeAgentStatusFromHost,
   decodeBotSummaries,
   decodeBotSummary,
-  decodeInstalledSkills,
+  decodeInstalledSkillsFromHost,
   decodeQueuedMessageReceipt,
   decodeQueueSnapshot,
   decodeSidebarLayoutSnapshot,
@@ -50,6 +51,7 @@ import {
   parseUpdateBot,
   parseUpdateQueuedMessage,
 } from "./agent-inputs";
+import { routeToServer } from "./route-to-server";
 import { requireString } from "./validation";
 
 export interface AgentIpcDependencies {
@@ -68,70 +70,72 @@ export function registerAgentIpcHandlers({
   skills,
 }: AgentIpcDependencies): void {
   handleTrusted(IPC_CHANNELS.agentGetStatus, parseAgentRequest, (parsed) => {
-    const { serverId } = parsed;
-    return serverId === "local"
-      ? service.getStatus()
-      : remoteServers.request("/v1/agents/status", {}, serverId, decodeAgentStatus);
+    return routeToServer(parsed.serverId, {
+      local: () => service.getStatus(),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.agents.status, {}, serverId, decodeAgentStatusFromHost),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentGetUsage, parseAgentRequest, (parsed) => {
-    const { serverId } = parsed;
-    return serverId === "local"
-      ? service.getUsage()
-      : remoteServers.request("/v1/agents/usage", {}, serverId, decodeAccountUsage);
+    return routeToServer(parsed.serverId, {
+      local: () => service.getUsage(),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.agents.usage, {}, serverId, decodeAccountUsageFromHost),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentListModels, parseAgentRequest, (parsed) => {
-    const { serverId } = parsed;
-    return serverId === "local"
-      ? service.listModels()
-      : remoteServers.request("/v1/agents/models", {}, serverId, decodeAgentModelOptions);
+    return routeToServer(parsed.serverId, {
+      local: () => service.listModels(),
+      remote: (serverId) => remoteServers.request(TEAM_API_ROUTES.agents.models, {}, serverId, decodeAgentModelOptions),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentListBots, parseAgentRequest, (parsed) => {
-    const { serverId } = parsed;
-    return serverId === "local"
-      ? service.listBots()
-      : remoteServers.request("/v1/agents", {}, serverId, decodeBotSummaries);
+    return routeToServer(parsed.serverId, {
+      local: () => service.listBots(),
+      remote: (serverId) => remoteServers.request(TEAM_API_ROUTES.agents.all, {}, serverId, decodeBotSummaries),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentListInstalledSkills, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
-    return scoped.serverId === "local"
-      ? skills.listInstalledForChatTags(botId)
-      : remoteServers
-            .list()
-            .find((server) => server.id === scoped.serverId)
-            ?.compatibility?.capabilities.includes("installed-skills")
-        ? remoteServers.request(
-            `/v1/agents/${encodeURIComponent(botId)}/skills`,
-            {},
-            scoped.serverId,
-            decodeInstalledSkills,
-          )
-        : Promise.resolve([]);
+    return routeToServer(scoped.serverId, {
+      local: () => skills.listInstalledForChatTags(botId),
+      // A server too old to know the endpoint would answer 404, so ask its advertised capabilities first.
+      remote: (serverId) =>
+        remoteServers
+          .list()
+          .find((server) => server.id === serverId)
+          ?.compatibility?.capabilities.includes("installed-skills")
+          ? remoteServers.request(TEAM_API_ROUTES.agent.skills(botId), {}, serverId, decodeInstalledSkillsFromHost)
+          : Promise.resolve([]),
+    });
   });
-  handleTrusted(
-    IPC_CHANNELS.agentGetSidebarLayout,
-    parseAgentRequest,
-    ({ serverId }): Promise<SidebarLayoutSnapshot> => {
-      return serverId === "local"
-        ? Promise.resolve(sidebarLayout.getSnapshot())
-        : remoteServers.request("/v1/sidebar-layout", {}, serverId, decodeSidebarLayoutSnapshot);
-    },
-  );
+  handleTrusted(IPC_CHANNELS.agentGetSidebarLayout, parseAgentRequest, (parsed): Promise<SidebarLayoutSnapshot> => {
+    return routeToServer(parsed.serverId, {
+      local: () => sidebarLayout.getSnapshot(),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.sidebarLayout.state, {}, serverId, decodeSidebarLayoutSnapshot),
+    });
+  });
   handleTrusted(IPC_CHANNELS.agentMutateSidebarLayout, parseAgentRequest, (scoped): Promise<SidebarLayoutSnapshot> => {
     const action = parseSidebarLayoutAction(scoped.payload);
-    return scoped.serverId === "local"
-      ? sidebarLayout.mutate(action, new Set(service.listBots().map((bot) => bot.id)))
-      : remoteServers.request(
-          "/v1/sidebar-layout/actions",
+    return routeToServer(scoped.serverId, {
+      local: () => sidebarLayout.mutate(action, new Set(service.listBots().map((bot) => bot.id))),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.sidebarLayout.actions,
           { method: "POST", body: action },
-          scoped.serverId,
+          serverId,
           decodeSidebarLayoutSnapshot,
-        );
+        ),
+    });
   });
-  handleTrusted(IPC_CHANNELS.agentCreateBot, parseAgentRequest, ({ serverId, payload }) => {
-    const parsed = parseCreateBot(payload);
-    return serverId === "local"
-      ? service.createBot(parsed)
-      : remoteServers.request("/v1/agents", { method: "POST", body: parsed }, serverId, decodeBotSummary);
+  handleTrusted(IPC_CHANNELS.agentCreateBot, parseAgentRequest, (scoped) => {
+    const parsed = parseCreateBot(scoped.payload);
+    return routeToServer(scoped.serverId, {
+      local: () => service.createBot(parsed),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.agents.all, { method: "POST", body: parsed }, serverId, decodeBotSummary),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentDuplicateBot, parseAgentRequest, (scoped): Promise<DuplicateBotResult> => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
@@ -142,9 +146,10 @@ export function registerAgentIpcHandlers({
   });
   handleTrusted(IPC_CHANNELS.agentSetAvatar, parseAgentRequest, (scoped) => {
     const parsed = parseSetAgentAvatar(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.setAvatar(parsed.botId, parsed.image)
-      : remoteServers.setAgentAvatar(parsed.botId, parsed.image, scoped.serverId);
+    return routeToServer(scoped.serverId, {
+      local: () => service.setAvatar(parsed.botId, parsed.image),
+      remote: (serverId) => remoteServers.setAgentAvatar(parsed.botId, parsed.image, serverId),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentDeleteBot, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId");
@@ -155,99 +160,104 @@ export function registerAgentIpcHandlers({
   });
   handleTrusted(IPC_CHANNELS.agentReadConversationPage, parseAgentRequest, (scoped) => {
     const parsed = parseReadConversationPage(scoped.payload);
-    return scoped.serverId === "local"
-      ? host.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit)
-      : remoteServers.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit, scoped.serverId);
+    return routeToServer(scoped.serverId, {
+      local: () => host.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit),
+      remote: (serverId) =>
+        remoteServers.readAgentConversationPage(parsed.botId, parsed.anchor, parsed.limit, serverId),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentSearchConversationMessages, parseAgentRequest, (scoped) => {
     const parsed = parseSearchConversationMessages(scoped.payload);
-    return scoped.serverId === "local"
-      ? host.searchAgentConversationMessages(parsed.query, parsed.botId, parsed.cursor, parsed.limit)
-      : remoteServers.searchAgentConversationMessages(
+    return routeToServer(scoped.serverId, {
+      local: () => host.searchAgentConversationMessages(parsed.query, parsed.botId, parsed.cursor, parsed.limit),
+      remote: (serverId) =>
+        remoteServers.searchAgentConversationMessages(
           parsed.query,
           parsed.botId,
           parsed.cursor,
           parsed.limit,
-          scoped.serverId,
-        );
+          serverId,
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentListConversationReads, parseAgentRequest, (parsed) => {
-    const { serverId } = parsed;
-    return serverId === "local"
-      ? host.listAgentConversationReads()
-      : remoteServers.listAgentConversationReads(serverId);
+    return routeToServer(parsed.serverId, {
+      local: () => host.listAgentConversationReads(),
+      remote: (serverId) => remoteServers.listAgentConversationReads(serverId),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentMarkConversationRead, parseAgentRequest, (scoped) => {
     const parsed = parseMarkConversationRead(scoped.payload);
-    return scoped.serverId === "local"
-      ? host.markAgentConversationRead(parsed)
-      : remoteServers.markAgentConversationRead(parsed, scoped.serverId);
+    return routeToServer(scoped.serverId, {
+      local: () => host.markAgentConversationRead(parsed),
+      remote: (serverId) => remoteServers.markAgentConversationRead(parsed, serverId),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentSendMessage, parseAgentRequest, (scoped) => {
     return routeSendMessage(service, remoteServers, scoped.serverId, parseSendMessage(scoped.payload));
   });
   handleTrusted(IPC_CHANNELS.agentSetMessageReaction, parseAgentRequest, (scoped) => {
     const parsed = parseMessageReaction(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.setMessageReaction(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/reactions`,
-          {
-            method: "POST",
-            body: parsed,
-          },
-          scoped.serverId,
+    return routeToServer(scoped.serverId, {
+      local: () => service.setMessageReaction(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.reactions(parsed.botId),
+          { method: "POST", body: parsed },
+          serverId,
           decodeVoid,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentListQueue, parseAgentRequest, (scoped) => {
     return routeListQueue(service, remoteServers, scoped.serverId, requireString(scoped.payload, "botId"));
   });
   handleTrusted(IPC_CHANNELS.agentAcknowledgeFailedTurn, parseAgentRequest, (scoped) => {
     const parsed = parseAcknowledgeFailedTurn(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.acknowledgeFailedTurn(parsed.botId, parsed.turnId)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/failures/acknowledge`,
+    return routeToServer(scoped.serverId, {
+      local: () => service.acknowledgeFailedTurn(parsed.botId, parsed.turnId),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.failuresAcknowledge(parsed.botId),
           { method: "POST", body: { turnId: parsed.turnId } },
-          scoped.serverId,
+          serverId,
           decodeVoid,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentCancelQueuedMessage, parseAgentRequest, (scoped) => {
     const parsed = parseCancelQueuedMessage(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.cancelQueuedMessage(parsed.botId, parsed.deliveryId)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/cancel`,
-          {
-            method: "POST",
-            body: { deliveryId: parsed.deliveryId },
-          },
-          scoped.serverId,
+    return routeToServer(scoped.serverId, {
+      local: () => service.cancelQueuedMessage(parsed.botId, parsed.deliveryId),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.queueCancel(parsed.botId),
+          { method: "POST", body: { deliveryId: parsed.deliveryId } },
+          serverId,
           decodeVoid,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentSteerQueuedMessage, parseAgentRequest, (scoped) => {
     const parsed = parseSteerQueuedMessage(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.steerQueuedMessage(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/steer`,
-          {
-            method: "POST",
-            body: { deliveryId: parsed.deliveryId, expectedTurnId: parsed.expectedTurnId },
-          },
-          scoped.serverId,
+    return routeToServer(scoped.serverId, {
+      local: () => service.steerQueuedMessage(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.queueSteer(parsed.botId),
+          { method: "POST", body: { deliveryId: parsed.deliveryId, expectedTurnId: parsed.expectedTurnId } },
+          serverId,
           decodeVoid,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentUpdateQueuedMessage, parseAgentRequest, (scoped) => {
     const parsed = parseUpdateQueuedMessage(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.updateQueuedMessage(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/update`,
+    return routeToServer(scoped.serverId, {
+      local: () => service.updateQueuedMessage(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.queueUpdate(parsed.botId),
           {
             method: "POST",
             body: {
@@ -257,57 +267,65 @@ export function registerAgentIpcHandlers({
               attachmentDraftIds: parsed.attachmentDraftIds,
             },
           },
-          scoped.serverId,
+          serverId,
           decodeVoid,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentReorderQueue, parseAgentRequest, (scoped) => {
     const parsed = parseReorderQueue(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.reorderQueue(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/queue/reorder`,
+    return routeToServer(scoped.serverId, {
+      local: () => service.reorderQueue(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.queueReorder(parsed.botId),
           { method: "POST", body: { deliveryIds: parsed.deliveryIds } },
-          scoped.serverId,
+          serverId,
           decodeVoid,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentInterrupt, parseAgentRequest, (scoped) => {
     const parsed = parseInterrupt(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.interrupt(parsed.botId, parsed.turnId)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/interrupt`,
-          {
-            method: "POST",
-            body: { turnId: parsed.turnId },
-          },
-          scoped.serverId,
+    return routeToServer(scoped.serverId, {
+      local: () => service.interrupt(parsed.botId, parsed.turnId),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.interrupt(parsed.botId),
+          { method: "POST", body: { turnId: parsed.turnId } },
+          serverId,
           decodeVoid,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentRespondToPrompt, parseAgentRequest, (scoped) => {
     const parsed = parsePromptResponse(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.respondToPrompt(parsed)
-      : remoteServers.request("/v1/prompts/respond", { method: "POST", body: parsed }, scoped.serverId, decodeVoid);
+    return routeToServer(scoped.serverId, {
+      local: () => service.respondToPrompt(parsed),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.respond.prompt, { method: "POST", body: parsed }, serverId, decodeVoid),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentRespondToApproval, parseAgentRequest, (scoped) => {
     const parsed = parseApprovalResponse(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.respondToApproval(parsed)
-      : remoteServers.request("/v1/approvals/respond", { method: "POST", body: parsed }, scoped.serverId, decodeVoid);
+    return routeToServer(scoped.serverId, {
+      local: () => service.respondToApproval(parsed),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.respond.approval, { method: "POST", body: parsed }, serverId, decodeVoid),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentRespondToBrowserTakeover, parseAgentRequest, (scoped) => {
     const parsed = parseBrowserTakeoverResponse(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.respondToBrowserTakeover(parsed)
-      : remoteServers.request(
-          "/v1/browser-takeovers/respond",
+    return routeToServer(scoped.serverId, {
+      local: () => service.respondToBrowserTakeover(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.respond.browserTakeover,
           { method: "POST", body: parsed },
-          scoped.serverId,
+          serverId,
           decodeVoid,
-        );
+        ),
+    });
   });
 }
 
@@ -317,44 +335,56 @@ function routeUpdateBot(
   serverId: string,
   input: UpdateBotInput,
 ) {
-  return serverId === "local"
-    ? service.updateBot(input)
-    : remoteServers.request(
-        `/v1/agents/${encodeURIComponent(input.botId)}`,
-        {
-          method: "PATCH",
-          body: input,
-        },
-        serverId,
+  return routeToServer(serverId, {
+    local: () => service.updateBot(input),
+    remote: (target) =>
+      remoteServers.request(
+        TEAM_API_ROUTES.agent.one(input.botId),
+        { method: "PATCH", body: input },
+        target,
         decodeBotSummary,
-      );
+      ),
+  });
 }
 
-async function routeDeleteBot(
+function routeDeleteBot(
   service: AgentService,
   sidebarLayout: SidebarLayoutStore,
   remoteServers: RemoteServerManager,
   serverId: string,
   botId: string,
 ): Promise<void> {
-  if (serverId === "local") {
-    await service.deleteBot(botId);
-    await sidebarLayout.removeAgent(botId);
-    return;
-  }
-  await remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}`, { method: "DELETE" }, serverId, decodeVoid);
+  return routeToServer<void>(serverId, {
+    local: async () => {
+      await service.deleteBot(botId);
+      await sidebarLayout.removeAgent(botId);
+    },
+    remote: async (target) => {
+      await remoteServers.request(TEAM_API_ROUTES.agent.one(botId), { method: "DELETE" }, target, decodeVoid);
+    },
+  });
 }
 
-async function routeDuplicateBot(
+function routeDuplicateBot(
   service: AgentService,
   sidebarLayout: SidebarLayoutStore,
   remoteServers: RemoteServerManager,
   serverId: string,
   botId: string,
 ): Promise<DuplicateBotResult> {
-  if (serverId !== "local") {
-    return remoteServers.duplicateBot(botId, serverId);
-  }
+  return routeToServer(serverId, {
+    local: () => duplicateBotLocally(service, sidebarLayout, botId),
+    remote: (target) => remoteServers.duplicateBot(botId, target),
+  });
+}
+
+// The local copy is a two-store transaction: the agent, then its place in the sidebar. If placing it
+// fails the half-made copy has to go, or the user is left with an agent they never asked for.
+async function duplicateBotLocally(
+  service: AgentService,
+  sidebarLayout: SidebarLayoutStore,
+  botId: string,
+): Promise<DuplicateBotResult> {
   const bot = await service.duplicateBot(botId);
   try {
     const layout = await sidebarLayout.placeDuplicateAfter(botId, bot.id, [
@@ -376,9 +406,10 @@ async function routeDuplicateBot(
 }
 
 function routeReadConversation(host: HostService, remoteServers: RemoteServerManager, serverId: string, botId: string) {
-  return serverId === "local"
-    ? host.readAgentConversation(botId)
-    : remoteServers.readAgentConversation(botId, serverId);
+  return routeToServer(serverId, {
+    local: () => host.readAgentConversation(botId),
+    remote: (target) => remoteServers.readAgentConversation(botId, target),
+  });
 }
 
 function routeSendMessage(
@@ -387,21 +418,21 @@ function routeSendMessage(
   serverId: string,
   input: SendMessageInput,
 ) {
-  return serverId === "local"
-    ? service.sendMessage(input)
-    : remoteServers.request(
-        `/v1/agents/${encodeURIComponent(input.botId)}/messages`,
-        {
-          method: "POST",
-          body: input,
-        },
-        serverId,
+  return routeToServer(serverId, {
+    local: () => service.sendMessage(input),
+    remote: (target) =>
+      remoteServers.request(
+        TEAM_API_ROUTES.agent.messages(input.botId),
+        { method: "POST", body: input },
+        target,
         decodeQueuedMessageReceipt,
-      );
+      ),
+  });
 }
 
 function routeListQueue(service: AgentService, remoteServers: RemoteServerManager, serverId: string, botId: string) {
-  return serverId === "local"
-    ? service.listQueue(botId)
-    : remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}/queue`, {}, serverId, decodeQueueSnapshot);
+  return routeToServer(serverId, {
+    local: () => service.listQueue(botId),
+    remote: (target) => remoteServers.request(TEAM_API_ROUTES.agent.queue(botId), {}, target, decodeQueueSnapshot),
+  });
 }

--- a/src/main/ipc/register-attachment-handlers.ts
+++ b/src/main/ipc/register-attachment-handlers.ts
@@ -12,6 +12,7 @@ import {
 } from "@openbot/contracts/attachment-files";
 import { ATTACHMENT_LIMITS, INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import { type FilePreview, type ImportAttachmentsInput, IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import { app, type BrowserWindow, dialog, type OpenDialogOptions, shell } from "electron";
 import type { AgentService } from "../../backend/agent-service";
 import type { MailboxStore } from "../../backend/mailbox-store";
@@ -26,6 +27,7 @@ import {
   parseOpenSharedFile,
   parseOpenWorkspaceFile,
 } from "./agent-inputs";
+import { routeToServer } from "./route-to-server";
 import { requireString } from "./validation";
 
 interface AttachmentIpcDependencies {
@@ -54,140 +56,157 @@ export function registerAttachmentIpcHandlers({
     };
     const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
     if (result.canceled) return [];
-    if (serverId === "local") return service.prepareAttachments(result.filePaths);
-    return uploadRemotePaths(remoteServers, serverId, result.filePaths);
+    return routeToServer(serverId, {
+      local: () => service.prepareAttachments(result.filePaths),
+      remote: (target) => uploadRemotePaths(remoteServers, target, result.filePaths),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentImportAttachments, parseAgentRequest, (scoped) => {
     const parsed = parseImportAttachments(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.prepareImportedAttachments(parsed.paths, parsed.data)
-      : uploadRemoteImports(remoteServers, scoped.serverId, parsed);
+    return routeToServer(scoped.serverId, {
+      local: () => service.prepareImportedAttachments(parsed.paths, parsed.data),
+      remote: (serverId) => uploadRemoteImports(remoteServers, serverId, parsed),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentDiscardDraftAttachment, parseAgentRequest, (scoped) => {
     const attachmentId = requireString(scoped.payload, "attachmentId");
-    return scoped.serverId === "local"
-      ? service.discardDraftAttachment(attachmentId)
-      : remoteServers.request(
-          `/v1/attachments/${encodeURIComponent(attachmentId)}`,
-          { method: "DELETE" },
-          scoped.serverId,
-          decodeVoid,
-        );
+    return routeToServer(scoped.serverId, {
+      local: () => service.discardDraftAttachment(attachmentId),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.attachment(attachmentId), { method: "DELETE" }, serverId, decodeVoid),
+    });
   });
-  handleTrusted(IPC_CHANNELS.agentOpenAttachment, parseAgentRequest, async (scoped) => {
-    const mainWindow = getMainWindow();
+  handleTrusted(IPC_CHANNELS.agentOpenAttachment, parseAgentRequest, (scoped) => {
     const parsed = parseOpenAttachment(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadAttachment(parsed.attachmentId, scoped.serverId);
-      const suggestedName = basename(downloaded.name) || `attachment-${parsed.attachmentId}`;
-      if (parsed.action === "download") {
-        const extension = extname(suggestedName).slice(1).toLowerCase();
-        const saveOptions: Electron.SaveDialogOptions = {
-          defaultPath: join(app.getPath("downloads"), suggestedName),
-          filters: [{ name: "Attachment", extensions: extension ? [extension] : ["*"] }],
-          showsTagField: false,
-        };
-        const result =
-          mainWindow && !mainWindow.isDestroyed()
-            ? await dialog.showSaveDialog(mainWindow, saveOptions)
-            : await dialog.showSaveDialog(saveOptions);
-        if (result.canceled || !result.filePath) return;
-        await writeFile(result.filePath, downloaded.bytes, { mode: 0o600 });
-        return;
-      }
-      const cacheRoot = join(app.getPath("userData"), "remote-attachments");
-      await mkdir(cacheRoot, { recursive: true });
-      const safeName = `${parsed.attachmentId}-${suggestedName}`;
-      const target = join(cacheRoot, safeName);
-      await writeFile(target, downloaded.bytes, { mode: 0o600 });
-      if (parsed.action === "reveal") shell.showItemInFolder(target);
-      else {
-        const openError = await shell.openPath(target);
-        if (openError) throw new Error(openError);
-      }
-      return;
-    }
-    const attachment = await mailbox.resolveAttachment(parsed.attachmentId);
-    if (!attachment) throw new Error("Attachment was not found.");
-    if (parsed.action === "download") {
-      const safeId = basename(parsed.attachmentId).replace(/[^a-z0-9_-]/gi, "-") || "attachment";
-      const mimeExtension = attachment.mimeType.split("/")[1]?.replace(/[^a-z0-9]/gi, "");
-      const suggestedName = `attachment-${safeId}${mimeExtension ? `.${mimeExtension}` : ""}`;
-      const extension = extname(suggestedName).slice(1).toLowerCase();
-      const saveOptions: Electron.SaveDialogOptions = {
-        defaultPath: join(app.getPath("downloads"), suggestedName),
-        filters: [{ name: "Attachment", extensions: extension ? [extension] : ["*"] }],
-        showsTagField: false,
-      };
-      const result =
-        mainWindow && !mainWindow.isDestroyed()
-          ? await dialog.showSaveDialog(mainWindow, saveOptions)
-          : await dialog.showSaveDialog(saveOptions);
-      if (result.canceled || !result.filePath) return;
-      await copyFile(attachment.path, result.filePath);
-      return;
-    }
-    if (parsed.action === "reveal") {
-      shell.showItemInFolder(attachment.path);
-      return;
-    }
-    const error = await shell.openPath(attachment.path);
-    if (error) throw new Error(error);
+    return routeToServer<void>(scoped.serverId, {
+      local: async () => {
+        const attachment = await mailbox.resolveAttachment(parsed.attachmentId);
+        if (!attachment) throw new Error("Attachment was not found.");
+        if (parsed.action === "download") {
+          const safeId = basename(parsed.attachmentId).replace(/[^a-z0-9_-]/gi, "-") || "attachment";
+          const mimeExtension = attachment.mimeType.split("/")[1]?.replace(/[^a-z0-9]/gi, "");
+          const suggestedName = `attachment-${safeId}${mimeExtension ? `.${mimeExtension}` : ""}`;
+          const filePath = await chooseSavePath(getMainWindow(), suggestedName);
+          if (!filePath) return;
+          await copyFile(attachment.path, filePath);
+          return;
+        }
+        if (parsed.action === "reveal") {
+          shell.showItemInFolder(attachment.path);
+          return;
+        }
+        await openPath(attachment.path);
+      },
+      remote: async (serverId) => {
+        const downloaded = await remoteServers.downloadAttachment(parsed.attachmentId, serverId);
+        const suggestedName = basename(downloaded.name) || `attachment-${parsed.attachmentId}`;
+        if (parsed.action === "download") {
+          const filePath = await chooseSavePath(getMainWindow(), suggestedName);
+          if (!filePath) return;
+          await writeFile(filePath, downloaded.bytes, { mode: 0o600 });
+          return;
+        }
+        const cacheRoot = join(app.getPath("userData"), "remote-attachments");
+        await mkdir(cacheRoot, { recursive: true });
+        const target = join(cacheRoot, `${parsed.attachmentId}-${suggestedName}`);
+        await writeFile(target, downloaded.bytes, { mode: 0o600 });
+        if (parsed.action === "reveal") shell.showItemInFolder(target);
+        else await openPath(target);
+      },
+    });
   });
-  handleTrusted(IPC_CHANNELS.agentOpenSharedFile, parseAgentRequest, async (scoped) => {
+  handleTrusted(IPC_CHANNELS.agentOpenSharedFile, parseAgentRequest, (scoped) => {
     const parsed = parseOpenSharedFile(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadSharedFile(parsed.path, scoped.serverId);
-      const cacheRoot = join(app.getPath("userData"), "remote-shared-files");
-      await mkdir(cacheRoot, { recursive: true, mode: 0o700 });
-      const cacheKey = createHash("sha256").update(`${scoped.serverId}:${parsed.path}`).digest("hex");
-      const target = join(cacheRoot, `${cacheKey}-${basename(downloaded.name)}`);
-      await writeFile(target, downloaded.bytes, { mode: 0o600 });
-      await chmod(target, 0o600);
-      const openError = await shell.openPath(target);
-      if (openError) throw new Error(openError);
-      return;
-    }
-    const sharedFile = await service.resolveSharedFile(parsed.path);
-    const openError = await shell.openPath(sharedFile.path);
-    if (openError) throw new Error(openError);
+    return routeToServer<void>(scoped.serverId, {
+      local: async () => {
+        const sharedFile = await service.resolveSharedFile(parsed.path);
+        await openPath(sharedFile.path);
+      },
+      remote: async (serverId) => {
+        const downloaded = await remoteServers.downloadSharedFile(parsed.path, serverId);
+        const target = await cacheRemoteFile("remote-shared-files", `${serverId}:${parsed.path}`, downloaded);
+        await openPath(target);
+      },
+    });
   });
-  handleTrusted(IPC_CHANNELS.agentOpenWorkspaceFile, parseAgentRequest, async (scoped) => {
+  handleTrusted(IPC_CHANNELS.agentOpenWorkspaceFile, parseAgentRequest, (scoped) => {
     const parsed = parseOpenWorkspaceFile(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, scoped.serverId);
-      const cacheRoot = join(app.getPath("userData"), "remote-workspace-files");
-      await mkdir(cacheRoot, { recursive: true, mode: 0o700 });
-      const cacheKey = createHash("sha256").update(`${scoped.serverId}:${parsed.botId}:${parsed.path}`).digest("hex");
-      const target = join(cacheRoot, `${cacheKey}-${basename(downloaded.name)}`);
-      await writeFile(target, downloaded.bytes, { mode: 0o600 });
-      await chmod(target, 0o600);
-      const openError = await shell.openPath(target);
-      if (openError) throw new Error(openError);
-      return;
-    }
-    const workspaceFile = await service.resolveWorkspaceFile(parsed.botId, parsed.path);
-    const openError = await shell.openPath(workspaceFile.path);
-    if (openError) throw new Error(openError);
+    return routeToServer<void>(scoped.serverId, {
+      local: async () => {
+        const workspaceFile = await service.resolveWorkspaceFile(parsed.botId, parsed.path);
+        await openPath(workspaceFile.path);
+      },
+      remote: async (serverId) => {
+        const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, serverId);
+        const key = `${serverId}:${parsed.botId}:${parsed.path}`;
+        const target = await cacheRemoteFile("remote-workspace-files", key, downloaded);
+        await openPath(target);
+      },
+    });
   });
-  handleTrusted(IPC_CHANNELS.agentPreviewSharedFile, parseAgentRequest, async (scoped): Promise<FilePreview> => {
+  handleTrusted(IPC_CHANNELS.agentPreviewSharedFile, parseAgentRequest, (scoped): Promise<FilePreview> => {
     const parsed = parseOpenSharedFile(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadSharedFile(parsed.path, scoped.serverId);
-      return filePreviewFromBytes(downloaded.name, downloaded.bytes);
-    }
-    const sharedFile = await service.resolveSharedFile(parsed.path);
-    return localFilePreview(sharedFile.path, sharedFile.name, sharedFile.size);
+    return routeToServer(scoped.serverId, {
+      local: async () => {
+        const sharedFile = await service.resolveSharedFile(parsed.path);
+        return localFilePreview(sharedFile.path, sharedFile.name, sharedFile.size);
+      },
+      remote: async (serverId) => {
+        const downloaded = await remoteServers.downloadSharedFile(parsed.path, serverId);
+        return filePreviewFromBytes(downloaded.name, downloaded.bytes);
+      },
+    });
   });
-  handleTrusted(IPC_CHANNELS.agentPreviewWorkspaceFile, parseAgentRequest, async (scoped): Promise<FilePreview> => {
+  handleTrusted(IPC_CHANNELS.agentPreviewWorkspaceFile, parseAgentRequest, (scoped): Promise<FilePreview> => {
     const parsed = parseOpenWorkspaceFile(scoped.payload);
-    if (scoped.serverId !== "local") {
-      const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, scoped.serverId);
-      return filePreviewFromBytes(downloaded.name, downloaded.bytes);
-    }
-    const workspaceFile = await service.resolveWorkspaceFile(parsed.botId, parsed.path);
-    return localFilePreview(workspaceFile.path, workspaceFile.name, workspaceFile.size);
+    return routeToServer(scoped.serverId, {
+      local: async () => {
+        const workspaceFile = await service.resolveWorkspaceFile(parsed.botId, parsed.path);
+        return localFilePreview(workspaceFile.path, workspaceFile.name, workspaceFile.size);
+      },
+      remote: async (serverId) => {
+        const downloaded = await remoteServers.downloadWorkspaceFile(parsed.botId, parsed.path, serverId);
+        return filePreviewFromBytes(downloaded.name, downloaded.bytes);
+      },
+    });
   });
+}
+
+// A remote file has to land on disk before the OS can open it. Owner-only, under a per-server and
+// per-path digest so two servers sharing a file name cannot overwrite each other.
+async function cacheRemoteFile(
+  directory: string,
+  cacheKeyInput: string,
+  downloaded: { name: string; bytes: Uint8Array },
+): Promise<string> {
+  const cacheRoot = join(app.getPath("userData"), directory);
+  await mkdir(cacheRoot, { recursive: true, mode: 0o700 });
+  const cacheKey = createHash("sha256").update(cacheKeyInput).digest("hex");
+  const target = join(cacheRoot, `${cacheKey}-${basename(downloaded.name)}`);
+  await writeFile(target, downloaded.bytes, { mode: 0o600 });
+  await chmod(target, 0o600);
+  return target;
+}
+
+// `shell.openPath` reports failure by resolving with the message rather than rejecting.
+async function openPath(path: string): Promise<void> {
+  const error = await shell.openPath(path);
+  if (error) throw new Error(error);
+}
+
+// Returns the chosen path, or undefined when the user cancelled.
+async function chooseSavePath(mainWindow: BrowserWindow | null, suggestedName: string): Promise<string | undefined> {
+  const extension = extname(suggestedName).slice(1).toLowerCase();
+  const options: Electron.SaveDialogOptions = {
+    defaultPath: join(app.getPath("downloads"), suggestedName),
+    filters: [{ name: "Attachment", extensions: extension ? [extension] : ["*"] }],
+    showsTagField: false,
+  };
+  const result =
+    mainWindow && !mainWindow.isDestroyed()
+      ? await dialog.showSaveDialog(mainWindow, options)
+      : await dialog.showSaveDialog(options);
+  return result.canceled ? undefined : result.filePath || undefined;
 }
 
 async function uploadRemotePaths(remoteServers: RemoteServerManager, serverId: string, paths: string[]) {

--- a/src/main/ipc/register-browser-handlers.ts
+++ b/src/main/ipc/register-browser-handlers.ts
@@ -1,11 +1,12 @@
 // The embedded browser and its picture-in-picture window.
 
 import { type BrowserDisplayState, IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import type { BrowserHost } from "../../backend/browser-host";
 import type { BrowserPictureInPicture } from "../browser-picture-in-picture";
 import {
   decodeBrowserControlState,
-  decodeBrowserPreview,
+  decodeBrowserPreviewFromHost,
   decodeBrowserTab,
   decodeBrowserTabs,
   decodeVoid,
@@ -13,6 +14,7 @@ import {
 } from "../remote-server-manager";
 import { handleTrusted } from "../trusted-ipc";
 import { parseBrowserBounds, parseBrowserNavigate, parseBrowserOpen, parseVisibility } from "./browser-inputs";
+import { routeToServer } from "./route-to-server";
 import { optionalPayload, stringPayload } from "./validation";
 
 export interface BrowserIpcDependencies {
@@ -26,58 +28,95 @@ export function registerBrowserIpcHandlers({
   browser,
   remoteServers,
 }: BrowserIpcDependencies): void {
-  handleTrusted(IPC_CHANNELS.browserOpen, parseBrowserOpen, (parsed) => {
-    return remoteServers.activeServerId === "local"
-      ? browser.open(parsed.url, parsed.ownerThreadId ?? null, parsed.ownerBotId ?? null, parsed.focus)
-      : remoteServers.request("/v1/browser/open", { method: "POST", body: parsed }, undefined, decodeBrowserTab);
-  });
-  handleTrusted(IPC_CHANNELS.browserActivate, stringPayload("tabId"), (tabId) =>
-    remoteServers.activeServerId === "local"
-      ? browser.activate(tabId)
-      : remoteServers.request("/v1/browser/activate", { method: "POST", body: { tabId } }, undefined, decodeVoid),
+  handleTrusted(IPC_CHANNELS.browserOpen, parseBrowserOpen, (parsed) =>
+    routeToServer(remoteServers.activeServerId, {
+      local: () => browser.open(parsed.url, parsed.ownerThreadId ?? null, parsed.ownerBotId ?? null, parsed.focus),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.browser.open,
+          { method: "POST", body: parsed },
+          serverId,
+          decodeBrowserTab,
+        ),
+    }),
   );
-  handleTrusted(IPC_CHANNELS.browserNavigate, parseBrowserNavigate, (parsed) => {
-    return remoteServers.activeServerId === "local"
-      ? browser.navigate(parsed.tabId, parsed.direction)
-      : remoteServers.request("/v1/browser/navigate", { method: "POST", body: parsed }, undefined, decodeVoid);
-  });
+  handleTrusted(IPC_CHANNELS.browserActivate, stringPayload("tabId"), (tabId) =>
+    routeToServer(remoteServers.activeServerId, {
+      local: () => browser.activate(tabId),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.browser.activate,
+          { method: "POST", body: { tabId } },
+          serverId,
+          decodeVoid,
+        ),
+    }),
+  );
+  handleTrusted(IPC_CHANNELS.browserNavigate, parseBrowserNavigate, (parsed) =>
+    routeToServer(remoteServers.activeServerId, {
+      local: () => browser.navigate(parsed.tabId, parsed.direction),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.browser.navigate, { method: "POST", body: parsed }, serverId, decodeVoid),
+    }),
+  );
   handleTrusted(IPC_CHANNELS.browserReload, stringPayload("tabId"), (tabId) =>
-    remoteServers.activeServerId === "local"
-      ? browser.reload(tabId)
-      : remoteServers.request("/v1/browser/reload", { method: "POST", body: { tabId } }, undefined, decodeVoid),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => browser.reload(tabId),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.browser.reload,
+          { method: "POST", body: { tabId } },
+          serverId,
+          decodeVoid,
+        ),
+    }),
   );
   handleTrusted(IPC_CHANNELS.browserClose, stringPayload("tabId"), (tabId) =>
-    remoteServers.activeServerId === "local"
-      ? browser.close(tabId)
-      : remoteServers.request("/v1/browser/close", { method: "POST", body: { tabId } }, undefined, decodeVoid),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => browser.close(tabId),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.browser.close, { method: "POST", body: { tabId } }, serverId, decodeVoid),
+    }),
   );
   handleTrusted(IPC_CHANNELS.browserListTabs, () =>
-    remoteServers.activeServerId === "local"
-      ? browser.listTabs()
-      : remoteServers.request("/v1/browser/tabs", {}, undefined, decodeBrowserTabs),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => browser.listTabs(),
+      remote: (serverId) => remoteServers.request(TEAM_API_ROUTES.browser.tabs, {}, serverId, decodeBrowserTabs),
+    }),
   );
   handleTrusted(IPC_CHANNELS.browserGetDisplayState, (): BrowserDisplayState => browser.getDisplayState());
   handleTrusted(IPC_CHANNELS.browserGetControlState, () =>
-    remoteServers.activeServerId === "local"
-      ? browser.getControlState()
-      : remoteServers.request("/v1/browser/control", {}, undefined, decodeBrowserControlState),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => browser.getControlState(),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.browser.control, {}, serverId, decodeBrowserControlState),
+    }),
   );
   handleTrusted(IPC_CHANNELS.browserCapturePreview, stringPayload("tabId"), (tabId) =>
-    remoteServers.activeServerId === "local"
-      ? browser.capturePreview(tabId)
-      : remoteServers.request(
-          "/v1/browser/preview",
+    routeToServer(remoteServers.activeServerId, {
+      local: () => browser.capturePreview(tabId),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.browser.preview,
           { method: "POST", body: { tabId } },
-          undefined,
-          decodeBrowserPreview,
+          serverId,
+          decodeBrowserPreviewFromHost,
         ),
+    }),
   );
-  handleTrusted(IPC_CHANNELS.browserSetVisible, parseVisibility, async (parsed) => {
-    if (remoteServers.activeServerId === "local") await browser.setVisible(parsed);
-    else {
-      await remoteServers.request("/v1/browser/visible", { method: "POST", body: parsed }, undefined, decodeVoid);
-    }
-  });
+  handleTrusted(IPC_CHANNELS.browserSetVisible, parseVisibility, (parsed) =>
+    routeToServer<void>(remoteServers.activeServerId, {
+      local: () => browser.setVisible(parsed),
+      remote: async (serverId) => {
+        await remoteServers.request(
+          TEAM_API_ROUTES.browser.visible,
+          { method: "POST", body: parsed },
+          serverId,
+          decodeVoid,
+        );
+      },
+    }),
+  );
   handleTrusted(IPC_CHANNELS.browserPictureInPictureOpen, optionalPayload(parseBrowserBounds), (bounds) =>
     browserPictureInPicture.open(bounds),
   );

--- a/src/main/ipc/register-memory-handlers.ts
+++ b/src/main/ipc/register-memory-handlers.ts
@@ -2,10 +2,12 @@
 
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import type { AgentService } from "../../backend/agent-service";
 import { decodeBotMemories, decodeBotMemory, decodeVoid, type RemoteServerManager } from "../remote-server-manager";
 import { handleTrusted } from "../trusted-ipc";
 import { parseAgentRequest, parseCreateBotMemory, parseDeleteBotMemory, parseUpdateBotMemory } from "./agent-inputs";
+import { routeToServer } from "./route-to-server";
 import { requireString } from "./validation";
 
 interface MemoryIpcDependencies {
@@ -16,55 +18,57 @@ interface MemoryIpcDependencies {
 export function registerMemoryIpcHandlers({ service, remoteServers }: MemoryIpcDependencies): void {
   handleTrusted(IPC_CHANNELS.agentListMemories, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
-    return scoped.serverId === "local"
-      ? service.listMemories(botId)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(botId)}/memories`,
-          {},
-          scoped.serverId,
-          decodeBotMemories,
-        );
+    return routeToServer(scoped.serverId, {
+      local: () => service.listMemories(botId),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.agent.memories(botId), {}, serverId, decodeBotMemories),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentCreateMemory, parseAgentRequest, (scoped) => {
     const parsed = parseCreateBotMemory(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.createMemory(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/memories`,
+    return routeToServer(scoped.serverId, {
+      local: () => service.createMemory(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.memories(parsed.botId),
           { method: "POST", body: { text: parsed.text } },
-          scoped.serverId,
+          serverId,
           decodeBotMemory,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentUpdateMemory, parseAgentRequest, (scoped) => {
     const parsed = parseUpdateBotMemory(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.updateMemory(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/memories/${encodeURIComponent(parsed.memoryId)}`,
+    return routeToServer(scoped.serverId, {
+      local: () => service.updateMemory(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.memory(parsed.botId, parsed.memoryId),
           { method: "PATCH", body: { text: parsed.text } },
-          scoped.serverId,
+          serverId,
           decodeBotMemory,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentDeleteMemory, parseAgentRequest, (scoped) => {
     const parsed = parseDeleteBotMemory(scoped.payload);
-    if (scoped.serverId === "local") return service.deleteMemory(parsed);
-    return remoteServers.request(
-      `/v1/agents/${encodeURIComponent(parsed.botId)}/memories/${encodeURIComponent(parsed.memoryId)}`,
-      { method: "DELETE" },
-      scoped.serverId,
-      decodeVoid,
-    );
+    return routeToServer(scoped.serverId, {
+      local: () => service.deleteMemory(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.memory(parsed.botId, parsed.memoryId),
+          { method: "DELETE" },
+          serverId,
+          decodeVoid,
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentClearMemories, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
-    if (scoped.serverId === "local") return service.clearMemories(botId);
-    return remoteServers.request(
-      `/v1/agents/${encodeURIComponent(botId)}/memories`,
-      { method: "DELETE" },
-      scoped.serverId,
-      decodeVoid,
-    );
+    return routeToServer(scoped.serverId, {
+      local: () => service.clearMemories(botId),
+      remote: (serverId) =>
+        remoteServers.request(TEAM_API_ROUTES.agent.memories(botId), { method: "DELETE" }, serverId, decodeVoid),
+    });
   });
 }

--- a/src/main/ipc/register-routine-handlers.ts
+++ b/src/main/ipc/register-routine-handlers.ts
@@ -2,6 +2,7 @@
 
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import { IPC_CHANNELS } from "@openbot/contracts/ipc";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import type { AgentService } from "../../backend/agent-service";
 import {
   decodeRoutine,
@@ -20,6 +21,7 @@ import {
   parseTestRoutine,
   parseUpdateRoutine,
 } from "./agent-inputs";
+import { routeToServer } from "./route-to-server";
 import { requireString } from "./validation";
 
 interface RoutineIpcDependencies {
@@ -30,62 +32,74 @@ interface RoutineIpcDependencies {
 export function registerRoutineIpcHandlers({ service, remoteServers }: RoutineIpcDependencies): void {
   handleTrusted(IPC_CHANNELS.agentListRoutines, parseAgentRequest, (scoped) => {
     const botId = requireString(scoped.payload, "botId", INPUT_LIMITS.identifier);
-    return scoped.serverId === "local"
-      ? service.listRoutines(botId)
-      : remoteServers.request(`/v1/agents/${encodeURIComponent(botId)}/routines`, {}, scoped.serverId, decodeRoutines);
+    return routeToServer(scoped.serverId, {
+      local: () => service.listRoutines(botId),
+      remote: (serverId) => remoteServers.request(TEAM_API_ROUTES.agent.routines(botId), {}, serverId, decodeRoutines),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentCreateRoutine, parseAgentRequest, (scoped) => {
     const parsed = parseCreateRoutine(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.createRoutine(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines`,
+    return routeToServer(scoped.serverId, {
+      local: () => service.createRoutine(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.routines(parsed.botId),
           { method: "POST", body: parsed },
-          scoped.serverId,
+          serverId,
           decodeRoutine,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentUpdateRoutine, parseAgentRequest, (scoped) => {
     const parsed = parseUpdateRoutine(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.updateRoutine(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}`,
+    return routeToServer(scoped.serverId, {
+      local: () => service.updateRoutine(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.routine(parsed.botId, parsed.routineId),
           { method: "PATCH", body: parsed },
-          scoped.serverId,
+          serverId,
           decodeRoutine,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentDeleteRoutine, parseAgentRequest, (scoped) => {
     const parsed = parseDeleteRoutine(scoped.payload);
-    if (scoped.serverId === "local") return service.deleteRoutine(parsed);
-    return remoteServers.request(
-      `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}`,
-      { method: "DELETE" },
-      scoped.serverId,
-      decodeVoid,
-    );
+    return routeToServer(scoped.serverId, {
+      local: () => service.deleteRoutine(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.routine(parsed.botId, parsed.routineId),
+          { method: "DELETE" },
+          serverId,
+          decodeVoid,
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentTestRoutine, parseAgentRequest, (scoped) => {
     const parsed = parseTestRoutine(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.testRoutine(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}/test`,
+    return routeToServer(scoped.serverId, {
+      local: () => service.testRoutine(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          TEAM_API_ROUTES.agent.routineTest(parsed.botId, parsed.routineId),
           { method: "POST" },
-          scoped.serverId,
+          serverId,
           decodeRoutineRun,
-        );
+        ),
+    });
   });
   handleTrusted(IPC_CHANNELS.agentListRoutineRuns, parseAgentRequest, (scoped) => {
     const parsed = parseListRoutineRuns(scoped.payload);
-    return scoped.serverId === "local"
-      ? service.listRoutineRuns(parsed)
-      : remoteServers.request(
-          `/v1/agents/${encodeURIComponent(parsed.botId)}/routines/${encodeURIComponent(parsed.routineId)}/runs?limit=${parsed.limit}`,
+    return routeToServer(scoped.serverId, {
+      local: () => service.listRoutineRuns(parsed),
+      remote: (serverId) =>
+        remoteServers.request(
+          `${TEAM_API_ROUTES.agent.routineRuns(parsed.botId, parsed.routineId)}?limit=${parsed.limit}`,
           {},
-          scoped.serverId,
+          serverId,
           decodeRoutineRuns,
-        );
+        ),
+    });
   });
 }

--- a/src/main/ipc/register-team-handlers.ts
+++ b/src/main/ipc/register-team-handlers.ts
@@ -4,6 +4,7 @@ import type { RemoteDesktopManager } from "../remote-desktop-manager";
 import type { RemoteServerManager } from "../remote-server-manager";
 import { handleTrusted } from "../trusted-ipc";
 import { parseAgentRequest } from "./agent-inputs";
+import { routeToServer } from "./route-to-server";
 import {
   parseCreateTeamInvite,
   parseDirectTyping,
@@ -51,10 +52,16 @@ export function registerTeamIpcHandlers({
   );
   handleTrusted(IPC_CHANNELS.serversRemove, stringPayload("serverId"), (serverId) => remoteServers.remove(serverId));
   handleTrusted(IPC_CHANNELS.serversGetPresence, () =>
-    remoteServers.activeServerId === "local" ? host.getPresence() : remoteServers.getPresence(),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => host.getPresence(),
+      remote: () => remoteServers.getPresence(),
+    }),
   );
   handleTrusted(IPC_CHANNELS.serversGetPresenceFor, stringPayload("serverId"), (serverId) =>
-    serverId === "local" ? host.getPresence() : remoteServers.getPresenceFor(serverId),
+    routeToServer(serverId, {
+      local: () => host.getPresence(),
+      remote: (target) => remoteServers.getPresenceFor(target),
+    }),
   );
   handleTrusted(IPC_CHANNELS.serversRefreshIdentity, stringPayload("serverId"), (serverId) =>
     remoteServers.refreshIdentity(serverId),

--- a/src/main/ipc/register-team-handlers.ts
+++ b/src/main/ipc/register-team-handlers.ts
@@ -1,4 +1,4 @@
-import { type HostStatus, IPC_CHANNELS, type ServerSummary } from "@openbot/contracts/ipc";
+import { type HostStatus, IPC_CHANNELS, LOCAL_SERVER_ID, type ServerSummary } from "@openbot/contracts/ipc";
 import type { HostService } from "../host-service";
 import type { RemoteDesktopManager } from "../remote-desktop-manager";
 import type { RemoteServerManager } from "../remote-server-manager";
@@ -84,33 +84,48 @@ export function registerTeamIpcHandlers({
   handleTrusted(IPC_CHANNELS.serversCreateInvite, parseAgentRequest, (request) =>
     remoteServers.createInvite(request.serverId, parseCreateTeamInvite(request.payload)),
   );
-  handleTrusted(IPC_CHANNELS.serversSetTyping, parseSetTeamTyping, (parsed) => {
-    if (remoteServers.activeServerId === "local") host.setTyping(parsed);
-    else remoteServers.setTyping(parsed);
-  });
+  handleTrusted(IPC_CHANNELS.serversSetTyping, parseSetTeamTyping, (parsed) =>
+    routeToServer<void>(remoteServers.activeServerId, {
+      local: () => host.setTyping(parsed),
+      remote: () => remoteServers.setTyping(parsed),
+    }),
+  );
   handleTrusted(IPC_CHANNELS.serversListDirectThreads, () =>
-    remoteServers.activeServerId === "local" ? host.listDirectThreads() : remoteServers.listDirectThreads(),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => host.listDirectThreads(),
+      remote: () => remoteServers.listDirectThreads(),
+    }),
   );
   handleTrusted(IPC_CHANNELS.serversReadDirectConversation, stringPayload("memberId"), (memberId) =>
-    remoteServers.activeServerId === "local"
-      ? host.readDirectConversation(memberId)
-      : remoteServers.readDirectConversation(memberId),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => host.readDirectConversation(memberId),
+      remote: () => remoteServers.readDirectConversation(memberId),
+    }),
   );
   handleTrusted(IPC_CHANNELS.serversReadDirectConversationPage, parseReadDirectConversationPage, (parsed) =>
-    remoteServers.activeServerId === "local"
-      ? host.readDirectConversationPage(parsed.memberId, parsed.anchor, parsed.limit)
-      : remoteServers.readDirectConversationPage(parsed.memberId, parsed.anchor, parsed.limit),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => host.readDirectConversationPage(parsed.memberId, parsed.anchor, parsed.limit),
+      remote: () => remoteServers.readDirectConversationPage(parsed.memberId, parsed.anchor, parsed.limit),
+    }),
   );
   handleTrusted(IPC_CHANNELS.serversSendDirectMessage, parseSendDirectMessage, (parsed) =>
-    remoteServers.activeServerId === "local" ? host.sendDirectMessage(parsed) : remoteServers.sendDirectMessage(parsed),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => host.sendDirectMessage(parsed),
+      remote: () => remoteServers.sendDirectMessage(parsed),
+    }),
   );
   handleTrusted(IPC_CHANNELS.serversMarkDirectRead, parseMarkDirectRead, (parsed) =>
-    remoteServers.activeServerId === "local" ? host.markDirectRead(parsed) : remoteServers.markDirectRead(parsed),
+    routeToServer(remoteServers.activeServerId, {
+      local: () => host.markDirectRead(parsed),
+      remote: () => remoteServers.markDirectRead(parsed),
+    }),
   );
-  handleTrusted(IPC_CHANNELS.serversSetDirectTyping, parseDirectTyping, (parsed) => {
-    if (remoteServers.activeServerId === "local") host.setDirectTyping(parsed);
-    else remoteServers.setDirectTyping(parsed);
-  });
+  handleTrusted(IPC_CHANNELS.serversSetDirectTyping, parseDirectTyping, (parsed) =>
+    routeToServer<void>(remoteServers.activeServerId, {
+      local: () => host.setDirectTyping(parsed),
+      remote: () => remoteServers.setDirectTyping(parsed),
+    }),
+  );
 
   handleTrusted(IPC_CHANNELS.hostGetStatus, () => host.getStatus());
   handleTrusted(IPC_CHANNELS.hostConfigure, parseHostConfig, (config) => host.configure(config));
@@ -143,7 +158,7 @@ export function registerTeamIpcHandlers({
 
 export function withLocalHostSummary(servers: ServerSummary[], status: HostStatus): ServerSummary[] {
   return servers.map((server) =>
-    server.id === "local"
+    server.id === LOCAL_SERVER_ID
       ? {
           ...server,
           name: status.serverName ?? "Local",

--- a/src/main/ipc/route-to-server.ts
+++ b/src/main/ipc/route-to-server.ts
@@ -1,0 +1,17 @@
+// One agent-scoped channel, two backends: the local `AgentService` or a remote team server over
+// HTTP. Every handler that takes a `serverId` has to pick, and the pick was written out by hand at
+// 54 call sites - a ternary on `serverId === "local"` whose two arms were far enough apart to read
+// as two handlers. The branch is the same shape every time, so it gets one name.
+//
+// Either arm may be synchronous - a local store read, or presence the server manager already holds -
+// so both are normalized with `Promise.resolve`. That is invisible at the IPC boundary, which
+// promisifies a handler's result either way.
+
+import { LOCAL_SERVER_ID } from "@openbot/contracts/ipc";
+
+export function routeToServer<T>(
+  serverId: string,
+  branches: { local: () => T | Promise<T>; remote: (serverId: string) => T | Promise<T> },
+): Promise<T> {
+  return Promise.resolve(serverId === LOCAL_SERVER_ID ? branches.local() : branches.remote(serverId));
+}

--- a/src/main/remote-screen-gateway.ts
+++ b/src/main/remote-screen-gateway.ts
@@ -10,6 +10,7 @@ import type {
   RemoteDesktopIceServer,
   RemoteDesktopSession,
 } from "@openbot/contracts/ipc";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import type * as Ws from "ws";
 import { z } from "zod";
 import type { RemoteDesktopRuntimePaths } from "./remote-desktop-runtime-artifact";
@@ -155,7 +156,7 @@ export class RemoteScreenGateway {
     const snapshot: RemoteDesktopSession = {
       id,
       serverId: input.serverId,
-      viewerUrl: `${input.publicHttpBaseUrl}/v1/remote-screen/sessions/${id}/viewer`,
+      viewerUrl: `${input.publicHttpBaseUrl}${TEAM_API_ROUTES.remoteScreen.viewer(id)}`,
       viewerGrant,
       displays: structuredClone(this.#availableDisplays()),
       selectedDisplayId: this.#selectedDisplayId,
@@ -274,7 +275,7 @@ export class RemoteScreenGateway {
       const cookiePolicy =
         request.headers["x-forwarded-proto"] === "https" ? "; Secure; SameSite=None" : "; SameSite=Strict";
       response.writeHead(204, {
-        "Set-Cookie": `${VIEWER_COOKIE}=${cookie}; HttpOnly${cookiePolicy}; Path=/v1/remote-screen/sessions/${session.snapshot.id}/; Max-Age=86400`,
+        "Set-Cookie": `${VIEWER_COOKIE}=${cookie}; HttpOnly${cookiePolicy}; Path=${TEAM_API_ROUTES.remoteScreen.session(session.snapshot.id)}/; Max-Age=86400`,
         "Cache-Control": "no-store",
       });
       response.end();
@@ -493,7 +494,7 @@ export class RemoteScreenGateway {
     if (upstreamPath === "/config.js") {
       response.writeHead(200, { "Content-Type": "text/javascript", "Cache-Control": "no-store" });
       response.end(
-        `export default ${JSON.stringify({ path_prefix: `/v1/remote-screen/sessions/${session.snapshot.id}/moonlight` })}`,
+        `export default ${JSON.stringify({ path_prefix: `${TEAM_API_ROUTES.remoteScreen.session(session.snapshot.id)}/moonlight` })}`,
       );
       return;
     }
@@ -570,7 +571,7 @@ function sendViewer(
   streamerSlot: number,
   runtime: SunshineMoonlightRuntimeState,
 ): void {
-  const sessionPath = `/v1/remote-screen/sessions/${sessionId}`;
+  const sessionPath = TEAM_API_ROUTES.remoteScreen.session(sessionId);
   const hostId = runtime.hostIds[streamerSlot - 1] ?? runtime.hostId;
   const target = `${sessionPath}/moonlight/stream.html?hostId=${hostId}&appId=${runtime.desktopAppId}`;
   const html = `<!doctype html><meta charset="utf-8"><title>OpenBot Moonlight Remote</title><meta name="color-scheme" content="dark"><style>html,body{margin:0;width:100%;height:100%;background:#090b0c;color:#fff;font:14px system-ui}main{display:grid;place-items:center;height:100%}</style><main>Connecting…</main><script type="module">const grant=new URL(location.href).hash.slice(1);history.replaceState(null,"",location.pathname);const response=await fetch(${JSON.stringify(`${sessionPath}/authorize`)},{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({grant})});if(!response.ok){document.querySelector("main").textContent="Remote access expired";throw new Error("grant rejected")}location.replace(${JSON.stringify(target)});</script>`;

--- a/src/main/remote-server-manager.test.ts
+++ b/src/main/remote-server-manager.test.ts
@@ -11,7 +11,7 @@ import { TEAM_CAPABILITIES_HEADER } from "@openbot/contracts/team-protocol/v1";
 import type { TeamProtocolV2Json } from "@openbot/contracts/team-protocol/v2";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  decodeBrowserPreview,
+  decodeBrowserPreviewFromHost,
   decodeBrowserTab,
   isValidRemoteApiUrl,
   RemoteServerManager,
@@ -43,14 +43,14 @@ describe("remote browser responses", () => {
 
   it("accepts only bounded JPEG browser previews", () => {
     expect(
-      decodeBrowserPreview({
+      decodeBrowserPreviewFromHost({
         dataUrl: "data:image/jpeg;base64,YWJj",
         width: 960,
         height: 600,
       }),
     ).toMatchObject({ width: 960, height: 600 });
     expect(() =>
-      decodeBrowserPreview({
+      decodeBrowserPreviewFromHost({
         dataUrl: "data:image/png;base64,YWJj",
         width: 960,
         height: 600,

--- a/src/main/remote-server-manager.ts
+++ b/src/main/remote-server-manager.ts
@@ -1126,7 +1126,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     mimeType: string;
   }> {
     const server = this.#requireServer(serverId);
-    const response = await this.#fetch(server, `${server.apiUrl}${TEAM_API_ROUTES.attachment(attachmentId)}`);
+    const response = await this.#fetch(server, new URL(TEAM_API_ROUTES.attachment(attachmentId), server.apiUrl));
     const disposition = response.headers.get("content-disposition") ?? "";
     const encodedName = disposition.match(/filename\*=UTF-8''([^;]+)/i)?.[1];
     return {

--- a/src/main/remote-server-manager.ts
+++ b/src/main/remote-server-manager.ts
@@ -42,8 +42,6 @@ import type {
   QueueSnapshot,
   RemoteDesktopCapabilities,
   RemoteDesktopSession,
-  Routine,
-  RoutineRun,
   SendDirectMessageInput,
   ServerCompatibility,
   ServerConnectionIssue,
@@ -73,15 +71,20 @@ import {
   isRoutineRun,
   isSidebarLayoutSnapshot,
   isTeamRealtimeEvent,
+  LOCAL_SERVER_ID,
 } from "@openbot/contracts/ipc";
 import {
-  type DynamicRecord,
-  isBoolean,
-  isDynamicRecord,
-  isNumber,
-  isOneOf,
-  isString,
-} from "@openbot/contracts/runtime-values";
+  decodeRecord,
+  emptyDecoder,
+  guardedDecoder,
+  guardedListDecoder,
+  nullableString,
+  requiredBoolean,
+  requiredNumber,
+  requiredString,
+} from "@openbot/contracts/ipc-decoding";
+import { isBoolean, isDynamicRecord, isNumber, isOneOf, isString } from "@openbot/contracts/runtime-values";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import {
   supportsTeamSemanticTags,
   TEAM_CURRENT_CAPABILITIES,
@@ -226,7 +229,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   readonly #centralAccount: CentralAccountSession;
   readonly #allowLocalDevelopmentInvites: boolean;
   readonly #appVersion: string | null;
-  #state: StoredRemoteServers = { version: 3, activeServerId: "local", servers: [], hiddenHostIds: [] };
+  #state: StoredRemoteServers = { version: 3, activeServerId: LOCAL_SERVER_ID, servers: [], hiddenHostIds: [] };
   #states = new Map<string, ServerSummary["state"]>();
   #compatibility = new Map<string, ServerCompatibility>();
   #issues = new Map<string, ServerConnectionIssue>();
@@ -338,7 +341,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   list(): ServerSummary[] {
     return [
       {
-        id: "local",
+        id: LOCAL_SERVER_ID,
         name: "Local",
         kind: "local",
         state: "online",
@@ -346,7 +349,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
         remoteDesktopAvailable: false,
         logoUrl: null,
         role: null,
-        active: this.#state.activeServerId === "local",
+        active: this.#state.activeServerId === LOCAL_SERVER_ID,
         compatibility: null,
         issue: null,
       },
@@ -405,7 +408,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
 
   select(serverId: string): Promise<ServerSummary[]> {
     const operation = this.#selectChain.then(async () => {
-      if (serverId !== "local" && !this.#state.servers.some((server) => server.id === serverId)) {
+      if (serverId !== LOCAL_SERVER_ID && !this.#state.servers.some((server) => server.id === serverId)) {
         throw new Error("Remote server not found.");
       }
       const previousServerId = this.#state.activeServerId;
@@ -481,7 +484,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     }
     const verifiedIdentity = await this.#verifyIdentity(invite.apiUrl, invite.serverId, invite.fingerprint);
     const accountTicket = await this.#centralAccount.createTeamAuthTicket(invite.serverId);
-    const result = await requestJson(invite.apiUrl, "/v1/join/account", decodeJoinResult, {
+    const result = await requestJson(invite.apiUrl, TEAM_API_ROUTES.join.account, decodeJoinResult, {
       method: "POST",
       body: {
         inviteToken: invite.token,
@@ -564,7 +567,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
       };
     }
     const identity = await this.#verifyIdentity(invite.apiUrl, invite.serverId, invite.fingerprint);
-    const preview = await requestJson(invite.apiUrl, "/v1/invitations/preview", decodeInvitePreview, {
+    const preview = await requestJson(invite.apiUrl, TEAM_API_ROUTES.join.invitationPreview, decodeInvitePreview, {
       method: "POST",
       body: { inviteToken: invite.token },
       ...this.#requestProtocol(identity.compatibility),
@@ -584,7 +587,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     try {
       const identity = await this.#verifyIdentity(server.apiUrl, server.id, server.fingerprint);
       const accountTicket = await this.#centralAccount.createTeamAuthTicket(server.id);
-      const result = await requestJson(server.apiUrl, "/v1/auth/account", decodeJoinResult, {
+      const result = await requestJson(server.apiUrl, TEAM_API_ROUTES.auth.account, decodeJoinResult, {
         method: "POST",
         body: { accountTicket },
         ...this.#requestProtocol(identity.compatibility),
@@ -631,7 +634,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   }
 
   async remove(serverId: string): Promise<void> {
-    if (serverId === "local") throw new Error("The local server cannot be removed.");
+    if (serverId === LOCAL_SERVER_ID) throw new Error("The local server cannot be removed.");
     const server = this.#state.servers.find((candidate) => candidate.id === serverId);
     if (server?.transport === "webrtc-v2") {
       if (!this.#webrtcTransport) throw new Error("The WebRTC transport is unavailable.");
@@ -644,7 +647,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     }
     this.#clearServerConnectionState(serverId);
     this.#state.servers = this.#state.servers.filter((server) => server.id !== serverId);
-    if (this.#state.activeServerId === serverId) this.#setActiveServerId("local");
+    if (this.#state.activeServerId === serverId) this.#setActiveServerId(LOCAL_SERVER_ID);
     await this.#persist();
     this.#emitChanged();
   }
@@ -716,10 +719,10 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     this.#duplicateOperationIds.set(key, operationId);
     try {
       const result = await this.request(
-        `/v1/agents/${encodeURIComponent(botId)}/duplicate`,
+        TEAM_API_ROUTES.agent.duplicate(botId),
         { method: "POST", body: { operationId }, timeoutMs: REMOTE_DUPLICATION_TIMEOUT_MS },
         serverId,
-        decodeDuplicateBotResult,
+        decodeDuplicateBotResultFromHost,
       );
       this.#duplicateOperationIds.delete(key);
       return result;
@@ -732,16 +735,11 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   }
 
   listAgentConversationReads(serverId = this.#state.activeServerId): Promise<Record<string, ConversationReadState>> {
-    return this.request("/v1/agents/conversation-reads", {}, serverId, decodeConversationReadStates);
+    return this.request(TEAM_API_ROUTES.agents.conversationReads, {}, serverId, decodeConversationReadStates);
   }
 
   readAgentConversation(botId: string, serverId = this.#state.activeServerId): Promise<ConversationWithReadState> {
-    return this.request(
-      `/v1/agents/${encodeURIComponent(botId)}/conversation`,
-      {},
-      serverId,
-      decodeConversationWithReadState,
-    );
+    return this.request(TEAM_API_ROUTES.agent.conversation(botId), {}, serverId, decodeConversationWithReadState);
   }
 
   readAgentConversationPage(
@@ -751,10 +749,10 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     serverId = this.#state.activeServerId,
   ): Promise<ConversationPage> {
     return this.request(
-      `/v1/agents/${encodeURIComponent(botId)}/conversation-page${pageQuery(anchor, limit)}`,
+      `${TEAM_API_ROUTES.agent.conversationPage(botId)}${pageQuery(anchor, limit)}`,
       {},
       serverId,
-      decodeConversationPage,
+      decodeConversationPageFromHost,
     );
   }
 
@@ -768,7 +766,12 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     const parameters = new URLSearchParams({ q: query, limit: String(limit) });
     if (botId) parameters.set("botId", botId);
     if (cursor) parameters.set("cursor", cursor);
-    return this.request(`/v1/messages/search?${parameters.toString()}`, {}, serverId, decodeConversationSearchPage);
+    return this.request(
+      `${TEAM_API_ROUTES.messages.search}?${parameters.toString()}`,
+      {},
+      serverId,
+      decodeConversationSearchPageFromHost,
+    );
   }
 
   markAgentConversationRead(
@@ -776,7 +779,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     serverId = this.#state.activeServerId,
   ): Promise<ConversationReadState> {
     return this.request(
-      `/v1/agents/${encodeURIComponent(input.botId)}/conversation/read`,
+      TEAM_API_ROUTES.agent.conversationRead(input.botId),
       { method: "POST", body: { throughMessageId: input.throughMessageId } },
       serverId,
       decodeConversationReadState,
@@ -791,7 +794,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
 
   async getPresenceFor(serverId: string): Promise<TeamPresenceSnapshot> {
     try {
-      const snapshot = await this.request("/v1/team/presence", {}, serverId, decodeTeamPresenceSnapshot);
+      const snapshot = await this.request(TEAM_API_ROUTES.team.presence, {}, serverId, decodeTeamPresenceSnapshot);
       this.#presence.set(serverId, snapshot);
       return structuredClone(snapshot);
     } catch (error) {
@@ -837,7 +840,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
         })),
       );
     }
-    return this.request("/v1/team/members", {}, serverId, decodeTeamMembers);
+    return this.request(TEAM_API_ROUTES.team.members, {}, serverId, decodeTeamMembers);
   }
 
   updateMember(serverId: string, input: UpdateTeamMemberInput): Promise<TeamMemberSummary> {
@@ -857,7 +860,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
       })();
     }
     return this.request(
-      `/v1/team/members/${encodeURIComponent(input.memberId)}`,
+      TEAM_API_ROUTES.team.member(input.memberId),
       { method: "PATCH", body: { role: input.role, disabled: input.disabled } },
       serverId,
       decodeTeamMember,
@@ -868,7 +871,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     const server = this.#requireServer(serverId);
     if (server.transport === "webrtc-v2" && this.#webrtcTransport)
       return this.#webrtcTransport.removeMember(serverId, memberId);
-    return this.request(`/v1/team/members/${encodeURIComponent(memberId)}`, { method: "DELETE" }, serverId, decodeVoid);
+    return this.request(TEAM_API_ROUTES.team.member(memberId), { method: "DELETE" }, serverId, decodeVoid);
   }
 
   listInvites(serverId: string): Promise<TeamInviteSummary[]> {
@@ -886,13 +889,13 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
           })),
       );
     }
-    return this.request("/v1/team/invites", {}, serverId, decodeTeamInvites);
+    return this.request(TEAM_API_ROUTES.team.invites, {}, serverId, decodeTeamInvites);
   }
 
   revokeInvite(serverId: string, inviteId: string): Promise<void> {
     const server = this.#requireServer(serverId);
     if (server.transport === "webrtc-v2" && this.#webrtcTransport) return this.#webrtcTransport.revokeInvite(inviteId);
-    return this.request(`/v1/team/invites/${encodeURIComponent(inviteId)}`, { method: "DELETE" }, serverId, decodeVoid);
+    return this.request(TEAM_API_ROUTES.team.invite(inviteId), { method: "DELETE" }, serverId, decodeVoid);
   }
 
   async createInvite(serverId: string, input: { role: "admin" | "member"; email?: string }): Promise<InviteSummary> {
@@ -930,7 +933,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
       }
       return result;
     }
-    return this.request("/v1/team/invites", { method: "POST", body: input }, serverId, decodeInviteSummary);
+    return this.request(TEAM_API_ROUTES.team.invites, { method: "POST", body: input }, serverId, decodeInviteSummary);
   }
 
   setTyping(input: SetTeamTypingInput, serverId = this.#state.activeServerId): void {
@@ -945,16 +948,11 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   }
 
   listDirectThreads(serverId = this.#state.activeServerId): Promise<DirectThreadSummary[]> {
-    return this.request("/v1/direct/threads", {}, serverId, decodeDirectThreadSummaries);
+    return this.request(TEAM_API_ROUTES.direct.threads, {}, serverId, decodeDirectThreadSummaries);
   }
 
   readDirectConversation(memberId: string, serverId = this.#state.activeServerId): Promise<DirectConversationSnapshot> {
-    return this.request(
-      `/v1/direct/conversations/${encodeURIComponent(memberId)}`,
-      {},
-      serverId,
-      decodeDirectConversationSnapshot,
-    );
+    return this.request(TEAM_API_ROUTES.direct.conversation(memberId), {}, serverId, decodeDirectConversationSnapshot);
   }
 
   readDirectConversationPage(
@@ -964,7 +962,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     serverId = this.#state.activeServerId,
   ): Promise<DirectConversationPage> {
     return this.request(
-      `/v1/direct/conversations/${encodeURIComponent(memberId)}/page${pageQuery(anchor, limit)}`,
+      `${TEAM_API_ROUTES.direct.conversationPage(memberId)}${pageQuery(anchor, limit)}`,
       {},
       serverId,
       decodeDirectConversationPage,
@@ -972,7 +970,12 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   }
 
   sendDirectMessage(input: SendDirectMessageInput, serverId = this.#state.activeServerId): Promise<DirectMessage> {
-    return this.request("/v1/direct/messages", { method: "POST", body: input }, serverId, decodeDirectMessage);
+    return this.request(
+      TEAM_API_ROUTES.direct.messages,
+      { method: "POST", body: input },
+      serverId,
+      decodeDirectMessage,
+    );
   }
 
   markDirectRead(
@@ -980,7 +983,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     serverId = this.#state.activeServerId,
   ): Promise<DirectConversationReadState> {
     return this.request(
-      `/v1/direct/conversations/${encodeURIComponent(input.memberId)}/read`,
+      TEAM_API_ROUTES.direct.conversationRead(input.memberId),
       { method: "POST", body: { throughSequence: input.throughSequence } },
       serverId,
       decodeDirectConversationReadState,
@@ -1006,7 +1009,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
 
   async createRemoteDesktopSession(serverId: string): Promise<RemoteDesktopSession> {
     const session = await this.request(
-      "/v1/remote-screen/sessions",
+      TEAM_API_ROUTES.remoteScreen.sessions,
       { method: "POST", body: {} },
       serverId,
       decodeRemoteDesktopSession,
@@ -1015,10 +1018,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     if (!this.#remoteViewerProxy) throw new Error("The local remote viewer proxy is unavailable.");
     return {
       ...session,
-      viewerUrl: await this.#remoteViewerProxy.viewerUrl(
-        serverId,
-        `/v1/remote-screen/sessions/${encodeURIComponent(session.id)}/viewer`,
-      ),
+      viewerUrl: await this.#remoteViewerProxy.viewerUrl(serverId, TEAM_API_ROUTES.remoteScreen.viewer(session.id)),
     };
   }
 
@@ -1029,16 +1029,16 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   }
 
   closeRemoteDesktopSession(serverId: string, sessionId: string): Promise<void> {
-    return this.request(
-      `/v1/remote-screen/sessions/${encodeURIComponent(sessionId)}`,
-      { method: "DELETE" },
-      serverId,
-      decodeVoid,
-    );
+    return this.request(TEAM_API_ROUTES.remoteScreen.session(sessionId), { method: "DELETE" }, serverId, decodeVoid);
   }
 
   selectRemoteDesktopDisplay(serverId: string, displayId: string): Promise<void> {
-    return this.request("/v1/remote-screen/display", { method: "PUT", body: { displayId } }, serverId, decodeVoid);
+    return this.request(
+      TEAM_API_ROUTES.remoteScreen.display,
+      { method: "PUT", body: { displayId } },
+      serverId,
+      decodeVoid,
+    );
   }
 
   async uploadAttachment(
@@ -1048,7 +1048,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     serverId = this.#state.activeServerId,
   ): Promise<DraftAttachment> {
     const server = this.#requireServer(serverId);
-    const url = new URL("/v1/attachments", server.apiUrl);
+    const url = new URL(TEAM_API_ROUTES.attachments, server.apiUrl);
     url.searchParams.set("name", name);
     url.searchParams.set("mime", mimeType || "application/octet-stream");
     const response = await this.#fetch(server, url, {
@@ -1068,7 +1068,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     serverId = this.#state.activeServerId,
   ): Promise<BotSummary> {
     const server = this.#requireServer(serverId);
-    const url = new URL(`/v1/agents/${encodeURIComponent(botId)}/avatar`, server.apiUrl);
+    const url = new URL(TEAM_API_ROUTES.agent.avatar(botId), server.apiUrl);
     const headers = new Headers();
     if (image) headers.set("Content-Type", image.mimeType);
     const response = await this.#fetch(server, url, {
@@ -1091,7 +1091,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     version?: string,
   ): Promise<{ bytes: Uint8Array; mimeType: string }> {
     const server = this.#requireServer(serverId);
-    const url = new URL(`/v1/agents/${encodeURIComponent(botId)}/avatar`, server.apiUrl);
+    const url = new URL(TEAM_API_ROUTES.agent.avatar(botId), server.apiUrl);
     if (version) url.searchParams.set("v", version);
     const response = await this.#fetch(server, url);
     return {
@@ -1108,7 +1108,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
       if (!isValidAvatarImage(logo.mimeType, logo.bytes)) throw new Error("Server logo response is invalid.");
       return logo;
     }
-    const url = new URL("/v1/team/logo", server.apiUrl);
+    const url = new URL(TEAM_API_ROUTES.team.logo, server.apiUrl);
     url.searchParams.set("v", version);
     const response = await this.#fetch(server, url);
     const bytes = new Uint8Array(await response.arrayBuffer());
@@ -1141,7 +1141,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     serverId = this.#state.activeServerId,
   ): Promise<{ bytes: Uint8Array; name: string }> {
     const server = this.#requireServer(serverId);
-    const url = new URL("/v1/shared-files", server.apiUrl);
+    const url = new URL(TEAM_API_ROUTES.sharedFiles, server.apiUrl);
     url.searchParams.set("path", sharedPath);
     const response = await this.#fetch(server, url);
     const disposition = response.headers.get("content-disposition") ?? "";
@@ -1158,7 +1158,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     serverId = this.#state.activeServerId,
   ): Promise<{ bytes: Uint8Array; name: string }> {
     const server = this.#requireServer(serverId);
-    const url = new URL("/v1/workspace-files", server.apiUrl);
+    const url = new URL(TEAM_API_ROUTES.workspaceFiles, server.apiUrl);
     url.searchParams.set("botId", botId);
     url.searchParams.set("path", workspacePath);
     const response = await this.#fetch(server, url);
@@ -1250,10 +1250,10 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     }
     this.#state.servers = servers;
     if (
-      this.#state.activeServerId !== "local" &&
+      this.#state.activeServerId !== LOCAL_SERVER_ID &&
       !this.#state.servers.some((server) => server.id === this.#state.activeServerId)
     ) {
-      this.#setActiveServerId("local");
+      this.#setActiveServerId(LOCAL_SERVER_ID);
     }
     await this.#persist();
   }
@@ -1271,7 +1271,9 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
 
   async #refreshWebRtcCompatibility(serverId: string): Promise<void> {
     if (!this.#webrtcTransport) return;
-    const host = decodeTeamProtocolSupportV1(await this.#webrtcTransport.request(serverId, "/v1/compatibility"));
+    const host = decodeTeamProtocolSupportV1(
+      await this.#webrtcTransport.request(serverId, TEAM_API_ROUTES.compatibility),
+    );
     this.#compatibility.set(serverId, {
       localAppVersion: this.#appVersion ?? "0.0.0",
       hostAppVersion: host.appVersion,
@@ -1458,7 +1460,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
 
   async #negotiateWebRtcCompatibility(serverId: string): Promise<ServerCompatibility> {
     if (!this.#webrtcTransport) throw new Error("The WebRTC transport is unavailable.");
-    const value = await this.#webrtcTransport.request(serverId, "/v1/compatibility");
+    const value = await this.#webrtcTransport.request(serverId, TEAM_API_ROUTES.compatibility);
     return this.#webrtcCompatibility(decodeTeamProtocolSupportV1(value));
   }
 
@@ -1466,7 +1468,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     if (!this.#appVersion) return this.#assumedCompatibility();
     let host: TeamProtocolSupportV1;
     try {
-      host = await requestJson(apiUrl, "/v1/compatibility", decodeTeamProtocolSupportV1);
+      host = await requestJson(apiUrl, TEAM_API_ROUTES.compatibility, decodeTeamProtocolSupportV1);
     } catch (error) {
       if (error instanceof RemoteRequestError && error.status === 404) {
         throw new RemoteProtocolError("host_update_required", "Update OpenBot on the host before connecting.");
@@ -1571,7 +1573,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     const challenge = randomBytes(24).toString("base64url");
     const proof = await requestJson(
       apiUrl,
-      `/v1/identity?challenge=${encodeURIComponent(challenge)}`,
+      `${TEAM_API_ROUTES.identity}?challenge=${encodeURIComponent(challenge)}`,
       decodeIdentityProof,
       {
         ...this.#requestProtocol(compatibility),
@@ -1603,14 +1605,14 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
       if (server.transport === "webrtc-v2") {
         if (!this.#webrtcTransport) throw new Error("The WebRTC transport is unavailable.");
         capabilities = decodeRemoteDesktopCapabilities(
-          await this.#webrtcTransport.request(server.id, "/v1/remote-screen/capabilities", {
+          await this.#webrtcTransport.request(server.id, TEAM_API_ROUTES.remoteScreen.capabilities, {
             preserveSemanticTags: supportsTeamSemanticTags(compatibility.capabilities),
           }),
         );
       } else {
         capabilities = await requestJson(
           server.apiUrl,
-          "/v1/remote-screen/capabilities",
+          TEAM_API_ROUTES.remoteScreen.capabilities,
           decodeRemoteDesktopCapabilities,
           {
             token: this.#token(server),
@@ -1648,7 +1650,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
         if (this.#eventControllers.get(serverId) === controller) this.#eventControllers.delete(serverId);
         return;
       }
-      const eventsUrl = new URL("/v1/events", server.apiUrl);
+      const eventsUrl = new URL(TEAM_API_ROUTES.events, server.apiUrl);
       eventsUrl.protocol = eventsUrl.protocol === "https:" ? "wss:" : "ws:";
       const socketProtocols = this.#appVersion
         ? [TEAM_PROTOCOL_V1_WEBSOCKET, `openbot-token.${this.#token(server)}`]
@@ -1893,7 +1895,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
   async #hasRejectedEventCredentials(server: StoredRemoteServer): Promise<boolean> {
     try {
       const compatibility = await this.#ensureCompatibility(server);
-      await requestJson(server.apiUrl, "/v1/me", (value) => decodeRecord(value, "team member"), {
+      await requestJson(server.apiUrl, TEAM_API_ROUTES.me, (value) => decodeRecord(value, "team member"), {
         token: this.#token(server),
         ...this.#requestProtocol(compatibility),
       });
@@ -1915,7 +1917,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
 
   async #refreshAgentStateFallback(serverId: string): Promise<void> {
     const generation = this.#advanceEventGeneration(serverId);
-    const bots = await this.request("/v1/agents", {}, serverId, decodeBotSummaries);
+    const bots = await this.request(TEAM_API_ROUTES.agents.all, {}, serverId, decodeBotSummaries);
     if (this.#eventGenerations.get(serverId) !== generation) return;
     this.emit("agent", serverId, { type: "bots-changed", bots });
     await Promise.all(
@@ -1923,7 +1925,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
         try {
           const [page, queue] = await Promise.all([
             this.readAgentConversationPage(bot.id, { type: "latest" }, 1, serverId),
-            this.request(`/v1/agents/${encodeURIComponent(bot.id)}/queue`, {}, serverId, decodeQueueSnapshot),
+            this.request(TEAM_API_ROUTES.agent.queue(bot.id), {}, serverId, decodeQueueSnapshot),
           ]);
           if (this.#eventGenerations.get(serverId) !== generation) return;
           const { pageInfo: _, references: __, readState: ___, ...snapshot } = page;
@@ -1993,12 +1995,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
         request.dirty = false;
         let snapshot: QueueSnapshot;
         try {
-          snapshot = await this.request(
-            `/v1/agents/${encodeURIComponent(botId)}/queue`,
-            {},
-            serverId,
-            decodeQueueSnapshot,
-          );
+          snapshot = await this.request(TEAM_API_ROUTES.agent.queue(botId), {}, serverId, decodeQueueSnapshot);
         } catch {
           if (request.dirty) continue;
           return;
@@ -2158,35 +2155,6 @@ async function requestJson<T>(
   }
 }
 
-function decodeRecord(value: unknown, label: string): DynamicRecord {
-  if (!isDynamicRecord(value)) throw new Error(`Invalid ${label}.`);
-  return value;
-}
-
-function requiredString(record: DynamicRecord, field: string): string {
-  const value = record[field];
-  if (!isString(value)) throw new Error(`Invalid ${field}.`);
-  return value;
-}
-
-function nullableString(record: DynamicRecord, field: string): string | null {
-  const value = record[field];
-  if (value === null || isString(value)) return value;
-  throw new Error(`Invalid ${field}.`);
-}
-
-function requiredNumber(record: DynamicRecord, field: string): number {
-  const value = record[field];
-  if (!isNumber(value)) throw new Error(`Invalid ${field}.`);
-  return value;
-}
-
-function requiredBoolean(record: DynamicRecord, field: string): boolean {
-  const value = record[field];
-  if (!isBoolean(value)) throw new Error(`Invalid ${field}.`);
-  return value;
-}
-
 function decodeJoinResult(value: unknown): { member: { role: TeamRole }; sessionToken: string } {
   const record = decodeRecord(value, "join response");
   const member = decodeRecord(record.member, "member");
@@ -2263,19 +2231,20 @@ function decodeMarketplaceSource(value: unknown): BotSummary["marketplaceSource"
   };
 }
 
-export function decodeVoid(value: unknown): undefined {
-  if (value !== undefined && value !== null) throw new Error("The remote server returned data.");
-  return undefined;
-}
+export const decodeVoid = emptyDecoder("The remote server returned data.");
 
-export function decodeAgentStatus(value: unknown): AgentStatus {
+// A `FromHost` decoder has a same-shaped `FromMain` twin in `src/preload/index.ts` and is
+// deliberately not the same function: a remote team server is an untrusted sender, so these enumerate
+// what the preload's twin is content to accept as a string. The suffix is there so a later reader
+// does not merge them onto whichever is looser.
+export function decodeAgentStatusFromHost(value: unknown): AgentStatus {
   if (!isAgentStatus(value)) {
     throw new Error("Invalid remote agent status.");
   }
   return value;
 }
 
-export function decodeAccountUsage(value: unknown): AccountUsage {
+export function decodeAccountUsageFromHost(value: unknown): AccountUsage {
   if (!isAccountUsage(value)) {
     throw new Error("Invalid remote account usage.");
   }
@@ -2294,7 +2263,7 @@ export function decodeBotSummaries(value: unknown): BotSummary[] {
   return value.map(decodeBotSummary);
 }
 
-export function decodeInstalledSkills(value: unknown): InstalledSkill[] {
+export function decodeInstalledSkillsFromHost(value: unknown): InstalledSkill[] {
   if (!Array.isArray(value)) throw new Error("Invalid installed skill list.");
   return value.map((item) => {
     const skill = decodeRecord(item, "installed skill");
@@ -2325,32 +2294,17 @@ export function decodeBotMemories(value: unknown): BotMemory[] {
   return value;
 }
 
-export function decodeRoutine(value: unknown): Routine {
-  if (!isRoutine(value)) throw new Error("Invalid remote routine.");
-  return value;
-}
-
-export function decodeRoutines(value: unknown): Routine[] {
-  if (!Array.isArray(value) || !value.every(isRoutine)) throw new Error("Invalid remote routine list.");
-  return value;
-}
-
-export function decodeRoutineRun(value: unknown): RoutineRun {
-  if (!isRoutineRun(value)) throw new Error("Invalid remote routine run.");
-  return value;
-}
-
-export function decodeRoutineRuns(value: unknown): RoutineRun[] {
-  if (!Array.isArray(value) || !value.every(isRoutineRun)) throw new Error("Invalid remote routine history.");
-  return value;
-}
+export const decodeRoutine = guardedDecoder(isRoutine, "remote routine");
+export const decodeRoutines = guardedListDecoder(isRoutine, "remote routine list");
+export const decodeRoutineRun = guardedDecoder(isRoutineRun, "remote routine run");
+export const decodeRoutineRuns = guardedListDecoder(isRoutineRun, "remote routine history");
 
 export function decodeSidebarLayoutSnapshot(value: unknown): SidebarLayoutSnapshot {
   if (!isSidebarLayoutSnapshot(value)) throw new Error("Invalid sidebar layout response.");
   return value;
 }
 
-export function decodeDuplicateBotResult(value: unknown): DuplicateBotResult {
+export function decodeDuplicateBotResultFromHost(value: unknown): DuplicateBotResult {
   const record = decodeRecord(value, "agent duplication");
   return {
     bot: decodeBotSummary(record.bot),
@@ -2384,7 +2338,7 @@ export function decodeBrowserTab(value: unknown): BrowserTab {
   return value;
 }
 
-export function decodeBrowserPreview(value: unknown): BrowserPreview {
+export function decodeBrowserPreviewFromHost(value: unknown): BrowserPreview {
   if (!isBrowserPreviewValue(value)) throw new Error("Invalid remote browser preview.");
   return value;
 }
@@ -2524,7 +2478,7 @@ function decodeConversationWithReadState(value: unknown): ConversationWithReadSt
   return { ...value, readState: decodeConversationReadState(value.readState) };
 }
 
-function decodeConversationPage(value: unknown): ConversationPage {
+function decodeConversationPageFromHost(value: unknown): ConversationPage {
   const record = decodeRecord(value, "agent conversation page");
   return {
     botId: requiredString(record, "botId"),
@@ -2532,13 +2486,13 @@ function decodeConversationPage(value: unknown): ConversationPage {
     activeTurnId: nullableString(record, "activeTurnId"),
     revision: requiredNumber(record, "revision"),
     messages: decodeConversationMessages(record.messages),
-    references: decodeConversationReferences(record.references),
+    references: decodeConversationReferencesFromHost(record.references),
     pageInfo: decodePageInfo(record.pageInfo),
     ...(record.readState === undefined ? {} : { readState: decodeConversationReadState(record.readState) }),
   };
 }
 
-function decodeConversationSearchPage(value: unknown): ConversationSearchPage {
+function decodeConversationSearchPageFromHost(value: unknown): ConversationSearchPage {
   const record = decodeRecord(value, "conversation search page");
   if (!Array.isArray(record.results)) throw new Error("Invalid conversation search results.");
   return {
@@ -2554,14 +2508,9 @@ function decodeConversationSearchPage(value: unknown): ConversationSearchPage {
   };
 }
 
-function decodeConversationMessages(value: unknown): ConversationMessage[] {
-  if (!Array.isArray(value) || !value.every(isConversationMessage)) {
-    throw new Error("Invalid conversation page messages.");
-  }
-  return value;
-}
+const decodeConversationMessages = guardedListDecoder(isConversationMessage, "conversation page messages");
 
-function decodeConversationReferences(value: unknown): Record<string, ConversationMessage> {
+function decodeConversationReferencesFromHost(value: unknown): Record<string, ConversationMessage> {
   const references = decodeRecord(value, "conversation references");
   const decoded: Record<string, ConversationMessage> = {};
   for (const [messageId, message] of Object.entries(references)) {

--- a/src/main/remote-server-manager.ts
+++ b/src/main/remote-server-manager.ts
@@ -1126,7 +1126,7 @@ export class RemoteServerManager extends EventEmitter<RemoteServerEvents> {
     mimeType: string;
   }> {
     const server = this.#requireServer(serverId);
-    const response = await this.#fetch(server, `${server.apiUrl}/v1/attachments/${encodeURIComponent(attachmentId)}`);
+    const response = await this.#fetch(server, `${server.apiUrl}${TEAM_API_ROUTES.attachment(attachmentId)}`);
     const disposition = response.headers.get("content-disposition") ?? "";
     const encodedName = disposition.match(/filename\*=UTF-8''([^;]+)/i)?.[1];
     return {

--- a/src/main/remote-viewer-proxy.ts
+++ b/src/main/remote-viewer-proxy.ts
@@ -8,6 +8,7 @@ import {
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { isString } from "@openbot/contracts/runtime-values";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import type * as Ws from "ws";
 import {
   decodeRemoteDesktopSignalBinary,
@@ -125,10 +126,14 @@ export class RemoteViewerProxy {
       if (contentType.includes("text/html") || contentType.includes("javascript")) {
         const prefix = this.#basePath(route.serverId);
         const escapedPrefix = prefix.replaceAll("/", "\\/");
+        // Both forms of the namespace the viewer's assets reference: plain in URLs, backslash-escaped
+        // where the bundle embeds it in a regex or a string literal.
+        const namespace = TEAM_API_ROUTES.remoteScreen.prefix;
+        const escapedNamespace = namespace.replaceAll("/", "\\/");
         const text = new TextDecoder()
           .decode(bytes)
-          .replaceAll("\\/v1\\/remote-screen", `${escapedPrefix}\\/v1\\/remote-screen`)
-          .replaceAll("/v1/remote-screen", `${prefix}/v1/remote-screen`);
+          .replaceAll(escapedNamespace, `${escapedPrefix}${escapedNamespace}`)
+          .replaceAll(namespace, `${prefix}${namespace}`);
         bytes = new TextEncoder().encode(text);
       }
       const responseHeaders: OutgoingHttpHeaders = {

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -30,6 +30,7 @@ import {
   TEAM_CAPABILITIES_HEADER,
   TEAM_PROTOCOL_V1_CAPABILITIES,
   TEAM_PROTOCOL_VERSION_HEADER,
+  teamProtocolV1HttpRoute,
 } from "@openbot/contracts/team-protocol/v1";
 import { TEAM_PROTOCOL_V3 } from "@openbot/contracts/team-protocol/v3";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -444,6 +445,37 @@ const ROUTE_METHODS: Record<string, string> = {
 // family `remote-screen-gateway.ts` owns, which answers 404 for a session that does not exist.
 const ROUTES_NOT_SERVED_OVER_HTTP = new Set(["remoteDesktopUpgrade", "remoteScreen.viewer"]);
 
+// Reaching the router is only half of what a route needs. `#json` encodes every JSON body through
+// the negotiated protocol's frozen adapter, and protocol v3 delegates all but agent duplication to
+// v1's route list, so a table entry that list cannot name is one the host answers 500 on for every
+// client - and the loop below cannot see it, because these stubs drive only ten routes as far as a
+// 2xx body. These are the entries whose response never passes through that classification, each for
+// a reason that is a property of the route rather than an omission.
+const ROUTES_WITHOUT_A_CLASSIFIED_JSON_BODY = new Set([
+  // Answered with 204 and no body at all.
+  "attachment",
+  "auth.logout",
+  "team.invite",
+  "team.session",
+  "remoteScreen.session",
+  // Answered with bytes rather than JSON, so `#json` is never the writer.
+  "team.logo",
+  "sharedFiles",
+  "workspaceFiles",
+  "agent.avatar",
+  // Answered only as a 426, which the codec projects through its error branch, where the route plays
+  // no part.
+  "events",
+  "host.remoteMac",
+  "host.remoteDesktopAccess",
+  // The v1 codec short-circuits this one ahead of classification, to keep a skill list it has no
+  // contract for intact.
+  "agent.skills",
+  // Protocol v3 only: its own adapter names this route before delegating the rest to v1. A v1 peer
+  // that calls it anyway is answered 500 rather than a protocol error - see the PR body.
+  "agent.duplicate",
+]);
+
 const ROUTE_SAMPLE_IDS = ["route-sample", "route-sample-other"];
 
 // The table's three shapes: a fixed path, a builder taking one or two ids, and a group of either.
@@ -486,8 +518,22 @@ describe("TeamApiServer routing", () => {
       const login = await jsonRequest<{ sessionToken: string }>(base, TEAM_API_ROUTES.auth.login, {
         body: { username: "owner", password: "correct horse battery" },
       });
-      const routes = collectRoutes(TEAM_API_ROUTES, []).filter((route) => !ROUTES_NOT_SERVED_OVER_HTTP.has(route.name));
+      const collected = collectRoutes(TEAM_API_ROUTES, []);
+      const routes = collected.filter((route) => !ROUTES_NOT_SERVED_OVER_HTTP.has(route.name));
+      // Both directions, because either one alone can pass while saying nothing: a table walk that
+      // returned nothing would satisfy the first check, and a method left behind by a deleted route
+      // would never be noticed without the second.
       expect(routes.filter((route) => !ROUTE_METHODS[route.name]).map((route) => route.name)).toEqual([]);
+      expect(Object.keys(ROUTE_METHODS).filter((name) => !collected.some((route) => route.name === name))).toEqual([]);
+
+      // Every route the codec has to name, it names. Renaming a path in the table moves the host and
+      // the client together, so the loop below stays green - this is the half of the surface that
+      // notices, because the frozen adapter does not move with them.
+      const unclassified = routes
+        .filter((route) => !ROUTES_WITHOUT_A_CLASSIFIED_JSON_BODY.has(route.name))
+        .filter((route) => !teamProtocolV1HttpRoute(ROUTE_METHODS[route.name], route.path))
+        .map((route) => `${ROUTE_METHODS[route.name]} ${route.path} (${route.name})`);
+      expect(unclassified).toEqual([]);
 
       // Signing out invalidates the token every other request needs, so it goes last - otherwise the
       // routes after it would answer 401 and never reach the router's 404.

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -443,7 +443,9 @@ const ROUTE_METHODS: Record<string, string> = {
 
 // Two entries this router deliberately never answers: the WebSocket upgrade path, and the viewer
 // family `remote-screen-gateway.ts` owns, which answers 404 for a session that does not exist.
-const ROUTES_NOT_SERVED_OVER_HTTP = new Set(["remoteDesktopUpgrade", "remoteScreen.viewer"]);
+// `remoteScreen.prefix` is a namespace, not an endpoint: nothing is served at it, and it exists so
+// `remote-viewer-proxy.ts` rewrites the same string the group's routes are built from.
+const ROUTES_NOT_SERVED_OVER_HTTP = new Set(["remoteDesktopUpgrade", "remoteScreen.viewer", "remoteScreen.prefix"]);
 
 // Reaching the router is only half of what a route needs. `#json` encodes every JSON body through
 // the negotiated protocol's frozen adapter, and protocol v3 delegates all but agent duplication to

--- a/src/main/team-api-server.test.ts
+++ b/src/main/team-api-server.test.ts
@@ -23,6 +23,7 @@ import {
   routineRunConversationEventItemType,
 } from "@openbot/contracts/ipc";
 import { isBoolean, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import { TEAM_CURRENT_CAPABILITIES, TEAM_SEMANTIC_TAGS_CAPABILITY } from "@openbot/contracts/team-protocol/current";
 import {
   TEAM_APP_VERSION_HEADER,
@@ -350,6 +351,166 @@ describe("TeamApiServer compatibility", () => {
       ]);
       expect(listInstalledForChatTags).toHaveBeenCalledWith("chief");
     } finally {
+      await api.stop();
+    }
+  });
+});
+
+// `TEAM_API_ROUTES` is the client's half of this router's surface, and until this case nothing linked
+// the two: a path renamed in the table but not in the branch below would leave every remote server
+// asking for a route the host answers "Route not found." to, with no test going red. The table is
+// walked rather than listed, so a new entry cannot quietly skip the check - it arrives with no method
+// declared and fails on `undeclared` until it is named here.
+const ROUTE_METHODS: Record<string, string> = {
+  compatibility: "GET",
+  identity: "GET",
+  events: "GET",
+  me: "GET",
+  attachments: "POST",
+  attachment: "DELETE",
+  sharedFiles: "GET",
+  workspaceFiles: "GET",
+  "join.server": "POST",
+  "join.account": "POST",
+  "join.invitationPreview": "POST",
+  "auth.login": "POST",
+  "auth.account": "POST",
+  "auth.logout": "POST",
+  "auth.password": "POST",
+  "host.remoteMac": "GET",
+  "host.remoteDesktopAccess": "GET",
+  "team.presence": "GET",
+  "team.logo": "GET",
+  "team.members": "GET",
+  "team.member": "PATCH",
+  "team.invites": "GET",
+  "team.invite": "DELETE",
+  "team.sessions": "GET",
+  "team.session": "DELETE",
+  "direct.threads": "GET",
+  "direct.messages": "POST",
+  "direct.conversation": "GET",
+  "direct.conversationPage": "GET",
+  "direct.conversationRead": "POST",
+  "messages.search": "GET",
+  "browser.open": "POST",
+  "browser.activate": "POST",
+  "browser.navigate": "POST",
+  "browser.reload": "POST",
+  "browser.close": "POST",
+  "browser.tabs": "GET",
+  "browser.control": "GET",
+  "browser.preview": "POST",
+  "browser.visible": "POST",
+  "remoteScreen.capabilities": "GET",
+  "remoteScreen.sessions": "POST",
+  "remoteScreen.session": "DELETE",
+  "remoteScreen.display": "PUT",
+  "sidebarLayout.state": "GET",
+  "sidebarLayout.actions": "POST",
+  "respond.prompt": "POST",
+  "respond.approval": "POST",
+  "respond.browserTakeover": "POST",
+  "agents.all": "GET",
+  "agents.status": "GET",
+  "agents.usage": "GET",
+  "agents.models": "GET",
+  "agents.conversationReads": "GET",
+  "agent.one": "PATCH",
+  "agent.skills": "GET",
+  "agent.duplicate": "POST",
+  "agent.avatar": "GET",
+  "agent.conversation": "GET",
+  "agent.conversationPage": "GET",
+  "agent.conversationRead": "POST",
+  "agent.messages": "POST",
+  "agent.reactions": "POST",
+  "agent.interrupt": "POST",
+  "agent.failuresAcknowledge": "POST",
+  "agent.queue": "GET",
+  "agent.queueCancel": "POST",
+  "agent.queueSteer": "POST",
+  "agent.queueUpdate": "POST",
+  "agent.queueReorder": "POST",
+  "agent.memories": "GET",
+  "agent.memory": "PATCH",
+  "agent.routines": "GET",
+  "agent.routine": "PATCH",
+  "agent.routineTest": "POST",
+  "agent.routineRuns": "GET",
+};
+
+// Two entries this router deliberately never answers: the WebSocket upgrade path, and the viewer
+// family `remote-screen-gateway.ts` owns, which answers 404 for a session that does not exist.
+const ROUTES_NOT_SERVED_OVER_HTTP = new Set(["remoteDesktopUpgrade", "remoteScreen.viewer"]);
+
+const ROUTE_SAMPLE_IDS = ["route-sample", "route-sample-other"];
+
+// The table's three shapes: a fixed path, a builder taking one or two ids, and a group of either.
+type RouteNode = string | ((...ids: string[]) => string) | { [key: string]: RouteNode };
+
+function collectRoutes(node: { [key: string]: RouteNode }, trail: string[]): { name: string; path: string }[] {
+  return Object.entries(node).flatMap(([key, value]) => {
+    const name = [...trail, key].join(".");
+    if (typeof value === "string") return [{ name, path: value }];
+    if (typeof value === "function") {
+      return [{ name, path: value(...ROUTE_SAMPLE_IDS.slice(0, value.length)) }];
+    }
+    return collectRoutes(value, [...trail, key]);
+  });
+}
+
+describe("TeamApiServer routing", () => {
+  it("answers every path the shared route table builds", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-team-api-routes-"));
+    roots.push(root);
+    const store = new TeamStore(join(root, "team.json"));
+    await store.initialize();
+    await store.configure("Studio Mac", "owner", "correct horse battery");
+    const sidebarLayout = new SidebarLayoutStore(join(root, "sidebar-layout.json"));
+    await sidebarLayout.initialize();
+    const api = new TeamApiServer({
+      store,
+      agents: createAgents({ listBots: () => [] }),
+      sidebarLayout,
+      mailbox: createMailbox(),
+      browser: createBrowser(),
+    });
+    const port = await api.start();
+    const base = `http://127.0.0.1:${port}`;
+    // The point is which paths route, not what the stubs do once reached, so the failures they raise
+    // are expected here and their logging would bury the assertion.
+    const requestFailures = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const login = await jsonRequest<{ sessionToken: string }>(base, TEAM_API_ROUTES.auth.login, {
+        body: { username: "owner", password: "correct horse battery" },
+      });
+      const routes = collectRoutes(TEAM_API_ROUTES, []).filter((route) => !ROUTES_NOT_SERVED_OVER_HTTP.has(route.name));
+      expect(routes.filter((route) => !ROUTE_METHODS[route.name]).map((route) => route.name)).toEqual([]);
+
+      // Signing out invalidates the token every other request needs, so it goes last - otherwise the
+      // routes after it would answer 401 and never reach the router's 404.
+      const ordered = [
+        ...routes.filter((route) => route.name !== "auth.logout"),
+        ...routes.filter((route) => route.name === "auth.logout"),
+      ];
+      const unrouted: string[] = [];
+      for (const route of ordered) {
+        const method = ROUTE_METHODS[route.name];
+        const response = await fetch(`${base}${route.path}`, {
+          method,
+          headers: { Authorization: `Bearer ${login.sessionToken}` },
+        });
+        const body = response.status === 404 ? await response.json() : null;
+        if (isDynamicRecord(body) && body.error === "Route not found.") {
+          unrouted.push(`${method} ${route.path} (${route.name})`);
+        }
+      }
+
+      expect(unrouted).toEqual([]);
+    } finally {
+      requestFailures.mockRestore();
       await api.stop();
     }
   });

--- a/src/main/team-api-server.ts
+++ b/src/main/team-api-server.ts
@@ -43,6 +43,7 @@ import {
   type UpdateQueuedMessageInput,
 } from "@openbot/contracts/ipc";
 import { type DynamicRecord, isBoolean, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import {
   isTeamCurrentCapability,
   supportsTeamSemanticTags,
@@ -289,7 +290,7 @@ export class TeamApiServer {
       const protocols = (request.headers["sec-websocket-protocol"] ?? "").split(",").map((value) => value.trim());
       if (
         this.#options.appVersion &&
-        url.pathname === "/v1/events" &&
+        url.pathname === TEAM_API_ROUTES.events &&
         !protocols.includes(TEAM_PROTOCOL_V1_WEBSOCKET)
       ) {
         socket.write("HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n");
@@ -305,7 +306,7 @@ export class TeamApiServer {
         return;
       }
       if (
-        url.pathname === "/v1/events" &&
+        url.pathname === TEAM_API_ROUTES.events &&
         (protocols.includes(TEAM_PROTOCOL_V1_WEBSOCKET) ||
           (!this.#options.appVersion &&
             (protocols.includes(TEST_LEGACY_SNAPSHOT_PROTOCOL) || protocols.includes(TEST_LEGACY_EVENT_PROTOCOL))))
@@ -321,7 +322,7 @@ export class TeamApiServer {
         });
         return;
       }
-      if (url.pathname === "/v1/remote-desktop") {
+      if (url.pathname === TEAM_API_ROUTES.remoteDesktopUpgrade) {
         socket.write("HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n");
         socket.destroy();
         return;
@@ -494,7 +495,7 @@ export class TeamApiServer {
         capabilities: clientCapabilities,
       });
 
-      if (method === "GET" && url.pathname === "/v1/compatibility") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.compatibility) {
         return this.#json(response, 200, this.#protocolSupport());
       }
 
@@ -506,7 +507,7 @@ export class TeamApiServer {
       const protocolIssue = this.#protocolIssue(request);
       if (protocolIssue) return this.#json(response, protocolIssue.status, protocolIssue.body);
 
-      if (method === "GET" && url.pathname === "/v1/identity") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.identity) {
         const challenge = url.searchParams.get("challenge");
         return this.#json(
           response,
@@ -514,7 +515,7 @@ export class TeamApiServer {
           challenge ? this.#options.store.getIdentityProof(challenge) : this.#options.store.getIdentity(),
         );
       }
-      if (method === "POST" && url.pathname === "/v1/invitations/preview") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.join.invitationPreview) {
         const body = await readJson(request);
         return this.#json(
           response,
@@ -522,7 +523,7 @@ export class TeamApiServer {
           this.#options.store.previewInvite(stringField(body, "inviteToken", false, INPUT_LIMITS.identifier)),
         );
       }
-      if (method === "POST" && url.pathname === "/v1/join") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.join.server) {
         const body = await readJson(request);
         this.#checkRate(request, stringField(body, "username", false, 64));
         const result = await this.#options.store.acceptInvite(
@@ -532,7 +533,7 @@ export class TeamApiServer {
         );
         return this.#json(response, 201, result);
       }
-      if (method === "POST" && url.pathname === "/v1/join/account") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.join.account) {
         const body = await readJson(request);
         const identity = this.#options.store.getIdentity();
         const user = identity
@@ -549,7 +550,7 @@ export class TeamApiServer {
         );
         return this.#json(response, 201, result);
       }
-      if (method === "POST" && url.pathname === "/v1/auth/login") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.auth.login) {
         const body = await readJson(request);
         this.#checkRate(request, stringField(body, "username", false, 64));
         const result = await this.#options.store.login(
@@ -558,7 +559,7 @@ export class TeamApiServer {
         );
         return this.#json(response, 200, result);
       }
-      if (method === "POST" && url.pathname === "/v1/auth/account") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.auth.account) {
         const body = await readJson(request);
         const identity = this.#options.store.getIdentity();
         const user = identity
@@ -579,13 +580,13 @@ export class TeamApiServer {
         return this.#json(response, 401, { error: "Authentication required." });
       }
 
-      if (method === "POST" && url.pathname === "/v1/auth/logout") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.auth.logout) {
         await this.#options.store.logout(token);
         await this.#options.remoteScreen?.revokeTeamSession(authenticated.sessionId);
         this.refreshPresence();
         return this.#empty(response, 204);
       }
-      if (method === "POST" && url.pathname === "/v1/auth/password") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.auth.password) {
         const body = await readJson(request);
         await this.#options.store.changePassword(
           member.id,
@@ -596,13 +597,13 @@ export class TeamApiServer {
         this.refreshPresence();
         return this.#empty(response, 204);
       }
-      if (method === "GET" && url.pathname === "/v1/me") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.me) {
         return this.#json(response, 200, member);
       }
-      if (method === "GET" && url.pathname === "/v1/team/presence") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.team.presence) {
         return this.#json(response, 200, this.getPresence());
       }
-      if (method === "GET" && url.pathname === "/v1/team/logo") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.team.logo) {
         const logo = this.#options.store.resolveLogo();
         if (!logo || (url.searchParams.get("v") && url.searchParams.get("v") !== logo.version)) {
           return this.#json(response, 404, { error: "Server logo not found." });
@@ -617,15 +618,15 @@ export class TeamApiServer {
         response.end(bytes);
         return;
       }
-      if (method === "GET" && url.pathname === "/v1/events") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.events) {
         return this.#json(response, 426, { error: "Use WebSocket for remote events." });
       }
-      if (method === "GET" && url.pathname === "/v1/remote-screen/capabilities") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.remoteScreen.capabilities) {
         if (!this.#options.remoteScreen)
           throw new RemoteScreenError(503, "host_unavailable", "Remote control is unavailable.");
         return this.#json(response, 200, this.#options.remoteScreen.capabilities());
       }
-      if (method === "POST" && url.pathname === "/v1/remote-screen/sessions") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.remoteScreen.sessions) {
         const identity = this.#options.store.getIdentity();
         if (!identity || !this.#options.remoteScreen) {
           throw new RemoteScreenError(503, "host_unavailable", "Remote control is unavailable.");
@@ -642,7 +643,7 @@ export class TeamApiServer {
           }),
         );
       }
-      if (method === "PUT" && url.pathname === "/v1/remote-screen/display") {
+      if (method === "PUT" && url.pathname === TEAM_API_ROUTES.remoteScreen.display) {
         if (!this.#options.remoteScreen) {
           throw new RemoteScreenError(503, "host_unavailable", "Remote control is unavailable.");
         }
@@ -661,16 +662,16 @@ export class TeamApiServer {
         }
         return this.#empty(response, 204);
       }
-      if (method === "GET" && url.pathname === "/v1/host/remote-mac") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.host.remoteMac) {
         return this.#json(response, 426, { error: "Update required.", code: "protocol_mismatch" });
       }
-      if (method === "GET" && url.pathname === "/v1/host/remote-desktop-access") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.host.remoteDesktopAccess) {
         return this.#json(response, 426, { error: "Update required.", code: "protocol_mismatch" });
       }
-      if (method === "GET" && url.pathname === "/v1/direct/threads") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.direct.threads) {
         return this.#json(response, 200, this.listDirectThreads(member.id));
       }
-      if (method === "GET" && url.pathname === "/v1/messages/search") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.messages.search) {
         const query = url.searchParams.get("q") ?? "";
         if (!query.trim() || query.length > INPUT_LIMITS.messageText) {
           throw new HttpError(400, "A valid search query is required.");
@@ -686,7 +687,7 @@ export class TeamApiServer {
           ),
         );
       }
-      if (method === "POST" && url.pathname === "/v1/direct/messages") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.direct.messages) {
         const body = await readJson(request);
         return this.#json(
           response,
@@ -730,13 +731,13 @@ export class TeamApiServer {
           ),
         );
       }
-      if (method === "GET" && url.pathname === "/v1/browser/tabs") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.browser.tabs) {
         return this.#json(response, 200, this.#options.browser.listTabs());
       }
-      if (method === "GET" && url.pathname === "/v1/browser/control") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.browser.control) {
         return this.#json(response, 200, this.#options.browser.getControlState());
       }
-      if (method === "POST" && url.pathname === "/v1/browser/open") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.browser.open) {
         const body = await readJson(request);
         const focus = body.focus ?? false;
         if (!isBoolean(focus)) throw new HttpError(400, "focus must be a boolean.");
@@ -751,12 +752,12 @@ export class TeamApiServer {
           ),
         );
       }
-      if (method === "POST" && url.pathname === "/v1/browser/activate") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.browser.activate) {
         const body = await readJson(request);
         await this.#options.browser.activate(stringField(body, "tabId"));
         return this.#empty(response, 204);
       }
-      if (method === "POST" && url.pathname === "/v1/browser/navigate") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.browser.navigate) {
         const body = await readJson(request);
         const direction = stringField(body, "direction");
         if (direction !== "back" && direction !== "forward") {
@@ -765,21 +766,21 @@ export class TeamApiServer {
         await this.#options.browser.navigate(stringField(body, "tabId"), direction);
         return this.#empty(response, 204);
       }
-      if (method === "POST" && url.pathname === "/v1/browser/reload") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.browser.reload) {
         const body = await readJson(request);
         await this.#options.browser.reload(stringField(body, "tabId"));
         return this.#empty(response, 204);
       }
-      if (method === "POST" && url.pathname === "/v1/browser/close") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.browser.close) {
         const body = await readJson(request);
         await this.#options.browser.close(stringField(body, "tabId"));
         return this.#empty(response, 204);
       }
-      if (method === "POST" && url.pathname === "/v1/browser/preview") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.browser.preview) {
         const body = await readJson(request);
         return this.#json(response, 200, await this.#options.browser.capturePreview(stringField(body, "tabId")));
       }
-      if (method === "POST" && url.pathname === "/v1/browser/visible") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.browser.visible) {
         const body = await readJson(request);
         if (!isBoolean(body.visible)) throw new HttpError(400, "visible is required.");
         await this.#options.browser.setVisible({
@@ -788,7 +789,7 @@ export class TeamApiServer {
         });
         return this.#empty(response, 204);
       }
-      if (method === "POST" && url.pathname === "/v1/attachments") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.attachments) {
         const name = url.searchParams.get("name")?.trim();
         const mimeType = url.searchParams.get("mime") ?? "application/octet-stream";
         if (!name || basename(name) !== name || name.length > INPUT_LIMITS.attachmentName) {
@@ -821,7 +822,7 @@ export class TeamApiServer {
           return;
         }
       }
-      if (method === "GET" && url.pathname === "/v1/shared-files") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.sharedFiles) {
         const sharedPath = url.searchParams.get("path");
         if (!sharedPath || sharedPath.length > INPUT_LIMITS.path) {
           throw new HttpError(400, "A valid shared file path is required.");
@@ -840,7 +841,7 @@ export class TeamApiServer {
         response.end(bytes);
         return;
       }
-      if (method === "GET" && url.pathname === "/v1/workspace-files") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.workspaceFiles) {
         const botId = url.searchParams.get("botId");
         const workspacePath = url.searchParams.get("path");
         if (!botId || botId.length > INPUT_LIMITS.identifier) {
@@ -863,7 +864,7 @@ export class TeamApiServer {
         response.end(bytes);
         return;
       }
-      if (method === "GET" && url.pathname === "/v1/team/members") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.team.members) {
         requireAdmin(member);
         return this.#json(response, 200, this.#options.store.listMembers());
       }
@@ -895,7 +896,7 @@ export class TeamApiServer {
         this.refreshPresence();
         return this.#empty(response, 204);
       }
-      if (method === "POST" && url.pathname === "/v1/team/invites") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.team.invites) {
         requireAdmin(member);
         const body = await readJson(request);
         const role = stringField(body, "role");
@@ -904,7 +905,7 @@ export class TeamApiServer {
         if (!this.#options.createInvite) throw new HttpError(503, "Invitation service is unavailable.");
         return this.#json(response, 201, await this.#options.createInvite({ role, ...(email ? { email } : {}) }));
       }
-      if (method === "GET" && url.pathname === "/v1/team/invites") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.team.invites) {
         requireAdmin(member);
         return this.#json(response, 200, this.#options.store.listInvites());
       }
@@ -914,7 +915,7 @@ export class TeamApiServer {
         await this.#options.store.revokeInvite(pathIdentifier(inviteMatch[1], "inviteId"));
         return this.#empty(response, 204);
       }
-      if (method === "GET" && url.pathname === "/v1/team/sessions") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.team.sessions) {
         requireAdmin(member);
         return this.#json(response, 200, this.#options.store.listSessions());
       }
@@ -929,13 +930,13 @@ export class TeamApiServer {
         return this.#empty(response, 204);
       }
 
-      if (method === "GET" && url.pathname === "/v1/agents/status") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.agents.status) {
         return this.#json(response, 200, this.#options.agents.getStatus());
       }
-      if (method === "GET" && url.pathname === "/v1/sidebar-layout") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.sidebarLayout.state) {
         return this.#json(response, 200, this.#options.sidebarLayout.getSnapshot());
       }
-      if (method === "POST" && url.pathname === "/v1/sidebar-layout/actions") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.sidebarLayout.actions) {
         const action = parseSidebarLayoutAction(await readJson(request));
         const layout = await this.#options.sidebarLayout.mutate(
           action,
@@ -943,23 +944,23 @@ export class TeamApiServer {
         );
         return this.#json(response, 200, layout);
       }
-      if (method === "GET" && url.pathname === "/v1/agents/usage") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.agents.usage) {
         return this.#json(response, 200, await this.#options.agents.getUsage());
       }
-      if (method === "GET" && url.pathname === "/v1/agents/models") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.agents.models) {
         return this.#json(response, 200, await this.#options.agents.listModels());
       }
-      if (method === "GET" && url.pathname === "/v1/agents") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.agents.all) {
         return this.#json(response, 200, this.#options.agents.listBots());
       }
-      if (method === "GET" && url.pathname === "/v1/agents/conversation-reads") {
+      if (method === "GET" && url.pathname === TEAM_API_ROUTES.agents.conversationReads) {
         return this.#json(
           response,
           200,
           this.#options.agents.listConversationReads(member.id, markerExclusionsForCapabilities(clientCapabilities)),
         );
       }
-      if (method === "POST" && url.pathname === "/v1/agents") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.agents.all) {
         const body = await readJson(request);
         return this.#json(response, 201, await this.#options.agents.createBot(botCreate(body)));
       }
@@ -1194,7 +1195,7 @@ export class TeamApiServer {
         }
       }
 
-      if (method === "POST" && url.pathname === "/v1/prompts/respond") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.respond.prompt) {
         const body = await readJson(request);
         await this.#options.agents.respondToPrompt({
           requestId: promptRequestId(body.requestId),
@@ -1202,7 +1203,7 @@ export class TeamApiServer {
         });
         return this.#empty(response, 204);
       }
-      if (method === "POST" && url.pathname === "/v1/approvals/respond") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.respond.approval) {
         const body = await readJson(request);
         await this.#options.agents.respondToApproval({
           requestId: promptRequestId(body.requestId),
@@ -1210,7 +1211,7 @@ export class TeamApiServer {
         });
         return this.#empty(response, 204);
       }
-      if (method === "POST" && url.pathname === "/v1/browser-takeovers/respond") {
+      if (method === "POST" && url.pathname === TEAM_API_ROUTES.respond.browserTakeover) {
         const body = await readJson(request);
         await this.#options.agents.respondToBrowserTakeover({
           requestId: promptRequestId(body.requestId),

--- a/src/main/team-api-server.ts
+++ b/src/main/team-api-server.ts
@@ -1644,12 +1644,17 @@ export class TeamApiServer {
   #json(response: ServerResponse, status: number, value: object | null): void {
     const route = this.#responseRoutes.get(response);
     if (!route) throw new Error("Team API response route is unavailable.");
-    response.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
     const options = { preserveSemanticTags: supportsTeamSemanticTags(route.capabilities) };
+    // The body is encoded before the head is written. A response the negotiated protocol cannot
+    // represent - a route its frozen adapter does not classify - makes the encoder throw, and with
+    // the headers already sent that throw could neither answer the caller nor end the request: it
+    // surfaced as a hung socket and an `ERR_HTTP_HEADERS_SENT` rejection out of `#handle`'s own
+    // error path. Encoding first lets that failure become the 500 the caller can read.
     const body =
       route.protocol === TEAM_PROTOCOL_V3
         ? encodeTeamProtocolV3CurrentHttpResponse(route.method, route.path, status, value, options)
         : encodeTeamProtocolV1CurrentHttpResponse(route.method, route.path, status, value, options);
+    response.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
     response.end(`${body}\n`);
   }
 

--- a/src/main/team-webrtc-host-gateway.ts
+++ b/src/main/team-webrtc-host-gateway.ts
@@ -2,6 +2,7 @@ import { randomBytes, verify } from "node:crypto";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { isDynamicRecord, isString } from "@openbot/contracts/runtime-values";
+import { TEAM_API_ROUTES } from "@openbot/contracts/team-api-routes";
 import { supportsTeamSemanticTags, TEAM_CURRENT_CAPABILITIES } from "@openbot/contracts/team-protocol/current";
 import { encodeTeamProtocolV1ClientEvent } from "@openbot/contracts/team-protocol/v1";
 import {
@@ -537,7 +538,7 @@ export class TeamWebRtcHostGateway {
   #connectLocalEvents(token: string): void {
     if (!this.#localApiPort) return;
     this.#eventsSocket?.close();
-    const socket = new webSockets.WebSocket(`ws://127.0.0.1:${this.#localApiPort}/v1/events`, [
+    const socket = new webSockets.WebSocket(`ws://127.0.0.1:${this.#localApiPort}${TEAM_API_ROUTES.events}`, [
       "openbot-team-v1",
       `openbot-token.${token}`,
     ]);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,7 @@ import {
   isRoutineSchedule,
   isSidebarLayoutSnapshot,
   isSkillCategory,
+  LOCAL_SERVER_ID,
   type MarketplaceAgentDetail,
   type MarketplaceAgentPage,
   type MarketplaceAgentSummary,
@@ -57,8 +58,6 @@ import {
   type ProviderRuntimeSnapshot,
   type QueuedMessageReceipt,
   type QueueSnapshot,
-  type Routine,
-  type RoutineRun,
   type ScopedAgentEvent,
   type ScopedDirectMessageEvent,
   type ScopedDirectTypingEvent,
@@ -69,18 +68,21 @@ import {
   type UpdateStatus,
 } from "@openbot/contracts/ipc";
 import {
-  type DynamicRecord,
-  isBoolean,
-  isDynamicRecord,
-  isNumber,
-  isOneOf,
-  isString,
-} from "@openbot/contracts/runtime-values";
+  decodeRecord,
+  emptyDecoder,
+  guardedDecoder,
+  guardedListDecoder,
+  nullableString,
+  requiredBoolean,
+  requiredNumber,
+  requiredString,
+} from "@openbot/contracts/ipc-decoding";
+import { isBoolean, isDynamicRecord, isNumber, isOneOf, isString } from "@openbot/contracts/runtime-values";
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import { clipboardFiles } from "./clipboard-files";
 
 const attachmentImportListeners = new Set<(event: AttachmentImportEvent) => void>();
-let selectedServerId = "local";
+let selectedServerId: string = LOCAL_SERVER_ID;
 
 function invokeAgent<TResult>(
   channel: string,
@@ -119,7 +121,7 @@ function decodeComputerUseMacSetupState(value: unknown): ComputerUseMacSetupStat
 }
 
 function rememberActiveServer<T extends { id: string; active: boolean }[]>(servers: T): T {
-  selectedServerId = servers.find((server) => server.active)?.id ?? "local";
+  selectedServerId = servers.find((server) => server.active)?.id ?? LOCAL_SERVER_ID;
   return servers;
 }
 
@@ -162,13 +164,12 @@ async function importFiles(files: File[]): Promise<void> {
   }
 }
 
-function record(value: unknown, label: string): DynamicRecord {
-  if (!isDynamicRecord(value)) throw new Error(`Invalid ${label}.`);
-  return value;
-}
-
-function decodeBrowserPreview(value: unknown): BrowserPreview {
-  const preview = record(value, "browser preview");
+// A `FromMain` decoder has a same-shaped `FromHost` twin in `remote-server-manager.ts` and is
+// deliberately not the same function: this side is checking what the main process sent the renderer,
+// which is a trusted sender, while that side is checking a remote team server, which is not. The
+// suffix is there so a later reader does not merge them onto whichever is looser.
+function decodeBrowserPreviewFromMain(value: unknown): BrowserPreview {
+  const preview = decodeRecord(value, "browser preview");
   const dataUrl = requiredString(preview, "dataUrl");
   const width = requiredNumber(preview, "width");
   const height = requiredNumber(preview, "height");
@@ -187,13 +188,10 @@ function decodeBrowserPreview(value: unknown): BrowserPreview {
   return { dataUrl, width, height };
 }
 
-function decodeVoid(value: unknown): undefined {
-  if (value !== undefined && value !== null) throw new Error("IPC returned unexpected data.");
-  return undefined;
-}
+const decodeVoid = emptyDecoder("IPC returned unexpected data.");
 
 function decodeHostedSite(value: unknown): HostedSiteSummary {
-  const site = record(value, "hosted site");
+  const site = decodeRecord(value, "hosted site");
   if (
     !isString(site.id) ||
     !isString(site.hostname) ||
@@ -260,28 +258,13 @@ function decodeDynamicIslandAction(value: unknown): DynamicIslandAction {
   throw new Error("Invalid Dynamic Island action.");
 }
 
-function decodeRoutine(value: unknown): Routine {
-  if (!isRoutine(value)) throw new Error("Invalid routine response.");
-  return value;
-}
-
-function decodeRoutines(value: unknown): Routine[] {
-  if (!Array.isArray(value) || !value.every(isRoutine)) throw new Error("Invalid routine list response.");
-  return value;
-}
-
-function decodeRoutineRun(value: unknown): RoutineRun {
-  if (!isRoutineRun(value)) throw new Error("Invalid routine run response.");
-  return value;
-}
-
-function decodeRoutineRuns(value: unknown): RoutineRun[] {
-  if (!Array.isArray(value) || !value.every(isRoutineRun)) throw new Error("Invalid routine history response.");
-  return value;
-}
+const decodeRoutine = guardedDecoder(isRoutine, "routine response");
+const decodeRoutines = guardedListDecoder(isRoutine, "routine list response");
+const decodeRoutineRun = guardedDecoder(isRoutineRun, "routine run response");
+const decodeRoutineRuns = guardedListDecoder(isRoutineRun, "routine history response");
 
 function decodeFilePreview(value: unknown): FilePreview {
-  const preview = record(value, "file preview");
+  const preview = decodeRecord(value, "file preview");
   if (
     !isString(preview.name) ||
     !isNumber(preview.size) ||
@@ -304,7 +287,7 @@ function decodeFilePreview(value: unknown): FilePreview {
   };
 }
 
-function decodeAgentStatus(value: unknown): AgentStatus {
+function decodeAgentStatusFromMain(value: unknown): AgentStatus {
   if (!isAgentStatus(value)) throw new Error("Invalid agent status response.");
   return value;
 }
@@ -337,7 +320,7 @@ function decodeProviderRuntimeSnapshot(value: unknown): ProviderRuntimeSnapshot 
   return { revision: value.revision, providers: { codex, claude, grok } };
 }
 
-function decodeAccountUsage(value: unknown): AccountUsage {
+function decodeAccountUsageFromMain(value: unknown): AccountUsage {
   if (!isAccountUsage(value)) throw new Error("Invalid agent usage response.");
   return value;
 }
@@ -376,8 +359,8 @@ function decodeSidebarLayout(value: unknown): SidebarLayoutSnapshot {
   return value;
 }
 
-function decodeDuplicateBotResult(value: unknown): DuplicateBotResult {
-  const item = record(value, "agent duplication");
+function decodeDuplicateBotResultFromMain(value: unknown): DuplicateBotResult {
+  const item = decodeRecord(value, "agent duplication");
   return { bot: decodeBot(item.bot), layout: decodeSidebarLayout(item.layout) };
 }
 
@@ -386,49 +369,44 @@ function decodeConversation(value: unknown): ConversationWithReadState {
   return value;
 }
 
-function decodeConversationPage(value: unknown): ConversationPage {
+function decodeConversationPageFromMain(value: unknown): ConversationPage {
   if (!isDynamicRecord(value) || !isString(value.botId) || !Array.isArray(value.messages)) {
     throw new Error("Invalid conversation page response.");
   }
-  const pageInfo = record(value.pageInfo, "conversation page info");
+  const pageInfo = decodeRecord(value.pageInfo, "conversation page info");
   return {
     botId: value.botId,
-    threadId: requiredNullableString(value, "threadId"),
-    activeTurnId: requiredNullableString(value, "activeTurnId"),
+    threadId: nullableString(value, "threadId"),
+    activeTurnId: nullableString(value, "activeTurnId"),
     revision: requiredNumber(value, "revision"),
     messages: decodeConversationMessages(value.messages),
-    references: decodeConversationReferences(value.references),
+    references: decodeConversationReferencesFromMain(value.references),
     pageInfo: {
       hasOlder: requiredBoolean(pageInfo, "hasOlder"),
-      olderCursor: requiredNullableString(pageInfo, "olderCursor"),
+      olderCursor: nullableString(pageInfo, "olderCursor"),
     },
     ...(value.readState === undefined ? {} : { readState: decodeReadState(value.readState) }),
   };
 }
 
-function decodeConversationSearchPage(value: unknown): ConversationSearchPage {
-  const item = record(value, "conversation search page");
+function decodeConversationSearchPageFromMain(value: unknown): ConversationSearchPage {
+  const item = decodeRecord(value, "conversation search page");
   if (!Array.isArray(item.results)) throw new Error("Invalid conversation search results.");
   return {
     results: item.results.map((value) => {
-      const result = record(value, "conversation search result");
+      const result = decodeRecord(value, "conversation search result");
       if (!isConversationMessage(result.message)) throw new Error("Invalid conversation search message.");
       return { botId: requiredString(result, "botId"), message: result.message };
     }),
     total: requiredNumber(item, "total"),
-    nextCursor: requiredNullableString(item, "nextCursor"),
+    nextCursor: nullableString(item, "nextCursor"),
   };
 }
 
-function decodeConversationMessages(value: unknown): ConversationMessage[] {
-  if (!Array.isArray(value) || !value.every(isConversationMessage)) {
-    throw new Error("Invalid conversation messages.");
-  }
-  return value;
-}
+const decodeConversationMessages = guardedListDecoder(isConversationMessage, "conversation messages");
 
-function decodeConversationReferences(value: unknown): Record<string, ConversationMessage> {
-  const references = record(value, "conversation references");
+function decodeConversationReferencesFromMain(value: unknown): Record<string, ConversationMessage> {
+  const references = decodeRecord(value, "conversation references");
   const decoded: Record<string, ConversationMessage> = {};
   for (const [messageId, message] of Object.entries(references)) {
     if (!isConversationMessage(message)) throw new Error("Invalid conversation reference.");
@@ -443,7 +421,7 @@ function decodeReadState(value: unknown): ConversationReadState {
 }
 
 function decodeReadStates(value: unknown): Record<string, ConversationReadState> {
-  const item = record(value, "conversation reads");
+  const item = decodeRecord(value, "conversation reads");
   return Object.fromEntries(Object.entries(item).map(([botId, state]) => [botId, decodeReadState(state)]));
 }
 
@@ -468,30 +446,8 @@ function decodeQueue(value: unknown): QueueSnapshot {
   return value;
 }
 
-function requiredNumber(value: DynamicRecord, field: string): number {
-  if (!isNumber(value[field])) throw new Error(`Invalid ${field}.`);
-  return value[field];
-}
-
-function requiredString(value: DynamicRecord, field: string): string {
-  const fieldValue = value[field];
-  if (!isString(fieldValue)) throw new Error(`Invalid ${field}.`);
-  return fieldValue;
-}
-
-function requiredBoolean(value: DynamicRecord, field: string): boolean {
-  if (!isBoolean(value[field])) throw new Error(`Invalid ${field}.`);
-  return value[field];
-}
-
-function requiredNullableString(value: DynamicRecord, field: string): string | null {
-  const item = value[field];
-  if (item !== null && !isString(item)) throw new Error(`Invalid ${field}.`);
-  return item;
-}
-
 function decodeSkillSummary(value: unknown) {
-  const item = record(value, "marketplace skill");
+  const item = decodeRecord(value, "marketplace skill");
   if (!isSkillCategory(item.category)) throw new Error("Invalid skill category.");
   return {
     id: requiredString(item, "id"),
@@ -503,19 +459,19 @@ function decodeSkillSummary(value: unknown) {
     version: requiredNumber(item, "version"),
     installs: requiredNumber(item, "installs"),
     featured: requiredBoolean(item, "featured"),
-    iconUrl: requiredNullableString(item, "iconUrl"),
+    iconUrl: nullableString(item, "iconUrl"),
     updatedAt: requiredString(item, "updatedAt"),
   };
 }
 
 function decodeSkillPage(value: unknown): MarketplaceSkillPage {
-  const page = record(value, "marketplace page");
+  const page = decodeRecord(value, "marketplace page");
   if (!Array.isArray(page.skills)) throw new Error("Invalid marketplace skills.");
-  return { skills: page.skills.map(decodeSkillSummary), nextCursor: requiredNullableString(page, "nextCursor") };
+  return { skills: page.skills.map(decodeSkillSummary), nextCursor: nullableString(page, "nextCursor") };
 }
 
 function decodeSkillDetail(value: unknown): MarketplaceSkillDetail {
-  const item = record(value, "skill detail");
+  const item = decodeRecord(value, "skill detail");
   const summary = decodeSkillSummary(item);
   if (!Array.isArray(item.files) || !item.files.every(isString)) throw new Error("Invalid skill files.");
   return {
@@ -528,7 +484,7 @@ function decodeSkillDetail(value: unknown): MarketplaceSkillDetail {
 }
 
 function decodeSubmission(value: unknown): SkillSubmission {
-  const item = record(value, "skill submission");
+  const item = decodeRecord(value, "skill submission");
   const status = item.status;
   if (!isSkillCategory(item.category) || !isOneOf(["pending", "approved", "rejected"], status)) {
     throw new Error("Invalid skill submission state.");
@@ -542,8 +498,8 @@ function decodeSubmission(value: unknown): SkillSubmission {
     category: item.category,
     version: requiredNumber(item, "version"),
     status,
-    rejectionNote: requiredNullableString(item, "rejectionNote"),
-    iconUrl: requiredNullableString(item, "iconUrl"),
+    rejectionNote: nullableString(item, "rejectionNote"),
+    iconUrl: nullableString(item, "iconUrl"),
     createdAt: requiredString(item, "createdAt"),
   };
 }
@@ -555,7 +511,7 @@ function decodeSubmissions(value: unknown): SkillSubmission[] {
 
 function decodeSkillPreview(value: unknown): SkillPackagePreview | null {
   if (value === null) return null;
-  const item = record(value, "skill package preview");
+  const item = decodeRecord(value, "skill package preview");
   if (!Array.isArray(item.files) || !item.files.every(isString)) throw new Error("Invalid skill package files.");
   return {
     draftId: requiredString(item, "draftId"),
@@ -568,7 +524,7 @@ function decodeSkillPreview(value: unknown): SkillPackagePreview | null {
 }
 
 function decodeInstalledSkill(value: unknown): InstalledSkill {
-  const item = record(value, "installed skill");
+  const item = decodeRecord(value, "installed skill");
   const state = item.state;
   if (!isOneOf(["installed", "update-available", "modified", "needs-repair"], state)) {
     throw new Error("Invalid installed skill state.");
@@ -583,13 +539,13 @@ function decodeInstalledSkill(value: unknown): InstalledSkill {
   };
 }
 
-function decodeInstalledSkills(value: unknown): InstalledSkill[] {
+function decodeInstalledSkillsFromMain(value: unknown): InstalledSkill[] {
   if (!Array.isArray(value)) throw new Error("Invalid installed skills.");
   return value.map(decodeInstalledSkill);
 }
 
 function decodeMarketplaceAgentSummary(value: unknown): MarketplaceAgentSummary {
-  const item = record(value, "marketplace agent");
+  const item = decodeRecord(value, "marketplace agent");
   if (!isAvatarSeed(item.avatarSeed) || (item.avatarHue !== null && !isAvatarHue(item.avatarHue)))
     throw new Error("Invalid marketplace agent avatar.");
   return {
@@ -603,7 +559,7 @@ function decodeMarketplaceAgentSummary(value: unknown): MarketplaceAgentSummary 
     featured: requiredBoolean(item, "featured"),
     avatarSeed: item.avatarSeed,
     avatarHue: item.avatarHue,
-    avatarUrl: requiredNullableString(item, "avatarUrl"),
+    avatarUrl: nullableString(item, "avatarUrl"),
     skillCount: requiredNumber(item, "skillCount"),
     routineCount: requiredNumber(item, "routineCount"),
     activeRoutineCount: requiredNumber(item, "activeRoutineCount"),
@@ -612,16 +568,16 @@ function decodeMarketplaceAgentSummary(value: unknown): MarketplaceAgentSummary 
 }
 
 function decodeMarketplaceAgentPage(value: unknown): MarketplaceAgentPage {
-  const page = record(value, "marketplace agent page");
+  const page = decodeRecord(value, "marketplace agent page");
   if (!Array.isArray(page.agents)) throw new Error("Invalid marketplace agents.");
   return {
     agents: page.agents.map(decodeMarketplaceAgentSummary),
-    nextCursor: requiredNullableString(page, "nextCursor"),
+    nextCursor: nullableString(page, "nextCursor"),
   };
 }
 
 function decodeMarketplaceAgentDetail(value: unknown): MarketplaceAgentDetail {
-  const item = record(value, "marketplace agent detail");
+  const item = decodeRecord(value, "marketplace agent detail");
   const summary = decodeMarketplaceAgentSummary(item);
   if (
     !Array.isArray(item.skills) ||
@@ -647,7 +603,7 @@ function decodeMarketplaceAgentDetail(value: unknown): MarketplaceAgentDetail {
 }
 
 function decodeAgentSubmission(value: unknown): AgentSubmission {
-  const item = record(value, "agent submission");
+  const item = decodeRecord(value, "agent submission");
   if (
     !isOneOf(["pending", "approved", "rejected"], item.status) ||
     !isAvatarSeed(item.avatarSeed) ||
@@ -662,10 +618,10 @@ function decodeAgentSubmission(value: unknown): AgentSubmission {
     description: requiredString(item, "description"),
     version: requiredNumber(item, "version"),
     status: item.status,
-    rejectionNote: requiredNullableString(item, "rejectionNote"),
+    rejectionNote: nullableString(item, "rejectionNote"),
     avatarSeed: item.avatarSeed,
     avatarHue: item.avatarHue,
-    avatarUrl: requiredNullableString(item, "avatarUrl"),
+    avatarUrl: nullableString(item, "avatarUrl"),
     skillCount: requiredNumber(item, "skillCount"),
     routineCount: requiredNumber(item, "routineCount"),
     activeRoutineCount: requiredNumber(item, "activeRoutineCount"),
@@ -679,7 +635,7 @@ function decodeAgentSubmissions(value: unknown): AgentSubmission[] {
 }
 
 function decodeAgentPublicationPreview(value: unknown): AgentPublicationPreview {
-  const item = record(value, "agent publication preview");
+  const item = decodeRecord(value, "agent publication preview");
   const detail = decodeMarketplaceAgentDetail({
     ...item,
     id: item.botId,
@@ -843,7 +799,8 @@ const openbotApi: OpenBotDesktopApi = {
     listMine: () => ipcRenderer.invoke(IPC_CHANNELS.skillsListMine).then(decodeSubmissions),
     choosePackage: () => ipcRenderer.invoke(IPC_CHANNELS.skillsChoosePackage).then(decodeSkillPreview),
     submit: (input) => ipcRenderer.invoke(IPC_CHANNELS.skillsSubmit, input).then(decodeSubmission),
-    listInstalled: (botId) => ipcRenderer.invoke(IPC_CHANNELS.skillsListInstalled, botId).then(decodeInstalledSkills),
+    listInstalled: (botId) =>
+      ipcRenderer.invoke(IPC_CHANNELS.skillsListInstalled, botId).then(decodeInstalledSkillsFromMain),
     install: (input) => ipcRenderer.invoke(IPC_CHANNELS.skillsInstall, input).then(decodeInstalledSkill),
     uninstall: (input) => ipcRenderer.invoke(IPC_CHANNELS.skillsUninstall, input).then(decodeVoid),
   },
@@ -864,20 +821,21 @@ const openbotApi: OpenBotDesktopApi = {
     submit: (input) => ipcRenderer.invoke(IPC_CHANNELS.marketplaceAgentsSubmit, input).then(decodeAgentSubmission),
     install: (input) =>
       ipcRenderer.invoke(IPC_CHANNELS.marketplaceAgentsInstall, input).then((value) => {
-        const item = record(value, "agent installation");
+        const item = decodeRecord(value, "agent installation");
         return { bot: decodeBot(item.bot) };
       }),
   },
   agent: {
-    getStatus: () => invokeAgent(IPC_CHANNELS.agentGetStatus, null, decodeAgentStatus),
-    getUsage: () => invokeAgent(IPC_CHANNELS.agentGetUsage, null, decodeAccountUsage),
+    getStatus: () => invokeAgent(IPC_CHANNELS.agentGetStatus, null, decodeAgentStatusFromMain),
+    getUsage: () => invokeAgent(IPC_CHANNELS.agentGetUsage, null, decodeAccountUsageFromMain),
     listModels: () => invokeAgent(IPC_CHANNELS.agentListModels, null, decodeAgentModels),
     listBots: () => invokeAgent(IPC_CHANNELS.agentListBots, null, decodeBots),
-    listInstalledSkills: (botId) => invokeAgent(IPC_CHANNELS.agentListInstalledSkills, botId, decodeInstalledSkills),
+    listInstalledSkills: (botId) =>
+      invokeAgent(IPC_CHANNELS.agentListInstalledSkills, botId, decodeInstalledSkillsFromMain),
     getSidebarLayout: () => invokeAgent(IPC_CHANNELS.agentGetSidebarLayout, null, decodeSidebarLayout),
     mutateSidebarLayout: (action) => invokeAgent(IPC_CHANNELS.agentMutateSidebarLayout, action, decodeSidebarLayout),
     createBot: (input) => invokeAgent(IPC_CHANNELS.agentCreateBot, input, decodeBot),
-    duplicateBot: (botId) => invokeAgent(IPC_CHANNELS.agentDuplicateBot, botId, decodeDuplicateBotResult),
+    duplicateBot: (botId) => invokeAgent(IPC_CHANNELS.agentDuplicateBot, botId, decodeDuplicateBotResultFromMain),
     updateBot: (input) => invokeAgent(IPC_CHANNELS.agentUpdateBot, input, decodeBot),
     setAvatar: (input) => invokeAgent(IPC_CHANNELS.agentSetAvatar, input, decodeBot),
     deleteBot: (botId) => invokeAgent(IPC_CHANNELS.agentDeleteBot, botId, decodeVoid),
@@ -894,9 +852,9 @@ const openbotApi: OpenBotDesktopApi = {
     listRoutineRuns: (input) => invokeAgent(IPC_CHANNELS.agentListRoutineRuns, input, decodeRoutineRuns),
     readConversation: (botId) => invokeAgent(IPC_CHANNELS.agentReadConversation, botId, decodeConversation),
     readConversationPage: (input, serverId = selectedServerId) =>
-      invokeAgentForServer(serverId, IPC_CHANNELS.agentReadConversationPage, input, decodeConversationPage),
+      invokeAgentForServer(serverId, IPC_CHANNELS.agentReadConversationPage, input, decodeConversationPageFromMain),
     searchConversationMessages: (input) =>
-      invokeAgent(IPC_CHANNELS.agentSearchConversationMessages, input, decodeConversationSearchPage),
+      invokeAgent(IPC_CHANNELS.agentSearchConversationMessages, input, decodeConversationSearchPageFromMain),
     listConversationReads: () => invokeAgent(IPC_CHANNELS.agentListConversationReads, null, decodeReadStates),
     markConversationRead: (input, serverId = selectedServerId) =>
       invokeAgentForServer(serverId, IPC_CHANNELS.agentMarkConversationRead, input, decodeReadState),
@@ -948,7 +906,8 @@ const openbotApi: OpenBotDesktopApi = {
     listTabs: () => ipcRenderer.invoke(IPC_CHANNELS.browserListTabs),
     getDisplayState: () => ipcRenderer.invoke(IPC_CHANNELS.browserGetDisplayState),
     getControlState: () => ipcRenderer.invoke(IPC_CHANNELS.browserGetControlState),
-    capturePreview: (tabId) => ipcRenderer.invoke(IPC_CHANNELS.browserCapturePreview, tabId).then(decodeBrowserPreview),
+    capturePreview: (tabId) =>
+      ipcRenderer.invoke(IPC_CHANNELS.browserCapturePreview, tabId).then(decodeBrowserPreviewFromMain),
     setVisible: (input) => ipcRenderer.invoke(IPC_CHANNELS.browserSetVisible, input),
     onDisplayState: (listener) => {
       const handler = (_event: Electron.IpcRendererEvent, state: Parameters<typeof listener>[0]) => listener(state);


### PR DESCRIPTION
Every `/v1/...` path the desktop builds was a bare string literal on **both**
halves of one HTTP surface — 51 in `team-api-server.ts`, 42 in
`remote-server-manager.ts`, and 43 more across the `register-*-handlers.ts`
modules that call through — with nothing linking the copies. A rename that
missed one half broke every remote server silently. The IPC-channel version of
that mistake is caught by `ipc-channel-coverage.test.ts`; this had no
equivalent.

## What changed

- **`packages/contracts/src/team-api-routes.ts`** (new, `"./team-api-routes"`
  subpath — the package has no root barrel, so this follows its 20 existing
  subpath exports). Static entries plus `(botId) => ...` builders. It is a table
  of path *builders*, not a matcher: the host regex-matches
  `/^\/v1\/agents\/([^/]+)(?:\/(.*))?$/` and switches on an action sub-segment,
  so its parametric branches stay literal. Unifying the matcher would mean
  rewriting the router's 404/405 semantics.
- **`src/main/ipc/route-to-server.ts`** (new, 35 lines) collapses the
  local-vs-remote fork that was hand-written **66 times**: 29 in
  `register-agent-handlers.ts`, 9 browser, 8 attachment, 5 memory, 6 routine, 9
  team. `Promise.resolve(branches.local())` normalizes the sync branches, which
  is invisible at an IPC boundary that promisifies anyway; the `void` cases use
  `T = void`.
- **`LOCAL_SERVER_ID`** moves into `packages/contracts/src/ipc-team-host.ts`,
  beside the other wire values, instead of `"local"` being retyped at each site.
- **`packages/contracts/src/ipc-decoding.ts`** (new) takes only the field
  readers `src/preload/index.ts` and `remote-server-manager.ts` had *verbatim*
  in common (`decodeRecord`, `requiredString`, `requiredNumber`,
  `requiredBoolean`, `nullableString`) plus the one-line wrappers over
  predicates already in contracts, each taking a `label` so call sites keep
  their messages.
- **`src/main/team-api-server.ts` `#json` encodes the body before writing the
  head.** It wrote the head first, so a response the negotiated protocol cannot
  represent — a route its frozen adapter does not classify — made the encoder
  throw with the headers already sent. That throw could then neither answer the
  caller nor end the request: it surfaced as a hung socket plus an
  `ERR_HTTP_HEADERS_SENT` rejection out of `#handle`'s own error path. The bug
  predates this PR, but the table is what makes the adapter's route list
  load-bearing, so it belongs here.

## What deliberately stayed duplicated

- **`team-protocol/v1.ts` keeps its own 41-entry route table.** It classifies
  requests for a *released* wire protocol; if it imported the shared table, a
  rename here would change how a shipped protocol interprets a request — the one
  thing a released adapter may never do. There is a comment beside both tables
  saying so, because this is exactly the cleanup a later reader will attempt.
- **The decoders that only *look* identical stay forked.** The 14 shared names
  are not 14 identical functions: `decodeAgentStatus` in preload accepts any
  string for `phase`, the remote client's enumerates it, because they guard
  *different* boundaries — main→renderer, where main is trusted, versus a remote
  host, which is not. Merging on the looser one would weaken the network
  boundary. Same for `decodeBrowserPreview`, `decodeInstalledSkills`,
  `decodeConversationPage`, `decodeConversationReferences`,
  `decodeConversationSearchPage`, `decodeDuplicateBotResult` and
  `decodeAccountUsage`. Both sides are renamed to say which boundary each guards.
- **The cloud Auth API's `/v1/...` paths are out of scope.**
  `central-auth-manager.ts`, `skill-marketplace-service.ts`,
  `agent-marketplace-service.ts` and `hosted-site-service.ts` also use `/v1/`,
  but that is `apps/auth-api` — an unrelated service. Conflating the two is this
  table's failure mode.

## Test

`AGENTS.md` rule 7 makes a test mandatory at the Team API wire boundary, and
rule 1 says modify rather than add, so this extends
**`src/main/team-api-server.test.ts`** with one case that walks the whole table
and closes the link in both directions:

1. Every static entry and every builder, against fixed sample ids, is driven at
   the real host router and must not answer `{ error: "Route not found." }`.
2. No collected route lacks a `ROUTE_METHODS` entry, and no `ROUTE_METHODS` key
   is orphaned — so deleting a table entry cannot quietly shrink the test's own
   input.
3. Every route the table builds is one **v1's frozen classifier can name**. The
   host encodes every JSON response through that adapter, and v3 delegates
   everything but agent-duplication to it, so a path the table builds that the
   frozen list cannot classify is a route no client can be answered on — before
   the `#json` fix above, a hung socket. Fourteen routes are excluded by
   category with a reason in the file: five answered `204` with no body, four
   answered with bytes rather than JSON, three answered only as a `426` the
   codec projects through its error branch, one the v1 codec short-circuits
   ahead of classification, and `agent.duplicate`, which is protocol v3 only.

Two entries stay excluded from (1) by name: the WebSocket upgrade path, and the
viewer family `remote-screen-gateway.ts` owns.

**I watched all of it fail**, four mutations, each red for the reason meant:

| Mutation | Result |
| --- | --- |
| Delete the host's `agents.usage` branch | `+ [ "GET /v1/agents/usage (agents.usage)" ]` — names the route, not a count |
| Rename a parametric path in the table | red naming that route (the original body claimed this stayed green; it does not) |
| Drop a `ROUTE_METHODS` key | red on the orphan assertion |
| Remove a route from v1's frozen list, with (3) bypassed | 20s timeout — the hung socket. With (3) in place: red in 2.33s naming the route |
| Rename the `remote-screen` namespace in the table | `remote-viewer-proxy.test.ts` red on the rewritten asset body |

## Follow-up, not fixed here

`POST /v1/agents/:id/duplicate` has no protocol guard
(`team-api-server.ts:979`). A protocol **v1** peer that calls it is answered
`500` rather than a `426` `protocol_mismatch`, because only v3's adapter names
the route. Fixing it means adding a capability gate to that handler, which is a
behaviour change to a released surface and does not belong in a path-table PR.
The test's exclusion comment records it.

## Approvability

No `biome-ignore`, `@ts-expect-error` or widened boundary type.

**One additive export from a frozen file.** `packages/contracts/src/team-protocol/v1.ts`
now exports `teamProtocolV1HttpRoute`, the classifier it already had and used
internally, for the coverage case above. It reads the frozen route list and
decides nothing — no route, status, shape or capability changes — so every
released response still means exactly what it did. Nothing else in that file
moves.

Biome reports **two warnings**, both on the new test's `collectRoutes`, for
`typeof value === "string"` / `=== "function"`. That walk discriminates the
route table's own heterogeneous shapes — a path, a builder, a nested group — so
the `typeof` is the domain branch, not a discarded type. Per `AGENTS.md` a
warning is a prompt to think and `biome-ignore` is not available, so they are
left as-is.

## Surfaces touched

Main process, preload and `packages/contracts` only. No renderer, mobile,
`apps/auth-api`, palette, schema or migration change. `mock-openbot.ts` needs
nothing — it mocks the IPC surface, which is unchanged. Beyond the modules
listed above the fix commit also touches `remote-screen-gateway.ts` (four path
builders the first pass missed — viewer URL, session cookie path, Moonlight
prefix, stream-matcher prefix), `remote-server-manager.ts` (the attachment URL,
likewise missed), and `register-team-handlers.ts` plus `index.ts`, where
`LOCAL_SERVER_ID` had landed in only half the comparisons.

## Verification

- `bun run test:desktop -- src/main/team-api-server.test.ts` — 21 passed
- `bun run test:desktop -- src/main/remote-server-manager.test.ts` — 33 passed
- four more desktop files covering the converted handlers and the gateway — 96 passed in total
- `bun run test:contracts` — 14 files, 120 passed
- `bun run typecheck:node`, `typecheck:team-client`, and every `typecheck:*` via the pre-commit hook
- `biome check src/main packages/contracts/src` — 178 files, the two warnings above
- Rebased onto `main` at `e8cb11e5`
- Review findings from `NorbiAI` addressed in `283a2a4b` and `d8aa3159`: the attachment URL now resolves against the host base with `new URL` instead of concatenating (a host whose `apiUrl` ends in a slash got `//v1/...` and a 404), the WebRTC gateway's local control socket uses `TEAM_API_ROUTES.events`, and the `remote-screen` namespace has one source the viewer proxy shares

Model: Claude Opus 5, via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
