### PR TITLE
refactor(backend): split OpenBotDatabase into nine controllers

### DIFF
--- a/.github/review/contracts-and-migrations.md
+++ b/.github/review/contracts-and-migrations.md
@@ -2,6 +2,7 @@
 include:
   - "src/backend/openbot-database-schema.ts"
   - "src/backend/openbot-database.ts"
+  - "src/backend/database/**"
   - "apps/auth-api/migrations/**"
   - "packages/contracts/**"
 ---
@@ -10,8 +11,9 @@ include:
 
 These files carry data the repository cannot re-derive: the user's SQLite database
 (`src/backend/openbot-database-schema.ts` holds every released schema and migration,
-`openbot-database.ts` is the boundary), the account service's D1 database, and every wire protocol
-already in the field. Findings here are P0 or P1 by default.
+`openbot-database.ts` and the controllers under `src/backend/database/` are the boundary), the
+account service's D1 database, and every wire protocol already in the field. Findings here are P0 or
+P1 by default.
 
 Report a finding when the diff:
 

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -74,8 +74,13 @@ doc comment saying what the class **owns** and that it never imports the facade.
 
 Two rules those controllers depend on and a reader cannot infer. They hold the core object and read
 `.connection` at each use — a cached handle survives `initialize()` and then silently addresses a
-closed database after `close()`. And none of them opens a transaction: `dispatch` opens one only if
-it finds none open, which is what lets a projector nest another dispatch inside the caller's.
+closed database after `close()`. And a projection controller does not open a transaction of its own.
+Four places do, and each is load-bearing: `dispatch` and `deleteEventsAndReceipt` open one only if
+they find none open, which is what lets a projector nest another dispatch inside the caller's, and
+`ThreadReplay.rebuildThreadProjection` and the facade's `persistConversationAndMailbox` open one
+unconditionally, which is what makes the dispatch inside each of them skip its own. Adding a fourth
+gets a nested `BEGIN` that SQLite rejects; removing one of these four silently drops the atomicity
+the replay and the mailbox write depend on.
 
 Do not add a new concern to the biggest file you can see; extract one when a change gives you the
 excuse.

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -78,9 +78,10 @@ closed database after `close()`. And a projection controller does not open a tra
 Four places do, and each is load-bearing: `dispatch` and `deleteEventsAndReceipt` open one only if
 they find none open, which is what lets a projector nest another dispatch inside the caller's, and
 `ThreadReplay.rebuildThreadProjection` and the facade's `persistConversationAndMailbox` open one
-unconditionally, which is what makes the dispatch inside each of them skip its own. Adding a fourth
-gets a nested `BEGIN` that SQLite rejects; removing one of these four silently drops the atomicity
-the replay and the mailbox write depend on.
+unconditionally, which is what makes the dispatch inside each of them skip its own. Open an
+unconditional one anywhere else and a caller already in a transaction gets a nested `BEGIN` that
+SQLite rejects; remove one of these four and the replay or the mailbox write silently stops being
+atomic.
 
 Do not add a new concern to the biggest file you can see; extract one when a change gives you the
 excuse.

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -1,8 +1,8 @@
 # `src/backend`
 
-The stores, the SQLite database, the provider clients and `agent-service.ts`. The user's SQLite is
-the source of truth here, not a cache of something remote — which is what makes the first section
-below non-negotiable.
+The stores, the SQLite database (`openbot-database.ts` and the controllers under `database/`), the
+provider clients and `agent-service.ts`. The user's SQLite is the source of truth here, not a cache
+of something remote — which is what makes the first section below non-negotiable.
 
 ## Database migrations
 
@@ -63,5 +63,19 @@ wrong.
 
 ## Size
 
-`agent-service.ts` is the largest hand-written file in the repository by a wide margin. Do not add a
-new concern to it; extract one when a change gives you the excuse.
+`mailbox-store.ts` is the largest file in this directory, at about 1,700 lines.
+
+The two that used to be larger are both worth copying. `agent-service.ts` was split into eight
+controllers; `openbot-database.ts` was split into nine under `database/`, leaving a ~300-line facade
+that had to keep its class name, instance identity, constructor signature and public surface because
+callers reach past it into `connection` and `dispatch`. The shape in both: one class per file,
+kebab-case, `<Name>Options` + `<Name>`, `readonly #` fields, a constructor that only assigns, and a
+doc comment saying what the class **owns** and that it never imports the facade. No barrel file.
+
+Two rules those controllers depend on and a reader cannot infer. They hold the core object and read
+`.connection` at each use — a cached handle survives `initialize()` and then silently addresses a
+closed database after `close()`. And none of them opens a transaction: `dispatch` opens one only if
+it finds none open, which is what lets a projector nest another dispatch inside the caller's.
+
+Do not add a new concern to the biggest file you can see; extract one when a change gives you the
+excuse.

--- a/src/backend/database/agent-roster.ts
+++ b/src/backend/database/agent-roster.ts
@@ -1,0 +1,177 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { BotSummary } from "@openbot/contracts/ipc";
+import type { DatabaseCore } from "./database-core";
+import { databaseRows, requiredStringColumn } from "./database-rows";
+
+export interface AgentRosterOptions {
+  core: DatabaseCore;
+}
+
+/**
+ * The set of agents that exist and the thread row each one owns.
+ *
+ * Owns `projection_agents` and the `projection_threads` row implied by an agent having a thread,
+ * which is why `ensureThreadProjection` is public here and not on the facade: the conversation
+ * writer calls it from inside its own dispatch, passing the `db` that dispatch handed it.
+ *
+ * `hardDeleteAgent` is the one method here that erases history rather than projecting it. Each
+ * receipt DELETE selects its command ids out of `orchestration_events`, so receipts must go before
+ * the matching events in all four blocks — grouping the receipt deletes together would leave orphan
+ * receipts, and `dispatch` replays an orphan receipt's stale result to a future command as though
+ * it had already run. The class never imports the facade.
+ */
+export class AgentRoster {
+  readonly #core: DatabaseCore;
+
+  constructor(options: AgentRosterOptions) {
+    this.#core = options.core;
+  }
+
+  listAgents(): BotSummary[] {
+    return databaseRows(
+      this.#core.connection.prepare("SELECT agent_json FROM projection_agents ORDER BY sort_order, agent_id").all(),
+    ).map((row) => JSON.parse(requiredStringColumn(row, "agent_json")));
+  }
+
+  replaceAgents(commandId: string, agents: BotSummary[], eventType: string): void {
+    this.#core.dispatch(
+      commandId,
+      [
+        {
+          aggregateType: "agents",
+          aggregateId: "agents",
+          eventType,
+          payload: { agents },
+        },
+      ],
+      (db, sequences) => {
+        db.exec("DELETE FROM projection_agents");
+        const insert = db.prepare(`
+          INSERT INTO projection_agents
+            (agent_id, thread_id, model, updated_at, sort_order, agent_json, last_event_sequence)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `);
+        agents.forEach((agent, index) => {
+          insert.run(
+            agent.id,
+            agent.threadId,
+            agent.model,
+            agent.updatedAt,
+            index,
+            JSON.stringify(agent),
+            sequences[0],
+          );
+          if (agent.threadId) this.ensureThreadProjection(db, agent, sequences[0] ?? 0);
+        });
+        return null;
+      },
+    );
+  }
+
+  hardDeleteAgent(commandId: string, botId: string, threadId: string | null, remainingAgents: BotSummary[]): void {
+    this.#core.dispatch(
+      commandId,
+      [
+        {
+          aggregateType: "agents",
+          aggregateId: "agents",
+          eventType: "agents.rebased-after-delete",
+          payload: { agents: remainingAgents },
+        },
+      ],
+      (db, sequences) => {
+        const sequence = sequences[0] ?? 0;
+        const memoryIds = databaseRows(
+          db.prepare("SELECT memory_id FROM projection_agent_memories WHERE agent_id = ?").all(botId),
+        ).map((row) => requiredStringColumn(row, "memory_id"));
+        const routineIds = databaseRows(
+          db.prepare("SELECT routine_id FROM projection_agent_routines WHERE agent_id = ?").all(botId),
+        ).map((row) => requiredStringColumn(row, "routine_id"));
+        if (memoryIds.length > 0) {
+          const placeholders = memoryIds.map(() => "?").join(", ");
+          db.prepare(
+            `DELETE FROM orchestration_command_receipts WHERE command_id IN (
+               SELECT DISTINCT command_id
+               FROM orchestration_events
+               WHERE aggregate_type = 'agent-memory' AND aggregate_id IN (${placeholders})
+             )`,
+          ).run(...memoryIds);
+          db.prepare(
+            `DELETE FROM orchestration_events
+             WHERE aggregate_type = 'agent-memory' AND aggregate_id IN (${placeholders})`,
+          ).run(...memoryIds);
+        }
+        if (routineIds.length > 0) {
+          const placeholders = routineIds.map(() => "?").join(", ");
+          db.prepare(
+            `DELETE FROM orchestration_command_receipts WHERE command_id IN (
+               SELECT DISTINCT command_id FROM orchestration_events
+               WHERE aggregate_type IN ('agent-routine', 'routine-run') AND aggregate_id IN (${placeholders})
+             )`,
+          ).run(...routineIds);
+          db.prepare(
+            `DELETE FROM orchestration_events
+             WHERE aggregate_type IN ('agent-routine', 'routine-run') AND aggregate_id IN (${placeholders})`,
+          ).run(...routineIds);
+        }
+        db.prepare(
+          `DELETE FROM orchestration_command_receipts WHERE command_id IN (
+             SELECT DISTINCT command_id FROM orchestration_events
+             WHERE aggregate_type = 'hosted-site-terminal'
+               AND event_type = 'hosted-site.terminal-pending'
+               AND json_extract(payload_json, '$.botId') = ?
+           )`,
+        ).run(botId);
+        db.prepare(
+          `DELETE FROM orchestration_events
+           WHERE aggregate_type = 'hosted-site-terminal'
+             AND event_type = 'hosted-site.terminal-pending'
+             AND json_extract(payload_json, '$.botId') = ?`,
+        ).run(botId);
+        const sensitiveFilter = threadId
+          ? `(aggregate_id = ? OR aggregate_id = ? OR
+              (aggregate_type = 'agents' AND aggregate_id = 'agents' AND sequence < ?))`
+          : `(aggregate_id = ? OR
+              (aggregate_type = 'agents' AND aggregate_id = 'agents' AND sequence < ?))`;
+        const sensitiveParameters = threadId ? ([botId, threadId, sequence] as const) : ([botId, sequence] as const);
+        db.prepare(
+          `DELETE FROM orchestration_command_receipts WHERE command_id IN (
+             SELECT DISTINCT command_id FROM orchestration_events WHERE ${sensitiveFilter}
+           )`,
+        ).run(...sensitiveParameters);
+        db.prepare(`DELETE FROM orchestration_events WHERE ${sensitiveFilter}`).run(...sensitiveParameters);
+        db.prepare("DELETE FROM projection_agents WHERE agent_id = ?").run(botId);
+        db.prepare("DELETE FROM projection_agent_memories WHERE agent_id = ?").run(botId);
+        db.prepare("DELETE FROM projection_agent_routines WHERE agent_id = ?").run(botId);
+        db.prepare("DELETE FROM projection_reactions WHERE agent_id = ?").run(botId);
+        db.prepare("DELETE FROM projection_deliveries WHERE recipient_agent_id = ?").run(botId);
+        db.prepare("DELETE FROM projection_queue_state WHERE agent_id = ?").run(botId);
+        if (threadId) {
+          db.prepare("DELETE FROM projection_threads WHERE thread_id = ?").run(threadId);
+        }
+        return null;
+      },
+    );
+  }
+
+  ensureThreadProjection(db: DatabaseSync, agent: BotSummary, sequence: number): void {
+    if (!agent.threadId) return;
+    db.prepare(`
+      INSERT INTO projection_threads
+        (thread_id, agent_id, title, active_turn_id, created_at, updated_at, last_event_sequence)
+      VALUES (?, ?, ?, NULL, ?, ?, ?)
+      ON CONFLICT(thread_id) DO UPDATE SET
+        agent_id = excluded.agent_id,
+        title = excluded.title,
+        updated_at = excluded.updated_at,
+        last_event_sequence = MAX(projection_threads.last_event_sequence, excluded.last_event_sequence)
+    `).run(
+      agent.threadId,
+      agent.id,
+      agent.name,
+      agent.updatedAt ?? new Date().toISOString(),
+      agent.updatedAt ?? new Date().toISOString(),
+      sequence,
+    );
+  }
+}

--- a/src/backend/database/conversation-queries.ts
+++ b/src/backend/database/conversation-queries.ts
@@ -1,0 +1,532 @@
+import type {
+  ConversationMessage,
+  ConversationPage,
+  ConversationPageAnchor,
+  ConversationSearchPage,
+  ConversationSnapshot,
+} from "@openbot/contracts/ipc";
+import {
+  HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX,
+  ROUTINE_EVENT_ITEM_TYPE_PREFIX,
+  ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX,
+} from "@openbot/contracts/ipc";
+import { type DynamicRecord, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import type { DatabaseCore } from "./database-core";
+import {
+  databaseRow,
+  databaseRows,
+  decodeConversationMessageJson,
+  decodeConversationThreadRow,
+  optionalStringColumn,
+  requiredNumberColumn,
+  requiredStringColumn,
+} from "./database-rows";
+
+export interface ConversationQueriesOptions {
+  core: DatabaseCore;
+}
+
+/**
+ * Every read of a thread's messages: the whole snapshot, one anchored page, a page's supported
+ * cursor, and a text search across the thread.
+ *
+ * Owns the read side of `projection_thread_messages` and the opaque base64url cursors that page it,
+ * including the marker filters that hide routine and hosted-site events from a page whose caller
+ * did not ask for them. Reads only — nothing here dispatches an event or opens a transaction. The
+ * class never imports the facade.
+ */
+export class ConversationQueries {
+  readonly #core: DatabaseCore;
+
+  constructor(options: ConversationQueriesOptions) {
+    this.#core = options.core;
+  }
+
+  readConversation(botId: string, threadId: string | null): ConversationSnapshot {
+    if (!threadId) return { botId, threadId: null, activeTurnId: null, revision: 0, messages: [] };
+    const thread = decodeConversationThreadRow(
+      this.#core.connection
+        .prepare(
+          `SELECT active_turn_id, last_event_sequence
+           FROM projection_threads WHERE thread_id = ? AND agent_id = ?`,
+        )
+        .get(threadId, botId),
+    );
+    const rows = databaseRows(
+      this.#core.connection
+        .prepare(
+          `SELECT message_json FROM projection_thread_messages
+           WHERE thread_id = ? ORDER BY created_at, ordinal, message_id`,
+        )
+        .all(threadId),
+    );
+    return {
+      botId,
+      threadId,
+      activeTurnId: thread?.active_turn_id ?? null,
+      revision: thread?.last_event_sequence ?? 0,
+      messages: rows.map((row) => JSON.parse(requiredStringColumn(row, "message_json"))),
+    };
+  }
+
+  readConversationRuntime(
+    botId: string,
+    threadId: string | null,
+  ): { activeTurnId: string | null; latestMessage: ConversationMessage | null } {
+    if (!threadId) return { activeTurnId: null, latestMessage: null };
+    const row = databaseRow(
+      this.#core.connection
+        .prepare(
+          `SELECT thread.active_turn_id,
+                  (SELECT message.message_json
+                   FROM projection_thread_messages message
+                   WHERE message.thread_id = thread.thread_id
+                     AND json_extract(message.message_json, '$.author') IN ('assistant', 'agent')
+                     AND COALESCE(json_extract(message.message_json, '$.itemType'), '') != 'commentary'
+                     AND COALESCE(json_extract(message.message_json, '$.itemType'), '') != 'question_prompt'
+                     AND COALESCE(json_extract(message.message_json, '$.itemType'), '') != 'agent_attachment'
+                   ORDER BY message.created_at DESC, message.ordinal DESC, message.message_id DESC
+                   LIMIT 1) AS latest_message_json
+           FROM projection_threads thread
+           WHERE thread.thread_id = ? AND thread.agent_id = ?`,
+        )
+        .get(threadId, botId),
+    );
+    if (!row) return { activeTurnId: null, latestMessage: null };
+    const latestMessage = optionalStringColumn(row, "latest_message_json");
+    return {
+      activeTurnId: optionalStringColumn(row, "active_turn_id"),
+      latestMessage: latestMessage ? decodeConversationMessageJson(latestMessage) : null,
+    };
+  }
+
+  readConversationPage(
+    botId: string,
+    threadId: string | null,
+    anchor: ConversationPageAnchor = { type: "latest" },
+    requestedLimit = 50,
+    options: {
+      excludeRoutineEvents?: boolean;
+      excludeRoutineRunEvents?: boolean;
+      excludeHostedSiteEvents?: boolean;
+    } = {},
+  ): ConversationPage {
+    if (!threadId) {
+      return {
+        botId,
+        threadId: null,
+        activeTurnId: null,
+        revision: 0,
+        messages: [],
+        references: {},
+        pageInfo: { hasOlder: false, olderCursor: null },
+      };
+    }
+    const limit = pageLimit(requestedLimit);
+    const thread = decodeConversationThreadRow(
+      this.#core.connection
+        .prepare(
+          `SELECT active_turn_id, last_event_sequence
+           FROM projection_threads WHERE thread_id = ? AND agent_id = ?`,
+        )
+        .get(threadId, botId),
+    );
+    const rows = this.#conversationPageRows(
+      threadId,
+      anchor,
+      limit,
+      options.excludeRoutineEvents === true,
+      options.excludeRoutineRunEvents === true,
+      options.excludeHostedSiteEvents === true,
+    );
+    const messages = rows.map((row) => decodeConversationMessageJson(requiredStringColumn(row, "message_json")));
+    const messageIds = new Set(messages.map((message) => message.id));
+    const referenceIdSet = new Set<string>();
+    for (const message of messages) {
+      const referenceId = message.replyToMessageId;
+      if (referenceId && !messageIds.has(referenceId)) referenceIdSet.add(referenceId);
+    }
+    const referenceIds = [...referenceIdSet];
+    const references: Record<string, ConversationMessage> = {};
+    if (referenceIds.length > 0) {
+      const placeholders = referenceIds.map(() => "?").join(", ");
+      const referenceRows = databaseRows(
+        this.#core.connection
+          .prepare(
+            `SELECT message_id, message_json FROM projection_thread_messages
+             WHERE thread_id = ? AND message_id IN (${placeholders})
+             ${conversationMarkerSqlFilter(
+               options.excludeRoutineEvents === true,
+               options.excludeRoutineRunEvents === true,
+               options.excludeHostedSiteEvents === true,
+             )}`,
+          )
+          .all(threadId, ...referenceIds),
+      );
+      for (const row of referenceRows) {
+        references[requiredStringColumn(row, "message_id")] = decodeConversationMessageJson(
+          requiredStringColumn(row, "message_json"),
+        );
+      }
+    }
+    const first = rows[0];
+    const hasOlder = first
+      ? this.#hasConversationRowsBefore(
+          threadId,
+          conversationRowCursor(first),
+          options.excludeRoutineEvents === true,
+          options.excludeRoutineRunEvents === true,
+          options.excludeHostedSiteEvents === true,
+        )
+      : false;
+    return {
+      botId,
+      threadId,
+      activeTurnId: thread?.active_turn_id ?? null,
+      revision: thread?.last_event_sequence ?? 0,
+      messages,
+      references,
+      pageInfo: {
+        hasOlder,
+        olderCursor: hasOlder && first ? encodePageCursor(conversationRowCursor(first)) : null,
+      },
+    };
+  }
+
+  supportedConversationCursor(
+    threadId: string,
+    throughMessageId: string | null,
+    options: {
+      excludeRoutineEvents?: boolean;
+      excludeRoutineRunEvents?: boolean;
+      excludeHostedSiteEvents?: boolean;
+    } = {},
+  ): string | null {
+    if (!throughMessageId) return null;
+    const boundary = databaseRow(
+      this.#core.connection
+        .prepare(
+          `SELECT created_at, ordinal, message_id FROM projection_thread_messages
+           WHERE thread_id = ? AND message_id = ?`,
+        )
+        .get(threadId, throughMessageId),
+    );
+    if (!boundary) return null;
+    const createdAt = requiredStringColumn(boundary, "created_at");
+    const ordinal = requiredNumberColumn(boundary, "ordinal");
+    const messageId = requiredStringColumn(boundary, "message_id");
+    const row = databaseRow(
+      this.#core.connection
+        .prepare(
+          `SELECT message_id FROM projection_thread_messages
+           WHERE thread_id = ?
+             AND (created_at, ordinal, message_id) <= (?, ?, ?)
+             ${conversationMarkerSqlFilter(
+               options.excludeRoutineEvents === true,
+               options.excludeRoutineRunEvents === true,
+               options.excludeHostedSiteEvents === true,
+             )}
+           ORDER BY created_at DESC, ordinal DESC, message_id DESC
+           LIMIT 1`,
+        )
+        .get(threadId, createdAt, ordinal, messageId),
+    );
+    return row ? requiredStringColumn(row, "message_id") : null;
+  }
+
+  searchConversationMessages(
+    query: string,
+    botId?: string,
+    cursor?: string,
+    requestedLimit = 100,
+  ): ConversationSearchPage {
+    const normalized = query.trim().replace(/\s+/g, " ").toLocaleLowerCase();
+    if (!normalized) return { results: [], total: 0, nextCursor: null };
+    const limit = pageLimit(requestedLimit);
+    const offset = cursor ? decodeSearchCursor(cursor) : 0;
+    const pattern = `%${escapeLike(normalized)}%`;
+    const filter = botId ? "AND thread.agent_id = ?" : "";
+    const parameters = botId ? [pattern, botId] : [pattern];
+    const countRow = databaseRow(
+      this.#core.connection
+        .prepare(
+          `SELECT COUNT(*) AS count
+           FROM projection_thread_messages message
+           JOIN projection_threads thread ON thread.thread_id = message.thread_id
+           WHERE LOWER(json_extract(message.message_json, '$.text')) LIKE ? ESCAPE '\\'
+             AND COALESCE(json_extract(message.message_json, '$.delivery.status'), '') NOT IN ('queued', 'cancelled')
+             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'
+             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX}%'
+             AND COALESCE(message.item_type, '') NOT LIKE '${HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX}%'
+             ${filter}`,
+        )
+        .get(...parameters),
+    );
+    const total = countRow ? requiredNumberColumn(countRow, "count") : 0;
+    const rows = databaseRows(
+      this.#core.connection
+        .prepare(
+          `SELECT thread.agent_id, message.message_json
+           FROM projection_thread_messages message
+           JOIN projection_threads thread ON thread.thread_id = message.thread_id
+           WHERE LOWER(json_extract(message.message_json, '$.text')) LIKE ? ESCAPE '\\'
+             AND COALESCE(json_extract(message.message_json, '$.delivery.status'), '') NOT IN ('queued', 'cancelled')
+             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'
+             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX}%'
+             AND COALESCE(message.item_type, '') NOT LIKE '${HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX}%'
+             ${filter}
+           ORDER BY message.created_at DESC, message.ordinal DESC, message.message_id DESC
+           LIMIT ? OFFSET ?`,
+        )
+        .all(...parameters, limit, offset),
+    );
+    const results = rows.map((row) => ({
+      botId: requiredStringColumn(row, "agent_id"),
+      message: decodeConversationMessageJson(requiredStringColumn(row, "message_json")),
+    }));
+    const nextOffset = offset + results.length;
+    return {
+      results,
+      total,
+      nextCursor: nextOffset < total ? encodeSearchCursor(nextOffset) : null,
+    };
+  }
+
+  #conversationPageRows(
+    threadId: string,
+    anchor: ConversationPageAnchor,
+    limit: number,
+    excludeRoutineEvents: boolean,
+    excludeRoutineRunEvents: boolean,
+    excludeHostedSiteEvents: boolean,
+  ): DynamicRecord[] {
+    const columns = "created_at, ordinal, message_id, message_json";
+    const routineFilter = conversationMarkerSqlFilter(
+      excludeRoutineEvents,
+      excludeRoutineRunEvents,
+      excludeHostedSiteEvents,
+    );
+    if (anchor.type === "latest") {
+      return databaseRows(
+        this.#core.connection
+          .prepare(
+            `SELECT ${columns} FROM projection_thread_messages
+             WHERE thread_id = ?
+             ${routineFilter}
+             ORDER BY created_at DESC, ordinal DESC, message_id DESC LIMIT ?`,
+          )
+          .all(threadId, limit),
+      ).reverse();
+    }
+    if (anchor.type === "before") {
+      const cursor = decodeConversationCursor(anchor.cursor);
+      return databaseRows(
+        this.#core.connection
+          .prepare(
+            `SELECT ${columns} FROM projection_thread_messages
+             WHERE thread_id = ? AND (
+               created_at < ? OR
+               (created_at = ? AND ordinal < ?) OR
+               (created_at = ? AND ordinal = ? AND message_id < ?)
+             )
+             ${routineFilter}
+             ORDER BY created_at DESC, ordinal DESC, message_id DESC LIMIT ?`,
+          )
+          .all(
+            threadId,
+            cursor.createdAt,
+            cursor.createdAt,
+            cursor.ordinal,
+            cursor.createdAt,
+            cursor.ordinal,
+            cursor.messageId,
+            limit,
+          ),
+      ).reverse();
+    }
+    const anchorRow = databaseRow(
+      this.#core.connection
+        .prepare(
+          `SELECT created_at, ordinal, message_id FROM projection_thread_messages
+           WHERE thread_id = ? AND message_id = ?
+           ${routineFilter}`,
+        )
+        .get(threadId, anchor.messageId),
+    );
+    if (!anchorRow) return [];
+    const cursor = conversationRowCursor(anchorRow);
+    const olderLimit = Math.floor(limit / 2);
+    const older = databaseRows(
+      this.#core.connection
+        .prepare(
+          `SELECT ${columns} FROM projection_thread_messages
+           WHERE thread_id = ? AND (
+             created_at < ? OR
+             (created_at = ? AND ordinal < ?) OR
+             (created_at = ? AND ordinal = ? AND message_id <= ?)
+           )
+           ${routineFilter}
+           ORDER BY created_at DESC, ordinal DESC, message_id DESC LIMIT ?`,
+        )
+        .all(
+          threadId,
+          cursor.createdAt,
+          cursor.createdAt,
+          cursor.ordinal,
+          cursor.createdAt,
+          cursor.ordinal,
+          cursor.messageId,
+          olderLimit + 1,
+        ),
+    ).reverse();
+    const newer = databaseRows(
+      this.#core.connection
+        .prepare(
+          `SELECT ${columns} FROM projection_thread_messages
+           WHERE thread_id = ? AND (
+             created_at > ? OR
+             (created_at = ? AND ordinal > ?) OR
+             (created_at = ? AND ordinal = ? AND message_id > ?)
+           )
+           ${routineFilter}
+           ORDER BY created_at, ordinal, message_id LIMIT ?`,
+        )
+        .all(
+          threadId,
+          cursor.createdAt,
+          cursor.createdAt,
+          cursor.ordinal,
+          cursor.createdAt,
+          cursor.ordinal,
+          cursor.messageId,
+          limit - older.length,
+        ),
+    );
+    return [...older, ...newer];
+  }
+
+  #hasConversationRowsBefore(
+    threadId: string,
+    cursor: ConversationPageCursor,
+    excludeRoutineEvents: boolean,
+    excludeRoutineRunEvents: boolean,
+    excludeHostedSiteEvents: boolean,
+  ): boolean {
+    const routineFilter = conversationMarkerSqlFilter(
+      excludeRoutineEvents,
+      excludeRoutineRunEvents,
+      excludeHostedSiteEvents,
+    );
+    return Boolean(
+      this.#core.connection
+        .prepare(
+          `SELECT 1 FROM projection_thread_messages
+           WHERE thread_id = ? AND (
+             created_at < ? OR
+             (created_at = ? AND ordinal < ?) OR
+             (created_at = ? AND ordinal = ? AND message_id < ?)
+           )
+           ${routineFilter}
+           LIMIT 1`,
+        )
+        .get(
+          threadId,
+          cursor.createdAt,
+          cursor.createdAt,
+          cursor.ordinal,
+          cursor.createdAt,
+          cursor.ordinal,
+          cursor.messageId,
+        ),
+    );
+  }
+}
+
+interface ConversationPageCursor {
+  version: 1;
+  createdAt: string;
+  ordinal: number;
+  messageId: string;
+}
+
+function pageLimit(value: number): number {
+  if (!Number.isInteger(value) || value < 1) throw new Error("The conversation page limit is invalid.");
+  return Math.min(value, 100);
+}
+
+function conversationRowCursor(row: DynamicRecord): ConversationPageCursor {
+  return {
+    version: 1,
+    createdAt: requiredStringColumn(row, "created_at"),
+    ordinal: requiredNumberColumn(row, "ordinal"),
+    messageId: requiredStringColumn(row, "message_id"),
+  };
+}
+
+function conversationMarkerSqlFilter(
+  excludeRoutineEvents: boolean,
+  excludeRoutineRunEvents: boolean,
+  excludeHostedSiteEvents: boolean,
+): string {
+  return [
+    excludeRoutineEvents ? `AND COALESCE(item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'` : "",
+    excludeRoutineRunEvents ? `AND COALESCE(item_type, '') NOT LIKE '${ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX}%'` : "",
+    excludeHostedSiteEvents ? `AND COALESCE(item_type, '') NOT LIKE '${HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX}%'` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function encodePageCursor(cursor: ConversationPageCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function decodeConversationCursor(value: string): ConversationPageCursor {
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (
+      !isDynamicRecord(parsed) ||
+      parsed.version !== 1 ||
+      !isString(parsed.createdAt) ||
+      !isNumber(parsed.ordinal) ||
+      !Number.isInteger(parsed.ordinal) ||
+      !isString(parsed.messageId)
+    ) {
+      throw new Error("invalid cursor");
+    }
+    return {
+      version: 1,
+      createdAt: parsed.createdAt,
+      ordinal: parsed.ordinal,
+      messageId: parsed.messageId,
+    };
+  } catch {
+    throw new Error("The conversation page cursor is invalid.");
+  }
+}
+
+function encodeSearchCursor(offset: number): string {
+  return Buffer.from(JSON.stringify({ version: 1, offset }), "utf8").toString("base64url");
+}
+
+function decodeSearchCursor(value: string): number {
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (
+      !isDynamicRecord(parsed) ||
+      parsed.version !== 1 ||
+      !isNumber(parsed.offset) ||
+      !Number.isSafeInteger(parsed.offset) ||
+      parsed.offset < 0
+    ) {
+      throw new Error("invalid cursor");
+    }
+    return parsed.offset;
+  } catch {
+    throw new Error("The conversation search cursor is invalid.");
+  }
+}
+
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (character) => `\\${character}`);
+}

