### PR TITLE
fix(island): stop clipping a collapsing island, and idle the avatars nobody is watching

### DIFF
--- a/src/main/dynamic-island-window.test.ts
+++ b/src/main/dynamic-island-window.test.ts
@@ -194,8 +194,13 @@ describe("dynamic island window geometry", () => {
     expect(windows[0]?.destroy).toHaveBeenCalledOnce();
     expect(windows[1]?.setBounds).toHaveBeenCalledWith({ x: 1793, y: 20, width: 614, height: 380 }, false);
 
+    // The window is the only thing clipping the island, so it keeps the tall bounds until the
+    // renderer's collapse animation has landed - otherwise the lower half is cut off at once.
     controller.setInteractive(43, false);
-    expect(windows[1]?.setBounds).toHaveBeenCalledWith({ x: 1793, y: 20, width: 614, height: 50 }, false);
+    expect(windows[1]?.setBounds).not.toHaveBeenCalledWith({ x: 1793, y: 20, width: 614, height: 50 }, false);
+    await vi.waitFor(() =>
+      expect(windows[1]?.setBounds).toHaveBeenCalledWith({ x: 1793, y: 20, width: 614, height: 50 }, false),
+    );
   });
 
   it("publishes updated geometry without reloading an existing overlay", async () => {

--- a/src/main/dynamic-island-window.test.ts
+++ b/src/main/dynamic-island-window.test.ts
@@ -15,6 +15,7 @@ import type { BrowserWindow, Display, Rectangle } from "electron";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as preferenceStore from "./dynamic-island-preference-store";
 import {
+  DYNAMIC_ISLAND_COLLAPSE_SETTLE_MS,
   DynamicIslandWindowController,
   dynamicIslandNotchSizeForDisplay,
   dynamicIslandWindowBounds,
@@ -77,6 +78,7 @@ function criticalPresentation(
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
@@ -196,11 +198,11 @@ describe("dynamic island window geometry", () => {
 
     // The window is the only thing clipping the island, so it keeps the tall bounds until the
     // renderer's collapse animation has landed - otherwise the lower half is cut off at once.
+    vi.useFakeTimers();
     controller.setInteractive(43, false);
     expect(windows[1]?.setBounds).not.toHaveBeenCalledWith({ x: 1793, y: 20, width: 614, height: 50 }, false);
-    await vi.waitFor(() =>
-      expect(windows[1]?.setBounds).toHaveBeenCalledWith({ x: 1793, y: 20, width: 614, height: 50 }, false),
-    );
+    await vi.advanceTimersByTimeAsync(DYNAMIC_ISLAND_COLLAPSE_SETTLE_MS);
+    expect(windows[1]?.setBounds).toHaveBeenCalledWith({ x: 1793, y: 20, width: 614, height: 50 }, false);
   });
 
   it("publishes updated geometry without reloading an existing overlay", async () => {

--- a/src/main/dynamic-island-window.ts
+++ b/src/main/dynamic-island-window.ts
@@ -23,7 +23,7 @@ const DYNAMIC_ISLAND_COMPACT_WINDOW_HEIGHT = 50;
 // then the shell springs back down to the notch. The window is the only thing clipping it, so
 // dropping to the compact height on the same tick guillotines the still-tall island - the lower
 // half disappears at once while the top morphs. Hold the tall window until the shell has landed.
-const DYNAMIC_ISLAND_COLLAPSE_SETTLE_MS = 700;
+export const DYNAMIC_ISLAND_COLLAPSE_SETTLE_MS = 700;
 
 const MACBOOK_NOTCH_REFERENCE = {
   displayWidth: 1512,
@@ -136,7 +136,12 @@ export class DynamicIslandWindowController {
       setTimeout(() => {
         this.#collapseTimers.delete(displayId);
         if (this.#interactiveDisplays.has(displayId) || window.isDestroyed()) return;
-        window.setBounds(dynamicIslandInteractiveWindowBounds(bounds, false), false);
+        // The display can be rearranged while the island animates shut, and reconciliation will
+        // have moved the still-tall window to the new geometry. Ask where the window belongs now
+        // rather than replaying the rectangle captured when the pointer left.
+        const current = this.#options.getDisplays().find((candidate) => candidate.id === displayId);
+        if (!current) return;
+        window.setBounds(dynamicIslandInteractiveWindowBounds(dynamicIslandWindowBounds(current), false), false);
       }, DYNAMIC_ISLAND_COLLAPSE_SETTLE_MS),
     );
   }

--- a/src/main/dynamic-island-window.ts
+++ b/src/main/dynamic-island-window.ts
@@ -19,6 +19,11 @@ const logger = createOpenBotLogger("dynamic-island-window");
 
 export const DYNAMIC_ISLAND_WINDOW_SIZE = { width: 614, height: 380 } as const;
 const DYNAMIC_ISLAND_COMPACT_WINDOW_HEIGHT = 50;
+// Leaving interaction starts a collapse the renderer animates for roughly 600ms: the panel fades,
+// then the shell springs back down to the notch. The window is the only thing clipping it, so
+// dropping to the compact height on the same tick guillotines the still-tall island - the lower
+// half disappears at once while the top morphs. Hold the tall window until the shell has landed.
+const DYNAMIC_ISLAND_COLLAPSE_SETTLE_MS = 700;
 
 const MACBOOK_NOTCH_REFERENCE = {
   displayWidth: 1512,
@@ -52,6 +57,7 @@ export class DynamicIslandWindowController {
   readonly #interactiveDisplays = new Set<number>();
   readonly #criticalActions = new Map<string, Promise<void>>();
   readonly #notchSizes = new Map<number, { width: number; height: number }>();
+  readonly #collapseTimers = new Map<number, ReturnType<typeof setTimeout>>();
   #preferenceMutation = Promise.resolve();
   #windowReconciliation = Promise.resolve();
   #destroyed = false;
@@ -120,10 +126,26 @@ export class DynamicIslandWindowController {
     else this.#interactiveDisplays.delete(displayId);
     const display = this.#options.getDisplays().find((candidate) => candidate.id === displayId);
     const bounds = display ? dynamicIslandWindowBounds(display) : undefined;
+    this.#cancelCollapse(displayId);
     if (interactive && bounds) window.setBounds(dynamicIslandInteractiveWindowBounds(bounds, true), false);
     window.setFocusable(interactive);
     window.setIgnoreMouseEvents(!interactive, { forward: true });
-    if (!interactive && bounds) window.setBounds(dynamicIslandInteractiveWindowBounds(bounds, false), false);
+    if (interactive || !bounds) return;
+    this.#collapseTimers.set(
+      displayId,
+      setTimeout(() => {
+        this.#collapseTimers.delete(displayId);
+        if (this.#interactiveDisplays.has(displayId) || window.isDestroyed()) return;
+        window.setBounds(dynamicIslandInteractiveWindowBounds(bounds, false), false);
+      }, DYNAMIC_ISLAND_COLLAPSE_SETTLE_MS),
+    );
+  }
+
+  #cancelCollapse(displayId: number): void {
+    const timer = this.#collapseTimers.get(displayId);
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    this.#collapseTimers.delete(displayId);
   }
 
   async performAction(action: DynamicIslandAction): Promise<void> {
@@ -179,6 +201,7 @@ export class DynamicIslandWindowController {
       this.#windows.delete(displayId);
       this.#interactiveDisplays.delete(displayId);
       this.#notchSizes.delete(displayId);
+      this.#cancelCollapse(displayId);
       if (!window.isDestroyed()) window.destroy();
     }
 
@@ -189,7 +212,10 @@ export class DynamicIslandWindowController {
       const current = this.#windows.get(display.id);
       if (current && !current.isDestroyed()) {
         current.setBounds(
-          dynamicIslandInteractiveWindowBounds(bounds, this.#interactiveDisplays.has(display.id)),
+          dynamicIslandInteractiveWindowBounds(
+            bounds,
+            this.#interactiveDisplays.has(display.id) || this.#collapseTimers.has(display.id),
+          ),
           false,
         );
         if (notchSizeChanged(this.#notchSizes.get(display.id), notchSize)) {
@@ -245,6 +271,7 @@ export class DynamicIslandWindowController {
         this.#windows.delete(display.id);
         this.#interactiveDisplays.delete(display.id);
         this.#notchSizes.delete(display.id);
+        this.#cancelCollapse(display.id);
       }
     });
     try {
@@ -274,6 +301,7 @@ export class DynamicIslandWindowController {
   }
 
   private destroyWindows(): void {
+    for (const displayId of [...this.#collapseTimers.keys()]) this.#cancelCollapse(displayId);
     const windows = [...this.#windows.values()];
     this.#windows.clear();
     this.#interactiveDisplays.clear();

--- a/src/renderer/src/components/AccountUpdateIsland.test.tsx
+++ b/src/renderer/src/components/AccountUpdateIsland.test.tsx
@@ -1,0 +1,75 @@
+import type { UpdateStatus } from "@openbot/contracts/ipc";
+import { render, screen } from "@solidjs/testing-library";
+import { createSignal, flush } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import { AccountUpdateIsland } from "./AccountUpdateIsland";
+
+function updateStatus(phase: UpdateStatus["phase"]): UpdateStatus {
+  return {
+    phase,
+    currentVersion: "0.1.0",
+    availableVersion: "0.2.0",
+    progress: null,
+    checkedAt: "2026-08-12T22:00:00.000Z",
+    message: null,
+    errorCode: null,
+  };
+}
+
+function renderIsland(initialPhase: UpdateStatus["phase"]) {
+  const [phase, setPhase] = createSignal<UpdateStatus["phase"]>(initialPhase);
+  render(() => <AccountUpdateIsland updateStatus={updateStatus(phase())} onUpdateAction={async () => {}} />);
+  return setPhase;
+}
+
+// Closed, the island used to stay mounted at `opacity: 0` — a composited layer
+// with a 12px backdrop-filter and a spinner rotating into it every frame, which
+// measured ~10% of a core on an idle window. These cases pin the presence
+// lifecycle that replaced it: absent when there is nothing to announce, and
+// still there when a close is interrupted.
+describe("AccountUpdateIsland", () => {
+  it("stays out of the document while no update is pending", () => {
+    renderIsland("idle");
+
+    expect(screen.queryByText("New update available")).not.toBeInTheDocument();
+  });
+
+  it("leaves the document once the update is gone and the slide-out has run", async () => {
+    vi.useFakeTimers();
+    try {
+      const setPhase = renderIsland("available");
+      expect(await screen.findByText("New update available")).toBeInTheDocument();
+
+      setPhase("idle");
+      flush();
+      vi.advanceTimersByTime(1_000);
+      flush();
+
+      expect(screen.queryByText("New update available")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("survives a close that a new update interrupts", async () => {
+    vi.useFakeTimers();
+    try {
+      const setPhase = renderIsland("available");
+      expect(await screen.findByText("New update available")).toBeInTheDocument();
+
+      setPhase("idle");
+      flush();
+      vi.advanceTimersByTime(100);
+      setPhase("available");
+      flush();
+      // Past the close hold. A timer left over from the interrupted close would
+      // take away an island that is open again, and nothing would bring it back.
+      vi.advanceTimersByTime(1_000);
+      flush();
+
+      expect(screen.queryByText("New update available")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/renderer/src/components/AccountUpdateIsland.tsx
+++ b/src/renderer/src/components/AccountUpdateIsland.tsx
@@ -1,7 +1,16 @@
 import type { UpdateStatus } from "@openbot/contracts/ipc";
 import { isUpdateActivePhase, isUpdateBusyPhase } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { rendererDuration } from "./conversation/activity-timing";
 import { Button, Download, RefreshCw, Spinner } from "./ui";
+
+// `--panel-close-dur` is a calc() on the island itself, so it cannot be read off
+// the document root the way `rendererDuration` reads a token. Sum the two tokens
+// it is built from; keep this in step with `--panel-close-dur` in
+// account-update-island.css.
+function islandCloseDuration(): number {
+  return rendererDuration("--openbot-duration-slow", 200) + rendererDuration("--openbot-duration-normal", 160);
+}
 
 interface AccountUpdateIslandProps {
   updateStatus: UpdateStatus;
@@ -92,6 +101,30 @@ export function AccountUpdateIsland(props: AccountUpdateIslandProps) {
     },
   );
 
+  // Closed, the island is `opacity: 0` but still a composited layer carrying a
+  // 12px backdrop-filter and a spinner on an infinite `ui-spin`. That rotation
+  // invalidates the backdrop every frame, so an island nobody can see measured
+  // ~10% of a core, forever. Keep it out of the DOM instead, held only for as
+  // long as the slide-out needs it.
+  const [present, setPresent] = createSignal(false);
+  createEffect(
+    () => open(),
+    (isOpen) => {
+      if (isOpen) {
+        setPresent(true);
+        return;
+      }
+      if (!present()) return;
+      const closeDuration = islandCloseDuration();
+      if (closeDuration === 0) {
+        setPresent(false);
+        return;
+      }
+      const timer = window.setTimeout(() => setPresent(false), closeDuration);
+      return () => window.clearTimeout(timer);
+    },
+  );
+
   async function runUpdateAction(): Promise<void> {
     if (!open() || busy()) return;
     setActionPending(true);
@@ -103,78 +136,80 @@ export function AccountUpdateIsland(props: AccountUpdateIslandProps) {
   }
 
   return (
-    <div
-      class="account-update-island t-panel-slide"
-      data-open={open() ? "true" : "false"}
-      data-phase={phase()}
-      aria-hidden={open() ? undefined : "true"}
-      inert={open() ? undefined : true}
-    >
+    <Show when={present()}>
       <div
-        class="account-update-island__copy t-update-text-swap"
-        data-state={failed() ? "error" : ready() ? "ready" : "available"}
-        role="status"
-        aria-live="polite"
+        class="account-update-island t-panel-slide"
+        data-open={open() ? "true" : "false"}
+        data-phase={phase()}
+        aria-hidden={open() ? undefined : "true"}
+        inert={open() ? undefined : true}
       >
-        <strong data-text="available" aria-hidden={ready() || failed() ? "true" : undefined}>
-          New update available
-        </strong>
-        <strong data-text="ready" aria-hidden={ready() && !failed() ? undefined : "true"}>
-          Update ready
-        </strong>
-        <strong data-text="error" aria-hidden={failed() ? undefined : "true"} title={errorMessage()}>
-          {errorMessage()}
-        </strong>
-      </div>
-      <div class="account-update-island__action-shell" data-downloading={busy() ? "true" : "false"}>
-        <Button
-          type="button"
-          size="xs"
-          class="account-update-island__action"
-          aria-label={accessibleActionLabel()}
-          aria-busy={busy() ? "true" : undefined}
-          disabled={!open() || busy()}
-          onClick={() => void runUpdateAction()}
+        <div
+          class="account-update-island__copy t-update-text-swap"
+          data-state={failed() ? "error" : ready() ? "ready" : "available"}
+          role="status"
+          aria-live="polite"
         >
-          <span class="account-update-island__action-content">
-            <span class="account-update-island__icon t-icon-swap" data-state={busy() ? "b" : "a"}>
-              <span class="t-icon" data-icon="a" aria-hidden="true">
-                <Show when={failed() || ready()} fallback={<Download />}>
-                  <RefreshCw />
-                </Show>
+          <strong data-text="available" aria-hidden={ready() || failed() ? "true" : undefined}>
+            New update available
+          </strong>
+          <strong data-text="ready" aria-hidden={ready() && !failed() ? undefined : "true"}>
+            Update ready
+          </strong>
+          <strong data-text="error" aria-hidden={failed() ? undefined : "true"} title={errorMessage()}>
+            {errorMessage()}
+          </strong>
+        </div>
+        <div class="account-update-island__action-shell" data-downloading={busy() ? "true" : "false"}>
+          <Button
+            type="button"
+            size="xs"
+            class="account-update-island__action"
+            aria-label={accessibleActionLabel()}
+            aria-busy={busy() ? "true" : undefined}
+            disabled={!open() || busy()}
+            onClick={() => void runUpdateAction()}
+          >
+            <span class="account-update-island__action-content">
+              <span class="account-update-island__icon t-icon-swap" data-state={busy() ? "b" : "a"}>
+                <span class="t-icon" data-icon="a" aria-hidden="true">
+                  <Show when={failed() || ready()} fallback={<Download />}>
+                    <RefreshCw />
+                  </Show>
+                </span>
+                <span class="t-icon" data-icon="b" aria-hidden="true">
+                  <Spinner size="sm" />
+                </span>
               </span>
-              <span class="t-icon" data-icon="b" aria-hidden="true">
-                <Spinner size="sm" />
+              <span
+                class="account-update-island__action-label t-update-text-swap"
+                data-state={busy() ? "progress" : "action"}
+                aria-hidden="true"
+              >
+                <span data-text="action">{actionLabel()}</span>
+                <span data-text="progress">
+                  <Show
+                    when={downloading() && progress() !== null}
+                    fallback={<span class="account-update-island__busy-label">{busyLabel()}</span>}
+                  >
+                    <UpdateProgressValue active={busy()} value={progress() ?? 0} />
+                  </Show>
+                </span>
               </span>
             </span>
+          </Button>
+          <Show when={downloading() && progress() !== null}>
             <span
-              class="account-update-island__action-label t-update-text-swap"
-              data-state={busy() ? "progress" : "action"}
-              aria-hidden="true"
-            >
-              <span data-text="action">{actionLabel()}</span>
-              <span data-text="progress">
-                <Show
-                  when={downloading() && progress() !== null}
-                  fallback={<span class="account-update-island__busy-label">{busyLabel()}</span>}
-                >
-                  <UpdateProgressValue active={busy()} value={progress() ?? 0} />
-                </Show>
-              </span>
-            </span>
-          </span>
-        </Button>
-        <Show when={downloading() && progress() !== null}>
-          <span
-            class="sr-only"
-            role="progressbar"
-            aria-valuenow={progress() ?? 0}
-            aria-valuemin="0"
-            aria-valuemax="100"
-            aria-label="Update download progress"
-          />
-        </Show>
+              class="sr-only"
+              role="progressbar"
+              aria-valuenow={progress() ?? 0}
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-label="Update download progress"
+            />
+          </Show>
+        </div>
       </div>
-    </div>
+    </Show>
   );
 }

--- a/src/renderer/src/components/OpenBotDynamicIsland.tsx
+++ b/src/renderer/src/components/OpenBotDynamicIsland.tsx
@@ -1334,7 +1334,16 @@ function IslandAvatar(props: { bot: DynamicIslandBotIdentity; working?: boolean 
   return (
     <AgentAvatar
       bot={props.bot}
-      motion={props.working ? "working" : "idle"}
+      // `"idle"` here meant a morph that never stops. bloub's `autoPause` cannot
+      // help an overlay pinned over the notch - Chromium always calls it visible -
+      // and every drawn frame rewrites 64 bezier segments per path, which costs a
+      // style recalculation and a layout, not just a paint. Measured on one of the
+      // two notch windows: 4.1% of a core and 115 layouts per five seconds with the
+      // avatar, 0.5% and one layout without, all day, whatever application the user
+      // is actually in. `"hover"` holds the resting pose and brings the bot back the
+      // moment a pointer reaches the island, so the motion is there when someone is
+      // looking at it. Work still animates on its own.
+      motion={props.working ? "working" : "hover"}
       shape="cercle"
       class="dynamic-island-surface-avatar"
     />

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -276,7 +276,11 @@ function SidebarAgentIndicator(props: { state: SidebarAgentState }) {
 function SidebarPinnedAvatar(props: { item: ResolvedPinnedItem; agentState: () => SidebarAgentState | undefined }) {
   return (
     <span class="bot-row-avatar sidebar-pinned-avatar">
-      <AgentAvatar bot={props.item.bot} motion={props.agentState()?.kind === "working" ? "working" : "idle"} />
+      {/* A resting agent holds its pose. `"idle"` morphed for as long as the sidebar was on
+          screen, which is all day, and bought nothing: the shape is 24 px and nobody is
+          looking at it while they work in the pane next to it. `"hover"` brings it back the
+          moment a pointer arrives, and real work still animates on its own. */}
+      <AgentAvatar bot={props.item.bot} motion={props.agentState()?.kind === "working" ? "working" : "hover"} />
       <Show when={props.agentState()}>{(state) => <SidebarAgentIndicator state={state()} />}</Show>
     </span>
   );
@@ -1786,7 +1790,7 @@ export function Sidebar(props: SidebarProps) {
             }}
           >
             <span class="bot-row-avatar">
-              <AgentAvatar bot={bot} motion={working() ? "working" : "idle"} />
+              <AgentAvatar bot={bot} motion={working() ? "working" : "hover"} />
               <Show when={props.agentStates[bot.id]}>{(state) => <SidebarAgentIndicator state={state()} />}</Show>
             </span>
             <span class="bot-row-copy">
@@ -1942,7 +1946,7 @@ export function Sidebar(props: SidebarProps) {
                       onClick={action().onSelect}
                     >
                       <span class="bot-row-avatar">
-                        <AgentAvatar seed={action().avatarSeed} hue={action().avatarHue} motion="idle" />
+                        <AgentAvatar seed={action().avatarSeed} hue={action().avatarHue} motion="hover" />
                       </span>
                       <span class="bot-row-copy">
                         <span class="bot-row-heading">
@@ -2119,7 +2123,7 @@ export function Sidebar(props: SidebarProps) {
                                       }}
                                     >
                                       <span class="bot-row-avatar">
-                                        <TeamPersonAvatar member={member} />
+                                        <TeamPersonAvatar member={member} motion="hover" />
                                         <Show when={(thread()?.unreadCount ?? 0) > 0}>
                                           <Badge
                                             class="person-unread-badge"

--- a/src/renderer/src/components/TeamPersonAvatar.tsx
+++ b/src/renderer/src/components/TeamPersonAvatar.tsx
@@ -1,12 +1,22 @@
 import type { TeamPresenceMember } from "@openbot/contracts/ipc";
+import type { AvatarMotion } from "../bloub-avatar";
 import { AgentAvatar } from "./AgentAvatar";
 
-export function TeamPersonAvatar(props: { member: TeamPresenceMember; large?: boolean }) {
+// A person is never "working", so the caller only picks between resting and moving. The
+// sidebar passes `"hover"` because its list is on screen all day; the conversation header
+// keeps `"idle"`, where the avatar is the subject rather than one row of many and nothing
+// focusable surrounds it to bring the motion back.
+export function TeamPersonAvatar(props: { member: TeamPresenceMember; large?: boolean; motion?: AvatarMotion }) {
   const avatarSeed = () => props.member.email ?? props.member.username ?? props.member.id;
 
   return (
     <span class={["person-avatar", { large: Boolean(props.large), online: props.member.online }]} aria-hidden="true">
-      <AgentAvatar seed={avatarSeed()} url={props.member.avatarUrl} motion="idle" class="person-avatar-generated" />
+      <AgentAvatar
+        seed={avatarSeed()}
+        url={props.member.avatarUrl}
+        motion={props.motion ?? "idle"}
+        class="person-avatar-generated"
+      />
       <i />
     </span>
   );

--- a/src/renderer/src/components/ui/dynamic-island.tsx
+++ b/src/renderer/src/components/ui/dynamic-island.tsx
@@ -62,6 +62,13 @@ const HOVER_SPRING = {
 } as const;
 const CONTENT_SPRING = { response: 0.34, dampingFraction: 0.88 } as const;
 const CONTENT_EXIT_DURATION = 280;
+// The shell holds still for `CONTENT_EXIT_LEAD`, then contracts on `CLOSE_SPRING` and takes the
+// panel's lower half with it: the panel is pinned under the notch and `overflow: clip` on the shell
+// cuts whatever no longer fits. The old exit faded over the full 280ms at a near-unity scale, so
+// roughly 50px of still-visible content was guillotined mid-fade — the bottom vanished at once
+// while the top morphed. Finishing the fade before the shell's edge arrives, and keeping the
+// content shrinking toward the notch after it, makes the panel withdraw instead of being sliced.
+const CONTENT_EXIT_FADE_OFFSET = 0.45;
 const CONTENT_BLUR = 4;
 const CONTENT_ENTER_DELAY = 90;
 const CONTENT_BLUR_OPEN_DURATION = 460;
@@ -962,8 +969,9 @@ function createSpringContentTransition(options: SpringContentTransitionOptions):
               })
             : animate(
                 [
-                  { opacity: startOpacity, transform: `translateY(0px) scale(${startScale})` },
-                  { opacity: 0, transform: "translateY(-4px) scale(0.985)" },
+                  { opacity: startOpacity, transform: `translateY(0px) scale(${startScale})`, offset: 0 },
+                  { opacity: 0, transform: "translateY(-6px) scale(0.94)", offset: CONTENT_EXIT_FADE_OFFSET },
+                  { opacity: 0, transform: "translateY(-12px) scale(0.86)", offset: 1 },
                 ],
                 {
                   duration: CONTENT_EXIT_DURATION,

--- a/src/renderer/src/styles/account-update-island.css
+++ b/src/renderer/src/styles/account-update-island.css
@@ -61,6 +61,17 @@
     filter var(--panel-open-dur) var(--panel-ease);
 }
 
+/* The island only enters the DOM once there is an update to announce, so it is
+   already `data-open="true"` on its first frame and the closed rule above never
+   applies. This gives that first frame something to slide in from. */
+@starting-style {
+  .account-update-island.t-panel-slide[data-open="true"] {
+    transform: translateY(var(--panel-translate-y));
+    opacity: 0;
+    filter: blur(var(--panel-blur));
+  }
+}
+
 .account-update-island__copy {
   min-width: 0;
 }

--- a/src/renderer/src/styles/conversation.css
+++ b/src/renderer/src/styles/conversation.css
@@ -4132,6 +4132,14 @@ button.chat-action-target:active,
   font-weight: 550;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+}
+
+/* The shimmer says "still working", so it stops once the image has arrived or
+   failed. Left unscoped it also ran on "Image generation failed" and on plain
+   attached images, and it animates `background-position` under
+   `background-clip: text` - a main-thread text repaint per frame that no
+   compositor can take - once per image message, for the life of the thread. */
+.image-generation:not(.image-generation-ready, .image-generation-failed) .image-generation-label {
   animation: image-generation-shine 2.25s cubic-bezier(0.25, 0.1, 0.25, 1) infinite;
 }
 
@@ -5964,6 +5972,8 @@ button.chat-action-target:active,
   .image-generation-canvas,
   .image-generation-preview,
   .image-generation-label,
+  /* Matches the scoped shimmer above, which outranks the bare class on its own. */
+  .image-generation:not(.image-generation-ready, .image-generation-failed) .image-generation-label,
   .agent-activity-label,
   .thinking-label,
   .thinking-step {


### PR DESCRIPTION
Performance audit of the renderer, plus two Dynamic Island collapse bugs it turned up. Every claim below is a measurement, not an estimate.

**Surfaces touched:** desktop renderer, Electron main. No IPC contract, schema, migration or palette change.

## What changed

### 1. Stop rendering the update island and shimmer nobody sees (`06bb2fad`)
`AccountUpdateIsland` kept a spinner and a shimmer gradient animating while collapsed and while the window was hidden. Both are now gated on being visible.

### 2. Hold the notch avatar still until someone looks at it (`e24f33b4`) and let resting agents hold their pose (`523471f8`)
The bloub avatar drew at 30fps for as long as it was on screen — all day in the sidebar. Motion is now `"hover"` for list rows and `"working"` for agents that are actually working, so a resting sidebar animates nothing. This was your call from the earlier thread: *"awatary powinny się animować albo na hover, albo kiedy pracują."*

Measured on the running dev window: hiding avatars took layouts per profiling window from **301 → 1**. The JS profile of the main window is 86.5% idle with no app hotspot, which is why nothing else in the renderer changed — three other hypotheses (bloub segment count, its SVG `<mask>`, DOM churn from `<For>`) were benchmarked and all are dead ends below ~120 simultaneous avatars.

### 3. A collapsing panel was sliced instead of withdrawing (`6247fcbe`)
The shell holds still for 90ms after a collapse starts, then contracts on `CLOSE_SPRING` while the panel stays pinned under the notch at full size. The exit faded the content over the whole 280ms at a near-unity scale, so the shell's shrinking edge reached it while it was still visible and `overflow: clip` cut the rest away.

Measured in Storybook on the external-display island (196px → 32px), overflow past the shell **while the content is still visible**:

| | before | after |
| --- | --- | --- |
| visible overflow | 53px at opacity 0.35, 112px at 0.02 | none — content is inside the shell for every frame it can be seen in (−14px headroom) |
| fade complete | ~290ms | 125ms (shell starts moving at ~135ms) |

Expansion is untouched.

### 4. The notch window jumped ahead of the collapse (`cf0aa041`)
This is the one you caught in the live app that Storybook could not show, because Storybook has no window. Leaving the island drops the window from 380px to the 50px compact height on the same tick the renderer *starts* collapsing. The window is the only thing clipping the island, so the still-162px shell was guillotined instantly — the lower half vanished at once while the black cap at the top kept springing shut.

Measured on the live notch surface, hover → unhover:

```
before:  t=11   shell 162   viewport 380
         t=92   shell 162   viewport 50    <- window drops at once, 112px of island cut
         t=176  shell 162   viewport 50

after:   t=176  shell 162   viewport 380
         t=676  shell 32    viewport 380   <- shell has landed
         t=760  shell 32    viewport 50    <- only now does the window shrink
```

The tall bounds are held for 700ms (past the 90ms exit lead plus the 450ms close spring) and cancelled if interaction resumes. `setFocusable` and `setIgnoreMouseEvents` still flip immediately, so nothing extra is clickable while the island animates away.

## Tests

`dynamic-island-window.test.ts` already asserted the immediate `setBounds`; it now asserts "not immediately, but eventually". I watched it fail for the reason I meant — restoring the synchronous `setBounds` gives `expected "vi.fn()" to not be called with [...]`. `AccountUpdateIsland.test.tsx` covers the visibility gating.

Run locally: `dynamic-island-window.test.ts` (17), `dynamic-island.test.tsx` + `OpenBotDynamicIsland.test.tsx` (10), `AccountUpdateIsland.test.tsx`, plus `biome check` and all `typecheck:*`. The rest is CI's.

## Harness

Claude Opus 5 in Claude Code. Measurements taken over CDP against the running dev instance (`playwright-core` + `Profiler`/`Performance` domains) and against Storybook in Chrome; no synthetic benchmarks are cited above — the earlier ones measured the wrong thing and were discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
