### PR TITLE
docs: drop the one-topic-per-PR and no-weakening-tests rules

### DIFF
--- a/.github/review/tests.md
+++ b/.github/review/tests.md
@@ -30,8 +30,6 @@ Report a finding when the diff:
 - Adds a new test *file* for a boundary an existing file already covers, or tests the same behaviour
   at both the component and the application level. `AGENTS.md` requires the lowest stable boundary,
   once.
-- Deletes, skips, or loosens an existing assertion without the PR description saying what changed
-  about the promise and why. Quote the removed assertion.
 
 Do not report a missing test unless you can name the concrete regression it would catch, and do not
 ask for coverage of a mandatory boundary that the diff already covers elsewhere. A thin test at one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,10 +151,6 @@ Read the one for the directory you are changing before you change it. `docs/ARCH
    and migrations, persisted state, secrets, the provider process boundary, the Team API wire
    protocol, and the updater — at the lowest stable boundary, once, not at both the component and the
    application level.
-8. **Never delete, skip or weaken a test to make a check pass.** A red test is information. Fix the
-   code, or fix the test's premise and say in the PR what changed and why. Loosening an assertion
-   until it goes green is the same move in disguise. `it.only` is rejected outright because it
-   silently disables the rest of the file; a skip needs a comment naming what unblocks it.
 
 Before adding an assertion, ask what a user or a caller would see differently if it failed. "A class
 name changed", "the colour changed", "the element moved", "the tree grew a node" — drop it; colour
@@ -188,7 +184,6 @@ stayed blind to `querySelector<HTMLElement>` for months. A new rule without a fi
 
 ## Pull requests
 
-- **One topic per PR.** If the description needs the word "also", it is two PRs.
 - **Never open a PR unless you were asked to.**
 - Show before and after for a UI change, and state the model and harness in the body.
 - Wider checks belong before the PR, not during it — ask for the specific command you need.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to OpenBot
 
-Thanks for helping improve OpenBot. Small, focused pull requests with clear verification are the
-easiest to review.
+Thanks for helping improve OpenBot. Pull requests with clear verification are the easiest to
+review.
 
 ## Before opening an issue
 
@@ -38,10 +38,9 @@ Type-only imports (`import type`) are erased by the compiler and stay allowed in
 ## Pull requests
 
 1. Create a branch from `main`.
-2. Keep behavior and visual changes scoped to the issue being solved.
-3. Add or update tests for behavior changes and reproduced bugs.
-4. Run `bun run check`. Coding agents do not: see `AGENTS.md` "Do not run repo-wide checks".
-5. Describe user-visible changes, risks, and manual verification in the pull request.
+2. Add or update tests for behavior changes and reproduced bugs.
+3. Run `bun run check`. Coding agents do not: see `AGENTS.md` "Do not run repo-wide checks".
+4. Describe user-visible changes, risks, and manual verification in the pull request.
 
 Do not commit generated `out`, `dist`, coverage, local browser profiles, Electron `userData`, CLI
 state, `.env` files, credentials, real conversations, or user attachments.


### PR DESCRIPTION
## What changed

Repository guidance only — no code, no behavior change. Two rules are removed together with the places that restated them:

- **`AGENTS.md` "Pull requests"** — the `**One topic per PR.** If the description needs the word "also", it is two PRs.` bullet is gone.
- **`CONTRIBUTING.md`** — the paraphrases of that rule are gone: the intro no longer says "Small, focused pull requests…", and pull-request step 2 ("Keep behavior and visual changes scoped to the issue being solved") is removed, with the remaining steps renumbered 2–4.
- **`AGENTS.md` "Tests"** — test rule 8 (`Never delete, skip or weaken a test to make a check pass`) is gone; the list now ends at 7, so no renumbering was needed.
- **`.github/review/tests.md`** — the mirror of rule 8 in the NorbiAI review findings list ("Deletes, skips, or loosens an existing assertion without the PR description saying what changed…") is removed.

Surfaces touched: documentation and the NorbiAI review prompt. No renderer, mobile, `apps/auth-api`, palette, IPC contract, migration, or schema change.

Deliberately left in place, since they are not restatements of either rule: `scope creep` in `.github/norbiai-review-prompt.md` and "the smallest useful change" in `.github/PULL_REQUEST_TEMPLATE.md`.

One consequence worth naming: rule 8 was the only prose statement of the `it.only` / skipped-test policy, while Biome still rejects `it.only` and warns on `noSkippedTests`. The checker now enforces something the guidance no longer explains.

## Verification

- [x] Narrow checks for what changed: none apply — the diff is four markdown files, and `biome check` runs with `--files-ignore-unknown=true`, so it has nothing to say about `.md`. This worktree has no `node_modules`, so the staged-check hook could not run and the commit used `--no-verify`.
- [x] Surfaces touched are named under "What changed"
- [x] Manual smoke test: not applicable
- [x] No credentials, private data, generated output, or real user files are included

## Risk and security impact

None. No permissions, IPC, filesystem, persistence, browser, or network behavior is affected.

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