--- a/src/backend/database/conversation-writer.ts
+++ b/src/backend/database/conversation-writer.ts
@@ -1,0 +1,311 @@
+import { randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import type { ConversationMessage, ConversationSnapshot } from "@openbot/contracts/ipc";
+import { isDynamicRecord, isString } from "@openbot/contracts/runtime-values";
+import type { AgentRoster } from "./agent-roster";
+import { type DatabaseCore, deleteOrphanReceipts } from "./database-core";
+import {
+  databaseRow,
+  databaseRows,
+  optionalStringColumn,
+  requiredNumberColumn,
+  requiredStringColumn,
+} from "./database-rows";
+
+export interface ConversationWriterOptions {
+  core: DatabaseCore;
+  roster: AgentRoster;
+}
+
+/**
+ * The write side of a thread's conversation: a whole snapshot, or one appended message.
+ *
+ * Owns `projection_thread_messages` and `projection_thread_activities`, and compacts the thread
+ * aggregate so the log keeps only the newest full snapshot. Both entry points run inside a single
+ * dispatch, so a caller already in a transaction has these writes pulled into it, and neither opens
+ * a transaction of its own. The agent lookup and the thread projection row come from the roster.
+ * The class never imports the facade.
+ */
+export class ConversationWriter {
+  readonly #core: DatabaseCore;
+  readonly #roster: AgentRoster;
+
+  constructor(options: ConversationWriterOptions) {
+    this.#core = options.core;
+    this.#roster = options.roster;
+  }
+
+  persistConversation(
+    snapshot: ConversationSnapshot,
+    eventType: string,
+    payload: unknown = {},
+    commandId = `conversation:${eventType}:${randomUUID()}`,
+  ): ConversationSnapshot {
+    if (!snapshot.threadId) return structuredClone(snapshot);
+    const threadId = snapshot.threadId;
+    const recovery = conversationRecoveryState(this.#core.connection, threadId, snapshot.activeTurnId);
+    const result = this.#core.dispatch(
+      commandId,
+      [
+        {
+          aggregateType: "thread",
+          aggregateId: threadId,
+          eventType,
+          payload: { detail: payload, snapshot, recovery },
+        },
+      ],
+      (db, sequences) => {
+        const sequence = sequences[0] ?? snapshot.revision;
+        const agent = this.#roster.listAgents().find((candidate) => candidate.id === snapshot.botId);
+        if (!agent) throw new Error(`Unknown agent for conversation: ${snapshot.botId}`);
+        this.#roster.ensureThreadProjection(db, agent, sequence);
+        db.prepare(
+          `UPDATE projection_threads
+           SET active_turn_id = ?, updated_at = ?, last_event_sequence = ? WHERE thread_id = ?`,
+        ).run(snapshot.activeTurnId, new Date().toISOString(), sequence, snapshot.threadId);
+        const messageIds = new Set(snapshot.messages.map((message) => message.id));
+        const staleMessageIds = databaseRows(
+          db.prepare("SELECT message_id FROM projection_thread_messages WHERE thread_id = ?").all(threadId),
+        )
+          .map((row) => requiredStringColumn(row, "message_id"))
+          .filter((messageId) => !messageIds.has(messageId));
+        const deleteMessage = db.prepare(
+          "DELETE FROM projection_thread_messages WHERE thread_id = ? AND message_id = ?",
+        );
+        const deleteAttachments = db.prepare(
+          "DELETE FROM projection_attachments WHERE owner_kind = 'thread-message' AND owner_id = ?",
+        );
+        for (const messageId of staleMessageIds) {
+          deleteAttachments.run(`${threadId}:${messageId}`);
+          deleteMessage.run(threadId, messageId);
+        }
+        const upsert = db.prepare(`
+          INSERT INTO projection_thread_messages (
+            thread_id, message_id, turn_id, author, status, item_type, created_at,
+            ordinal, message_json, last_event_sequence
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(thread_id, message_id) DO UPDATE SET
+            turn_id = excluded.turn_id,
+            author = excluded.author,
+            status = excluded.status,
+            item_type = excluded.item_type,
+            created_at = excluded.created_at,
+            ordinal = excluded.ordinal,
+            message_json = excluded.message_json,
+            last_event_sequence = excluded.last_event_sequence
+        `);
+        snapshot.messages.forEach((message, ordinal) => {
+          upsert.run(
+            snapshot.threadId,
+            message.id,
+            message.turnId ?? null,
+            message.author,
+            message.status,
+            message.itemType ?? null,
+            message.createdAt,
+            ordinal,
+            JSON.stringify(message),
+            sequence,
+          );
+          for (const attachment of message.attachments ?? []) {
+            db.prepare(`
+              INSERT OR REPLACE INTO projection_attachments
+                (attachment_id, owner_kind, owner_id, name, path, metadata_json, created_at, last_event_sequence)
+              VALUES (?, 'thread-message', ?, ?, '', ?, ?, ?)
+            `).run(
+              `${snapshot.threadId}:${message.id}:${attachment.id}`,
+              `${snapshot.threadId}:${message.id}`,
+              attachment.name,
+              JSON.stringify(attachment),
+              message.createdAt,
+              sequence,
+            );
+          }
+        });
+        db.prepare(`
+          INSERT INTO projection_thread_activities
+            (activity_id, thread_id, turn_id, activity_type, payload_json, created_at, last_event_sequence)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `).run(
+          randomUUID(),
+          snapshot.threadId,
+          snapshot.activeTurnId,
+          eventType,
+          JSON.stringify(payload),
+          new Date().toISOString(),
+          sequence,
+        );
+        if (snapshot.activeTurnId) {
+          db.prepare(`
+            INSERT INTO projection_turns
+              (turn_id, thread_id, provider_session_id, status, started_at, completed_at, last_event_sequence)
+            VALUES (?, ?, (
+              SELECT id FROM projection_provider_sessions
+              WHERE thread_id = ? AND state = 'active' ORDER BY created_at DESC LIMIT 1
+            ), 'running', ?, NULL, ?)
+            ON CONFLICT(turn_id) DO UPDATE SET status = 'running', last_event_sequence = excluded.last_event_sequence
+          `).run(snapshot.activeTurnId, snapshot.threadId, snapshot.threadId, new Date().toISOString(), sequence);
+        }
+        if (
+          ["turn.completed", "turn.reconciled-after-restart", "turn.interrupted-by-restart"].includes(eventType) &&
+          isDynamicRecord(payload) &&
+          "turnId" in payload &&
+          isString(payload.turnId)
+        ) {
+          const status =
+            "status" in payload && isString(payload.status)
+              ? payload.status
+              : eventType === "turn.interrupted-by-restart"
+                ? "interrupted"
+                : "completed";
+          db.prepare(
+            `UPDATE projection_turns
+             SET status = ?, completed_at = ?, last_event_sequence = ?
+             WHERE thread_id = ? AND turn_id = ?`,
+          ).run(status, new Date().toISOString(), sequence, snapshot.threadId, payload.turnId);
+        }
+        pruneConversationSnapshots(db, threadId, sequence);
+        return { revision: sequence };
+      },
+    );
+    return { ...structuredClone(snapshot), revision: result.revision };
+  }
+
+  appendConversationMessage(input: {
+    botId: string;
+    threadId: string;
+    activeTurnId: string | null;
+    message: ConversationMessage;
+    eventType: string;
+    detail?: unknown;
+    commandId?: string;
+  }): number {
+    const result = this.#core.dispatch(
+      input.commandId ?? `conversation:${input.eventType}:${randomUUID()}`,
+      [
+        {
+          aggregateType: "thread",
+          aggregateId: input.threadId,
+          eventType: input.eventType,
+          occurredAt: input.message.createdAt,
+          payload: {
+            detail: input.detail ?? {},
+            appendedMessage: input.message,
+            activeTurnId: input.activeTurnId,
+          },
+        },
+      ],
+      (db, sequences) => {
+        const sequence = sequences[0] ?? 0;
+        const agent = this.#roster.listAgents().find((candidate) => candidate.id === input.botId);
+        if (!agent || agent.threadId !== input.threadId) {
+          throw new Error(`Unknown agent thread for conversation append: ${input.botId}`);
+        }
+        this.#roster.ensureThreadProjection(db, agent, sequence);
+        const ordinalRow = databaseRow(
+          db
+            .prepare(
+              `SELECT COALESCE(MAX(ordinal), -1) + 1 AS ordinal
+               FROM projection_thread_messages WHERE thread_id = ?`,
+            )
+            .get(input.threadId),
+        );
+        const ordinal = ordinalRow ? requiredNumberColumn(ordinalRow, "ordinal") : 0;
+        db.prepare(
+          `INSERT INTO projection_thread_messages (
+             thread_id, message_id, turn_id, author, status, item_type, created_at,
+             ordinal, message_json, last_event_sequence
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          input.threadId,
+          input.message.id,
+          input.message.turnId ?? null,
+          input.message.author,
+          input.message.status,
+          input.message.itemType ?? null,
+          input.message.createdAt,
+          ordinal,
+          JSON.stringify(input.message),
+          sequence,
+        );
+        for (const attachment of input.message.attachments ?? []) {
+          db.prepare(
+            `INSERT INTO projection_attachments
+               (attachment_id, owner_kind, owner_id, name, path, metadata_json, created_at, last_event_sequence)
+             VALUES (?, 'thread-message', ?, ?, '', ?, ?, ?)`,
+          ).run(
+            `${input.threadId}:${input.message.id}:${attachment.id}`,
+            `${input.threadId}:${input.message.id}`,
+            attachment.name,
+            JSON.stringify(attachment),
+            input.message.createdAt,
+            sequence,
+          );
+        }
+        db.prepare(
+          `UPDATE projection_threads
+           SET active_turn_id = ?, updated_at = ?, last_event_sequence = ? WHERE thread_id = ?`,
+        ).run(input.activeTurnId, input.message.createdAt, sequence, input.threadId);
+        db.prepare(
+          `INSERT INTO projection_thread_activities
+             (activity_id, thread_id, turn_id, activity_type, payload_json, created_at, last_event_sequence)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          randomUUID(),
+          input.threadId,
+          input.message.turnId ?? input.activeTurnId,
+          input.eventType,
+          JSON.stringify(input.detail ?? {}),
+          input.message.createdAt,
+          sequence,
+        );
+        return { revision: sequence };
+      },
+    );
+    return result.revision;
+  }
+}
+
+function conversationRecoveryState(
+  db: DatabaseSync,
+  threadId: string,
+  activeTurnId: string | null,
+): { turnProviderSessionIds: Record<string, string | null> } {
+  const turnProviderSessionIds: Record<string, string | null> = {};
+  for (const row of databaseRows(
+    db.prepare("SELECT turn_id, provider_session_id FROM projection_turns WHERE thread_id = ?").all(threadId),
+  )) {
+    const turnId = requiredStringColumn(row, "turn_id");
+    turnProviderSessionIds[turnId] = optionalStringColumn(row, "provider_session_id");
+  }
+  if (activeTurnId && !(activeTurnId in turnProviderSessionIds)) {
+    const activeSession = databaseRow(
+      db
+        .prepare(
+          `SELECT id FROM projection_provider_sessions
+           WHERE thread_id = ? AND state = 'active'
+           ORDER BY created_at DESC, last_event_sequence DESC LIMIT 1`,
+        )
+        .get(threadId),
+    );
+    turnProviderSessionIds[activeTurnId] = activeSession ? requiredStringColumn(activeSession, "id") : null;
+  }
+  return { turnProviderSessionIds };
+}
+
+function pruneConversationSnapshots(db: DatabaseSync, threadId: string, retainedSequence: number): void {
+  db.prepare(
+    `DELETE FROM projection_thread_activities
+     WHERE thread_id = ? AND last_event_sequence IN (
+       SELECT sequence FROM orchestration_events
+       WHERE aggregate_type = 'thread' AND aggregate_id = ? AND sequence < ?
+         AND json_type(payload_json, '$.snapshot') = 'object'
+     )`,
+  ).run(threadId, threadId, retainedSequence);
+  db.prepare(
+    `DELETE FROM orchestration_events
+     WHERE aggregate_type = 'thread' AND aggregate_id = ? AND sequence < ?
+       AND json_type(payload_json, '$.snapshot') = 'object'`,
+  ).run(threadId, retainedSequence);
+  deleteOrphanReceipts(db);
+}

