### PR TITLE
chore(ci): review pull requests with gpt-6-astra

### DIFF
--- a/.github/workflows/norbiai-review.yml
+++ b/.github/workflows/norbiai-review.yml
@@ -458,7 +458,7 @@ jobs:
             --ephemeral \
             --ignore-user-config \
             --sandbox read-only \
-            --model gpt-5.6-sol \
+            --model gpt-6-astra \
             --config 'model_reasoning_effort="medium"' \
             --color never \
             --output-last-message "$last_message_file" \


### PR DESCRIPTION
Switches the NorbiAI reviewer from `gpt-5.6-sol` to `gpt-6-astra`. One line, in the `codex exec` invocation in `.github/workflows/norbiai-review.yml`. No other file names the review model — `gpt-5.6-*` elsewhere in the repo is the product's own agent model list (`packages/contracts/src/ipc-conversation.ts`) and is untouched.

**Surface touched:** CI only (`.github/workflows/norbiai-review.yml`). No renderer, mobile, web, IPC, palette, migration or docs change.

## Blocking prerequisite: upgrade Codex on the self-hosted runner

The workflow uses whatever `codex` is on the runner. `gpt-6-astra` is rejected by older CLIs:

- `codex-cli 0.144.1` → `400 invalid_request_error: The 'gpt-6-astra' model requires a newer version of Codex`, plus `warning: Model metadata for 'gpt-6-astra' not found`. Every review would fail.
- `codex-cli 0.153.3` (current npm latest) → works, `reasoning effort: medium` applied, no metadata warning.

Merge only once the runner is on 0.153.3 or newer.

## Verification

Ran the real review locally against this PR's own diff with `codex 0.153.3`, assembling the prompt exactly as the workflow does (base-commit `norbiai-review-prompt.md` + `compose-review-prompt.ts` fragments + the same `## PR context` block), then applied the workflow's own output-shape check:

```
codex exec --ephemeral --ignore-user-config --sandbox read-only \
  --model gpt-6-astra --config 'model_reasoning_effort="medium"' ...
exit=0
verdict=1 resolved=5 findings=9 withdrawn=13   # ordering the workflow requires
```

Exit 0, and `## Verdict` < `## Resolved Since Previous Review` < `## Findings` < `## Withdrawn Findings`, so the validation in the "Run NorbiAI review" step accepts the output and the run publishes as `success`. The review itself returned no findings.

No test: the change is a model string in a workflow, and the behaviour it affects is the runner's live `codex` call, which the local end-to-end run above is the only honest check for.

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)