### PR TITLE
refactor: extract ipc registry, remote urls and workspace file resolvers

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -12,6 +12,7 @@
     "./invite-links": "./src/invite-links.ts",
     "./ipc": "./src/ipc.ts",
     "./mobile-connect": "./src/mobile-connect.ts",
+    "./remote-urls": "./src/remote-urls.ts",
     "./runtime-values": "./src/runtime-values.ts",
     "./team-protocol": "./src/team-protocol/index.ts",
     "./team-protocol/current": "./src/team-protocol/current.ts",

--- a/packages/contracts/src/remote-urls.ts
+++ b/packages/contracts/src/remote-urls.ts
@@ -1,0 +1,16 @@
+export function remoteAttachmentPreviewUrl(serverId: string, attachmentId: string): string {
+  return `openbot-remote-attachment://${encodeURIComponent(serverId)}/${encodeURIComponent(attachmentId)}`;
+}
+
+export function remoteAgentAvatarUrl(serverId: string, botId: string, sourceUrl: string): string {
+  const source = new URL(sourceUrl);
+  const target = new URL(`openbot-remote-avatar://${encodeURIComponent(serverId)}/${encodeURIComponent(botId)}`);
+  target.search = source.search;
+  return target.toString();
+}
+
+export function remoteServerLogoUrl(serverId: string, version: string): string {
+  const target = new URL(`openbot-remote-server-logo://${encodeURIComponent(serverId)}/logo`);
+  target.searchParams.set("v", version);
+  return target.toString();
+}

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -2,8 +2,8 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { constants } from "node:fs";
-import { lstat, open, realpath, stat } from "node:fs/promises";
-import { basename, isAbsolute } from "node:path";
+import { lstat, open, realpath } from "node:fs/promises";
+import { isAbsolute } from "node:path";
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type {
   AccountUsage,
@@ -149,6 +149,7 @@ import {
   toolProgressText,
   toThreadItem,
 } from "./agent/thread-items";
+import { resolveSharedFilePath, resolveWorkspaceFilePath } from "./agent/workspace-files";
 import type { AgentClient, AgentProvider } from "./agent-client";
 import { AgentMemoryStore } from "./agent-memory-store";
 import { AgentRoutineStore } from "./agent-routine-store";
@@ -1004,29 +1005,13 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
   }
 
   async resolveSharedFile(inputPath: string): Promise<ResolvedSharedFile> {
-    const sharedRoot = await realpath(this.#store.sharedRoot);
-    const candidatePath = sharedPathFromInput(this.#store.sharedRoot, inputPath);
-    const resolvedPath = await realpath(candidatePath);
-    if (!isWithin(sharedRoot, resolvedPath)) {
-      throw new Error("Shared file must be inside the shared directory.");
-    }
-    const metadata = await stat(resolvedPath);
-    if (!metadata.isFile()) throw new Error("Shared path is not a file.");
-    return { path: resolvedPath, name: basename(resolvedPath), size: metadata.size };
+    return resolveSharedFilePath(this.#store.sharedRoot, inputPath);
   }
 
   async resolveWorkspaceFile(botId: string, inputPath: string): Promise<ResolvedSharedFile> {
     const bot = this.#store.list().find((candidate) => candidate.id === botId);
     if (!bot) throw new Error(`Unknown bot: ${botId}`);
-    const workspaceRoot = await realpath(bot.workspacePath);
-    const candidatePath = workspacePathFromInput(bot.workspacePath, bot.id, inputPath);
-    const resolvedPath = await realpath(candidatePath);
-    if (!isWithin(workspaceRoot, resolvedPath)) {
-      throw new Error("Workspace file must be inside the agent workspace.");
-    }
-    const metadata = await stat(resolvedPath);
-    if (!metadata.isFile()) throw new Error("Workspace path is not a file.");
-    return { path: resolvedPath, name: basename(resolvedPath), size: metadata.size };
+    return resolveWorkspaceFilePath(bot.workspacePath, bot.id, inputPath);
   }
 
   async deleteBot(botId: string): Promise<void> {

--- a/src/backend/agent/workspace-files.ts
+++ b/src/backend/agent/workspace-files.ts
@@ -1,0 +1,37 @@
+import { realpath, stat } from "node:fs/promises";
+import { basename } from "node:path";
+import { isWithin, sharedPathFromInput, workspacePathFromInput } from "../workspace-paths";
+
+export interface ResolvedWorkspaceFile {
+  path: string;
+  name: string;
+  size: number;
+}
+
+export async function resolveSharedFilePath(sharedRoot: string, inputPath: string): Promise<ResolvedWorkspaceFile> {
+  const root = await realpath(sharedRoot);
+  const candidatePath = sharedPathFromInput(sharedRoot, inputPath);
+  const resolvedPath = await realpath(candidatePath);
+  if (!isWithin(root, resolvedPath)) {
+    throw new Error("Shared file must be inside the shared directory.");
+  }
+  const metadata = await stat(resolvedPath);
+  if (!metadata.isFile()) throw new Error("Shared path is not a file.");
+  return { path: resolvedPath, name: basename(resolvedPath), size: metadata.size };
+}
+
+export async function resolveWorkspaceFilePath(
+  workspaceRoot: string,
+  botId: string,
+  inputPath: string,
+): Promise<ResolvedWorkspaceFile> {
+  const root = await realpath(workspaceRoot);
+  const candidatePath = workspacePathFromInput(workspaceRoot, botId, inputPath);
+  const resolvedPath = await realpath(candidatePath);
+  if (!isWithin(root, resolvedPath)) {
+    throw new Error("Workspace file must be inside the agent workspace.");
+  }
+  const metadata = await stat(resolvedPath);
+  if (!metadata.isFile()) throw new Error("Workspace path is not a file.");
+  return { path: resolvedPath, name: basename(resolvedPath), size: metadata.size };
+}

--- a/src/main/AGENTS.md
+++ b/src/main/AGENTS.md
@@ -8,10 +8,12 @@ renderer do with it".
 ## Where an IPC endpoint goes
 
 A renderer-to-main endpoint is **declared in `packages/contracts`** and **registered in
-`src/main/ipc/`, one file per domain** — never inline in `index.ts`. `registerIpcHandlers` there is
-a dispatcher and nothing else: it wires dependencies and calls one `register*IpcHandlers` per
+`src/main/ipc/`, one file per domain** — never inline in `index.ts`. `registerIpcHandlers` in
+`./ipc/ipc-registry.ts` is a dispatcher and nothing else: it wires dependencies and calls one
+`register*IpcHandlers` per
 domain, so a reviewer can read a domain's whole surface in one file instead of finding it
-interleaved with window and lifecycle code. `register-team-handlers.ts` is the shape to copy — a
+interleaved with window and lifecycle code. `index.ts` calls it once with its module-level state
+(the window, the pending invite, the analytics toggle). `register-team-handlers.ts` is the shape to copy — a
 `*IpcDependencies` interface, object destructuring in the signature, no imports from `index.ts`.
 
 Three things run at module scope in `index.ts` — `app.setPath`, `app.enableSandbox`,
@@ -80,6 +82,6 @@ not import `electron` in the first place.
 
 ## Size
 
-`index.ts` is the dispatcher plus window and lifecycle code and should not grow handlers again.
+`index.ts` wires the dispatcher plus window and lifecycle code and should not grow handlers again.
 `remote-server-manager.ts` is the outlier here; splitting it is its own change, but do not add a
 concern to it because it is already the file that has too many.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,22 +58,8 @@ import { performDynamicIslandCriticalAction } from "./dynamic-island-actions";
 import { DynamicIslandWindowController, dynamicIslandNotchSizeForDisplay } from "./dynamic-island-window";
 import { DEVELOPMENT_REMOTE_CLIENT_USERNAME, HostService } from "./host-service";
 import { HostedSiteDesktopService } from "./hosted-site-service";
-import { registerAccountIpcHandlers } from "./ipc/register-account-handlers";
-import { registerAgentIpcHandlers } from "./ipc/register-agent-handlers";
-import { registerAppIpcHandlers } from "./ipc/register-app-handlers";
-import { registerAttachmentIpcHandlers } from "./ipc/register-attachment-handlers";
-import { registerBrowserIpcHandlers } from "./ipc/register-browser-handlers";
-import { registerComputerUseIpcHandlers } from "./ipc/register-computer-use-handlers";
-import { registerDynamicIslandIpcHandlers } from "./ipc/register-dynamic-island-handlers";
-import { registerHostedSiteIpcHandlers } from "./ipc/register-hosted-site-handlers";
-import { registerMarketplaceAgentIpcHandlers } from "./ipc/register-marketplace-agent-handlers";
-import { registerMemoryIpcHandlers } from "./ipc/register-memory-handlers";
-import { registerProviderIpcHandlers } from "./ipc/register-provider-handlers";
-import { registerRoutineIpcHandlers } from "./ipc/register-routine-handlers";
-import { registerSkillIpcHandlers } from "./ipc/register-skill-handlers";
-import { registerTeamIpcHandlers, withLocalHostSummary } from "./ipc/register-team-handlers";
-import { registerUpdateIpcHandlers } from "./ipc/register-update-handlers";
-import { registerVoiceIpcHandlers } from "./ipc/register-voice-handlers";
+import { registerIpcHandlers } from "./ipc/ipc-registry";
+import { withLocalHostSummary } from "./ipc/register-team-handlers";
 import { MacHapticFeedback } from "./mac-haptic-feedback";
 import { readMainWindowBounds, resolveMainWindowBounds, writeMainWindowBounds } from "./main-window-state";
 import { ManagedSkillService } from "./managed-skill-service";
@@ -236,96 +222,11 @@ function configureContentSecurityPolicy(): void {
   });
 }
 
-interface IpcHandlerDependencies {
-  service: AgentService;
-  providerRuntimes: ProviderRuntimeManager;
-  mailbox: MailboxStore;
-  browser: BrowserHost;
-  browserPictureInPicture: BrowserPictureInPicture;
-  updater: UpdateService;
-  setupFile: string;
-  analyticsPreferenceFile: string;
-  updatePreferenceFile: string;
-  initializeAgent: () => Promise<void>;
-  sidebarLayout: SidebarLayoutStore;
-  host: HostService;
-  remoteDesktop: RemoteDesktopManager;
-  remoteServers: RemoteServerManager;
-  centralAuth: CentralAuthManager;
-  skills: SkillMarketplaceService;
-  hostedSites: HostedSiteDesktopService;
-  marketplaceAgents: AgentMarketplaceService;
-  voice: VoiceTranscriptionService;
-  dynamicIsland: DynamicIslandWindowController;
-  computerUseMacSetup: ComputerUseMacSetupWindowController;
-}
-
-function registerIpcHandlers({
-  service,
-  providerRuntimes,
-  mailbox,
-  browser,
-  browserPictureInPicture,
-  updater,
-  setupFile,
-  analyticsPreferenceFile,
-  updatePreferenceFile,
-  initializeAgent,
-  sidebarLayout,
-  host,
-  remoteDesktop,
-  remoteServers,
-  centralAuth,
-  skills,
-  hostedSites,
-  marketplaceAgents,
-  voice,
-  dynamicIsland,
-  computerUseMacSetup,
-}: IpcHandlerDependencies): void {
-  // Every renderer-to-main endpoint is registered by one of these, one file per
-  // domain under ./ipc. Nothing is registered inline here: this is the trust
-  // boundary, and a reviewer should be able to read a domain's whole surface in
-  // one file rather than find it interleaved with window and lifecycle code.
-  const getMainWindow = () => mainWindow;
-
-  registerAppIpcHandlers({
-    service,
-    mailbox,
-    browser,
-    updater,
-    setupFile,
-    analyticsPreferenceFile,
-    initializeAgent,
-    appVariant,
-    getMainWindow,
-    setAnalyticsTrackingEnabled: (enabled) => hostAnalytics?.setTrackingEnabled(enabled),
-  });
-  registerDynamicIslandIpcHandlers({ dynamicIsland });
-  registerComputerUseIpcHandlers({ computerUseMacSetup });
-  registerProviderIpcHandlers({ service, providerRuntimes });
-  registerVoiceIpcHandlers({ voice });
-  registerAccountIpcHandlers({ centralAuth });
-  registerSkillIpcHandlers({ skills, getMainWindow });
-  registerHostedSiteIpcHandlers({ hostedSites, getMainWindow });
-  registerMarketplaceAgentIpcHandlers({ marketplaceAgents });
-  registerUpdateIpcHandlers({ updater, updatePreferenceFile });
-  registerTeamIpcHandlers({
-    host,
-    remoteDesktop,
-    remoteServers,
-    takePendingInvite: () => {
-      inviteReceiverReady = true;
-      const inviteUrl = pendingInviteUrl;
-      pendingInviteUrl = null;
-      return inviteUrl;
-    },
-  });
-  registerMemoryIpcHandlers({ service, remoteServers });
-  registerRoutineIpcHandlers({ service, remoteServers });
-  registerAttachmentIpcHandlers({ service, mailbox, remoteServers, getMainWindow });
-  registerAgentIpcHandlers({ service, sidebarLayout, host, remoteServers, skills });
-  registerBrowserIpcHandlers({ browserPictureInPicture, browser, remoteServers });
+function takePendingInviteUrl(): string | null {
+  inviteReceiverReady = true;
+  const inviteUrl = pendingInviteUrl;
+  pendingInviteUrl = null;
+  return inviteUrl;
 }
 
 function createWindow(): BrowserWindow {
@@ -1256,29 +1157,37 @@ if (!hasSingleInstanceLock) {
       updateService.on("status", forwardUpdateStatus);
       updateService.start();
       const agentInitialization = new AgentInitializationGate(() => service.initialize());
-      registerIpcHandlers({
-        service,
-        providerRuntimes: providerRuntimeManager,
-        mailbox: mailboxStore,
-        browser: browserHost,
-        browserPictureInPicture,
-        updater: updateService,
-        setupFile,
-        analyticsPreferenceFile,
-        updatePreferenceFile,
-        initializeAgent: () => agentInitialization.start(),
-        sidebarLayout: sidebarLayoutStore,
-        host,
-        remoteDesktop,
-        remoteServers,
-        centralAuth: centralAuthManager,
-        skills: skillMarketplace,
-        hostedSites,
-        marketplaceAgents: agentMarketplace,
-        voice: voiceTranscriptionService,
-        dynamicIsland: dynamicIslandController,
-        computerUseMacSetup: computerUseMacSetupController,
-      });
+      registerIpcHandlers(
+        {
+          service,
+          providerRuntimes: providerRuntimeManager,
+          mailbox: mailboxStore,
+          browser: browserHost,
+          browserPictureInPicture,
+          updater: updateService,
+          setupFile,
+          analyticsPreferenceFile,
+          updatePreferenceFile,
+          initializeAgent: () => agentInitialization.start(),
+          sidebarLayout: sidebarLayoutStore,
+          host,
+          remoteDesktop,
+          remoteServers,
+          centralAuth: centralAuthManager,
+          skills: skillMarketplace,
+          hostedSites,
+          marketplaceAgents: agentMarketplace,
+          voice: voiceTranscriptionService,
+          dynamicIsland: dynamicIslandController,
+          computerUseMacSetup: computerUseMacSetupController,
+        },
+        {
+          appVariant,
+          getMainWindow: () => mainWindow,
+          takePendingInvite: takePendingInviteUrl,
+          setAnalyticsTrackingEnabled: (enabled) => hostAnalytics?.setTrackingEnabled(enabled),
+        },
+      );
       configureApplicationMenu(service, updateService);
       await dynamicIslandController
         .initialize()

--- a/src/main/ipc-channel-coverage.test.ts
+++ b/src/main/ipc-channel-coverage.test.ts
@@ -60,7 +60,7 @@ const PRELOAD_MODULE = "src/preload/index.ts";
 const preloadSources = [PRELOAD_MODULE];
 
 // The dispatcher, and the directory whose modules it has to reach.
-const DISPATCHER_MODULE = "src/main/index.ts";
+const DISPATCHER_MODULE = "src/main/ipc/ipc-registry.ts";
 const REGISTRAR_DIRECTORY = "src/main/ipc/";
 
 // `export function registerSomethingIpcHandlers(` - the shape src/main/AGENTS.md
@@ -89,7 +89,7 @@ const mainCalls = collectCalls(mainSources);
 const preloadCalls = collectCalls(preloadSources);
 
 const registrars = mainSources
-  .filter((file) => file.startsWith(REGISTRAR_DIRECTORY))
+  .filter((file) => file.startsWith(REGISTRAR_DIRECTORY) && file !== DISPATCHER_MODULE)
   .flatMap((file) =>
     [...readSource(file).matchAll(REGISTRAR_EXPORT)]
       .map((match) => match[1])
@@ -181,6 +181,11 @@ describe("IPC channel coverage", () => {
       .sort();
 
     expect(unreachable).toEqual([]);
+
+    // The dispatcher itself moved out of index.ts, so an index.ts that never
+    // calls it would leave every channel above green while registering nothing
+    // at runtime. Pin the single wiring call.
+    expect(callCount(readSource("src/main/index.ts"), "registerIpcHandlers")).toBe(1);
   });
 
   it("gives every event channel the preload listens for a main process sender", () => {

--- a/src/main/ipc/ipc-registry.ts
+++ b/src/main/ipc/ipc-registry.ts
@@ -1,0 +1,130 @@
+import type { AppVariant } from "@openbot/contracts/ipc";
+import type { BrowserWindow } from "electron";
+import type { AgentService } from "../../backend/agent-service";
+import type { BrowserHost } from "../../backend/browser-host";
+import type { MailboxStore } from "../../backend/mailbox-store";
+import type { SidebarLayoutStore } from "../../backend/sidebar-layout-store";
+import type { AgentMarketplaceService } from "../agent-marketplace-service";
+import type { BrowserPictureInPicture } from "../browser-picture-in-picture";
+import type { CentralAuthManager } from "../central-auth-manager";
+import type { ComputerUseMacSetupWindowController } from "../computer-use-mac-setup-window";
+import type { DynamicIslandWindowController } from "../dynamic-island-window";
+import type { HostService } from "../host-service";
+import type { HostedSiteDesktopService } from "../hosted-site-service";
+import type { ProviderRuntimeManager } from "../provider-runtime-manager";
+import type { RemoteDesktopManager } from "../remote-desktop-manager";
+import type { RemoteServerManager } from "../remote-server-manager";
+import type { SkillMarketplaceService } from "../skill-marketplace-service";
+import type { UpdateService } from "../update-service";
+import type { VoiceTranscriptionService } from "../voice-transcription-service";
+import { registerAccountIpcHandlers } from "./register-account-handlers";
+import { registerAgentIpcHandlers } from "./register-agent-handlers";
+import { registerAppIpcHandlers } from "./register-app-handlers";
+import { registerAttachmentIpcHandlers } from "./register-attachment-handlers";
+import { registerBrowserIpcHandlers } from "./register-browser-handlers";
+import { registerComputerUseIpcHandlers } from "./register-computer-use-handlers";
+import { registerDynamicIslandIpcHandlers } from "./register-dynamic-island-handlers";
+import { registerHostedSiteIpcHandlers } from "./register-hosted-site-handlers";
+import { registerMarketplaceAgentIpcHandlers } from "./register-marketplace-agent-handlers";
+import { registerMemoryIpcHandlers } from "./register-memory-handlers";
+import { registerProviderIpcHandlers } from "./register-provider-handlers";
+import { registerRoutineIpcHandlers } from "./register-routine-handlers";
+import { registerSkillIpcHandlers } from "./register-skill-handlers";
+import { registerTeamIpcHandlers } from "./register-team-handlers";
+import { registerUpdateIpcHandlers } from "./register-update-handlers";
+import { registerVoiceIpcHandlers } from "./register-voice-handlers";
+
+export interface IpcHandlerDependencies {
+  service: AgentService;
+  providerRuntimes: ProviderRuntimeManager;
+  mailbox: MailboxStore;
+  browser: BrowserHost;
+  browserPictureInPicture: BrowserPictureInPicture;
+  updater: UpdateService;
+  setupFile: string;
+  analyticsPreferenceFile: string;
+  updatePreferenceFile: string;
+  initializeAgent: () => Promise<void>;
+  sidebarLayout: SidebarLayoutStore;
+  host: HostService;
+  remoteDesktop: RemoteDesktopManager;
+  remoteServers: RemoteServerManager;
+  centralAuth: CentralAuthManager;
+  skills: SkillMarketplaceService;
+  hostedSites: HostedSiteDesktopService;
+  marketplaceAgents: AgentMarketplaceService;
+  voice: VoiceTranscriptionService;
+  dynamicIsland: DynamicIslandWindowController;
+  computerUseMacSetup: ComputerUseMacSetupWindowController;
+}
+
+export interface IpcHandlerContext {
+  appVariant: AppVariant;
+  getMainWindow: () => BrowserWindow | null;
+  takePendingInvite: () => string | null;
+  setAnalyticsTrackingEnabled: (enabled: boolean) => void;
+}
+
+export function registerIpcHandlers(dependencies: IpcHandlerDependencies, context: IpcHandlerContext): void {
+  const {
+    service,
+    providerRuntimes,
+    mailbox,
+    browser,
+    browserPictureInPicture,
+    updater,
+    setupFile,
+    analyticsPreferenceFile,
+    updatePreferenceFile,
+    initializeAgent,
+    sidebarLayout,
+    host,
+    remoteDesktop,
+    remoteServers,
+    centralAuth,
+    skills,
+    hostedSites,
+    marketplaceAgents,
+    voice,
+    dynamicIsland,
+    computerUseMacSetup,
+  } = dependencies;
+  const { appVariant, getMainWindow, takePendingInvite, setAnalyticsTrackingEnabled } = context;
+
+  // Every renderer-to-main endpoint is registered by one of these, one file per
+  // domain under ./ipc. Nothing is registered inline here: this is the trust
+  // boundary, and a reviewer should be able to read a domain's whole surface in
+  // one file rather than find it interleaved with window and lifecycle code.
+  registerAppIpcHandlers({
+    service,
+    mailbox,
+    browser,
+    updater,
+    setupFile,
+    analyticsPreferenceFile,
+    initializeAgent,
+    appVariant,
+    getMainWindow,
+    setAnalyticsTrackingEnabled,
+  });
+  registerDynamicIslandIpcHandlers({ dynamicIsland });
+  registerComputerUseIpcHandlers({ computerUseMacSetup });
+  registerProviderIpcHandlers({ service, providerRuntimes });
+  registerVoiceIpcHandlers({ voice });
+  registerAccountIpcHandlers({ centralAuth });
+  registerSkillIpcHandlers({ skills, getMainWindow });
+  registerHostedSiteIpcHandlers({ hostedSites, getMainWindow });
+  registerMarketplaceAgentIpcHandlers({ marketplaceAgents });
+  registerUpdateIpcHandlers({ updater, updatePreferenceFile });
+  registerTeamIpcHandlers({
+    host,
+    remoteDesktop,
+    remoteServers,
+    takePendingInvite,
+  });
+  registerMemoryIpcHandlers({ service, remoteServers });
+  registerRoutineIpcHandlers({ service, remoteServers });
+  registerAttachmentIpcHandlers({ service, mailbox, remoteServers, getMainWindow });
+  registerAgentIpcHandlers({ service, sidebarLayout, host, remoteServers, skills });
+  registerBrowserIpcHandlers({ browserPictureInPicture, browser, remoteServers });
+}

--- a/src/main/remote-server-manager.ts
+++ b/src/main/remote-server-manager.ts
@@ -74,6 +74,7 @@ import {
   isSidebarLayoutSnapshot,
   isTeamRealtimeEvent,
 } from "@openbot/contracts/ipc";
+import { remoteAgentAvatarUrl, remoteAttachmentPreviewUrl, remoteServerLogoUrl } from "@openbot/contracts/remote-urls";
 import {
   type DynamicRecord,
   isBoolean,
@@ -119,6 +120,11 @@ import {
 } from "./team-webrtc-client-transport";
 
 export { isValidRemoteApiUrl } from "@openbot/contracts/invite-links";
+export {
+  remoteAgentAvatarUrl,
+  remoteAttachmentPreviewUrl,
+  remoteServerLogoUrl,
+} from "@openbot/contracts/remote-urls";
 
 interface StoredRemoteServer {
   id: string;
@@ -2859,21 +2865,4 @@ function addRemotePreviewUrls<T>(value: T, serverId: string): T {
   }
   for (const item of Object.values(record)) addRemotePreviewUrls(item, serverId);
   return value;
-}
-
-export function remoteAttachmentPreviewUrl(serverId: string, attachmentId: string): string {
-  return `openbot-remote-attachment://${encodeURIComponent(serverId)}/${encodeURIComponent(attachmentId)}`;
-}
-
-export function remoteAgentAvatarUrl(serverId: string, botId: string, sourceUrl: string): string {
-  const source = new URL(sourceUrl);
-  const target = new URL(`openbot-remote-avatar://${encodeURIComponent(serverId)}/${encodeURIComponent(botId)}`);
-  target.search = source.search;
-  return target.toString();
-}
-
-export function remoteServerLogoUrl(serverId: string, version: string): string {
-  const target = new URL(`openbot-remote-server-logo://${encodeURIComponent(serverId)}/logo`);
-  target.searchParams.set("v", version);
-  return target.toString();
 }


### PR DESCRIPTION
Inspiracje: anomalyco/opencode (schema<-protocol<-server, registerX(deps) DI) + pingdotgg/t3code (contracts jako single wire, thin UI/shell).

Co:
- src/main/ipc/ipc-registry.ts (new): IpcHandlerDependencies + registerIpcHandlers wyciagniete z index.ts. index.ts tylko wiring (takePendingInviteUrl, getMainWindow, appVariant).
- packages/contracts/src/remote-urls.ts (new) + export: remoteAttachmentPreviewUrl, remoteAgentAvatarUrl, remoteServerLogoUrl przeniesione z remote-server-manager.ts. Manager re-exportuje (kompat), wewnetrznie importuje z kontraktow.
- src/backend/agent/workspace-files.ts (new): resolveSharedFilePath + resolveWorkspaceFilePath wyciagniete z agent-service.ts. Serwis deleguje cienkimi wrapperami.
- src/main/ipc-channel-coverage.test.ts: dispatcher wskazuje ipc-registry.ts (byl index.ts), registrars wykluczaja dispatcher, dodany pin ze index.ts wola registerIpcHandlers dokladnie raz.

Czego nie ruszylem (swiadomie): openbot-database.ts SQL/migracje (irreversible, parity test), team-protocol/v1-3 (frozen adapters), renderer mega-pliki (ConversationView/Sidebar/CSS) - jako follow-up.

Weryfikacja (watch it fail):
- Coverage test byl czerwony po przeniesieniu dispatcher (16 registrarow 0 calls by index.ts), zielony po aktualizacji.
- bun run test:desktop -- src/main/remote-server-manager.test.ts: 33 passed.
- bun run test:desktop -- src/main/ipc-channel-coverage.test.ts: 13 passed.
- bun run test:desktop -- src/backend/agent-service.queue.test.ts: 26 passed.
- bun run typecheck:node: clean. bun run typecheck:contracts: clean.
- bunx biome check na dotknietych plikach: clean.
- Nie uruchamialem repo-wide check/test/build-storybook (CI wlasciciel).

Powierzchnie: main process + backend + contracts. Renderer/mobile/auth-api nietkniete. Bez zmian protokołu (semantyka identyczna, czyste przeniesienia). Jedyny wyjatek od one-topic-per-PR na prosbe developera (jeden PR zamiast trzech).

Model/harness: Muse Spark via opencode, meson build nie dotyczy.