--- a/src/backend/database/database-core.ts
+++ b/src/backend/database/database-core.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from "node:crypto";
+import { chmod, copyFile, mkdir, readFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { migrateOpenBotDatabase } from "../openbot-database-schema";
+import { databaseRow, errorCode, requiredNumberColumn, requiredStringColumn } from "./database-rows";
+
+export interface OrchestrationEventInput {
+  aggregateType: string;
+  aggregateId: string;
+  eventType: string;
+  payload: unknown;
+  occurredAt?: string;
+}
+
+interface ReceiptRow {
+  last_sequence: number;
+  result_json: string;
+}
+
+export interface DatabaseCoreOptions {
+  userDataPath: string;
+}
+
+/**
+ * The SQLite handle and the append-events, project, write-receipt primitive every other database
+ * controller is built on.
+ *
+ * Owns the open connection, the file on disk and its migration, the orchestration event log and
+ * its command receipts, and the transaction ownership rule: only the caller that finds no open
+ * transaction opens and closes one, so a projector may nest another dispatch inside its own.
+ * Controllers hold this object and read `connection` at each use — a cached handle survives
+ * `initialize` and then silently addresses a closed database after `close`. The class knows
+ * nothing about projections and never imports the facade.
+ */
+export class DatabaseCore {
+  readonly path: string;
+  readonly #legacyBackupRoot: string;
+  #db: DatabaseSync | null = null;
+
+  constructor(options: DatabaseCoreOptions) {
+    this.path = join(options.userDataPath, "openbot.db");
+    this.#legacyBackupRoot = join(options.userDataPath, "legacy-backup-v1");
+  }
+
+  async initialize(): Promise<void> {
+    if (this.#db) return;
+    await mkdir(dirname(this.path), { recursive: true, mode: 0o700 });
+    const db = new DatabaseSync(this.path);
+    try {
+      db.exec("PRAGMA journal_mode = WAL");
+      db.exec("PRAGMA foreign_keys = ON");
+      db.exec("PRAGMA busy_timeout = 5000");
+      db.exec("PRAGMA synchronous = NORMAL");
+      this.#db = db;
+      this.#migrate();
+      await chmod(this.path, 0o600);
+    } catch (error) {
+      db.close();
+      this.#db = null;
+      throw error;
+    }
+  }
+
+  close(): void {
+    this.#db?.close();
+    this.#db = null;
+  }
+
+  get connection(): DatabaseSync {
+    if (!this.#db) throw new Error("OpenBot database is not initialized.");
+    return this.#db;
+  }
+
+  dispatch<T>(
+    commandId: string,
+    events: OrchestrationEventInput[],
+    project: (db: DatabaseSync, sequences: number[]) => T,
+  ): T {
+    const db = this.connection;
+    const receipt = decodeReceiptRow(
+      db
+        .prepare("SELECT last_sequence, result_json FROM orchestration_command_receipts WHERE command_id = ?")
+        .get(commandId),
+    );
+    if (receipt) return JSON.parse(receipt.result_json);
+
+    const ownsTransaction = !db.isTransaction;
+    if (ownsTransaction) db.exec("BEGIN IMMEDIATE");
+    try {
+      const sequences: number[] = [];
+      const append = db.prepare(`
+        INSERT INTO orchestration_events (
+          event_id, command_id, aggregate_type, aggregate_id, event_type, occurred_at, payload_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const event of events) {
+        const result = append.run(
+          randomUUID(),
+          commandId,
+          event.aggregateType,
+          event.aggregateId,
+          event.eventType,
+          event.occurredAt ?? new Date().toISOString(),
+          JSON.stringify(event.payload),
+        );
+        sequences.push(Number(result.lastInsertRowid));
+      }
+      const result = project(db, sequences);
+      db.prepare(
+        `INSERT INTO orchestration_command_receipts
+          (command_id, accepted_at, first_sequence, last_sequence, result_json)
+         VALUES (?, ?, ?, ?, ?)`,
+      ).run(
+        commandId,
+        new Date().toISOString(),
+        sequences[0] ?? 0,
+        sequences.at(-1) ?? 0,
+        JSON.stringify(result ?? null),
+      );
+      if (ownsTransaction) db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      if (ownsTransaction && db.isTransaction) db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  commandResult(commandId: string): unknown | undefined {
+    const receipt = decodeReceiptRow(
+      this.connection
+        .prepare("SELECT last_sequence, result_json FROM orchestration_command_receipts WHERE command_id = ?")
+        .get(commandId),
+    );
+    return receipt ? JSON.parse(receipt.result_json) : undefined;
+  }
+
+  deleteEventsAndReceipt(commandId: string): void {
+    const db = this.connection;
+    const ownsTransaction = !db.isTransaction;
+    if (ownsTransaction) db.exec("BEGIN IMMEDIATE");
+    try {
+      db.prepare("DELETE FROM orchestration_events WHERE command_id = ?").run(commandId);
+      db.prepare("DELETE FROM orchestration_command_receipts WHERE command_id = ?").run(commandId);
+      if (ownsTransaction) db.exec("COMMIT");
+    } catch (error) {
+      if (ownsTransaction && db.isTransaction) db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  async backupLegacyFile(path: string): Promise<void> {
+    try {
+      await readFile(path);
+    } catch (error) {
+      if (errorCode(error) === "ENOENT") return;
+      throw error;
+    }
+    await mkdir(this.#legacyBackupRoot, { recursive: true, mode: 0o700 });
+    const target = join(this.#legacyBackupRoot, basename(path));
+    try {
+      await copyFile(path, target, 1);
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") throw error;
+    }
+    await chmod(target, 0o600);
+  }
+
+  hasAggregateEvents(aggregateType: string, aggregateId: string): boolean {
+    return Boolean(
+      this.connection
+        .prepare("SELECT 1 FROM orchestration_events WHERE aggregate_type = ? AND aggregate_id = ? LIMIT 1")
+        .get(aggregateType, aggregateId),
+    );
+  }
+
+  #migrate(): void {
+    migrateOpenBotDatabase(this.connection);
+  }
+}
+
+function decodeReceiptRow(value: unknown): ReceiptRow | null {
+  const row = databaseRow(value);
+  if (!row) return null;
+  return {
+    last_sequence: requiredNumberColumn(row, "last_sequence"),
+    result_json: requiredStringColumn(row, "result_json"),
+  };
+}
+
+export function deleteOrphanReceipts(db: DatabaseSync): void {
+  db.exec(`DELETE FROM orchestration_command_receipts
+    WHERE NOT EXISTS (
+      SELECT 1 FROM orchestration_events
+      WHERE orchestration_events.command_id = orchestration_command_receipts.command_id
+    )`);
+}

--- a/src/backend/database/database-rows.ts
+++ b/src/backend/database/database-rows.ts
@@ -1,0 +1,85 @@
+import type { ConversationMessage } from "@openbot/contracts/ipc";
+import { isConversationMessage } from "@openbot/contracts/ipc";
+import { type DynamicRecord, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+
+/**
+ * Decoding for raw `node:sqlite` results, shared by every database controller.
+ *
+ * `DatabaseSync` hands back `unknown`, so each of these narrows one shape and throws naming the
+ * column that failed rather than letting an undefined propagate into a projection. Pure functions
+ * over a row: they hold no connection, open no transaction, and never import the facade.
+ */
+
+export function databaseRow(value: unknown): DynamicRecord | null {
+  return isDynamicRecord(value) ? value : null;
+}
+
+export function databaseRows(value: unknown): DynamicRecord[] {
+  if (!Array.isArray(value)) throw new Error("Invalid SQLite result set.");
+  return value.map((row, index) => {
+    if (!isDynamicRecord(row)) throw new Error(`Invalid SQLite row at index ${index}.`);
+    return row;
+  });
+}
+
+export function requiredStringColumn(row: DynamicRecord, key: string): string {
+  const value = row[key];
+  if (!isString(value)) throw new Error(`Invalid SQLite column ${key}.`);
+  return value;
+}
+
+export function requiredNumberColumn(row: DynamicRecord, key: string): number {
+  const value = row[key];
+  if (!isNumber(value)) throw new Error(`Invalid SQLite column ${key}.`);
+  return value;
+}
+
+export function optionalStringColumn(row: DynamicRecord, key: string): string | null {
+  const value = row[key];
+  if (value === null || isString(value)) return value;
+  throw new Error(`Invalid SQLite column ${key}.`);
+}
+
+export function decodeConversationThreadRow(
+  value: unknown,
+): { active_turn_id: string | null; last_event_sequence: number } | null {
+  const row = databaseRow(value);
+  if (!row) return null;
+  return {
+    active_turn_id: optionalStringColumn(row, "active_turn_id"),
+    last_event_sequence: requiredNumberColumn(row, "last_event_sequence"),
+  };
+}
+
+export function requiredEventRow(value: DynamicRecord): {
+  sequence: number;
+  event_type: string;
+  occurred_at: string;
+  payload_json: string;
+} {
+  return {
+    sequence: requiredNumberColumn(value, "sequence"),
+    event_type: requiredStringColumn(value, "event_type"),
+    occurred_at: requiredStringColumn(value, "occurred_at"),
+    payload_json: requiredStringColumn(value, "payload_json"),
+  };
+}
+
+export function decodeThreadAgentRow(value: unknown): { agent_id: string } | null {
+  const row = databaseRow(value);
+  return row ? { agent_id: requiredStringColumn(row, "agent_id") } : null;
+}
+
+export function decodeConversationMessageJson(value: string): ConversationMessage {
+  const parsed = JSON.parse(value);
+  if (!isConversationMessage(parsed)) throw new Error("Invalid conversation message.");
+  return parsed;
+}
+
+export function errorCode(value: unknown): string | null {
+  return isDynamicRecord(value) && isString(value.code) ? value.code : null;
+}
+
+export function objectValue(value: unknown): DynamicRecord | null {
+  return isDynamicRecord(value) ? value : null;
+}

--- a/src/backend/database/hosted-site-event-log.ts
+++ b/src/backend/database/hosted-site-event-log.ts
@@ -1,0 +1,241 @@
+import type {
+  HostedSiteConversationEvent,
+  HostedSiteConversationEventAction,
+  HostedSiteConversationEventDetails,
+  HostedSiteConversationEventStatus,
+} from "@openbot/contracts/ipc";
+import { hostedSiteConversationEvent } from "@openbot/contracts/ipc";
+import { isDynamicRecord, isString } from "@openbot/contracts/runtime-values";
+import type { DatabaseCore } from "./database-core";
+import { databaseRows, requiredStringColumn } from "./database-rows";
+
+export interface PendingHostedSiteTerminalEvent {
+  botId: string;
+  threadId: string;
+  turnId: string;
+  operationId: string;
+  action: HostedSiteConversationEventAction;
+  status: Exclude<HostedSiteConversationEventStatus, "running">;
+  details: HostedSiteConversationEventDetails;
+  markerCommandId: string;
+  createdAt: string;
+}
+
+export interface ActiveHostedSiteConversationEvent {
+  botId: string;
+  threadId: string;
+  turnId: string;
+  createdAt: string;
+  event: HostedSiteConversationEvent & { status: "running" };
+}
+
+export interface HostedSiteEventLogOptions {
+  core: DatabaseCore;
+}
+
+/**
+ * The hosted-site publish operations a conversation is waiting on, and the terminal events whose
+ * conversation marker has not been written yet.
+ *
+ * Owns both hosted-site aggregates in the orchestration event log — `hosted-site-operation` for a
+ * running operation and `hosted-site-terminal` for a pending terminal event — and the validators
+ * that refuse a payload the conversation marker could not be rebuilt from. Reads them back by
+ * scanning the event log directly, so a pending event survives a restart with no projection table
+ * behind it. The class never imports the facade.
+ */
+export class HostedSiteEventLog {
+  readonly #core: DatabaseCore;
+
+  constructor(options: HostedSiteEventLogOptions) {
+    this.#core = options.core;
+  }
+
+  recordPendingHostedSiteTerminalEvent(event: PendingHostedSiteTerminalEvent): void {
+    validatePendingHostedSiteTerminalEvent(event);
+    this.#core.dispatch(
+      `hosted-site-terminal-pending:${event.botId}:${event.operationId}:${event.status}`,
+      [
+        {
+          aggregateType: "hosted-site-terminal",
+          aggregateId: event.botId,
+          eventType: "hosted-site.terminal-pending",
+          occurredAt: event.createdAt,
+          payload: event,
+        },
+      ],
+      () => null,
+    );
+  }
+
+  pendingHostedSiteTerminalEvents(): PendingHostedSiteTerminalEvent[] {
+    const pending: PendingHostedSiteTerminalEvent[] = [];
+    for (const row of databaseRows(
+      this.#core.connection
+        .prepare(
+          `SELECT pending.payload_json
+           FROM orchestration_events pending
+           LEFT JOIN orchestration_command_receipts marker
+             ON marker.command_id = json_extract(pending.payload_json, '$.markerCommandId')
+           WHERE pending.aggregate_type = 'hosted-site-terminal'
+             AND pending.event_type = 'hosted-site.terminal-pending'
+             AND marker.command_id IS NULL
+           ORDER BY pending.sequence`,
+        )
+        .all(),
+    )) {
+      const event = pendingHostedSiteTerminalEventValue(JSON.parse(requiredStringColumn(row, "payload_json")));
+      if (event) pending.push(event);
+    }
+    return pending;
+  }
+
+  deletePendingHostedSiteTerminalEvent(
+    botId: string,
+    operationId: string,
+    status: Exclude<HostedSiteConversationEventStatus, "running">,
+  ): void {
+    const commandId = `hosted-site-terminal-pending:${botId}:${operationId}:${status}`;
+    this.#core.deleteEventsAndReceipt(commandId);
+  }
+
+  recordActiveHostedSiteConversationEvent(event: ActiveHostedSiteConversationEvent): void {
+    validateActiveHostedSiteConversationEvent(event);
+    this.#core.dispatch(
+      `hosted-site-active:${event.botId}:${event.event.operationId}`,
+      [
+        {
+          aggregateType: "hosted-site-operation",
+          aggregateId: event.botId,
+          eventType: "hosted-site.active",
+          occurredAt: event.createdAt,
+          payload: event,
+        },
+      ],
+      () => null,
+    );
+  }
+
+  deleteActiveHostedSiteConversationEvent(botId: string, operationId: string): void {
+    this.#core.deleteEventsAndReceipt(`hosted-site-active:${botId}:${operationId}`);
+  }
+
+  activeHostedSiteConversationEvents(): ActiveHostedSiteConversationEvent[] {
+    const active: ActiveHostedSiteConversationEvent[] = [];
+    for (const row of databaseRows(
+      this.#core.connection
+        .prepare(
+          `SELECT payload_json FROM orchestration_events
+           WHERE aggregate_type = 'hosted-site-operation' AND event_type = 'hosted-site.active'
+           ORDER BY sequence`,
+        )
+        .all(),
+    )) {
+      const event = activeHostedSiteConversationEventValue(JSON.parse(requiredStringColumn(row, "payload_json")));
+      if (event) active.push(event);
+    }
+    return active;
+  }
+}
+
+function validatePendingHostedSiteTerminalEvent(event: PendingHostedSiteTerminalEvent): void {
+  if (!pendingHostedSiteTerminalEventValue(event)) {
+    throw new Error("The pending hosted site terminal event is invalid.");
+  }
+}
+
+function validateActiveHostedSiteConversationEvent(event: ActiveHostedSiteConversationEvent): void {
+  if (!activeHostedSiteConversationEventValue(event)) {
+    throw new Error("The active hosted site event is invalid.");
+  }
+}
+
+function activeHostedSiteConversationEventValue(value: unknown): ActiveHostedSiteConversationEvent | null {
+  if (
+    !isDynamicRecord(value) ||
+    !isString(value.botId) ||
+    !value.botId ||
+    !isString(value.threadId) ||
+    !value.threadId ||
+    !isString(value.turnId) ||
+    !value.turnId ||
+    !isString(value.createdAt) ||
+    !isDynamicRecord(value.event) ||
+    (value.event.action !== "publish" && value.event.action !== "replace" && value.event.action !== "delete") ||
+    value.event.status !== "running" ||
+    !isString(value.event.operationId)
+  ) {
+    return null;
+  }
+  const marker = hostedSiteConversationEvent({
+    id: `hosted-site-event:${value.event.operationId}:running`,
+    author: "system",
+    source: "system",
+    text: JSON.stringify({
+      siteId: value.event.siteId,
+      title: value.event.title,
+      hostname: value.event.hostname,
+      url: value.event.url,
+    }),
+    createdAt: value.createdAt,
+    status: "completed",
+    itemType: `hosted-site-event:${value.event.action}:running:${value.event.operationId}`,
+  });
+  if (marker?.status !== "running") return null;
+  return {
+    botId: value.botId,
+    threadId: value.threadId,
+    turnId: value.turnId,
+    createdAt: value.createdAt,
+    event: { ...marker, status: "running" },
+  };
+}
+
+function pendingHostedSiteTerminalEventValue(value: unknown): PendingHostedSiteTerminalEvent | null {
+  if (
+    !isDynamicRecord(value) ||
+    !isString(value.botId) ||
+    !value.botId ||
+    !isString(value.threadId) ||
+    !value.threadId ||
+    !isString(value.turnId) ||
+    !value.turnId ||
+    !isString(value.operationId) ||
+    (value.action !== "publish" && value.action !== "replace" && value.action !== "delete") ||
+    (value.status !== "succeeded" &&
+      value.status !== "failed" &&
+      value.status !== "interrupted" &&
+      value.status !== "cancelled") ||
+    !isDynamicRecord(value.details) ||
+    !isString(value.markerCommandId) ||
+    !isString(value.createdAt)
+  ) {
+    return null;
+  }
+  const marker = hostedSiteConversationEvent({
+    id: value.markerCommandId,
+    author: "system",
+    source: "system",
+    text: JSON.stringify(value.details),
+    createdAt: value.createdAt,
+    status: "completed",
+    itemType: `hosted-site-event:${value.action}:${value.status}:${value.operationId}`,
+  });
+  if (!marker || marker.status === "running") return null;
+  if (value.markerCommandId !== `hosted-site-event:${value.botId}:${value.operationId}:${value.status}`) return null;
+  return {
+    botId: value.botId,
+    threadId: value.threadId,
+    turnId: value.turnId,
+    operationId: marker.operationId,
+    action: marker.action,
+    status: marker.status,
+    details: {
+      siteId: marker.siteId,
+      title: marker.title,
+      hostname: marker.hostname,
+      url: marker.url,
+    },
+    markerCommandId: value.markerCommandId,
+    createdAt: value.createdAt,
+  };
+}

--- a/src/backend/database/mailbox-projection.ts
+++ b/src/backend/database/mailbox-projection.ts
@@ -1,0 +1,316 @@
+import { randomUUID } from "node:crypto";
+import { isDynamicRecord, isString } from "@openbot/contracts/runtime-values";
+import { type DatabaseCore, deleteOrphanReceipts } from "./database-core";
+import { databaseRow, databaseRows, requiredStringColumn } from "./database-rows";
+
+export interface MailboxProjectionAttachment {
+  id: string;
+  name: string;
+  path: string;
+}
+
+export interface MailboxProjectionMessage {
+  id: string;
+  sender: {
+    kind: string;
+    botId?: string;
+    routineId?: string;
+    runId?: string;
+    routineName?: string;
+    scheduledFor?: string;
+  };
+  text: string;
+  replyToMessageId: string | null;
+  createdAt: string;
+  attachments: MailboxProjectionAttachment[];
+}
+
+export interface MailboxProjectionDelivery {
+  id: string;
+  messageId: string;
+  recipientBotId: string;
+  status: string;
+  turnId: string | null;
+  error: string | null;
+  createdAt: string;
+}
+
+export interface MailboxProjectionDraft extends MailboxProjectionAttachment {
+  createdAt: string;
+}
+
+export interface MailboxProjectionGeneratedAttachment extends MailboxProjectionAttachment {
+  size: number;
+  kind: string;
+  mimeType: string;
+  previewKind: string;
+  previewUrl: string | null;
+  sha256: string;
+}
+
+export interface MailboxProjectionReaction {
+  botId: string;
+  messageId: string;
+  emoji: string;
+  actor: { kind: "user" } | { kind: "bot"; botId: string };
+  updatedAt: string;
+}
+
+export interface MailboxProjectionState {
+  messages: MailboxProjectionMessage[];
+  deliveries: MailboxProjectionDelivery[];
+  drafts: MailboxProjectionDraft[];
+  generatedAttachments: MailboxProjectionGeneratedAttachment[];
+  pausedBotIds: string[];
+  idempotency: Record<string, string>;
+  reactions: MailboxProjectionReaction[];
+}
+
+export interface MailboxProjectionOptions {
+  core: DatabaseCore;
+}
+
+/**
+ * The mailbox read model: messages, deliveries, drafts, generated attachments, reactions, per-agent
+ * queue state, and the outbox of files still to be deleted from disk.
+ *
+ * Owns `projection_mailbox_messages`, `projection_deliveries`, `projection_queue_state`,
+ * `projection_attachments`, `projection_reactions` and `file_deletion_outbox`. Unlike every other
+ * projection here, mailbox state is stored whole: each write replaces the tables and compacts the
+ * `mailbox` aggregate down to its newest event, so the log never accumulates superseded snapshots.
+ * The class never imports the facade.
+ */
+export class MailboxProjection {
+  readonly #core: DatabaseCore;
+
+  constructor(options: MailboxProjectionOptions) {
+    this.#core = options.core;
+  }
+
+  replaceMailboxState(
+    commandId: string,
+    state: MailboxProjectionState,
+    eventType: string,
+    fileDeletions: string[] = [],
+    _rebaseHistory = false,
+  ): void {
+    this.#core.dispatch(
+      commandId,
+      [
+        {
+          aggregateType: "mailbox",
+          aggregateId: "mailbox",
+          eventType,
+          payload: state,
+        },
+      ],
+      (db, sequences) => {
+        const sequence = sequences[0] ?? 0;
+        db.prepare(
+          `DELETE FROM orchestration_events
+           WHERE aggregate_type = 'mailbox' AND aggregate_id = 'mailbox' AND sequence < ?`,
+        ).run(sequence);
+        deleteOrphanReceipts(db);
+        const value = state;
+        db.exec("DELETE FROM projection_deliveries");
+        db.exec("DELETE FROM projection_mailbox_messages");
+        db.exec("DELETE FROM projection_queue_state");
+        db.exec("DELETE FROM projection_reactions");
+        db.exec("DELETE FROM projection_attachments WHERE owner_kind IN ('mailbox-message', 'draft', 'generated')");
+        const messageInsert = db.prepare(`
+          INSERT INTO projection_mailbox_messages
+            (message_id, sender_kind, sender_agent_id, text, reply_to_message_id, created_at, message_json, last_event_sequence)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+        const attachmentInsert = db.prepare(`
+          INSERT INTO projection_attachments
+            (attachment_id, owner_kind, owner_id, name, path, metadata_json, created_at, last_event_sequence)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+        for (const message of value.messages) {
+          const sender = message.sender;
+          messageInsert.run(
+            String(message.id),
+            sender.kind,
+            sender.botId ?? null,
+            String(message.text),
+            isString(message.replyToMessageId) ? message.replyToMessageId : null,
+            String(message.createdAt),
+            JSON.stringify(message),
+            sequence,
+          );
+          for (const attachment of message.attachments) {
+            attachmentInsert.run(
+              String(attachment.id),
+              "mailbox-message",
+              String(message.id),
+              String(attachment.name),
+              String(attachment.path),
+              JSON.stringify(attachment),
+              String(message.createdAt),
+              sequence,
+            );
+          }
+        }
+        const deliveryInsert = db.prepare(`
+          INSERT INTO projection_deliveries
+            (delivery_id, message_id, recipient_agent_id, status, turn_id, error, created_at, delivery_json, last_event_sequence)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+        for (const delivery of value.deliveries) {
+          deliveryInsert.run(
+            String(delivery.id),
+            String(delivery.messageId),
+            String(delivery.recipientBotId),
+            String(delivery.status),
+            isString(delivery.turnId) ? delivery.turnId : null,
+            isString(delivery.error) ? delivery.error : null,
+            String(delivery.createdAt),
+            JSON.stringify(delivery),
+            sequence,
+          );
+        }
+        const queueInsert = db.prepare(`
+          INSERT INTO projection_queue_state
+            (agent_id, paused, metadata_json, last_event_sequence) VALUES (?, ?, ?, ?)
+        `);
+        queueInsert.run("__mailbox__", 0, JSON.stringify({ idempotency: value.idempotency }), sequence);
+        for (const botId of value.pausedBotIds) queueInsert.run(botId, 1, "{}", sequence);
+        const reactionInsert = db.prepare(`
+          INSERT INTO projection_reactions
+            (agent_id, message_id, emoji, actor_kind, actor_bot_id, updated_at, last_event_sequence)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `);
+        for (const reaction of value.reactions) {
+          reactionInsert.run(
+            String(reaction.botId),
+            String(reaction.messageId),
+            String(reaction.emoji),
+            reaction.actor.kind,
+            reaction.actor.kind === "bot" ? reaction.actor.botId : "",
+            String(reaction.updatedAt),
+            sequence,
+          );
+        }
+        for (const draft of value.drafts) {
+          attachmentInsert.run(
+            String(draft.id),
+            "draft",
+            String(draft.id),
+            String(draft.name),
+            String(draft.path),
+            JSON.stringify(draft),
+            String(draft.createdAt),
+            sequence,
+          );
+        }
+        for (const attachment of value.generatedAttachments) {
+          attachmentInsert.run(
+            String(attachment.id),
+            "generated",
+            String(attachment.id),
+            String(attachment.name),
+            String(attachment.path),
+            JSON.stringify(attachment),
+            new Date().toISOString(),
+            sequence,
+          );
+        }
+        const outboxInsert = db.prepare(`
+          INSERT OR IGNORE INTO file_deletion_outbox
+            (id, path, reason, created_at, attempts, last_error)
+          VALUES (?, ?, ?, ?, 0, NULL)
+        `);
+        for (const path of fileDeletions) {
+          outboxInsert.run(randomUUID(), path, eventType, new Date().toISOString());
+        }
+        return null;
+      },
+    );
+  }
+
+  pendingFileDeletions(): Array<{ id: string; path: string }> {
+    return databaseRows(
+      this.#core.connection.prepare("SELECT id, path FROM file_deletion_outbox ORDER BY created_at").all(),
+    ).map((row) => ({
+      id: requiredStringColumn(row, "id"),
+      path: requiredStringColumn(row, "path"),
+    }));
+  }
+
+  completeFileDeletion(id: string): void {
+    this.#core.connection.prepare("DELETE FROM file_deletion_outbox WHERE id = ?").run(id);
+  }
+
+  failFileDeletion(id: string, error: string): void {
+    this.#core.connection
+      .prepare(
+        `UPDATE file_deletion_outbox
+         SET attempts = attempts + 1, last_error = ? WHERE id = ?`,
+      )
+      .run(error.slice(0, 2_000), id);
+  }
+
+  readMailboxState(): unknown | null {
+    const db = this.#core.connection;
+    const marker = databaseRow(
+      db.prepare("SELECT metadata_json FROM projection_queue_state WHERE agent_id = '__mailbox__'").get(),
+    );
+    if (!marker) return null;
+    const metadata = parseMailboxMetadata(requiredStringColumn(marker, "metadata_json"));
+    const messages = databaseRows(
+      db.prepare("SELECT message_json FROM projection_mailbox_messages ORDER BY created_at, message_id").all(),
+    ).map((row) => JSON.parse(requiredStringColumn(row, "message_json")));
+    const deliveries = databaseRows(
+      db.prepare("SELECT delivery_json FROM projection_deliveries ORDER BY created_at, delivery_id").all(),
+    ).map((row) => JSON.parse(requiredStringColumn(row, "delivery_json")));
+    const drafts = databaseRows(
+      db.prepare("SELECT metadata_json FROM projection_attachments WHERE owner_kind = 'draft'").all(),
+    ).map((row) => JSON.parse(requiredStringColumn(row, "metadata_json")));
+    const generatedAttachments = databaseRows(
+      db.prepare("SELECT metadata_json FROM projection_attachments WHERE owner_kind = 'generated'").all(),
+    ).map((row) => JSON.parse(requiredStringColumn(row, "metadata_json")));
+    const pausedBotIds = databaseRows(
+      db.prepare("SELECT agent_id FROM projection_queue_state WHERE paused = 1").all(),
+    ).map((row) => requiredStringColumn(row, "agent_id"));
+    const reactions = databaseRows(
+      db
+        .prepare("SELECT agent_id, message_id, emoji, actor_kind, actor_bot_id, updated_at FROM projection_reactions")
+        .all(),
+    ).map((row) => ({
+      botId: requiredStringColumn(row, "agent_id"),
+      messageId: requiredStringColumn(row, "message_id"),
+      emoji: requiredStringColumn(row, "emoji"),
+      actor:
+        requiredStringColumn(row, "actor_kind") === "bot"
+          ? { kind: "bot" as const, botId: requiredStringColumn(row, "actor_bot_id") }
+          : { kind: "user" as const },
+      updatedAt: requiredStringColumn(row, "updated_at"),
+    }));
+    return {
+      version: 3,
+      messages,
+      deliveries,
+      drafts,
+      generatedAttachments,
+      pausedBotIds,
+      idempotency: metadata.idempotency ?? {},
+      reactions,
+    };
+  }
+}
+
+function parseMailboxMetadata(value: string): { idempotency?: Record<string, string> } {
+  const parsed = JSON.parse(value);
+  if (!isDynamicRecord(parsed)) throw new Error("Invalid mailbox metadata.");
+  const idempotency = parsed.idempotency;
+  if (idempotency === undefined) return {};
+  if (!isDynamicRecord(idempotency)) throw new Error("Invalid mailbox idempotency metadata.");
+  const entries = Object.entries(idempotency);
+  const values: Record<string, string> = {};
+  for (const [key, entry] of entries) {
+    if (!isString(entry)) throw new Error("Invalid mailbox idempotency entry.");
+    values[key] = entry;
+  }
+  return { idempotency: values };
+}

--- a/src/backend/database/provider-sessions.ts
+++ b/src/backend/database/provider-sessions.ts
@@ -1,0 +1,229 @@
+import { randomUUID } from "node:crypto";
+import { type AgentProviderId, isAgentProvider } from "@openbot/contracts/ipc";
+import type { DynamicRecord } from "@openbot/contracts/runtime-values";
+import type { DatabaseCore } from "./database-core";
+import { databaseRow, databaseRows, optionalStringColumn, requiredStringColumn } from "./database-rows";
+
+export interface ProviderSession {
+  id: string;
+  threadId: string;
+  provider: AgentProviderId;
+  externalSessionId: string;
+  model: string;
+  effort: string;
+  state: "active" | "inactive" | "failed";
+  createdAt: string;
+  updatedAt: string;
+  resumeCursor: string | null;
+}
+
+interface SessionRow {
+  id: string;
+  thread_id: string;
+  provider: AgentProviderId;
+  external_session_id: string;
+  model: string;
+  effort: string;
+  state: ProviderSession["state"];
+  created_at: string;
+  updated_at: string;
+  resume_cursor: string | null;
+}
+
+export interface ProviderSessionsOptions {
+  core: DatabaseCore;
+}
+
+/**
+ * The provider-side resume state of a thread: which CLI session a provider is attached to now, and
+ * the inactive ones it was attached to before.
+ *
+ * Owns `projection_provider_sessions` and the `provider-session.*` events behind it. Binding a
+ * session deactivates the thread's previous active one inside the same dispatch, so a thread never
+ * holds two. This state is deliberately private to the provider boundary and never reaches a
+ * renderer. The class never imports the facade.
+ */
+export class ProviderSessions {
+  readonly #core: DatabaseCore;
+
+  constructor(options: ProviderSessionsOptions) {
+    this.#core = options.core;
+  }
+
+  activeProviderSession(threadId: string, provider: AgentProviderId): ProviderSession | null {
+    const row = decodeSessionRow(
+      this.#core.connection
+        .prepare(
+          `SELECT id, thread_id, provider, external_session_id, model, effort, state,
+                  created_at, updated_at, resume_cursor
+           FROM projection_provider_sessions
+           WHERE thread_id = ? AND provider = ? AND state = 'active'
+           ORDER BY created_at DESC, last_event_sequence DESC LIMIT 1`,
+        )
+        .get(threadId, provider),
+    );
+    return row ? toProviderSession(row) : null;
+  }
+
+  listProviderSessions(threadId: string): ProviderSession[] {
+    return databaseRows(
+      this.#core.connection
+        .prepare(
+          `SELECT id, thread_id, provider, external_session_id, model, effort, state,
+                  created_at, updated_at, resume_cursor
+           FROM projection_provider_sessions
+           WHERE thread_id = ?
+           ORDER BY created_at, last_event_sequence`,
+        )
+        .all(threadId),
+    ).map((row) => toProviderSession(requiredSessionRow(row)));
+  }
+
+  bindProviderSession(input: {
+    threadId: string;
+    provider: AgentProviderId;
+    externalSessionId: string;
+    model: string;
+    effort: string;
+    resumeCursor?: string | null;
+  }): ProviderSession {
+    const now = new Date().toISOString();
+    const session: ProviderSession = {
+      id: randomUUID(),
+      threadId: input.threadId,
+      provider: input.provider,
+      externalSessionId: input.externalSessionId,
+      model: input.model,
+      effort: input.effort,
+      state: "active",
+      createdAt: now,
+      updatedAt: now,
+      resumeCursor: input.resumeCursor ?? input.externalSessionId,
+    };
+    return this.#core.dispatch(
+      `provider-session:bind:${input.threadId}:${input.provider}:${input.externalSessionId}`,
+      [
+        {
+          aggregateType: "thread",
+          aggregateId: input.threadId,
+          eventType: "provider-session.bound",
+          payload: session,
+        },
+      ],
+      (db, sequences) => {
+        db.prepare(
+          `UPDATE projection_provider_sessions SET state = 'inactive', updated_at = ?
+           WHERE thread_id = ? AND state = 'active'`,
+        ).run(now, input.threadId);
+        db.prepare(`
+          INSERT INTO projection_provider_sessions (
+            id, thread_id, provider, external_session_id, model, effort, state,
+            created_at, updated_at, resume_cursor, last_event_sequence
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `).run(
+          session.id,
+          session.threadId,
+          session.provider,
+          session.externalSessionId,
+          session.model,
+          session.effort,
+          session.state,
+          session.createdAt,
+          session.updatedAt,
+          session.resumeCursor,
+          sequences[0],
+        );
+        return session;
+      },
+    );
+  }
+
+  deactivateProviderSessions(threadId: string): void {
+    const active = this.listProviderSessions(threadId).filter((session) => session.state === "active");
+    if (active.length === 0) return;
+    this.#core.dispatch(
+      `provider-session:deactivate:${threadId}:${randomUUID()}`,
+      [
+        {
+          aggregateType: "thread",
+          aggregateId: threadId,
+          eventType: "provider-session.deactivated",
+          payload: { sessionIds: active.map((session) => session.id) },
+        },
+      ],
+      (db, sequences) => {
+        db.prepare(
+          `UPDATE projection_provider_sessions
+           SET state = 'inactive', updated_at = ?, last_event_sequence = ?
+           WHERE thread_id = ? AND state = 'active'`,
+        ).run(new Date().toISOString(), sequences[0], threadId);
+        return null;
+      },
+    );
+  }
+
+  updateProviderSessionConfig(sessionId: string, threadId: string, model: string, effort: string): void {
+    this.#core.dispatch(
+      `provider-session:config:${sessionId}:${model}:${effort}`,
+      [
+        {
+          aggregateType: "thread",
+          aggregateId: threadId,
+          eventType: "provider-session.config-updated",
+          payload: { sessionId, model, effort },
+        },
+      ],
+      (db, sequences) => {
+        db.prepare(
+          `UPDATE projection_provider_sessions
+           SET model = ?, effort = ?, updated_at = ?, last_event_sequence = ? WHERE id = ?`,
+        ).run(model, effort, new Date().toISOString(), sequences[0], sessionId);
+        return null;
+      },
+    );
+  }
+}
+
+function toProviderSession(row: SessionRow): ProviderSession {
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    provider: row.provider,
+    externalSessionId: row.external_session_id,
+    model: row.model,
+    effort: row.effort,
+    state: row.state,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    resumeCursor: row.resume_cursor,
+  };
+}
+
+function decodeSessionRow(value: unknown): SessionRow | null {
+  const row = databaseRow(value);
+  if (!row) return null;
+  const provider = requiredStringColumn(row, "provider");
+  const state = requiredStringColumn(row, "state");
+  if (!isAgentProvider(provider)) throw new Error("Invalid provider column.");
+  if (state !== "active" && state !== "inactive" && state !== "failed") {
+    throw new Error("Invalid provider session state column.");
+  }
+  return {
+    id: requiredStringColumn(row, "id"),
+    thread_id: requiredStringColumn(row, "thread_id"),
+    provider,
+    external_session_id: requiredStringColumn(row, "external_session_id"),
+    model: requiredStringColumn(row, "model"),
+    effort: requiredStringColumn(row, "effort"),
+    state,
+    created_at: requiredStringColumn(row, "created_at"),
+    updated_at: requiredStringColumn(row, "updated_at"),
+    resume_cursor: optionalStringColumn(row, "resume_cursor"),
+  };
+}
+
+function requiredSessionRow(value: DynamicRecord): SessionRow {
+  const row = decodeSessionRow(value);
+  if (!row) throw new Error("Invalid provider session row.");
+  return row;
+}

--- a/src/backend/database/thread-replay.ts
+++ b/src/backend/database/thread-replay.ts
@@ -1,0 +1,341 @@
+import { randomUUID } from "node:crypto";
+import type { ConversationMessage, ConversationSnapshot } from "@openbot/contracts/ipc";
+import { isAgentProvider, isConversationMessage } from "@openbot/contracts/ipc";
+import { type DynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import type { ConversationQueries } from "./conversation-queries";
+import type { DatabaseCore } from "./database-core";
+import { databaseRows, decodeThreadAgentRow, objectValue, requiredEventRow } from "./database-rows";
+import type { ProviderSession } from "./provider-sessions";
+import type { StoredThreadSummary } from "./thread-summaries";
+
+export interface ThreadReplayOptions {
+  core: DatabaseCore;
+  conversations: ConversationQueries;
+}
+
+/**
+ * Rebuilds a thread's projections by replaying its orchestration events from the start.
+ *
+ * Owns the recovery path taken when a projection is missing or stale: messages, turns, provider
+ * session links, summaries and attachment projections are all reconstructed from the event log,
+ * then read back through the conversation queries. This is the one place that opens an
+ * unconditional transaction of its own, because the replay must be all-or-nothing and the
+ * dispatches nested inside it must join it rather than commit piecemeal. The class never imports
+ * the facade.
+ */
+export class ThreadReplay {
+  readonly #core: DatabaseCore;
+  readonly #conversations: ConversationQueries;
+
+  constructor(options: ThreadReplayOptions) {
+    this.#core = options.core;
+    this.#conversations = options.conversations;
+  }
+
+  rebuildThreadProjection(threadId: string): ConversationSnapshot {
+    const db = this.#core.connection;
+    const events = databaseRows(
+      db
+        .prepare(
+          `SELECT sequence, event_type, occurred_at, payload_json
+           FROM orchestration_events
+           WHERE aggregate_type = 'thread' AND aggregate_id = ? ORDER BY sequence`,
+        )
+        .all(threadId),
+    ).map(requiredEventRow);
+    const thread = decodeThreadAgentRow(
+      db.prepare("SELECT agent_id FROM projection_threads WHERE thread_id = ?").get(threadId),
+    );
+    if (!thread) throw new Error(`Unknown OpenBot thread: ${threadId}`);
+
+    let latest: ConversationSnapshot | null = null;
+    let latestSequence = 0;
+    const sessions = new Map<string, ProviderSession & { sequence: number }>();
+    const summaries: Array<StoredThreadSummary & { sequence: number }> = [];
+    const turnSessions = new Map<string, string | null>();
+    for (const event of events) {
+      const payload = JSON.parse(event.payload_json);
+      const record = objectValue(payload);
+      if (event.event_type === "provider-session.bound") {
+        const session = providerSessionValue(record);
+        if (session) {
+          for (const current of sessions.values()) current.state = "inactive";
+          sessions.set(session.id, { ...session, sequence: event.sequence });
+        }
+      } else if (event.event_type === "provider-session.deactivated") {
+        const ids = Array.isArray(record?.sessionIds) ? record.sessionIds : [];
+        for (const id of ids) {
+          if (isString(id)) {
+            const session = sessions.get(id);
+            if (session) session.state = "inactive";
+          }
+        }
+      } else if (event.event_type === "provider-session.config-updated") {
+        const session = isString(record?.sessionId) ? sessions.get(record.sessionId) : null;
+        if (session) {
+          if (isString(record?.model)) session.model = record.model;
+          if (isString(record?.effort)) session.effort = record.effort;
+          session.sequence = event.sequence;
+        }
+      } else if (event.event_type === "thread.summary-created") {
+        const summary = summaryValue(record);
+        if (summary) summaries.push({ ...summary, sequence: event.sequence });
+      }
+      const snapshot = conversationSnapshotValue(objectValue(record?.snapshot));
+      const appendedMessage = record?.appendedMessage;
+      const appendedActiveTurnId = record?.activeTurnId;
+      if (snapshot) {
+        latest = snapshot;
+        latestSequence = event.sequence;
+        for (const [turnId, sessionId] of turnProviderSessionIdsValue(record?.recovery)) {
+          turnSessions.set(turnId, sessionId);
+        }
+        if (snapshot.activeTurnId && !turnSessions.has(snapshot.activeTurnId)) {
+          const activeSession = [...sessions.values()].find((session) => session.state === "active");
+          turnSessions.set(snapshot.activeTurnId, activeSession?.id ?? null);
+        }
+      } else if (latest && isConversationMessage(appendedMessage)) {
+        if (!latest.messages.some((message) => message.id === appendedMessage.id)) {
+          latest.messages.push(structuredClone(appendedMessage));
+        }
+        if (isString(appendedActiveTurnId) || appendedActiveTurnId === null) {
+          latest.activeTurnId = appendedActiveTurnId;
+        }
+        latestSequence = event.sequence;
+      }
+    }
+    if (!latest) throw new Error(`Thread ${threadId} has no conversation events to replay.`);
+
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      db.prepare("DELETE FROM projection_thread_activities WHERE thread_id = ?").run(threadId);
+      db.prepare("DELETE FROM projection_turns WHERE thread_id = ?").run(threadId);
+      db.prepare("DELETE FROM projection_thread_messages WHERE thread_id = ?").run(threadId);
+      db.prepare("DELETE FROM projection_thread_summaries WHERE thread_id = ?").run(threadId);
+      db.prepare("DELETE FROM projection_provider_sessions WHERE thread_id = ?").run(threadId);
+      db.prepare("DELETE FROM projection_attachments WHERE owner_kind = 'thread-message' AND owner_id LIKE ?").run(
+        `${threadId}:%`,
+      );
+      const sessionInsert = db.prepare(`
+        INSERT INTO projection_provider_sessions (
+          id, thread_id, provider, external_session_id, model, effort, state,
+          created_at, updated_at, resume_cursor, last_event_sequence
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const session of sessions.values()) {
+        sessionInsert.run(
+          session.id,
+          threadId,
+          session.provider,
+          session.externalSessionId,
+          session.model,
+          session.effort,
+          session.state,
+          session.createdAt,
+          session.updatedAt,
+          session.resumeCursor,
+          session.sequence,
+        );
+      }
+      const messageInsert = db.prepare(`
+        INSERT INTO projection_thread_messages (
+          thread_id, message_id, turn_id, author, status, item_type, created_at,
+          ordinal, message_json, last_event_sequence
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      latest.messages.forEach((message, ordinal) => {
+        messageInsert.run(
+          threadId,
+          message.id,
+          message.turnId ?? null,
+          message.author,
+          message.status,
+          message.itemType ?? null,
+          message.createdAt,
+          ordinal,
+          JSON.stringify(message),
+          latestSequence,
+        );
+        for (const attachment of message.attachments ?? []) {
+          db.prepare(`
+            INSERT INTO projection_attachments
+              (attachment_id, owner_kind, owner_id, name, path, metadata_json, created_at, last_event_sequence)
+            VALUES (?, 'thread-message', ?, ?, '', ?, ?, ?)
+          `).run(
+            `${threadId}:${message.id}:${attachment.id}`,
+            `${threadId}:${message.id}`,
+            attachment.name,
+            JSON.stringify(attachment),
+            message.createdAt,
+            latestSequence,
+          );
+        }
+      });
+      const messagesByTurn = new Map<string, ConversationMessage[]>();
+      for (const message of latest.messages) {
+        if (!message.turnId) continue;
+        const messages = messagesByTurn.get(message.turnId) ?? [];
+        messages.push(message);
+        messagesByTurn.set(message.turnId, messages);
+      }
+      const turnInsert = db.prepare(`
+        INSERT INTO projection_turns (
+          turn_id, thread_id, provider_session_id, status, started_at, completed_at, last_event_sequence
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const [turnId, messages] of messagesByTurn) {
+        const running = latest.activeTurnId === turnId;
+        const status = running
+          ? "running"
+          : messages.some((message) => message.status === "failed")
+            ? "failed"
+            : messages.some((message) => message.status === "interrupted")
+              ? "interrupted"
+              : "completed";
+        turnInsert.run(
+          turnId,
+          threadId,
+          turnSessions.get(turnId) ?? null,
+          status,
+          messages[0]?.createdAt ?? new Date().toISOString(),
+          running ? null : (messages.at(-1)?.createdAt ?? new Date().toISOString()),
+          latestSequence,
+        );
+      }
+      const summaryInsert = db.prepare(`
+        INSERT INTO projection_thread_summaries (
+          summary_id, thread_id, through_message_id, summary_text,
+          estimated_tokens, created_at, last_event_sequence
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const summary of summaries) {
+        summaryInsert.run(
+          summary.id,
+          threadId,
+          summary.throughMessageId,
+          summary.text,
+          summary.estimatedTokens,
+          summary.createdAt,
+          summary.sequence,
+        );
+      }
+      const activityInsert = db.prepare(`
+        INSERT INTO projection_thread_activities (
+          activity_id, thread_id, turn_id, activity_type,
+          payload_json, created_at, last_event_sequence
+        ) VALUES (?, ?, NULL, ?, ?, ?, ?)
+      `);
+      for (const event of events) {
+        const eventPayload = JSON.parse(event.payload_json);
+        const eventRecord = objectValue(eventPayload);
+        const activityPayload =
+          conversationSnapshotValue(objectValue(eventRecord?.snapshot)) ||
+          isConversationMessage(eventRecord?.appendedMessage)
+            ? (eventRecord?.detail ?? {})
+            : eventPayload;
+        activityInsert.run(
+          randomUUID(),
+          threadId,
+          event.event_type,
+          JSON.stringify(activityPayload),
+          event.occurred_at,
+          event.sequence,
+        );
+      }
+      db.prepare(
+        `UPDATE projection_threads
+         SET active_turn_id = ?, updated_at = ?, last_event_sequence = ? WHERE thread_id = ?`,
+      ).run(latest.activeTurnId, new Date().toISOString(), latestSequence, threadId);
+      db.exec("COMMIT");
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw error;
+    }
+    return this.#conversations.readConversation(thread.agent_id, threadId);
+  }
+}
+
+function providerSessionValue(value: DynamicRecord | null): ProviderSession | null {
+  if (
+    !value ||
+    !isString(value.id) ||
+    !isString(value.threadId) ||
+    !isAgentProvider(value.provider) ||
+    !isString(value.externalSessionId) ||
+    !isString(value.model) ||
+    !isString(value.effort) ||
+    (value.state !== "active" && value.state !== "inactive" && value.state !== "failed") ||
+    !isString(value.createdAt) ||
+    !isString(value.updatedAt) ||
+    (!isString(value.resumeCursor) && value.resumeCursor !== null)
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    threadId: value.threadId,
+    provider: value.provider,
+    externalSessionId: value.externalSessionId,
+    model: value.model,
+    effort: value.effort,
+    state: value.state,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+    resumeCursor: value.resumeCursor,
+  };
+}
+
+function summaryValue(value: DynamicRecord | null): StoredThreadSummary | null {
+  if (
+    !value ||
+    !isString(value.id) ||
+    !isString(value.threadId) ||
+    (!isString(value.throughMessageId) && value.throughMessageId !== null) ||
+    !isString(value.text) ||
+    !isNumber(value.estimatedTokens) ||
+    !isString(value.createdAt)
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    threadId: value.threadId,
+    throughMessageId: value.throughMessageId,
+    text: value.text,
+    estimatedTokens: value.estimatedTokens,
+    createdAt: value.createdAt,
+  };
+}
+
+function conversationSnapshotValue(value: DynamicRecord | null): ConversationSnapshot | null {
+  if (
+    !value ||
+    !isString(value.botId) ||
+    (!isString(value.threadId) && value.threadId !== null) ||
+    (!isString(value.activeTurnId) && value.activeTurnId !== null) ||
+    !isNumber(value.revision) ||
+    !Array.isArray(value.messages)
+  ) {
+    return null;
+  }
+  const messages = value.messages.filter(isConversationMessage);
+  if (messages.length !== value.messages.length) return null;
+  return {
+    botId: value.botId,
+    threadId: value.threadId,
+    activeTurnId: value.activeTurnId,
+    revision: value.revision,
+    messages,
+  };
+}
+
+function turnProviderSessionIdsValue(value: unknown): Array<[string, string | null]> {
+  const recovery = objectValue(value);
+  const turnProviderSessionIds = objectValue(recovery?.turnProviderSessionIds);
+  if (!turnProviderSessionIds) return [];
+  const result: Array<[string, string | null]> = [];
+  for (const [turnId, sessionId] of Object.entries(turnProviderSessionIds)) {
+    if (sessionId === null || isString(sessionId)) result.push([turnId, sessionId]);
+  }
+  return result;
+}

--- a/src/backend/database/thread-replay.ts
+++ b/src/backend/database/thread-replay.ts
@@ -248,7 +248,10 @@ export class ThreadReplay {
       ).run(latest.activeTurnId, new Date().toISOString(), latestSequence, threadId);
       db.exec("COMMIT");
     } catch (error) {
-      db.exec("ROLLBACK");
+      // SQLite auto-rolls back on some failures (a full disk, a statement-level abort). An
+      // unguarded ROLLBACK then throws "cannot rollback - no transaction is active" and replaces
+      // the original error, so the user is told about the rollback instead of the full disk.
+      if (db.isTransaction) db.exec("ROLLBACK");
       throw error;
     }
     return this.#conversations.readConversation(thread.agent_id, threadId);

--- a/src/backend/database/thread-summaries.ts
+++ b/src/backend/database/thread-summaries.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from "node:crypto";
+import type { DatabaseCore } from "./database-core";
+import { databaseRow, optionalStringColumn, requiredNumberColumn, requiredStringColumn } from "./database-rows";
+
+export interface StoredThreadSummary {
+  id: string;
+  threadId: string;
+  throughMessageId: string | null;
+  text: string;
+  estimatedTokens: number;
+  createdAt: string;
+}
+
+export interface ThreadSummariesOptions {
+  core: DatabaseCore;
+}
+
+/**
+ * The compaction summaries of a thread: the text standing in for messages a provider no longer
+ * receives, and the message each summary runs through.
+ *
+ * Owns `projection_thread_summaries` and the `thread.summary-created` events behind it. Summaries
+ * are append-only and the latest one wins, so a replay rebuilds them in order with no
+ * reconciliation. The class never imports the facade.
+ */
+export class ThreadSummaries {
+  readonly #core: DatabaseCore;
+
+  constructor(options: ThreadSummariesOptions) {
+    this.#core = options.core;
+  }
+
+  saveThreadSummary(
+    threadId: string,
+    throughMessageId: string | null,
+    text: string,
+    estimatedTokens: number,
+  ): StoredThreadSummary {
+    const summary: StoredThreadSummary = {
+      id: randomUUID(),
+      threadId,
+      throughMessageId,
+      text,
+      estimatedTokens,
+      createdAt: new Date().toISOString(),
+    };
+    return this.#core.dispatch(
+      `thread-summary:${summary.id}`,
+      [
+        {
+          aggregateType: "thread",
+          aggregateId: threadId,
+          eventType: "thread.summary-created",
+          payload: summary,
+        },
+      ],
+      (db, sequences) => {
+        db.prepare(`
+          INSERT INTO projection_thread_summaries
+            (summary_id, thread_id, through_message_id, summary_text, estimated_tokens, created_at, last_event_sequence)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `).run(summary.id, threadId, throughMessageId, text, estimatedTokens, summary.createdAt, sequences[0]);
+        return summary;
+      },
+    );
+  }
+
+  latestThreadSummary(threadId: string): StoredThreadSummary | null {
+    const row = decodeSummaryRow(
+      this.#core.connection
+        .prepare(
+          `SELECT summary_id, thread_id, through_message_id, summary_text, estimated_tokens, created_at
+           FROM projection_thread_summaries WHERE thread_id = ? ORDER BY created_at DESC LIMIT 1`,
+        )
+        .get(threadId),
+    );
+    return row
+      ? {
+          id: row.summary_id,
+          threadId: row.thread_id,
+          throughMessageId: row.through_message_id,
+          text: row.summary_text,
+          estimatedTokens: row.estimated_tokens,
+          createdAt: row.created_at,
+        }
+      : null;
+  }
+}
+
+function decodeSummaryRow(value: unknown): {
+  summary_id: string;
+  thread_id: string;
+  through_message_id: string | null;
+  summary_text: string;
+  estimated_tokens: number;
+  created_at: string;
+} | null {
+  const row = databaseRow(value);
+  if (!row) return null;
+  return {
+    summary_id: requiredStringColumn(row, "summary_id"),
+    thread_id: requiredStringColumn(row, "thread_id"),
+    through_message_id: optionalStringColumn(row, "through_message_id"),
+    summary_text: requiredStringColumn(row, "summary_text"),
+    estimated_tokens: requiredNumberColumn(row, "estimated_tokens"),
+    created_at: requiredStringColumn(row, "created_at"),
+  };
+}

--- a/src/backend/openbot-database.test.ts
+++ b/src/backend/openbot-database.test.ts
@@ -1130,6 +1130,74 @@ describe("OpenBotDatabase", () => {
     ).not.toThrow();
     migrated.close();
   });
+
+  it("erases an agent's history without leaving a receipt whose events are gone", async () => {
+    const database = await createDatabase();
+    const bot = testBot();
+    const createdAt = "2026-08-18T10:00:01.000Z";
+    database.replaceAgents("agents:seed", [bot], "agents.replaced");
+    database.dispatch(
+      "agent-memory:seed",
+      [{ aggregateType: "agent-memory", aggregateId: "memory-1", eventType: "agent-memory.created", payload: {} }],
+      (db, sequences) => {
+        db.prepare(
+          `INSERT INTO projection_agent_memories
+             (memory_id, agent_id, text, normalized_text, origin, source_turn_id,
+              created_at, updated_at, last_event_sequence)
+           VALUES ('memory-1', ?, 'remembers', 'remembers', 'manual', NULL, ?, ?, ?)`,
+        ).run(bot.id, createdAt, createdAt, sequences[0] ?? 0);
+        return null;
+      },
+    );
+    database.dispatch(
+      "agent-routine:seed",
+      [{ aggregateType: "agent-routine", aggregateId: "routine-1", eventType: "agent-routine.created", payload: {} }],
+      (db, sequences) => {
+        db.prepare(
+          `INSERT INTO projection_agent_routines
+             (routine_id, agent_id, name, instruction, active, timezone,
+              created_at, updated_at, last_event_sequence)
+           VALUES ('routine-1', ?, 'Standup', 'Report status', 1, 'UTC', ?, ?, ?)`,
+        ).run(bot.id, createdAt, createdAt, sequences[0] ?? 0);
+        return null;
+      },
+    );
+    database.recordPendingHostedSiteTerminalEvent({
+      botId: bot.id,
+      threadId: "openbot-thread-chief",
+      turnId: "turn-1",
+      operationId: "operation-1",
+      action: "publish",
+      status: "succeeded",
+      details: { siteId: "site-1", title: "Site", hostname: null, url: null },
+      markerCommandId: `hosted-site-event:${bot.id}:operation-1:succeeded`,
+      createdAt,
+    });
+
+    database.hardDeleteAgent("agents:delete", bot.id, bot.threadId, []);
+
+    expect(database.listAgents()).toEqual([]);
+    expect(database.connection.prepare("SELECT COUNT(*) AS count FROM projection_agent_memories").get()).toMatchObject({
+      count: 0,
+    });
+    expect(database.connection.prepare("SELECT COUNT(*) AS count FROM projection_agent_routines").get()).toMatchObject({
+      count: 0,
+    });
+    expect(database.pendingHostedSiteTerminalEvents()).toEqual([]);
+    // An orphan receipt makes `dispatch` replay its stale result for a command that never ran.
+    expect(
+      database.connection
+        .prepare(
+          `SELECT command_id FROM orchestration_command_receipts receipt
+           WHERE NOT EXISTS (
+             SELECT 1 FROM orchestration_events
+             WHERE orchestration_events.command_id = receipt.command_id
+           )`,
+        )
+        .all(),
+    ).toEqual([]);
+    database.close();
+  });
 });
 
 function downgradeReactionsToV7(database: DatabaseSync): void {

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -10,21 +10,13 @@ import type {
   ConversationSnapshot,
   HostedSiteConversationEventStatus,
 } from "@openbot/contracts/ipc";
-import {
-  HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX,
-  isAgentProvider,
-  isConversationMessage,
-  providerForLegacyModel,
-  ROUTINE_EVENT_ITEM_TYPE_PREFIX,
-  ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX,
-} from "@openbot/contracts/ipc";
+import { isAgentProvider, isConversationMessage, providerForLegacyModel } from "@openbot/contracts/ipc";
 import { type DynamicRecord, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { ConversationQueries } from "./database/conversation-queries";
 import { DatabaseCore, deleteOrphanReceipts, type OrchestrationEventInput } from "./database/database-core";
 import {
   databaseRow,
   databaseRows,
-  decodeConversationMessageJson,
-  decodeConversationThreadRow,
   decodeThreadAgentRow,
   objectValue,
   optionalStringColumn,
@@ -60,6 +52,7 @@ export type { StoredThreadSummary } from "./database/thread-summaries";
  */
 export class OpenBotDatabase {
   readonly #core: DatabaseCore;
+  readonly #conversations: ConversationQueries;
   readonly #hostedSiteEvents: HostedSiteEventLog;
   readonly #mailbox: MailboxProjection;
   readonly #sessions: ProviderSessions;
@@ -67,6 +60,7 @@ export class OpenBotDatabase {
 
   constructor(readonly userDataPath: string) {
     this.#core = new DatabaseCore({ userDataPath });
+    this.#conversations = new ConversationQueries({ core: this.#core });
     this.#hostedSiteEvents = new HostedSiteEventLog({ core: this.#core });
     this.#mailbox = new MailboxProjection({ core: this.#core });
     this.#sessions = new ProviderSessions({ core: this.#core });
@@ -265,61 +259,14 @@ export class OpenBotDatabase {
   }
 
   readConversation(botId: string, threadId: string | null): ConversationSnapshot {
-    if (!threadId) return { botId, threadId: null, activeTurnId: null, revision: 0, messages: [] };
-    const thread = decodeConversationThreadRow(
-      this.connection
-        .prepare(
-          `SELECT active_turn_id, last_event_sequence
-           FROM projection_threads WHERE thread_id = ? AND agent_id = ?`,
-        )
-        .get(threadId, botId),
-    );
-    const rows = databaseRows(
-      this.connection
-        .prepare(
-          `SELECT message_json FROM projection_thread_messages
-           WHERE thread_id = ? ORDER BY created_at, ordinal, message_id`,
-        )
-        .all(threadId),
-    );
-    return {
-      botId,
-      threadId,
-      activeTurnId: thread?.active_turn_id ?? null,
-      revision: thread?.last_event_sequence ?? 0,
-      messages: rows.map((row) => JSON.parse(requiredStringColumn(row, "message_json"))),
-    };
+    return this.#conversations.readConversation(botId, threadId);
   }
 
   readConversationRuntime(
     botId: string,
     threadId: string | null,
   ): { activeTurnId: string | null; latestMessage: ConversationMessage | null } {
-    if (!threadId) return { activeTurnId: null, latestMessage: null };
-    const row = databaseRow(
-      this.connection
-        .prepare(
-          `SELECT thread.active_turn_id,
-                  (SELECT message.message_json
-                   FROM projection_thread_messages message
-                   WHERE message.thread_id = thread.thread_id
-                     AND json_extract(message.message_json, '$.author') IN ('assistant', 'agent')
-                     AND COALESCE(json_extract(message.message_json, '$.itemType'), '') != 'commentary'
-                     AND COALESCE(json_extract(message.message_json, '$.itemType'), '') != 'question_prompt'
-                     AND COALESCE(json_extract(message.message_json, '$.itemType'), '') != 'agent_attachment'
-                   ORDER BY message.created_at DESC, message.ordinal DESC, message.message_id DESC
-                   LIMIT 1) AS latest_message_json
-           FROM projection_threads thread
-           WHERE thread.thread_id = ? AND thread.agent_id = ?`,
-        )
-        .get(threadId, botId),
-    );
-    if (!row) return { activeTurnId: null, latestMessage: null };
-    const latestMessage = optionalStringColumn(row, "latest_message_json");
-    return {
-      activeTurnId: optionalStringColumn(row, "active_turn_id"),
-      latestMessage: latestMessage ? decodeConversationMessageJson(latestMessage) : null,
-    };
+    return this.#conversations.readConversationRuntime(botId, threadId);
   }
 
   readConversationPage(
@@ -333,86 +280,7 @@ export class OpenBotDatabase {
       excludeHostedSiteEvents?: boolean;
     } = {},
   ): ConversationPage {
-    if (!threadId) {
-      return {
-        botId,
-        threadId: null,
-        activeTurnId: null,
-        revision: 0,
-        messages: [],
-        references: {},
-        pageInfo: { hasOlder: false, olderCursor: null },
-      };
-    }
-    const limit = pageLimit(requestedLimit);
-    const thread = decodeConversationThreadRow(
-      this.connection
-        .prepare(
-          `SELECT active_turn_id, last_event_sequence
-           FROM projection_threads WHERE thread_id = ? AND agent_id = ?`,
-        )
-        .get(threadId, botId),
-    );
-    const rows = this.#conversationPageRows(
-      threadId,
-      anchor,
-      limit,
-      options.excludeRoutineEvents === true,
-      options.excludeRoutineRunEvents === true,
-      options.excludeHostedSiteEvents === true,
-    );
-    const messages = rows.map((row) => decodeConversationMessageJson(requiredStringColumn(row, "message_json")));
-    const messageIds = new Set(messages.map((message) => message.id));
-    const referenceIdSet = new Set<string>();
-    for (const message of messages) {
-      const referenceId = message.replyToMessageId;
-      if (referenceId && !messageIds.has(referenceId)) referenceIdSet.add(referenceId);
-    }
-    const referenceIds = [...referenceIdSet];
-    const references: Record<string, ConversationMessage> = {};
-    if (referenceIds.length > 0) {
-      const placeholders = referenceIds.map(() => "?").join(", ");
-      const referenceRows = databaseRows(
-        this.connection
-          .prepare(
-            `SELECT message_id, message_json FROM projection_thread_messages
-             WHERE thread_id = ? AND message_id IN (${placeholders})
-             ${conversationMarkerSqlFilter(
-               options.excludeRoutineEvents === true,
-               options.excludeRoutineRunEvents === true,
-               options.excludeHostedSiteEvents === true,
-             )}`,
-          )
-          .all(threadId, ...referenceIds),
-      );
-      for (const row of referenceRows) {
-        references[requiredStringColumn(row, "message_id")] = decodeConversationMessageJson(
-          requiredStringColumn(row, "message_json"),
-        );
-      }
-    }
-    const first = rows[0];
-    const hasOlder = first
-      ? this.#hasConversationRowsBefore(
-          threadId,
-          conversationRowCursor(first),
-          options.excludeRoutineEvents === true,
-          options.excludeRoutineRunEvents === true,
-          options.excludeHostedSiteEvents === true,
-        )
-      : false;
-    return {
-      botId,
-      threadId,
-      activeTurnId: thread?.active_turn_id ?? null,
-      revision: thread?.last_event_sequence ?? 0,
-      messages,
-      references,
-      pageInfo: {
-        hasOlder,
-        olderCursor: hasOlder && first ? encodePageCursor(conversationRowCursor(first)) : null,
-      },
-    };
+    return this.#conversations.readConversationPage(botId, threadId, anchor, requestedLimit, options);
   }
 
   supportedConversationCursor(
@@ -424,36 +292,7 @@ export class OpenBotDatabase {
       excludeHostedSiteEvents?: boolean;
     } = {},
   ): string | null {
-    if (!throughMessageId) return null;
-    const boundary = databaseRow(
-      this.connection
-        .prepare(
-          `SELECT created_at, ordinal, message_id FROM projection_thread_messages
-           WHERE thread_id = ? AND message_id = ?`,
-        )
-        .get(threadId, throughMessageId),
-    );
-    if (!boundary) return null;
-    const createdAt = requiredStringColumn(boundary, "created_at");
-    const ordinal = requiredNumberColumn(boundary, "ordinal");
-    const messageId = requiredStringColumn(boundary, "message_id");
-    const row = databaseRow(
-      this.connection
-        .prepare(
-          `SELECT message_id FROM projection_thread_messages
-           WHERE thread_id = ?
-             AND (created_at, ordinal, message_id) <= (?, ?, ?)
-             ${conversationMarkerSqlFilter(
-               options.excludeRoutineEvents === true,
-               options.excludeRoutineRunEvents === true,
-               options.excludeHostedSiteEvents === true,
-             )}
-           ORDER BY created_at DESC, ordinal DESC, message_id DESC
-           LIMIT 1`,
-        )
-        .get(threadId, createdAt, ordinal, messageId),
-    );
-    return row ? requiredStringColumn(row, "message_id") : null;
+    return this.#conversations.supportedConversationCursor(threadId, throughMessageId, options);
   }
 
   searchConversationMessages(
@@ -462,205 +301,7 @@ export class OpenBotDatabase {
     cursor?: string,
     requestedLimit = 100,
   ): ConversationSearchPage {
-    const normalized = query.trim().replace(/\s+/g, " ").toLocaleLowerCase();
-    if (!normalized) return { results: [], total: 0, nextCursor: null };
-    const limit = pageLimit(requestedLimit);
-    const offset = cursor ? decodeSearchCursor(cursor) : 0;
-    const pattern = `%${escapeLike(normalized)}%`;
-    const filter = botId ? "AND thread.agent_id = ?" : "";
-    const parameters = botId ? [pattern, botId] : [pattern];
-    const countRow = databaseRow(
-      this.connection
-        .prepare(
-          `SELECT COUNT(*) AS count
-           FROM projection_thread_messages message
-           JOIN projection_threads thread ON thread.thread_id = message.thread_id
-           WHERE LOWER(json_extract(message.message_json, '$.text')) LIKE ? ESCAPE '\\'
-             AND COALESCE(json_extract(message.message_json, '$.delivery.status'), '') NOT IN ('queued', 'cancelled')
-             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'
-             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX}%'
-             AND COALESCE(message.item_type, '') NOT LIKE '${HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX}%'
-             ${filter}`,
-        )
-        .get(...parameters),
-    );
-    const total = countRow ? requiredNumberColumn(countRow, "count") : 0;
-    const rows = databaseRows(
-      this.connection
-        .prepare(
-          `SELECT thread.agent_id, message.message_json
-           FROM projection_thread_messages message
-           JOIN projection_threads thread ON thread.thread_id = message.thread_id
-           WHERE LOWER(json_extract(message.message_json, '$.text')) LIKE ? ESCAPE '\\'
-             AND COALESCE(json_extract(message.message_json, '$.delivery.status'), '') NOT IN ('queued', 'cancelled')
-             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'
-             AND COALESCE(message.item_type, '') NOT LIKE '${ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX}%'
-             AND COALESCE(message.item_type, '') NOT LIKE '${HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX}%'
-             ${filter}
-           ORDER BY message.created_at DESC, message.ordinal DESC, message.message_id DESC
-           LIMIT ? OFFSET ?`,
-        )
-        .all(...parameters, limit, offset),
-    );
-    const results = rows.map((row) => ({
-      botId: requiredStringColumn(row, "agent_id"),
-      message: decodeConversationMessageJson(requiredStringColumn(row, "message_json")),
-    }));
-    const nextOffset = offset + results.length;
-    return {
-      results,
-      total,
-      nextCursor: nextOffset < total ? encodeSearchCursor(nextOffset) : null,
-    };
-  }
-
-  #conversationPageRows(
-    threadId: string,
-    anchor: ConversationPageAnchor,
-    limit: number,
-    excludeRoutineEvents: boolean,
-    excludeRoutineRunEvents: boolean,
-    excludeHostedSiteEvents: boolean,
-  ): DynamicRecord[] {
-    const columns = "created_at, ordinal, message_id, message_json";
-    const routineFilter = conversationMarkerSqlFilter(
-      excludeRoutineEvents,
-      excludeRoutineRunEvents,
-      excludeHostedSiteEvents,
-    );
-    if (anchor.type === "latest") {
-      return databaseRows(
-        this.connection
-          .prepare(
-            `SELECT ${columns} FROM projection_thread_messages
-             WHERE thread_id = ?
-             ${routineFilter}
-             ORDER BY created_at DESC, ordinal DESC, message_id DESC LIMIT ?`,
-          )
-          .all(threadId, limit),
-      ).reverse();
-    }
-    if (anchor.type === "before") {
-      const cursor = decodeConversationCursor(anchor.cursor);
-      return databaseRows(
-        this.connection
-          .prepare(
-            `SELECT ${columns} FROM projection_thread_messages
-             WHERE thread_id = ? AND (
-               created_at < ? OR
-               (created_at = ? AND ordinal < ?) OR
-               (created_at = ? AND ordinal = ? AND message_id < ?)
-             )
-             ${routineFilter}
-             ORDER BY created_at DESC, ordinal DESC, message_id DESC LIMIT ?`,
-          )
-          .all(
-            threadId,
-            cursor.createdAt,
-            cursor.createdAt,
-            cursor.ordinal,
-            cursor.createdAt,
-            cursor.ordinal,
-            cursor.messageId,
-            limit,
-          ),
-      ).reverse();
-    }
-    const anchorRow = databaseRow(
-      this.connection
-        .prepare(
-          `SELECT created_at, ordinal, message_id FROM projection_thread_messages
-           WHERE thread_id = ? AND message_id = ?
-           ${routineFilter}`,
-        )
-        .get(threadId, anchor.messageId),
-    );
-    if (!anchorRow) return [];
-    const cursor = conversationRowCursor(anchorRow);
-    const olderLimit = Math.floor(limit / 2);
-    const older = databaseRows(
-      this.connection
-        .prepare(
-          `SELECT ${columns} FROM projection_thread_messages
-           WHERE thread_id = ? AND (
-             created_at < ? OR
-             (created_at = ? AND ordinal < ?) OR
-             (created_at = ? AND ordinal = ? AND message_id <= ?)
-           )
-           ${routineFilter}
-           ORDER BY created_at DESC, ordinal DESC, message_id DESC LIMIT ?`,
-        )
-        .all(
-          threadId,
-          cursor.createdAt,
-          cursor.createdAt,
-          cursor.ordinal,
-          cursor.createdAt,
-          cursor.ordinal,
-          cursor.messageId,
-          olderLimit + 1,
-        ),
-    ).reverse();
-    const newer = databaseRows(
-      this.connection
-        .prepare(
-          `SELECT ${columns} FROM projection_thread_messages
-           WHERE thread_id = ? AND (
-             created_at > ? OR
-             (created_at = ? AND ordinal > ?) OR
-             (created_at = ? AND ordinal = ? AND message_id > ?)
-           )
-           ${routineFilter}
-           ORDER BY created_at, ordinal, message_id LIMIT ?`,
-        )
-        .all(
-          threadId,
-          cursor.createdAt,
-          cursor.createdAt,
-          cursor.ordinal,
-          cursor.createdAt,
-          cursor.ordinal,
-          cursor.messageId,
-          limit - older.length,
-        ),
-    );
-    return [...older, ...newer];
-  }
-
-  #hasConversationRowsBefore(
-    threadId: string,
-    cursor: ConversationPageCursor,
-    excludeRoutineEvents: boolean,
-    excludeRoutineRunEvents: boolean,
-    excludeHostedSiteEvents: boolean,
-  ): boolean {
-    const routineFilter = conversationMarkerSqlFilter(
-      excludeRoutineEvents,
-      excludeRoutineRunEvents,
-      excludeHostedSiteEvents,
-    );
-    return Boolean(
-      this.connection
-        .prepare(
-          `SELECT 1 FROM projection_thread_messages
-           WHERE thread_id = ? AND (
-             created_at < ? OR
-             (created_at = ? AND ordinal < ?) OR
-             (created_at = ? AND ordinal = ? AND message_id < ?)
-           )
-           ${routineFilter}
-           LIMIT 1`,
-        )
-        .get(
-          threadId,
-          cursor.createdAt,
-          cursor.createdAt,
-          cursor.ordinal,
-          cursor.createdAt,
-          cursor.ordinal,
-          cursor.messageId,
-        ),
-    );
+    return this.#conversations.searchConversationMessages(query, botId, cursor, requestedLimit);
   }
 
   persistConversation(
@@ -1177,7 +818,7 @@ export class OpenBotDatabase {
       db.exec("ROLLBACK");
       throw error;
     }
-    return this.readConversation(thread.agent_id, threadId);
+    return this.#conversations.readConversation(thread.agent_id, threadId);
   }
 
   replaceMailboxState(
@@ -1226,95 +867,6 @@ export class OpenBotDatabase {
       sequence,
     );
   }
-}
-
-interface ConversationPageCursor {
-  version: 1;
-  createdAt: string;
-  ordinal: number;
-  messageId: string;
-}
-
-function pageLimit(value: number): number {
-  if (!Number.isInteger(value) || value < 1) throw new Error("The conversation page limit is invalid.");
-  return Math.min(value, 100);
-}
-
-function conversationRowCursor(row: DynamicRecord): ConversationPageCursor {
-  return {
-    version: 1,
-    createdAt: requiredStringColumn(row, "created_at"),
-    ordinal: requiredNumberColumn(row, "ordinal"),
-    messageId: requiredStringColumn(row, "message_id"),
-  };
-}
-
-function conversationMarkerSqlFilter(
-  excludeRoutineEvents: boolean,
-  excludeRoutineRunEvents: boolean,
-  excludeHostedSiteEvents: boolean,
-): string {
-  return [
-    excludeRoutineEvents ? `AND COALESCE(item_type, '') NOT LIKE '${ROUTINE_EVENT_ITEM_TYPE_PREFIX}%'` : "",
-    excludeRoutineRunEvents ? `AND COALESCE(item_type, '') NOT LIKE '${ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX}%'` : "",
-    excludeHostedSiteEvents ? `AND COALESCE(item_type, '') NOT LIKE '${HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX}%'` : "",
-  ]
-    .filter(Boolean)
-    .join("\n");
-}
-
-function encodePageCursor(cursor: ConversationPageCursor): string {
-  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
-}
-
-function decodeConversationCursor(value: string): ConversationPageCursor {
-  try {
-    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
-    if (
-      !isDynamicRecord(parsed) ||
-      parsed.version !== 1 ||
-      !isString(parsed.createdAt) ||
-      !isNumber(parsed.ordinal) ||
-      !Number.isInteger(parsed.ordinal) ||
-      !isString(parsed.messageId)
-    ) {
-      throw new Error("invalid cursor");
-    }
-    return {
-      version: 1,
-      createdAt: parsed.createdAt,
-      ordinal: parsed.ordinal,
-      messageId: parsed.messageId,
-    };
-  } catch {
-    throw new Error("The conversation page cursor is invalid.");
-  }
-}
-
-function encodeSearchCursor(offset: number): string {
-  return Buffer.from(JSON.stringify({ version: 1, offset }), "utf8").toString("base64url");
-}
-
-function decodeSearchCursor(value: string): number {
-  try {
-    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
-    if (
-      !isDynamicRecord(parsed) ||
-      parsed.version !== 1 ||
-      !isNumber(parsed.offset) ||
-      !Number.isSafeInteger(parsed.offset) ||
-      parsed.offset < 0
-    ) {
-      throw new Error("invalid cursor");
-    }
-    return parsed.offset;
-  } catch {
-    throw new Error("The conversation search cursor is invalid.");
-  }
-}
-
-function escapeLike(value: string): string {
-  return value.replace(/[\\%_]/g, (character) => `\\${character}`);
 }
 
 function providerSessionValue(value: DynamicRecord | null): ProviderSession | null {

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -1,7 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { chmod, copyFile, mkdir, readFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
+import type { DatabaseSync } from "node:sqlite";
 import type {
   AgentProviderId,
   BotSummary,
@@ -25,28 +23,19 @@ import {
   ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX,
 } from "@openbot/contracts/ipc";
 import { type DynamicRecord, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { DatabaseCore, deleteOrphanReceipts, type OrchestrationEventInput } from "./database/database-core";
 import {
   databaseRow,
   databaseRows,
   decodeConversationMessageJson,
   decodeConversationThreadRow,
   decodeThreadAgentRow,
-  errorCode,
   objectValue,
   optionalStringColumn,
   requiredEventRow,
   requiredNumberColumn,
   requiredStringColumn,
 } from "./database/database-rows";
-import { migrateOpenBotDatabase } from "./openbot-database-schema";
-
-export interface OrchestrationEventInput {
-  aggregateType: string;
-  aggregateId: string;
-  eventType: string;
-  payload: unknown;
-  occurredAt?: string;
-}
 
 export interface ProviderSession {
   id: string;
@@ -88,11 +77,6 @@ export interface ActiveHostedSiteConversationEvent {
   turnId: string;
   createdAt: string;
   event: HostedSiteConversationEvent & { status: "running" };
-}
-
-interface ReceiptRow {
-  last_sequence: number;
-  result_json: string;
 }
 
 interface SessionRow {
@@ -171,6 +155,11 @@ interface MailboxProjectionState {
   reactions: MailboxProjectionReaction[];
 }
 
+// Declared in this module before the split and part of the frozen public surface, so it stays
+// reachable from here rather than only from the controller that owns it now. Structural `Pick<...>`
+// types over this class do not cover exported types.
+export type { OrchestrationEventInput } from "./database/database-core";
+
 /**
  * The local OpenBot event log and its read projections.
  *
@@ -178,42 +167,26 @@ interface MailboxProjectionState {
  * SQLite transaction. Providers never receive direct access to this database.
  */
 export class OpenBotDatabase {
-  readonly path: string;
-  readonly #legacyBackupRoot: string;
-  #db: DatabaseSync | null = null;
+  readonly #core: DatabaseCore;
 
   constructor(readonly userDataPath: string) {
-    this.path = join(userDataPath, "openbot.db");
-    this.#legacyBackupRoot = join(userDataPath, "legacy-backup-v1");
+    this.#core = new DatabaseCore({ userDataPath });
+  }
+
+  get path(): string {
+    return this.#core.path;
   }
 
   async initialize(): Promise<void> {
-    if (this.#db) return;
-    await mkdir(dirname(this.path), { recursive: true, mode: 0o700 });
-    const db = new DatabaseSync(this.path);
-    try {
-      db.exec("PRAGMA journal_mode = WAL");
-      db.exec("PRAGMA foreign_keys = ON");
-      db.exec("PRAGMA busy_timeout = 5000");
-      db.exec("PRAGMA synchronous = NORMAL");
-      this.#db = db;
-      this.#migrate();
-      await chmod(this.path, 0o600);
-    } catch (error) {
-      db.close();
-      this.#db = null;
-      throw error;
-    }
+    await this.#core.initialize();
   }
 
   close(): void {
-    this.#db?.close();
-    this.#db = null;
+    this.#core.close();
   }
 
   get connection(): DatabaseSync {
-    if (!this.#db) throw new Error("OpenBot database is not initialized.");
-    return this.#db;
+    return this.#core.connection;
   }
 
   dispatch<T>(
@@ -221,62 +194,19 @@ export class OpenBotDatabase {
     events: OrchestrationEventInput[],
     project: (db: DatabaseSync, sequences: number[]) => T,
   ): T {
-    const db = this.connection;
-    const receipt = decodeReceiptRow(
-      db
-        .prepare("SELECT last_sequence, result_json FROM orchestration_command_receipts WHERE command_id = ?")
-        .get(commandId),
-    );
-    if (receipt) return JSON.parse(receipt.result_json);
-
-    const ownsTransaction = !db.isTransaction;
-    if (ownsTransaction) db.exec("BEGIN IMMEDIATE");
-    try {
-      const sequences: number[] = [];
-      const append = db.prepare(`
-        INSERT INTO orchestration_events (
-          event_id, command_id, aggregate_type, aggregate_id, event_type, occurred_at, payload_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-      `);
-      for (const event of events) {
-        const result = append.run(
-          randomUUID(),
-          commandId,
-          event.aggregateType,
-          event.aggregateId,
-          event.eventType,
-          event.occurredAt ?? new Date().toISOString(),
-          JSON.stringify(event.payload),
-        );
-        sequences.push(Number(result.lastInsertRowid));
-      }
-      const result = project(db, sequences);
-      db.prepare(
-        `INSERT INTO orchestration_command_receipts
-          (command_id, accepted_at, first_sequence, last_sequence, result_json)
-         VALUES (?, ?, ?, ?, ?)`,
-      ).run(
-        commandId,
-        new Date().toISOString(),
-        sequences[0] ?? 0,
-        sequences.at(-1) ?? 0,
-        JSON.stringify(result ?? null),
-      );
-      if (ownsTransaction) db.exec("COMMIT");
-      return result;
-    } catch (error) {
-      if (ownsTransaction && db.isTransaction) db.exec("ROLLBACK");
-      throw error;
-    }
+    return this.#core.dispatch(commandId, events, project);
   }
 
   commandResult(commandId: string): unknown | undefined {
-    const receipt = decodeReceiptRow(
-      this.connection
-        .prepare("SELECT last_sequence, result_json FROM orchestration_command_receipts WHERE command_id = ?")
-        .get(commandId),
-    );
-    return receipt ? JSON.parse(receipt.result_json) : undefined;
+    return this.#core.commandResult(commandId);
+  }
+
+  hasAggregateEvents(aggregateType: string, aggregateId: string): boolean {
+    return this.#core.hasAggregateEvents(aggregateType, aggregateId);
+  }
+
+  async backupLegacyFile(path: string): Promise<void> {
+    await this.#core.backupLegacyFile(path);
   }
 
   recordPendingHostedSiteTerminalEvent(event: PendingHostedSiteTerminalEvent): void {
@@ -324,21 +254,7 @@ export class OpenBotDatabase {
     status: Exclude<HostedSiteConversationEventStatus, "running">,
   ): void {
     const commandId = `hosted-site-terminal-pending:${botId}:${operationId}:${status}`;
-    this.#deleteEventsAndReceipt(commandId);
-  }
-
-  #deleteEventsAndReceipt(commandId: string): void {
-    const db = this.connection;
-    const ownsTransaction = !db.isTransaction;
-    if (ownsTransaction) db.exec("BEGIN IMMEDIATE");
-    try {
-      db.prepare("DELETE FROM orchestration_events WHERE command_id = ?").run(commandId);
-      db.prepare("DELETE FROM orchestration_command_receipts WHERE command_id = ?").run(commandId);
-      if (ownsTransaction) db.exec("COMMIT");
-    } catch (error) {
-      if (ownsTransaction && db.isTransaction) db.exec("ROLLBACK");
-      throw error;
-    }
+    this.#core.deleteEventsAndReceipt(commandId);
   }
 
   recordActiveHostedSiteConversationEvent(event: ActiveHostedSiteConversationEvent): void {
@@ -359,7 +275,7 @@ export class OpenBotDatabase {
   }
 
   deleteActiveHostedSiteConversationEvent(botId: string, operationId: string): void {
-    this.#deleteEventsAndReceipt(`hosted-site-active:${botId}:${operationId}`);
+    this.#core.deleteEventsAndReceipt(`hosted-site-active:${botId}:${operationId}`);
   }
 
   activeHostedSiteConversationEvents(): ActiveHostedSiteConversationEvent[] {
@@ -1783,31 +1699,6 @@ export class OpenBotDatabase {
     };
   }
 
-  async backupLegacyFile(path: string): Promise<void> {
-    try {
-      await readFile(path);
-    } catch (error) {
-      if (errorCode(error) === "ENOENT") return;
-      throw error;
-    }
-    await mkdir(this.#legacyBackupRoot, { recursive: true, mode: 0o700 });
-    const target = join(this.#legacyBackupRoot, basename(path));
-    try {
-      await copyFile(path, target, 1);
-    } catch (error) {
-      if (errorCode(error) !== "EEXIST") throw error;
-    }
-    await chmod(target, 0o600);
-  }
-
-  hasAggregateEvents(aggregateType: string, aggregateId: string): boolean {
-    return Boolean(
-      this.connection
-        .prepare("SELECT 1 FROM orchestration_events WHERE aggregate_type = ? AND aggregate_id = ? LIMIT 1")
-        .get(aggregateType, aggregateId),
-    );
-  }
-
   #ensureThreadProjection(db: DatabaseSync, agent: BotSummary, sequence: number): void {
     if (!agent.threadId) return;
     db.prepare(`
@@ -1827,10 +1718,6 @@ export class OpenBotDatabase {
       agent.updatedAt ?? new Date().toISOString(),
       sequence,
     );
-  }
-
-  #migrate(): void {
-    migrateOpenBotDatabase(this.connection);
   }
 }
 
@@ -1936,15 +1823,6 @@ function decodeSearchCursor(value: string): number {
 
 function escapeLike(value: string): string {
   return value.replace(/[\\%_]/g, (character) => `\\${character}`);
-}
-
-function decodeReceiptRow(value: unknown): ReceiptRow | null {
-  const row = databaseRow(value);
-  if (!row) return null;
-  return {
-    last_sequence: requiredNumberColumn(row, "last_sequence"),
-    result_json: requiredStringColumn(row, "result_json"),
-  };
 }
 
 function decodeSessionRow(value: unknown): SessionRow | null {
@@ -2138,14 +2016,6 @@ function pruneConversationSnapshots(db: DatabaseSync, threadId: string, retained
        AND json_type(payload_json, '$.snapshot') = 'object'`,
   ).run(threadId, retainedSequence);
   deleteOrphanReceipts(db);
-}
-
-function deleteOrphanReceipts(db: DatabaseSync): void {
-  db.exec(`DELETE FROM orchestration_command_receipts
-    WHERE NOT EXISTS (
-      SELECT 1 FROM orchestration_events
-      WHERE orchestration_events.command_id = orchestration_command_receipts.command_id
-    )`);
 }
 
 function validatePendingHostedSiteTerminalEvent(event: PendingHostedSiteTerminalEvent): void {

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -37,104 +37,9 @@ import {
   HostedSiteEventLog,
   type PendingHostedSiteTerminalEvent,
 } from "./database/hosted-site-event-log";
-
-export interface ProviderSession {
-  id: string;
-  threadId: string;
-  provider: AgentProviderId;
-  externalSessionId: string;
-  model: string;
-  effort: string;
-  state: "active" | "inactive" | "failed";
-  createdAt: string;
-  updatedAt: string;
-  resumeCursor: string | null;
-}
-
-export interface StoredThreadSummary {
-  id: string;
-  threadId: string;
-  throughMessageId: string | null;
-  text: string;
-  estimatedTokens: number;
-  createdAt: string;
-}
-
-interface SessionRow {
-  id: string;
-  thread_id: string;
-  provider: AgentProviderId;
-  external_session_id: string;
-  model: string;
-  effort: string;
-  state: ProviderSession["state"];
-  created_at: string;
-  updated_at: string;
-  resume_cursor: string | null;
-}
-
-interface MailboxProjectionAttachment {
-  id: string;
-  name: string;
-  path: string;
-}
-
-interface MailboxProjectionMessage {
-  id: string;
-  sender: {
-    kind: string;
-    botId?: string;
-    routineId?: string;
-    runId?: string;
-    routineName?: string;
-    scheduledFor?: string;
-  };
-  text: string;
-  replyToMessageId: string | null;
-  createdAt: string;
-  attachments: MailboxProjectionAttachment[];
-}
-
-interface MailboxProjectionDelivery {
-  id: string;
-  messageId: string;
-  recipientBotId: string;
-  status: string;
-  turnId: string | null;
-  error: string | null;
-  createdAt: string;
-}
-
-interface MailboxProjectionDraft extends MailboxProjectionAttachment {
-  createdAt: string;
-}
-
-interface MailboxProjectionGeneratedAttachment extends MailboxProjectionAttachment {
-  size: number;
-  kind: string;
-  mimeType: string;
-  previewKind: string;
-  previewUrl: string | null;
-  sha256: string;
-}
-
-interface MailboxProjectionReaction {
-  botId: string;
-  messageId: string;
-  emoji: string;
-  actor: { kind: "user" } | { kind: "bot"; botId: string };
-  updatedAt: string;
-}
-
-interface MailboxProjectionState {
-  messages: MailboxProjectionMessage[];
-  deliveries: MailboxProjectionDelivery[];
-  drafts: MailboxProjectionDraft[];
-  generatedAttachments: MailboxProjectionGeneratedAttachment[];
-  pausedBotIds: string[];
-  idempotency: Record<string, string>;
-  reactions: MailboxProjectionReaction[];
-}
+import { MailboxProjection, type MailboxProjectionState } from "./database/mailbox-projection";
+import { type ProviderSession, ProviderSessions } from "./database/provider-sessions";
+import { type StoredThreadSummary, ThreadSummaries } from "./database/thread-summaries";
 
 // Declared in this module before the split and part of the frozen public surface, so it stays
 // reachable from here rather than only from the controller that owns it now. Structural `Pick<...>`
@@ -144,6 +49,8 @@ export type {
   ActiveHostedSiteConversationEvent,
   PendingHostedSiteTerminalEvent,
 } from "./database/hosted-site-event-log";
+export type { ProviderSession } from "./database/provider-sessions";
+export type { StoredThreadSummary } from "./database/thread-summaries";
 
 /**
  * The local OpenBot event log and its read projections.
@@ -154,10 +61,16 @@ export type {
 export class OpenBotDatabase {
   readonly #core: DatabaseCore;
   readonly #hostedSiteEvents: HostedSiteEventLog;
+  readonly #mailbox: MailboxProjection;
+  readonly #sessions: ProviderSessions;
+  readonly #summaries: ThreadSummaries;
 
   constructor(readonly userDataPath: string) {
     this.#core = new DatabaseCore({ userDataPath });
     this.#hostedSiteEvents = new HostedSiteEventLog({ core: this.#core });
+    this.#mailbox = new MailboxProjection({ core: this.#core });
+    this.#sessions = new ProviderSessions({ core: this.#core });
+    this.#summaries = new ThreadSummaries({ core: this.#core });
   }
 
   get path(): string {
@@ -1006,32 +919,11 @@ export class OpenBotDatabase {
   }
 
   activeProviderSession(threadId: string, provider: AgentProviderId): ProviderSession | null {
-    const row = decodeSessionRow(
-      this.connection
-        .prepare(
-          `SELECT id, thread_id, provider, external_session_id, model, effort, state,
-                  created_at, updated_at, resume_cursor
-           FROM projection_provider_sessions
-           WHERE thread_id = ? AND provider = ? AND state = 'active'
-           ORDER BY created_at DESC, last_event_sequence DESC LIMIT 1`,
-        )
-        .get(threadId, provider),
-    );
-    return row ? toProviderSession(row) : null;
+    return this.#sessions.activeProviderSession(threadId, provider);
   }
 
   listProviderSessions(threadId: string): ProviderSession[] {
-    return databaseRows(
-      this.connection
-        .prepare(
-          `SELECT id, thread_id, provider, external_session_id, model, effort, state,
-                  created_at, updated_at, resume_cursor
-           FROM projection_provider_sessions
-           WHERE thread_id = ?
-           ORDER BY created_at, last_event_sequence`,
-        )
-        .all(threadId),
-    ).map((row) => toProviderSession(requiredSessionRow(row)));
+    return this.#sessions.listProviderSessions(threadId);
   }
 
   bindProviderSession(input: {
@@ -1042,100 +934,15 @@ export class OpenBotDatabase {
     effort: string;
     resumeCursor?: string | null;
   }): ProviderSession {
-    const now = new Date().toISOString();
-    const session: ProviderSession = {
-      id: randomUUID(),
-      threadId: input.threadId,
-      provider: input.provider,
-      externalSessionId: input.externalSessionId,
-      model: input.model,
-      effort: input.effort,
-      state: "active",
-      createdAt: now,
-      updatedAt: now,
-      resumeCursor: input.resumeCursor ?? input.externalSessionId,
-    };
-    return this.dispatch(
-      `provider-session:bind:${input.threadId}:${input.provider}:${input.externalSessionId}`,
-      [
-        {
-          aggregateType: "thread",
-          aggregateId: input.threadId,
-          eventType: "provider-session.bound",
-          payload: session,
-        },
-      ],
-      (db, sequences) => {
-        db.prepare(
-          `UPDATE projection_provider_sessions SET state = 'inactive', updated_at = ?
-           WHERE thread_id = ? AND state = 'active'`,
-        ).run(now, input.threadId);
-        db.prepare(`
-          INSERT INTO projection_provider_sessions (
-            id, thread_id, provider, external_session_id, model, effort, state,
-            created_at, updated_at, resume_cursor, last_event_sequence
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `).run(
-          session.id,
-          session.threadId,
-          session.provider,
-          session.externalSessionId,
-          session.model,
-          session.effort,
-          session.state,
-          session.createdAt,
-          session.updatedAt,
-          session.resumeCursor,
-          sequences[0],
-        );
-        return session;
-      },
-    );
+    return this.#sessions.bindProviderSession(input);
   }
 
   deactivateProviderSessions(threadId: string): void {
-    const active = this.listProviderSessions(threadId).filter((session) => session.state === "active");
-    if (active.length === 0) return;
-    this.dispatch(
-      `provider-session:deactivate:${threadId}:${randomUUID()}`,
-      [
-        {
-          aggregateType: "thread",
-          aggregateId: threadId,
-          eventType: "provider-session.deactivated",
-          payload: { sessionIds: active.map((session) => session.id) },
-        },
-      ],
-      (db, sequences) => {
-        db.prepare(
-          `UPDATE projection_provider_sessions
-           SET state = 'inactive', updated_at = ?, last_event_sequence = ?
-           WHERE thread_id = ? AND state = 'active'`,
-        ).run(new Date().toISOString(), sequences[0], threadId);
-        return null;
-      },
-    );
+    this.#sessions.deactivateProviderSessions(threadId);
   }
 
   updateProviderSessionConfig(sessionId: string, threadId: string, model: string, effort: string): void {
-    this.dispatch(
-      `provider-session:config:${sessionId}:${model}:${effort}`,
-      [
-        {
-          aggregateType: "thread",
-          aggregateId: threadId,
-          eventType: "provider-session.config-updated",
-          payload: { sessionId, model, effort },
-        },
-      ],
-      (db, sequences) => {
-        db.prepare(
-          `UPDATE projection_provider_sessions
-           SET model = ?, effort = ?, updated_at = ?, last_event_sequence = ? WHERE id = ?`,
-        ).run(model, effort, new Date().toISOString(), sequences[0], sessionId);
-        return null;
-      },
-    );
+    this.#sessions.updateProviderSessionConfig(sessionId, threadId, model, effort);
   }
 
   saveThreadSummary(
@@ -1144,54 +951,11 @@ export class OpenBotDatabase {
     text: string,
     estimatedTokens: number,
   ): StoredThreadSummary {
-    const summary: StoredThreadSummary = {
-      id: randomUUID(),
-      threadId,
-      throughMessageId,
-      text,
-      estimatedTokens,
-      createdAt: new Date().toISOString(),
-    };
-    return this.dispatch(
-      `thread-summary:${summary.id}`,
-      [
-        {
-          aggregateType: "thread",
-          aggregateId: threadId,
-          eventType: "thread.summary-created",
-          payload: summary,
-        },
-      ],
-      (db, sequences) => {
-        db.prepare(`
-          INSERT INTO projection_thread_summaries
-            (summary_id, thread_id, through_message_id, summary_text, estimated_tokens, created_at, last_event_sequence)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
-        `).run(summary.id, threadId, throughMessageId, text, estimatedTokens, summary.createdAt, sequences[0]);
-        return summary;
-      },
-    );
+    return this.#summaries.saveThreadSummary(threadId, throughMessageId, text, estimatedTokens);
   }
 
   latestThreadSummary(threadId: string): StoredThreadSummary | null {
-    const row = decodeSummaryRow(
-      this.connection
-        .prepare(
-          `SELECT summary_id, thread_id, through_message_id, summary_text, estimated_tokens, created_at
-           FROM projection_thread_summaries WHERE thread_id = ? ORDER BY created_at DESC LIMIT 1`,
-        )
-        .get(threadId),
-    );
-    return row
-      ? {
-          id: row.summary_id,
-          threadId: row.thread_id,
-          throughMessageId: row.through_message_id,
-          text: row.summary_text,
-          estimatedTokens: row.estimated_tokens,
-          createdAt: row.created_at,
-        }
-      : null;
+    return this.#summaries.latestThreadSummary(threadId);
   }
 
   rebuildThreadProjection(threadId: string): ConversationSnapshot {
@@ -1421,211 +1185,25 @@ export class OpenBotDatabase {
     state: MailboxProjectionState,
     eventType: string,
     fileDeletions: string[] = [],
-    _rebaseHistory = false,
+    rebaseHistory = false,
   ): void {
-    this.dispatch(
-      commandId,
-      [
-        {
-          aggregateType: "mailbox",
-          aggregateId: "mailbox",
-          eventType,
-          payload: state,
-        },
-      ],
-      (db, sequences) => {
-        const sequence = sequences[0] ?? 0;
-        db.prepare(
-          `DELETE FROM orchestration_events
-           WHERE aggregate_type = 'mailbox' AND aggregate_id = 'mailbox' AND sequence < ?`,
-        ).run(sequence);
-        deleteOrphanReceipts(db);
-        const value = state;
-        db.exec("DELETE FROM projection_deliveries");
-        db.exec("DELETE FROM projection_mailbox_messages");
-        db.exec("DELETE FROM projection_queue_state");
-        db.exec("DELETE FROM projection_reactions");
-        db.exec("DELETE FROM projection_attachments WHERE owner_kind IN ('mailbox-message', 'draft', 'generated')");
-        const messageInsert = db.prepare(`
-          INSERT INTO projection_mailbox_messages
-            (message_id, sender_kind, sender_agent_id, text, reply_to_message_id, created_at, message_json, last_event_sequence)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        `);
-        const attachmentInsert = db.prepare(`
-          INSERT INTO projection_attachments
-            (attachment_id, owner_kind, owner_id, name, path, metadata_json, created_at, last_event_sequence)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        `);
-        for (const message of value.messages) {
-          const sender = message.sender;
-          messageInsert.run(
-            String(message.id),
-            sender.kind,
-            sender.botId ?? null,
-            String(message.text),
-            isString(message.replyToMessageId) ? message.replyToMessageId : null,
-            String(message.createdAt),
-            JSON.stringify(message),
-            sequence,
-          );
-          for (const attachment of message.attachments) {
-            attachmentInsert.run(
-              String(attachment.id),
-              "mailbox-message",
-              String(message.id),
-              String(attachment.name),
-              String(attachment.path),
-              JSON.stringify(attachment),
-              String(message.createdAt),
-              sequence,
-            );
-          }
-        }
-        const deliveryInsert = db.prepare(`
-          INSERT INTO projection_deliveries
-            (delivery_id, message_id, recipient_agent_id, status, turn_id, error, created_at, delivery_json, last_event_sequence)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `);
-        for (const delivery of value.deliveries) {
-          deliveryInsert.run(
-            String(delivery.id),
-            String(delivery.messageId),
-            String(delivery.recipientBotId),
-            String(delivery.status),
-            isString(delivery.turnId) ? delivery.turnId : null,
-            isString(delivery.error) ? delivery.error : null,
-            String(delivery.createdAt),
-            JSON.stringify(delivery),
-            sequence,
-          );
-        }
-        const queueInsert = db.prepare(`
-          INSERT INTO projection_queue_state
-            (agent_id, paused, metadata_json, last_event_sequence) VALUES (?, ?, ?, ?)
-        `);
-        queueInsert.run("__mailbox__", 0, JSON.stringify({ idempotency: value.idempotency }), sequence);
-        for (const botId of value.pausedBotIds) queueInsert.run(botId, 1, "{}", sequence);
-        const reactionInsert = db.prepare(`
-          INSERT INTO projection_reactions
-            (agent_id, message_id, emoji, actor_kind, actor_bot_id, updated_at, last_event_sequence)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
-        `);
-        for (const reaction of value.reactions) {
-          reactionInsert.run(
-            String(reaction.botId),
-            String(reaction.messageId),
-            String(reaction.emoji),
-            reaction.actor.kind,
-            reaction.actor.kind === "bot" ? reaction.actor.botId : "",
-            String(reaction.updatedAt),
-            sequence,
-          );
-        }
-        for (const draft of value.drafts) {
-          attachmentInsert.run(
-            String(draft.id),
-            "draft",
-            String(draft.id),
-            String(draft.name),
-            String(draft.path),
-            JSON.stringify(draft),
-            String(draft.createdAt),
-            sequence,
-          );
-        }
-        for (const attachment of value.generatedAttachments) {
-          attachmentInsert.run(
-            String(attachment.id),
-            "generated",
-            String(attachment.id),
-            String(attachment.name),
-            String(attachment.path),
-            JSON.stringify(attachment),
-            new Date().toISOString(),
-            sequence,
-          );
-        }
-        const outboxInsert = db.prepare(`
-          INSERT OR IGNORE INTO file_deletion_outbox
-            (id, path, reason, created_at, attempts, last_error)
-          VALUES (?, ?, ?, ?, 0, NULL)
-        `);
-        for (const path of fileDeletions) {
-          outboxInsert.run(randomUUID(), path, eventType, new Date().toISOString());
-        }
-        return null;
-      },
-    );
+    this.#mailbox.replaceMailboxState(commandId, state, eventType, fileDeletions, rebaseHistory);
   }
 
   pendingFileDeletions(): Array<{ id: string; path: string }> {
-    return databaseRows(
-      this.connection.prepare("SELECT id, path FROM file_deletion_outbox ORDER BY created_at").all(),
-    ).map((row) => ({
-      id: requiredStringColumn(row, "id"),
-      path: requiredStringColumn(row, "path"),
-    }));
+    return this.#mailbox.pendingFileDeletions();
   }
 
   completeFileDeletion(id: string): void {
-    this.connection.prepare("DELETE FROM file_deletion_outbox WHERE id = ?").run(id);
+    this.#mailbox.completeFileDeletion(id);
   }
 
   failFileDeletion(id: string, error: string): void {
-    this.connection
-      .prepare(
-        `UPDATE file_deletion_outbox
-         SET attempts = attempts + 1, last_error = ? WHERE id = ?`,
-      )
-      .run(error.slice(0, 2_000), id);
+    this.#mailbox.failFileDeletion(id, error);
   }
 
   readMailboxState(): unknown | null {
-    const db = this.connection;
-    const marker = databaseRow(
-      db.prepare("SELECT metadata_json FROM projection_queue_state WHERE agent_id = '__mailbox__'").get(),
-    );
-    if (!marker) return null;
-    const metadata = parseMailboxMetadata(requiredStringColumn(marker, "metadata_json"));
-    const messages = databaseRows(
-      db.prepare("SELECT message_json FROM projection_mailbox_messages ORDER BY created_at, message_id").all(),
-    ).map((row) => JSON.parse(requiredStringColumn(row, "message_json")));
-    const deliveries = databaseRows(
-      db.prepare("SELECT delivery_json FROM projection_deliveries ORDER BY created_at, delivery_id").all(),
-    ).map((row) => JSON.parse(requiredStringColumn(row, "delivery_json")));
-    const drafts = databaseRows(
-      db.prepare("SELECT metadata_json FROM projection_attachments WHERE owner_kind = 'draft'").all(),
-    ).map((row) => JSON.parse(requiredStringColumn(row, "metadata_json")));
-    const generatedAttachments = databaseRows(
-      db.prepare("SELECT metadata_json FROM projection_attachments WHERE owner_kind = 'generated'").all(),
-    ).map((row) => JSON.parse(requiredStringColumn(row, "metadata_json")));
-    const pausedBotIds = databaseRows(
-      db.prepare("SELECT agent_id FROM projection_queue_state WHERE paused = 1").all(),
-    ).map((row) => requiredStringColumn(row, "agent_id"));
-    const reactions = databaseRows(
-      db
-        .prepare("SELECT agent_id, message_id, emoji, actor_kind, actor_bot_id, updated_at FROM projection_reactions")
-        .all(),
-    ).map((row) => ({
-      botId: requiredStringColumn(row, "agent_id"),
-      messageId: requiredStringColumn(row, "message_id"),
-      emoji: requiredStringColumn(row, "emoji"),
-      actor:
-        requiredStringColumn(row, "actor_kind") === "bot"
-          ? { kind: "bot" as const, botId: requiredStringColumn(row, "actor_bot_id") }
-          : { kind: "user" as const },
-      updatedAt: requiredStringColumn(row, "updated_at"),
-    }));
-    return {
-      version: 3,
-      messages,
-      deliveries,
-      drafts,
-      generatedAttachments,
-      pausedBotIds,
-      idempotency: metadata.idempotency ?? {},
-      reactions,
-    };
+    return this.#mailbox.readMailboxState();
   }
 
   #ensureThreadProjection(db: DatabaseSync, agent: BotSummary, sequence: number): void {
@@ -1648,21 +1226,6 @@ export class OpenBotDatabase {
       sequence,
     );
   }
-}
-
-function toProviderSession(row: SessionRow): ProviderSession {
-  return {
-    id: row.id,
-    threadId: row.thread_id,
-    provider: row.provider,
-    externalSessionId: row.external_session_id,
-    model: row.model,
-    effort: row.effort,
-    state: row.state,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-    resumeCursor: row.resume_cursor,
-  };
 }
 
 interface ConversationPageCursor {
@@ -1752,70 +1315,6 @@ function decodeSearchCursor(value: string): number {
 
 function escapeLike(value: string): string {
   return value.replace(/[\\%_]/g, (character) => `\\${character}`);
-}
-
-function decodeSessionRow(value: unknown): SessionRow | null {
-  const row = databaseRow(value);
-  if (!row) return null;
-  const provider = requiredStringColumn(row, "provider");
-  const state = requiredStringColumn(row, "state");
-  if (!isAgentProvider(provider)) throw new Error("Invalid provider column.");
-  if (state !== "active" && state !== "inactive" && state !== "failed") {
-    throw new Error("Invalid provider session state column.");
-  }
-  return {
-    id: requiredStringColumn(row, "id"),
-    thread_id: requiredStringColumn(row, "thread_id"),
-    provider,
-    external_session_id: requiredStringColumn(row, "external_session_id"),
-    model: requiredStringColumn(row, "model"),
-    effort: requiredStringColumn(row, "effort"),
-    state,
-    created_at: requiredStringColumn(row, "created_at"),
-    updated_at: requiredStringColumn(row, "updated_at"),
-    resume_cursor: optionalStringColumn(row, "resume_cursor"),
-  };
-}
-
-function requiredSessionRow(value: DynamicRecord): SessionRow {
-  const row = decodeSessionRow(value);
-  if (!row) throw new Error("Invalid provider session row.");
-  return row;
-}
-
-function decodeSummaryRow(value: unknown): {
-  summary_id: string;
-  thread_id: string;
-  through_message_id: string | null;
-  summary_text: string;
-  estimated_tokens: number;
-  created_at: string;
-} | null {
-  const row = databaseRow(value);
-  if (!row) return null;
-  return {
-    summary_id: requiredStringColumn(row, "summary_id"),
-    thread_id: requiredStringColumn(row, "thread_id"),
-    through_message_id: optionalStringColumn(row, "through_message_id"),
-    summary_text: requiredStringColumn(row, "summary_text"),
-    estimated_tokens: requiredNumberColumn(row, "estimated_tokens"),
-    created_at: requiredStringColumn(row, "created_at"),
-  };
-}
-
-function parseMailboxMetadata(value: string): { idempotency?: Record<string, string> } {
-  const parsed = JSON.parse(value);
-  if (!isDynamicRecord(parsed)) throw new Error("Invalid mailbox metadata.");
-  const idempotency = parsed.idempotency;
-  if (idempotency === undefined) return {};
-  if (!isDynamicRecord(idempotency)) throw new Error("Invalid mailbox idempotency metadata.");
-  const entries = Object.entries(idempotency);
-  const values: Record<string, string> = {};
-  for (const [key, entry] of entries) {
-    if (!isString(entry)) throw new Error("Invalid mailbox idempotency entry.");
-    values[key] = entry;
-  }
-  return { idempotency: values };
 }
 
 function providerSessionValue(value: DynamicRecord | null): ProviderSession | null {

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -10,21 +10,11 @@ import type {
   ConversationSnapshot,
   HostedSiteConversationEventStatus,
 } from "@openbot/contracts/ipc";
-import { isAgentProvider, isConversationMessage, providerForLegacyModel } from "@openbot/contracts/ipc";
-import { type DynamicRecord, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { providerForLegacyModel } from "@openbot/contracts/ipc";
 import { AgentRoster } from "./database/agent-roster";
 import { ConversationQueries } from "./database/conversation-queries";
-import { DatabaseCore, deleteOrphanReceipts, type OrchestrationEventInput } from "./database/database-core";
-import {
-  databaseRow,
-  databaseRows,
-  decodeThreadAgentRow,
-  objectValue,
-  optionalStringColumn,
-  requiredEventRow,
-  requiredNumberColumn,
-  requiredStringColumn,
-} from "./database/database-rows";
+import { ConversationWriter } from "./database/conversation-writer";
+import { DatabaseCore, type OrchestrationEventInput } from "./database/database-core";
 import {
   type ActiveHostedSiteConversationEvent,
   HostedSiteEventLog,
@@ -32,6 +22,7 @@ import {
 } from "./database/hosted-site-event-log";
 import { MailboxProjection, type MailboxProjectionState } from "./database/mailbox-projection";
 import { type ProviderSession, ProviderSessions } from "./database/provider-sessions";
+import { ThreadReplay } from "./database/thread-replay";
 import { type StoredThreadSummary, ThreadSummaries } from "./database/thread-summaries";
 
 // Declared in this module before the split and part of the frozen public surface, so it stays
@@ -55,6 +46,8 @@ export class OpenBotDatabase {
   readonly #core: DatabaseCore;
   readonly #conversations: ConversationQueries;
   readonly #roster: AgentRoster;
+  readonly #conversationWrites: ConversationWriter;
+  readonly #replay: ThreadReplay;
   readonly #hostedSiteEvents: HostedSiteEventLog;
   readonly #mailbox: MailboxProjection;
   readonly #sessions: ProviderSessions;
@@ -64,6 +57,8 @@ export class OpenBotDatabase {
     this.#core = new DatabaseCore({ userDataPath });
     this.#conversations = new ConversationQueries({ core: this.#core });
     this.#roster = new AgentRoster({ core: this.#core });
+    this.#conversationWrites = new ConversationWriter({ core: this.#core, roster: this.#roster });
+    this.#replay = new ThreadReplay({ core: this.#core, conversations: this.#conversations });
     this.#hostedSiteEvents = new HostedSiteEventLog({ core: this.#core });
     this.#mailbox = new MailboxProjection({ core: this.#core });
     this.#sessions = new ProviderSessions({ core: this.#core });
@@ -198,134 +193,7 @@ export class OpenBotDatabase {
     payload: unknown = {},
     commandId = `conversation:${eventType}:${randomUUID()}`,
   ): ConversationSnapshot {
-    if (!snapshot.threadId) return structuredClone(snapshot);
-    const threadId = snapshot.threadId;
-    const recovery = conversationRecoveryState(this.connection, threadId, snapshot.activeTurnId);
-    const result = this.dispatch(
-      commandId,
-      [
-        {
-          aggregateType: "thread",
-          aggregateId: threadId,
-          eventType,
-          payload: { detail: payload, snapshot, recovery },
-        },
-      ],
-      (db, sequences) => {
-        const sequence = sequences[0] ?? snapshot.revision;
-        const agent = this.#roster.listAgents().find((candidate) => candidate.id === snapshot.botId);
-        if (!agent) throw new Error(`Unknown agent for conversation: ${snapshot.botId}`);
-        this.#roster.ensureThreadProjection(db, agent, sequence);
-        db.prepare(
-          `UPDATE projection_threads
-           SET active_turn_id = ?, updated_at = ?, last_event_sequence = ? WHERE thread_id = ?`,
-        ).run(snapshot.activeTurnId, new Date().toISOString(), sequence, snapshot.threadId);
-        const messageIds = new Set(snapshot.messages.map((message) => message.id));
-        const staleMessageIds = databaseRows(
-          db.prepare("SELECT message_id FROM projection_thread_messages WHERE thread_id = ?").all(threadId),
-        )
-          .map((row) => requiredStringColumn(row, "message_id"))
-          .filter((messageId) => !messageIds.has(messageId));
-        const deleteMessage = db.prepare(
-          "DELETE FROM projection_thread_messages WHERE thread_id = ? AND message_id = ?",
-        );
-        const deleteAttachments = db.prepare(
-          "DELETE FROM projection_attachments WHERE owner_kind = 'thread-message' AND owner_id = ?",
-        );
-        for (const messageId of staleMessageIds) {
-          deleteAttachments.run(`${threadId}:${messageId}`);
-          deleteMessage.run(threadId, messageId);
-        }
-        const upsert = db.prepare(`
-          INSERT INTO projection_thread_messages (
-            thread_id, message_id, turn_id, author, status, item_type, created_at,
-            ordinal, message_json, last_event_sequence
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(thread_id, message_id) DO UPDATE SET
-            turn_id = excluded.turn_id,
-            author = excluded.author,
-            status = excluded.status,
-            item_type = excluded.item_type,
-            created_at = excluded.created_at,
-            ordinal = excluded.ordinal,
-            message_json = excluded.message_json,
-            last_event_sequence = excluded.last_event_sequence
-        `);
-        snapshot.messages.forEach((message, ordinal) => {
-          upsert.run(
-            snapshot.threadId,
-            message.id,
-            message.turnId ?? null,
-            message.author,
-            message.status,
-            message.itemType ?? null,
-            message.createdAt,
-            ordinal,
-            JSON.stringify(message),
-            sequence,
-          );
-          for (const attachment of message.attachments ?? []) {
-            db.prepare(`
-              INSERT OR REPLACE INTO projection_attachments
-                (attachment_id, owner_kind, owner_id, name, path, metadata_json, created_at, last_event_sequence)
-              VALUES (?, 'thread-message', ?, ?, '', ?, ?, ?)
-            `).run(
-              `${snapshot.threadId}:${message.id}:${attachment.id}`,
-              `${snapshot.threadId}:${message.id}`,
-              attachment.name,
-              JSON.stringify(attachment),
-              message.createdAt,
-              sequence,
-            );
-          }
-        });
-        db.prepare(`
-          INSERT INTO projection_thread_activities
-            (activity_id, thread_id, turn_id, activity_type, payload_json, created_at, last_event_sequence)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
-        `).run(
-          randomUUID(),
-          snapshot.threadId,
-          snapshot.activeTurnId,
-          eventType,
-          JSON.stringify(payload),
-          new Date().toISOString(),
-          sequence,
-        );
-        if (snapshot.activeTurnId) {
-          db.prepare(`
-            INSERT INTO projection_turns
-              (turn_id, thread_id, provider_session_id, status, started_at, completed_at, last_event_sequence)
-            VALUES (?, ?, (
-              SELECT id FROM projection_provider_sessions
-              WHERE thread_id = ? AND state = 'active' ORDER BY created_at DESC LIMIT 1
-            ), 'running', ?, NULL, ?)
-            ON CONFLICT(turn_id) DO UPDATE SET status = 'running', last_event_sequence = excluded.last_event_sequence
-          `).run(snapshot.activeTurnId, snapshot.threadId, snapshot.threadId, new Date().toISOString(), sequence);
-        }
-        if (
-          ["turn.completed", "turn.reconciled-after-restart", "turn.interrupted-by-restart"].includes(eventType) &&
-          isDynamicRecord(payload) &&
-          "turnId" in payload &&
-          isString(payload.turnId)
-        ) {
-          const status =
-            "status" in payload && isString(payload.status)
-              ? payload.status
-              : eventType === "turn.interrupted-by-restart"
-                ? "interrupted"
-                : "completed";
-          db.prepare(
-            `UPDATE projection_turns
-             SET status = ?, completed_at = ?, last_event_sequence = ?
-             WHERE thread_id = ? AND turn_id = ?`,
-          ).run(status, new Date().toISOString(), sequence, snapshot.threadId, payload.turnId);
-        }
-        pruneConversationSnapshots(db, threadId, sequence);
-        return { revision: sequence };
-      },
-    );
-    return { ...structuredClone(snapshot), revision: result.revision };
+    return this.#conversationWrites.persistConversation(snapshot, eventType, payload, commandId);
   }
 
   appendConversationMessage(input: {
@@ -337,89 +205,7 @@ export class OpenBotDatabase {
     detail?: unknown;
     commandId?: string;
   }): number {
-    const result = this.dispatch(
-      input.commandId ?? `conversation:${input.eventType}:${randomUUID()}`,
-      [
-        {
-          aggregateType: "thread",
-          aggregateId: input.threadId,
-          eventType: input.eventType,
-          occurredAt: input.message.createdAt,
-          payload: {
-            detail: input.detail ?? {},
-            appendedMessage: input.message,
-            activeTurnId: input.activeTurnId,
-          },
-        },
-      ],
-      (db, sequences) => {
-        const sequence = sequences[0] ?? 0;
-        const agent = this.#roster.listAgents().find((candidate) => candidate.id === input.botId);
-        if (!agent || agent.threadId !== input.threadId) {
-          throw new Error(`Unknown agent thread for conversation append: ${input.botId}`);
-        }
-        this.#roster.ensureThreadProjection(db, agent, sequence);
-        const ordinalRow = databaseRow(
-          db
-            .prepare(
-              `SELECT COALESCE(MAX(ordinal), -1) + 1 AS ordinal
-               FROM projection_thread_messages WHERE thread_id = ?`,
-            )
-            .get(input.threadId),
-        );
-        const ordinal = ordinalRow ? requiredNumberColumn(ordinalRow, "ordinal") : 0;
-        db.prepare(
-          `INSERT INTO projection_thread_messages (
-             thread_id, message_id, turn_id, author, status, item_type, created_at,
-             ordinal, message_json, last_event_sequence
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        ).run(
-          input.threadId,
-          input.message.id,
-          input.message.turnId ?? null,
-          input.message.author,
-          input.message.status,
-          input.message.itemType ?? null,
-          input.message.createdAt,
-          ordinal,
-          JSON.stringify(input.message),
-          sequence,
-        );
-        for (const attachment of input.message.attachments ?? []) {
-          db.prepare(
-            `INSERT INTO projection_attachments
-               (attachment_id, owner_kind, owner_id, name, path, metadata_json, created_at, last_event_sequence)
-             VALUES (?, 'thread-message', ?, ?, '', ?, ?, ?)`,
-          ).run(
-            `${input.threadId}:${input.message.id}:${attachment.id}`,
-            `${input.threadId}:${input.message.id}`,
-            attachment.name,
-            JSON.stringify(attachment),
-            input.message.createdAt,
-            sequence,
-          );
-        }
-        db.prepare(
-          `UPDATE projection_threads
-           SET active_turn_id = ?, updated_at = ?, last_event_sequence = ? WHERE thread_id = ?`,
-        ).run(input.activeTurnId, input.message.createdAt, sequence, input.threadId);
-        db.prepare(
-          `INSERT INTO projection_thread_activities
-             (activity_id, thread_id, turn_id, activity_type, payload_json, created_at, last_event_sequence)
-           VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        ).run(
-          randomUUID(),
-          input.threadId,
-          input.message.turnId ?? input.activeTurnId,
-          input.eventType,
-          JSON.stringify(input.detail ?? {}),
-          input.message.createdAt,
-          sequence,
-        );
-        return { revision: sequence };
-      },
-    );
-    return result.revision;
+    return this.#conversationWrites.appendConversationMessage(input);
   }
 
   persistConversationAndMailbox(
@@ -433,7 +219,7 @@ export class OpenBotDatabase {
     db.exec("BEGIN IMMEDIATE");
     try {
       this.replaceMailboxState(`mailbox:${mailboxEventType}:${randomUUID()}`, mailboxState, mailboxEventType);
-      const persisted = this.persistConversation(
+      const persisted = this.#conversationWrites.persistConversation(
         snapshot,
         eventType,
         payload,
@@ -488,225 +274,7 @@ export class OpenBotDatabase {
   }
 
   rebuildThreadProjection(threadId: string): ConversationSnapshot {
-    const db = this.connection;
-    const events = databaseRows(
-      db
-        .prepare(
-          `SELECT sequence, event_type, occurred_at, payload_json
-           FROM orchestration_events
-           WHERE aggregate_type = 'thread' AND aggregate_id = ? ORDER BY sequence`,
-        )
-        .all(threadId),
-    ).map(requiredEventRow);
-    const thread = decodeThreadAgentRow(
-      db.prepare("SELECT agent_id FROM projection_threads WHERE thread_id = ?").get(threadId),
-    );
-    if (!thread) throw new Error(`Unknown OpenBot thread: ${threadId}`);
-
-    let latest: ConversationSnapshot | null = null;
-    let latestSequence = 0;
-    const sessions = new Map<string, ProviderSession & { sequence: number }>();
-    const summaries: Array<StoredThreadSummary & { sequence: number }> = [];
-    const turnSessions = new Map<string, string | null>();
-    for (const event of events) {
-      const payload = JSON.parse(event.payload_json);
-      const record = objectValue(payload);
-      if (event.event_type === "provider-session.bound") {
-        const session = providerSessionValue(record);
-        if (session) {
-          for (const current of sessions.values()) current.state = "inactive";
-          sessions.set(session.id, { ...session, sequence: event.sequence });
-        }
-      } else if (event.event_type === "provider-session.deactivated") {
-        const ids = Array.isArray(record?.sessionIds) ? record.sessionIds : [];
-        for (const id of ids) {
-          if (isString(id)) {
-            const session = sessions.get(id);
-            if (session) session.state = "inactive";
-          }
-        }
-      } else if (event.event_type === "provider-session.config-updated") {
-        const session = isString(record?.sessionId) ? sessions.get(record.sessionId) : null;
-        if (session) {
-          if (isString(record?.model)) session.model = record.model;
-          if (isString(record?.effort)) session.effort = record.effort;
-          session.sequence = event.sequence;
-        }
-      } else if (event.event_type === "thread.summary-created") {
-        const summary = summaryValue(record);
-        if (summary) summaries.push({ ...summary, sequence: event.sequence });
-      }
-      const snapshot = conversationSnapshotValue(objectValue(record?.snapshot));
-      const appendedMessage = record?.appendedMessage;
-      const appendedActiveTurnId = record?.activeTurnId;
-      if (snapshot) {
-        latest = snapshot;
-        latestSequence = event.sequence;
-        for (const [turnId, sessionId] of turnProviderSessionIdsValue(record?.recovery)) {
-          turnSessions.set(turnId, sessionId);
-        }
-        if (snapshot.activeTurnId && !turnSessions.has(snapshot.activeTurnId)) {
-          const activeSession = [...sessions.values()].find((session) => session.state === "active");
-          turnSessions.set(snapshot.activeTurnId, activeSession?.id ?? null);
-        }
-      } else if (latest && isConversationMessage(appendedMessage)) {
-        if (!latest.messages.some((message) => message.id === appendedMessage.id)) {
-          latest.messages.push(structuredClone(appendedMessage));
-        }
-        if (isString(appendedActiveTurnId) || appendedActiveTurnId === null) {
-          latest.activeTurnId = appendedActiveTurnId;
-        }
-        latestSequence = event.sequence;
-      }
-    }
-    if (!latest) throw new Error(`Thread ${threadId} has no conversation events to replay.`);
-
-    db.exec("BEGIN IMMEDIATE");
-    try {
-      db.prepare("DELETE FROM projection_thread_activities WHERE thread_id = ?").run(threadId);
-      db.prepare("DELETE FROM projection_turns WHERE thread_id = ?").run(threadId);
-      db.prepare("DELETE FROM projection_thread_messages WHERE thread_id = ?").run(threadId);
-      db.prepare("DELETE FROM projection_thread_summaries WHERE thread_id = ?").run(threadId);
-      db.prepare("DELETE FROM projection_provider_sessions WHERE thread_id = ?").run(threadId);
-      db.prepare("DELETE FROM projection_attachments WHERE owner_kind = 'thread-message' AND owner_id LIKE ?").run(
-        `${threadId}:%`,
-      );
-      const sessionInsert = db.prepare(`
-        INSERT INTO projection_provider_sessions (
-          id, thread_id, provider, external_session_id, model, effort, state,
-          created_at, updated_at, resume_cursor, last_event_sequence
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `);
-      for (const session of sessions.values()) {
-        sessionInsert.run(
-          session.id,
-          threadId,
-          session.provider,
-          session.externalSessionId,
-          session.model,
-          session.effort,
-          session.state,
-          session.createdAt,
-          session.updatedAt,
-          session.resumeCursor,
-          session.sequence,
-        );
-      }
-      const messageInsert = db.prepare(`
-        INSERT INTO projection_thread_messages (
-          thread_id, message_id, turn_id, author, status, item_type, created_at,
-          ordinal, message_json, last_event_sequence
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `);
-      latest.messages.forEach((message, ordinal) => {
-        messageInsert.run(
-          threadId,
-          message.id,
-          message.turnId ?? null,
-          message.author,
-          message.status,
-          message.itemType ?? null,
-          message.createdAt,
-          ordinal,
-          JSON.stringify(message),
-          latestSequence,
-        );
-        for (const attachment of message.attachments ?? []) {
-          db.prepare(`
-            INSERT INTO projection_attachments
-              (attachment_id, owner_kind, owner_id, name, path, metadata_json, created_at, last_event_sequence)
-            VALUES (?, 'thread-message', ?, ?, '', ?, ?, ?)
-          `).run(
-            `${threadId}:${message.id}:${attachment.id}`,
-            `${threadId}:${message.id}`,
-            attachment.name,
-            JSON.stringify(attachment),
-            message.createdAt,
-            latestSequence,
-          );
-        }
-      });
-      const messagesByTurn = new Map<string, ConversationMessage[]>();
-      for (const message of latest.messages) {
-        if (!message.turnId) continue;
-        const messages = messagesByTurn.get(message.turnId) ?? [];
-        messages.push(message);
-        messagesByTurn.set(message.turnId, messages);
-      }
-      const turnInsert = db.prepare(`
-        INSERT INTO projection_turns (
-          turn_id, thread_id, provider_session_id, status, started_at, completed_at, last_event_sequence
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-      `);
-      for (const [turnId, messages] of messagesByTurn) {
-        const running = latest.activeTurnId === turnId;
-        const status = running
-          ? "running"
-          : messages.some((message) => message.status === "failed")
-            ? "failed"
-            : messages.some((message) => message.status === "interrupted")
-              ? "interrupted"
-              : "completed";
-        turnInsert.run(
-          turnId,
-          threadId,
-          turnSessions.get(turnId) ?? null,
-          status,
-          messages[0]?.createdAt ?? new Date().toISOString(),
-          running ? null : (messages.at(-1)?.createdAt ?? new Date().toISOString()),
-          latestSequence,
-        );
-      }
-      const summaryInsert = db.prepare(`
-        INSERT INTO projection_thread_summaries (
-          summary_id, thread_id, through_message_id, summary_text,
-          estimated_tokens, created_at, last_event_sequence
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-      `);
-      for (const summary of summaries) {
-        summaryInsert.run(
-          summary.id,
-          threadId,
-          summary.throughMessageId,
-          summary.text,
-          summary.estimatedTokens,
-          summary.createdAt,
-          summary.sequence,
-        );
-      }
-      const activityInsert = db.prepare(`
-        INSERT INTO projection_thread_activities (
-          activity_id, thread_id, turn_id, activity_type,
-          payload_json, created_at, last_event_sequence
-        ) VALUES (?, ?, NULL, ?, ?, ?, ?)
-      `);
-      for (const event of events) {
-        const eventPayload = JSON.parse(event.payload_json);
-        const eventRecord = objectValue(eventPayload);
-        const activityPayload =
-          conversationSnapshotValue(objectValue(eventRecord?.snapshot)) ||
-          isConversationMessage(eventRecord?.appendedMessage)
-            ? (eventRecord?.detail ?? {})
-            : eventPayload;
-        activityInsert.run(
-          randomUUID(),
-          threadId,
-          event.event_type,
-          JSON.stringify(activityPayload),
-          event.occurred_at,
-          event.sequence,
-        );
-      }
-      db.prepare(
-        `UPDATE projection_threads
-         SET active_turn_id = ?, updated_at = ?, last_event_sequence = ? WHERE thread_id = ?`,
-      ).run(latest.activeTurnId, new Date().toISOString(), latestSequence, threadId);
-      db.exec("COMMIT");
-    } catch (error) {
-      db.exec("ROLLBACK");
-      throw error;
-    }
-    return this.#conversations.readConversation(thread.agent_id, threadId);
+    return this.#replay.rebuildThreadProjection(threadId);
   }
 
   replaceMailboxState(
@@ -734,135 +302,6 @@ export class OpenBotDatabase {
   readMailboxState(): unknown | null {
     return this.#mailbox.readMailboxState();
   }
-}
-
-function providerSessionValue(value: DynamicRecord | null): ProviderSession | null {
-  if (
-    !value ||
-    !isString(value.id) ||
-    !isString(value.threadId) ||
-    !isAgentProvider(value.provider) ||
-    !isString(value.externalSessionId) ||
-    !isString(value.model) ||
-    !isString(value.effort) ||
-    (value.state !== "active" && value.state !== "inactive" && value.state !== "failed") ||
-    !isString(value.createdAt) ||
-    !isString(value.updatedAt) ||
-    (!isString(value.resumeCursor) && value.resumeCursor !== null)
-  ) {
-    return null;
-  }
-  return {
-    id: value.id,
-    threadId: value.threadId,
-    provider: value.provider,
-    externalSessionId: value.externalSessionId,
-    model: value.model,
-    effort: value.effort,
-    state: value.state,
-    createdAt: value.createdAt,
-    updatedAt: value.updatedAt,
-    resumeCursor: value.resumeCursor,
-  };
-}
-
-function summaryValue(value: DynamicRecord | null): StoredThreadSummary | null {
-  if (
-    !value ||
-    !isString(value.id) ||
-    !isString(value.threadId) ||
-    (!isString(value.throughMessageId) && value.throughMessageId !== null) ||
-    !isString(value.text) ||
-    !isNumber(value.estimatedTokens) ||
-    !isString(value.createdAt)
-  ) {
-    return null;
-  }
-  return {
-    id: value.id,
-    threadId: value.threadId,
-    throughMessageId: value.throughMessageId,
-    text: value.text,
-    estimatedTokens: value.estimatedTokens,
-    createdAt: value.createdAt,
-  };
-}
-
-function conversationSnapshotValue(value: DynamicRecord | null): ConversationSnapshot | null {
-  if (
-    !value ||
-    !isString(value.botId) ||
-    (!isString(value.threadId) && value.threadId !== null) ||
-    (!isString(value.activeTurnId) && value.activeTurnId !== null) ||
-    !isNumber(value.revision) ||
-    !Array.isArray(value.messages)
-  ) {
-    return null;
-  }
-  const messages = value.messages.filter(isConversationMessage);
-  if (messages.length !== value.messages.length) return null;
-  return {
-    botId: value.botId,
-    threadId: value.threadId,
-    activeTurnId: value.activeTurnId,
-    revision: value.revision,
-    messages,
-  };
-}
-
-function conversationRecoveryState(
-  db: DatabaseSync,
-  threadId: string,
-  activeTurnId: string | null,
-): { turnProviderSessionIds: Record<string, string | null> } {
-  const turnProviderSessionIds: Record<string, string | null> = {};
-  for (const row of databaseRows(
-    db.prepare("SELECT turn_id, provider_session_id FROM projection_turns WHERE thread_id = ?").all(threadId),
-  )) {
-    const turnId = requiredStringColumn(row, "turn_id");
-    turnProviderSessionIds[turnId] = optionalStringColumn(row, "provider_session_id");
-  }
-  if (activeTurnId && !(activeTurnId in turnProviderSessionIds)) {
-    const activeSession = databaseRow(
-      db
-        .prepare(
-          `SELECT id FROM projection_provider_sessions
-           WHERE thread_id = ? AND state = 'active'
-           ORDER BY created_at DESC, last_event_sequence DESC LIMIT 1`,
-        )
-        .get(threadId),
-    );
-    turnProviderSessionIds[activeTurnId] = activeSession ? requiredStringColumn(activeSession, "id") : null;
-  }
-  return { turnProviderSessionIds };
-}
-
-function turnProviderSessionIdsValue(value: unknown): Array<[string, string | null]> {
-  const recovery = objectValue(value);
-  const turnProviderSessionIds = objectValue(recovery?.turnProviderSessionIds);
-  if (!turnProviderSessionIds) return [];
-  const result: Array<[string, string | null]> = [];
-  for (const [turnId, sessionId] of Object.entries(turnProviderSessionIds)) {
-    if (sessionId === null || isString(sessionId)) result.push([turnId, sessionId]);
-  }
-  return result;
-}
-
-function pruneConversationSnapshots(db: DatabaseSync, threadId: string, retainedSequence: number): void {
-  db.prepare(
-    `DELETE FROM projection_thread_activities
-     WHERE thread_id = ? AND last_event_sequence IN (
-       SELECT sequence FROM orchestration_events
-       WHERE aggregate_type = 'thread' AND aggregate_id = ? AND sequence < ?
-         AND json_type(payload_json, '$.snapshot') = 'object'
-     )`,
-  ).run(threadId, threadId, retainedSequence);
-  db.prepare(
-    `DELETE FROM orchestration_events
-     WHERE aggregate_type = 'thread' AND aggregate_id = ? AND sequence < ?
-       AND json_type(payload_json, '$.snapshot') = 'object'`,
-  ).run(threadId, retainedSequence);
-  deleteOrphanReceipts(db);
 }
 
 export function providerForStoredModel(model: BotSummary["model"]): AgentProviderId {

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -25,6 +25,19 @@ import {
   ROUTINE_RUN_EVENT_ITEM_TYPE_PREFIX,
 } from "@openbot/contracts/ipc";
 import { type DynamicRecord, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import {
+  databaseRow,
+  databaseRows,
+  decodeConversationMessageJson,
+  decodeConversationThreadRow,
+  decodeThreadAgentRow,
+  errorCode,
+  objectValue,
+  optionalStringColumn,
+  requiredEventRow,
+  requiredNumberColumn,
+  requiredStringColumn,
+} from "./database/database-rows";
 import { migrateOpenBotDatabase } from "./openbot-database-schema";
 
 export interface OrchestrationEventInput {
@@ -1925,53 +1938,12 @@ function escapeLike(value: string): string {
   return value.replace(/[\\%_]/g, (character) => `\\${character}`);
 }
 
-function databaseRow(value: unknown): DynamicRecord | null {
-  return isDynamicRecord(value) ? value : null;
-}
-
-function databaseRows(value: unknown): DynamicRecord[] {
-  if (!Array.isArray(value)) throw new Error("Invalid SQLite result set.");
-  return value.map((row, index) => {
-    if (!isDynamicRecord(row)) throw new Error(`Invalid SQLite row at index ${index}.`);
-    return row;
-  });
-}
-
-function requiredStringColumn(row: DynamicRecord, key: string): string {
-  const value = row[key];
-  if (!isString(value)) throw new Error(`Invalid SQLite column ${key}.`);
-  return value;
-}
-
-function requiredNumberColumn(row: DynamicRecord, key: string): number {
-  const value = row[key];
-  if (!isNumber(value)) throw new Error(`Invalid SQLite column ${key}.`);
-  return value;
-}
-
-function optionalStringColumn(row: DynamicRecord, key: string): string | null {
-  const value = row[key];
-  if (value === null || isString(value)) return value;
-  throw new Error(`Invalid SQLite column ${key}.`);
-}
-
 function decodeReceiptRow(value: unknown): ReceiptRow | null {
   const row = databaseRow(value);
   if (!row) return null;
   return {
     last_sequence: requiredNumberColumn(row, "last_sequence"),
     result_json: requiredStringColumn(row, "result_json"),
-  };
-}
-
-function decodeConversationThreadRow(
-  value: unknown,
-): { active_turn_id: string | null; last_event_sequence: number } | null {
-  const row = databaseRow(value);
-  if (!row) return null;
-  return {
-    active_turn_id: optionalStringColumn(row, "active_turn_id"),
-    last_event_sequence: requiredNumberColumn(row, "last_event_sequence"),
   };
 }
 
@@ -2024,25 +1996,6 @@ function decodeSummaryRow(value: unknown): {
   };
 }
 
-function requiredEventRow(value: DynamicRecord): {
-  sequence: number;
-  event_type: string;
-  occurred_at: string;
-  payload_json: string;
-} {
-  return {
-    sequence: requiredNumberColumn(value, "sequence"),
-    event_type: requiredStringColumn(value, "event_type"),
-    occurred_at: requiredStringColumn(value, "occurred_at"),
-    payload_json: requiredStringColumn(value, "payload_json"),
-  };
-}
-
-function decodeThreadAgentRow(value: unknown): { agent_id: string } | null {
-  const row = databaseRow(value);
-  return row ? { agent_id: requiredStringColumn(row, "agent_id") } : null;
-}
-
 function parseMailboxMetadata(value: string): { idempotency?: Record<string, string> } {
   const parsed = JSON.parse(value);
   if (!isDynamicRecord(parsed)) throw new Error("Invalid mailbox metadata.");
@@ -2056,20 +2009,6 @@ function parseMailboxMetadata(value: string): { idempotency?: Record<string, str
     values[key] = entry;
   }
   return { idempotency: values };
-}
-
-function decodeConversationMessageJson(value: string): ConversationMessage {
-  const parsed = JSON.parse(value);
-  if (!isConversationMessage(parsed)) throw new Error("Invalid conversation message.");
-  return parsed;
-}
-
-function errorCode(value: unknown): string | null {
-  return isDynamicRecord(value) && isString(value.code) ? value.code : null;
-}
-
-function objectValue(value: unknown): DynamicRecord | null {
-  return isDynamicRecord(value) ? value : null;
 }
 
 function providerSessionValue(value: DynamicRecord | null): ProviderSession | null {

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -8,14 +8,10 @@ import type {
   ConversationPageAnchor,
   ConversationSearchPage,
   ConversationSnapshot,
-  HostedSiteConversationEvent,
-  HostedSiteConversationEventAction,
-  HostedSiteConversationEventDetails,
   HostedSiteConversationEventStatus,
 } from "@openbot/contracts/ipc";
 import {
   HOSTED_SITE_EVENT_ITEM_TYPE_PREFIX,
-  hostedSiteConversationEvent,
   isAgentProvider,
   isConversationMessage,
   providerForLegacyModel,
@@ -36,6 +32,11 @@ import {
   requiredNumberColumn,
   requiredStringColumn,
 } from "./database/database-rows";
+import {
+  type ActiveHostedSiteConversationEvent,
+  HostedSiteEventLog,
+  type PendingHostedSiteTerminalEvent,
+} from "./database/hosted-site-event-log";
 
 export interface ProviderSession {
   id: string;
@@ -57,26 +58,6 @@ export interface StoredThreadSummary {
   text: string;
   estimatedTokens: number;
   createdAt: string;
-}
-
-export interface PendingHostedSiteTerminalEvent {
-  botId: string;
-  threadId: string;
-  turnId: string;
-  operationId: string;
-  action: HostedSiteConversationEventAction;
-  status: Exclude<HostedSiteConversationEventStatus, "running">;
-  details: HostedSiteConversationEventDetails;
-  markerCommandId: string;
-  createdAt: string;
-}
-
-export interface ActiveHostedSiteConversationEvent {
-  botId: string;
-  threadId: string;
-  turnId: string;
-  createdAt: string;
-  event: HostedSiteConversationEvent & { status: "running" };
 }
 
 interface SessionRow {
@@ -159,6 +140,10 @@ interface MailboxProjectionState {
 // reachable from here rather than only from the controller that owns it now. Structural `Pick<...>`
 // types over this class do not cover exported types.
 export type { OrchestrationEventInput } from "./database/database-core";
+export type {
+  ActiveHostedSiteConversationEvent,
+  PendingHostedSiteTerminalEvent,
+} from "./database/hosted-site-event-log";
 
 /**
  * The local OpenBot event log and its read projections.
@@ -168,9 +153,11 @@ export type { OrchestrationEventInput } from "./database/database-core";
  */
 export class OpenBotDatabase {
   readonly #core: DatabaseCore;
+  readonly #hostedSiteEvents: HostedSiteEventLog;
 
   constructor(readonly userDataPath: string) {
     this.#core = new DatabaseCore({ userDataPath });
+    this.#hostedSiteEvents = new HostedSiteEventLog({ core: this.#core });
   }
 
   get path(): string {
@@ -210,42 +197,11 @@ export class OpenBotDatabase {
   }
 
   recordPendingHostedSiteTerminalEvent(event: PendingHostedSiteTerminalEvent): void {
-    validatePendingHostedSiteTerminalEvent(event);
-    this.dispatch(
-      `hosted-site-terminal-pending:${event.botId}:${event.operationId}:${event.status}`,
-      [
-        {
-          aggregateType: "hosted-site-terminal",
-          aggregateId: event.botId,
-          eventType: "hosted-site.terminal-pending",
-          occurredAt: event.createdAt,
-          payload: event,
-        },
-      ],
-      () => null,
-    );
+    this.#hostedSiteEvents.recordPendingHostedSiteTerminalEvent(event);
   }
 
   pendingHostedSiteTerminalEvents(): PendingHostedSiteTerminalEvent[] {
-    const pending: PendingHostedSiteTerminalEvent[] = [];
-    for (const row of databaseRows(
-      this.connection
-        .prepare(
-          `SELECT pending.payload_json
-           FROM orchestration_events pending
-           LEFT JOIN orchestration_command_receipts marker
-             ON marker.command_id = json_extract(pending.payload_json, '$.markerCommandId')
-           WHERE pending.aggregate_type = 'hosted-site-terminal'
-             AND pending.event_type = 'hosted-site.terminal-pending'
-             AND marker.command_id IS NULL
-           ORDER BY pending.sequence`,
-        )
-        .all(),
-    )) {
-      const event = pendingHostedSiteTerminalEventValue(JSON.parse(requiredStringColumn(row, "payload_json")));
-      if (event) pending.push(event);
-    }
-    return pending;
+    return this.#hostedSiteEvents.pendingHostedSiteTerminalEvents();
   }
 
   deletePendingHostedSiteTerminalEvent(
@@ -253,46 +209,19 @@ export class OpenBotDatabase {
     operationId: string,
     status: Exclude<HostedSiteConversationEventStatus, "running">,
   ): void {
-    const commandId = `hosted-site-terminal-pending:${botId}:${operationId}:${status}`;
-    this.#core.deleteEventsAndReceipt(commandId);
+    this.#hostedSiteEvents.deletePendingHostedSiteTerminalEvent(botId, operationId, status);
   }
 
   recordActiveHostedSiteConversationEvent(event: ActiveHostedSiteConversationEvent): void {
-    validateActiveHostedSiteConversationEvent(event);
-    this.dispatch(
-      `hosted-site-active:${event.botId}:${event.event.operationId}`,
-      [
-        {
-          aggregateType: "hosted-site-operation",
-          aggregateId: event.botId,
-          eventType: "hosted-site.active",
-          occurredAt: event.createdAt,
-          payload: event,
-        },
-      ],
-      () => null,
-    );
+    this.#hostedSiteEvents.recordActiveHostedSiteConversationEvent(event);
   }
 
   deleteActiveHostedSiteConversationEvent(botId: string, operationId: string): void {
-    this.#core.deleteEventsAndReceipt(`hosted-site-active:${botId}:${operationId}`);
+    this.#hostedSiteEvents.deleteActiveHostedSiteConversationEvent(botId, operationId);
   }
 
   activeHostedSiteConversationEvents(): ActiveHostedSiteConversationEvent[] {
-    const active: ActiveHostedSiteConversationEvent[] = [];
-    for (const row of databaseRows(
-      this.connection
-        .prepare(
-          `SELECT payload_json FROM orchestration_events
-           WHERE aggregate_type = 'hosted-site-operation' AND event_type = 'hosted-site.active'
-           ORDER BY sequence`,
-        )
-        .all(),
-    )) {
-      const event = activeHostedSiteConversationEventValue(JSON.parse(requiredStringColumn(row, "payload_json")));
-      if (event) active.push(event);
-    }
-    return active;
+    return this.#hostedSiteEvents.activeHostedSiteConversationEvents();
   }
 
   listAgents(): BotSummary[] {
@@ -2016,109 +1945,6 @@ function pruneConversationSnapshots(db: DatabaseSync, threadId: string, retained
        AND json_type(payload_json, '$.snapshot') = 'object'`,
   ).run(threadId, retainedSequence);
   deleteOrphanReceipts(db);
-}
-
-function validatePendingHostedSiteTerminalEvent(event: PendingHostedSiteTerminalEvent): void {
-  if (!pendingHostedSiteTerminalEventValue(event)) {
-    throw new Error("The pending hosted site terminal event is invalid.");
-  }
-}
-
-function validateActiveHostedSiteConversationEvent(event: ActiveHostedSiteConversationEvent): void {
-  if (!activeHostedSiteConversationEventValue(event)) {
-    throw new Error("The active hosted site event is invalid.");
-  }
-}
-
-function activeHostedSiteConversationEventValue(value: unknown): ActiveHostedSiteConversationEvent | null {
-  if (
-    !isDynamicRecord(value) ||
-    !isString(value.botId) ||
-    !value.botId ||
-    !isString(value.threadId) ||
-    !value.threadId ||
-    !isString(value.turnId) ||
-    !value.turnId ||
-    !isString(value.createdAt) ||
-    !isDynamicRecord(value.event) ||
-    (value.event.action !== "publish" && value.event.action !== "replace" && value.event.action !== "delete") ||
-    value.event.status !== "running" ||
-    !isString(value.event.operationId)
-  ) {
-    return null;
-  }
-  const marker = hostedSiteConversationEvent({
-    id: `hosted-site-event:${value.event.operationId}:running`,
-    author: "system",
-    source: "system",
-    text: JSON.stringify({
-      siteId: value.event.siteId,
-      title: value.event.title,
-      hostname: value.event.hostname,
-      url: value.event.url,
-    }),
-    createdAt: value.createdAt,
-    status: "completed",
-    itemType: `hosted-site-event:${value.event.action}:running:${value.event.operationId}`,
-  });
-  if (marker?.status !== "running") return null;
-  return {
-    botId: value.botId,
-    threadId: value.threadId,
-    turnId: value.turnId,
-    createdAt: value.createdAt,
-    event: { ...marker, status: "running" },
-  };
-}
-
-function pendingHostedSiteTerminalEventValue(value: unknown): PendingHostedSiteTerminalEvent | null {
-  if (
-    !isDynamicRecord(value) ||
-    !isString(value.botId) ||
-    !value.botId ||
-    !isString(value.threadId) ||
-    !value.threadId ||
-    !isString(value.turnId) ||
-    !value.turnId ||
-    !isString(value.operationId) ||
-    (value.action !== "publish" && value.action !== "replace" && value.action !== "delete") ||
-    (value.status !== "succeeded" &&
-      value.status !== "failed" &&
-      value.status !== "interrupted" &&
-      value.status !== "cancelled") ||
-    !isDynamicRecord(value.details) ||
-    !isString(value.markerCommandId) ||
-    !isString(value.createdAt)
-  ) {
-    return null;
-  }
-  const marker = hostedSiteConversationEvent({
-    id: value.markerCommandId,
-    author: "system",
-    source: "system",
-    text: JSON.stringify(value.details),
-    createdAt: value.createdAt,
-    status: "completed",
-    itemType: `hosted-site-event:${value.action}:${value.status}:${value.operationId}`,
-  });
-  if (!marker || marker.status === "running") return null;
-  if (value.markerCommandId !== `hosted-site-event:${value.botId}:${value.operationId}:${value.status}`) return null;
-  return {
-    botId: value.botId,
-    threadId: value.threadId,
-    turnId: value.turnId,
-    operationId: marker.operationId,
-    action: marker.action,
-    status: marker.status,
-    details: {
-      siteId: marker.siteId,
-      title: marker.title,
-      hostname: marker.hostname,
-      url: marker.url,
-    },
-    markerCommandId: value.markerCommandId,
-    createdAt: value.createdAt,
-  };
 }
 
 export function providerForStoredModel(model: BotSummary["model"]): AgentProviderId {

--- a/src/backend/openbot-database.ts
+++ b/src/backend/openbot-database.ts
@@ -12,6 +12,7 @@ import type {
 } from "@openbot/contracts/ipc";
 import { isAgentProvider, isConversationMessage, providerForLegacyModel } from "@openbot/contracts/ipc";
 import { type DynamicRecord, isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { AgentRoster } from "./database/agent-roster";
 import { ConversationQueries } from "./database/conversation-queries";
 import { DatabaseCore, deleteOrphanReceipts, type OrchestrationEventInput } from "./database/database-core";
 import {
@@ -53,6 +54,7 @@ export type { StoredThreadSummary } from "./database/thread-summaries";
 export class OpenBotDatabase {
   readonly #core: DatabaseCore;
   readonly #conversations: ConversationQueries;
+  readonly #roster: AgentRoster;
   readonly #hostedSiteEvents: HostedSiteEventLog;
   readonly #mailbox: MailboxProjection;
   readonly #sessions: ProviderSessions;
@@ -61,6 +63,7 @@ export class OpenBotDatabase {
   constructor(readonly userDataPath: string) {
     this.#core = new DatabaseCore({ userDataPath });
     this.#conversations = new ConversationQueries({ core: this.#core });
+    this.#roster = new AgentRoster({ core: this.#core });
     this.#hostedSiteEvents = new HostedSiteEventLog({ core: this.#core });
     this.#mailbox = new MailboxProjection({ core: this.#core });
     this.#sessions = new ProviderSessions({ core: this.#core });
@@ -132,130 +135,15 @@ export class OpenBotDatabase {
   }
 
   listAgents(): BotSummary[] {
-    return databaseRows(
-      this.connection.prepare("SELECT agent_json FROM projection_agents ORDER BY sort_order, agent_id").all(),
-    ).map((row) => JSON.parse(requiredStringColumn(row, "agent_json")));
+    return this.#roster.listAgents();
   }
 
   replaceAgents(commandId: string, agents: BotSummary[], eventType: string): void {
-    this.dispatch(
-      commandId,
-      [
-        {
-          aggregateType: "agents",
-          aggregateId: "agents",
-          eventType,
-          payload: { agents },
-        },
-      ],
-      (db, sequences) => {
-        db.exec("DELETE FROM projection_agents");
-        const insert = db.prepare(`
-          INSERT INTO projection_agents
-            (agent_id, thread_id, model, updated_at, sort_order, agent_json, last_event_sequence)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
-        `);
-        agents.forEach((agent, index) => {
-          insert.run(
-            agent.id,
-            agent.threadId,
-            agent.model,
-            agent.updatedAt,
-            index,
-            JSON.stringify(agent),
-            sequences[0],
-          );
-          if (agent.threadId) this.#ensureThreadProjection(db, agent, sequences[0] ?? 0);
-        });
-        return null;
-      },
-    );
+    this.#roster.replaceAgents(commandId, agents, eventType);
   }
 
   hardDeleteAgent(commandId: string, botId: string, threadId: string | null, remainingAgents: BotSummary[]): void {
-    this.dispatch(
-      commandId,
-      [
-        {
-          aggregateType: "agents",
-          aggregateId: "agents",
-          eventType: "agents.rebased-after-delete",
-          payload: { agents: remainingAgents },
-        },
-      ],
-      (db, sequences) => {
-        const sequence = sequences[0] ?? 0;
-        const memoryIds = databaseRows(
-          db.prepare("SELECT memory_id FROM projection_agent_memories WHERE agent_id = ?").all(botId),
-        ).map((row) => requiredStringColumn(row, "memory_id"));
-        const routineIds = databaseRows(
-          db.prepare("SELECT routine_id FROM projection_agent_routines WHERE agent_id = ?").all(botId),
-        ).map((row) => requiredStringColumn(row, "routine_id"));
-        if (memoryIds.length > 0) {
-          const placeholders = memoryIds.map(() => "?").join(", ");
-          db.prepare(
-            `DELETE FROM orchestration_command_receipts WHERE command_id IN (
-               SELECT DISTINCT command_id
-               FROM orchestration_events
-               WHERE aggregate_type = 'agent-memory' AND aggregate_id IN (${placeholders})
-             )`,
-          ).run(...memoryIds);
-          db.prepare(
-            `DELETE FROM orchestration_events
-             WHERE aggregate_type = 'agent-memory' AND aggregate_id IN (${placeholders})`,
-          ).run(...memoryIds);
-        }
-        if (routineIds.length > 0) {
-          const placeholders = routineIds.map(() => "?").join(", ");
-          db.prepare(
-            `DELETE FROM orchestration_command_receipts WHERE command_id IN (
-               SELECT DISTINCT command_id FROM orchestration_events
-               WHERE aggregate_type IN ('agent-routine', 'routine-run') AND aggregate_id IN (${placeholders})
-             )`,
-          ).run(...routineIds);
-          db.prepare(
-            `DELETE FROM orchestration_events
-             WHERE aggregate_type IN ('agent-routine', 'routine-run') AND aggregate_id IN (${placeholders})`,
-          ).run(...routineIds);
-        }
-        db.prepare(
-          `DELETE FROM orchestration_command_receipts WHERE command_id IN (
-             SELECT DISTINCT command_id FROM orchestration_events
-             WHERE aggregate_type = 'hosted-site-terminal'
-               AND event_type = 'hosted-site.terminal-pending'
-               AND json_extract(payload_json, '$.botId') = ?
-           )`,
-        ).run(botId);
-        db.prepare(
-          `DELETE FROM orchestration_events
-           WHERE aggregate_type = 'hosted-site-terminal'
-             AND event_type = 'hosted-site.terminal-pending'
-             AND json_extract(payload_json, '$.botId') = ?`,
-        ).run(botId);
-        const sensitiveFilter = threadId
-          ? `(aggregate_id = ? OR aggregate_id = ? OR
-              (aggregate_type = 'agents' AND aggregate_id = 'agents' AND sequence < ?))`
-          : `(aggregate_id = ? OR
-              (aggregate_type = 'agents' AND aggregate_id = 'agents' AND sequence < ?))`;
-        const sensitiveParameters = threadId ? ([botId, threadId, sequence] as const) : ([botId, sequence] as const);
-        db.prepare(
-          `DELETE FROM orchestration_command_receipts WHERE command_id IN (
-             SELECT DISTINCT command_id FROM orchestration_events WHERE ${sensitiveFilter}
-           )`,
-        ).run(...sensitiveParameters);
-        db.prepare(`DELETE FROM orchestration_events WHERE ${sensitiveFilter}`).run(...sensitiveParameters);
-        db.prepare("DELETE FROM projection_agents WHERE agent_id = ?").run(botId);
-        db.prepare("DELETE FROM projection_agent_memories WHERE agent_id = ?").run(botId);
-        db.prepare("DELETE FROM projection_agent_routines WHERE agent_id = ?").run(botId);
-        db.prepare("DELETE FROM projection_reactions WHERE agent_id = ?").run(botId);
-        db.prepare("DELETE FROM projection_deliveries WHERE recipient_agent_id = ?").run(botId);
-        db.prepare("DELETE FROM projection_queue_state WHERE agent_id = ?").run(botId);
-        if (threadId) {
-          db.prepare("DELETE FROM projection_threads WHERE thread_id = ?").run(threadId);
-        }
-        return null;
-      },
-    );
+    this.#roster.hardDeleteAgent(commandId, botId, threadId, remainingAgents);
   }
 
   readConversation(botId: string, threadId: string | null): ConversationSnapshot {
@@ -325,9 +213,9 @@ export class OpenBotDatabase {
       ],
       (db, sequences) => {
         const sequence = sequences[0] ?? snapshot.revision;
-        const agent = this.listAgents().find((candidate) => candidate.id === snapshot.botId);
+        const agent = this.#roster.listAgents().find((candidate) => candidate.id === snapshot.botId);
         if (!agent) throw new Error(`Unknown agent for conversation: ${snapshot.botId}`);
-        this.#ensureThreadProjection(db, agent, sequence);
+        this.#roster.ensureThreadProjection(db, agent, sequence);
         db.prepare(
           `UPDATE projection_threads
            SET active_turn_id = ?, updated_at = ?, last_event_sequence = ? WHERE thread_id = ?`,
@@ -466,11 +354,11 @@ export class OpenBotDatabase {
       ],
       (db, sequences) => {
         const sequence = sequences[0] ?? 0;
-        const agent = this.listAgents().find((candidate) => candidate.id === input.botId);
+        const agent = this.#roster.listAgents().find((candidate) => candidate.id === input.botId);
         if (!agent || agent.threadId !== input.threadId) {
           throw new Error(`Unknown agent thread for conversation append: ${input.botId}`);
         }
-        this.#ensureThreadProjection(db, agent, sequence);
+        this.#roster.ensureThreadProjection(db, agent, sequence);
         const ordinalRow = databaseRow(
           db
             .prepare(
@@ -845,27 +733,6 @@ export class OpenBotDatabase {
 
   readMailboxState(): unknown | null {
     return this.#mailbox.readMailboxState();
-  }
-
-  #ensureThreadProjection(db: DatabaseSync, agent: BotSummary, sequence: number): void {
-    if (!agent.threadId) return;
-    db.prepare(`
-      INSERT INTO projection_threads
-        (thread_id, agent_id, title, active_turn_id, created_at, updated_at, last_event_sequence)
-      VALUES (?, ?, ?, NULL, ?, ?, ?)
-      ON CONFLICT(thread_id) DO UPDATE SET
-        agent_id = excluded.agent_id,
-        title = excluded.title,
-        updated_at = excluded.updated_at,
-        last_event_sequence = MAX(projection_threads.last_event_sequence, excluded.last_event_sequence)
-    `).run(
-      agent.threadId,
-      agent.id,
-      agent.name,
-      agent.updatedAt ?? new Date().toISOString(),
-      agent.updatedAt ?? new Date().toISOString(),
-      sequence,
-    );
   }
 }
 


### PR DESCRIPTION
`src/backend/openbot-database.ts` was 2321 lines, of which the class itself was 1655 — 36 methods with blocks of 411, 222 and 207 lines. It is now a **313-line facade** over nine files in `src/backend/database/`. Same pattern as bf0a9112 (`AgentService` → eight controllers): one class per file, kebab-case, `<Name>Options` + `<Name>`, `readonly #` fields, a constructor that only assigns, and a doc comment on each class stating what it **owns** and that it never imports the facade. No barrel file.

**Pure refactor except for one clearly labelled commit.** No schema change, no migration change; `openbot-database-schema.ts` and `openbot-database-schema-parity.test.ts` are untouched.

| File | Lines | Owns |
| --- | --- | --- |
| `openbot-database.ts` (facade) | 313 | the nine controllers, `persistConversationAndMailbox`, the type re-exports |
| `database/database-core.ts` | 197 | the SQLite handle, lifecycle, migration, `dispatch`, receipts |
| `database/database-rows.ts` | 85 | free functions narrowing `unknown` out of `DatabaseSync` |
| `database/agent-roster.ts` | 177 | `projection_agents`, the thread row, `hardDeleteAgent` |
| `database/conversation-queries.ts` | 532 | every read of a thread's messages, and the page cursors |
| `database/conversation-writer.ts` | 311 | the write side of a conversation, and snapshot compaction |
| `database/thread-replay.ts` | 341 | `rebuildThreadProjection` |
| `database/mailbox-projection.ts` | 316 | the mailbox read model and the file-deletion outbox |
| `database/hosted-site-event-log.ts` | 241 | both hosted-site aggregates and their validators |
| `database/provider-sessions.ts` | 229 | `projection_provider_sessions` |
| `database/thread-summaries.ts` | 108 | `projection_thread_summaries` |

## Surfaces touched

**Desktop backend, plus two documentation/config files.** No renderer, mobile, web, palette, IPC contract or migration change.

`.github/review/contracts-and-migrations.md` gains `src/backend/database/**`: its `include:` list named `openbot-database.ts` because that file *was* the boundary onto the user's SQLite, and after the split most of that boundary — `dispatch`, receipts, transaction ownership, the history erasure — lives in the new directory, where the rule would no longer have fired. `src/backend/AGENTS.md` loses the claim that `agent-service.ts` is the largest hand-written file in the repository (untrue since it was split into eight controllers, and this PR removes the file that actually held the title) and gains the two rules the new controllers depend on: read `.connection` at each use, and never open a transaction. External modules reach into this class 42 times through `database.connection` and 13 times through `database.dispatch`, and `withDatabaseTransaction` (`src/backend/agent/conversation-runtime.ts:14`) keys a `WeakMap` on the instance — so the facade keeps its class name, instance identity, constructor signature and full public surface, and simply delegates.

## Invariants preserved

- **Conditional transaction ownership.** `dispatch` and `deleteEventsAndReceipt` each independently repeat `const ownsTransaction = !db.isTransaction`. Both copies are moved verbatim and are not harmonized — that is what lets a projector nest another dispatch inside the caller's transaction.
- **The two unconditional `BEGIN IMMEDIATE`s** — `persistConversationAndMailbox` and `rebuildThreadProjection` — are load-bearing: they are why the dispatches nested inside them see `isTransaction === true` and skip opening their own. **No new controller opens a transaction.**
- **Don't cache the connection.** Controllers hold a `DatabaseCore` and read `.connection` at each use. A handle cached lazily survives `initialize()` and then silently addresses a closed database after `close()` + reopen. No `prepare()` is memoized either — none was before, and extraction is exactly when someone would "optimize" that.
- **`hardDeleteAgent` delete ordering.** Every receipt DELETE selects its command ids out of `orchestration_events`, so receipts go before the matching events in all four blocks. Moved statement for statement.
- **`conversationMarkerSqlFilter` moved with its three `*_EVENT_ITEM_TYPE_PREFIX` constants**, not left at its callers: a filter interpolating `undefined` still runs and returns the wrong rows.
- **Default arguments duplicated** on both facade and controller signatures (`anchor`, `requestedLimit`, `options`, `payload`, `commandId`, `fileDeletions`).

## New test, and watching it fail

`hardDeleteAgent` had no test naming it (only callers: `bot-store.ts:460,516`), and an ordering mistake across its nine tables is silent — it type-checks and lights no existing assertion. One test added to `openbot-database.test.ts`: seed an agent with a thread, memory, routine and pending hosted-site terminal event, hard-delete it, assert the projections are gone **and** that no receipt survives whose events do not. The second assertion names the consequence — `dispatch` short-circuits on a receipt, so an orphan replays a stale result for a command that never ran.

**Watched it fail** (AGENTS.md rule 2): moving the memory block's receipt DELETE after its event DELETE turns it red on the orphan-receipt assertion — `expected [ { command_id: 'agent-memory:seed' } ] to deeply equal []` — not on a projection row count.

No controller-level unit tests and no new test file: tests stay pointed at the facade, per the bf0a9112 precedent.

## One deliberate behaviour change, isolated

Commit `1a04391b`: the `catch` in `rebuildThreadProjection` was the only rollback in the file without a `db.isTransaction` guard. SQLite auto-rolls back on some failures (a full disk, a statement-level abort), after which `ROLLBACK` itself throws *"cannot rollback - no transaction is active"* and **replaces** the original error — the user is told about the rollback instead of the disk. Moved byte-for-byte in the extraction commit and fixed in its own commit. No test: reaching it needs a fault injected at the SQLite level.

## Verification

Nine commits, each compiling and green on `openbot-database.test.ts`, so `git bisect` stays useful. Per AGENTS.md, no repo-wide checks were run; CI owns the full suite.

```
bun run test:desktop -- src/backend/openbot-database.test.ts \
  src/backend/openbot-database-schema-parity.test.ts src/backend/conversation-read-store.test.ts \
  src/backend/agent-memory-store.test.ts src/backend/agent-routine-store.test.ts \
  src/backend/team-chat-store.test.ts src/main/team-api-server.test.ts \
  src/backend/mailbox-store.test.ts src/backend/bot-store.test.ts \
  src/backend/agent/conversation-transaction.test.ts
# 10 files, 137 tests passed
```

Plus `bunx biome check src/backend/openbot-database.ts src/backend/database` (clean) and the full parallel typecheck via the pre-commit hook on every commit. `agent/conversation-transaction.test.ts` is the guard on `withDatabaseTransaction`'s instance-identity `WeakMap` and passes.

## Follow-ups, deliberately not in this PR

- **`_rebaseHistory` in `replaceMailboxState` is dead through three levels** — `mailbox-store.ts:1329` forwards it and no caller of `#persist` ever passes a fourth argument. Removing it opens `mailbox-store.ts`, which this PR otherwise leaves closed.
- **`providerForStoredModel` has zero callers repo-wide**, tests included. Left beside `stableThreadId` — after the split it looks like it "belongs" to `provider-sessions.ts` and would get moved there for no reason.
- **Split `openbot-database.test.ts`.** Roughly 350 of its lines test `openbot-database-schema.ts`, not this class. They enter through `new OpenBotDatabase(...).initialize()`, a stable boundary, so they are not misplaced — but moving the most safety-critical tests in the file into the same changeset as a large mechanical move would make a red test uninformative. Separate PR, no production change.

## Approvability

No `biome-ignore`, `@ts-expect-error`, `@ts-ignore`, no `overrides` entry, no unregistered GritQL plugin, and no widening to `any` or `unknown` at a boundary.

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
