### PR TITLE
chore(tooling): put check:ui where an agent will run it

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,5 +11,8 @@ if git diff --cached --name-only --diff-filter=ACMR | grep -q .; then
   git diff --cached --name-only -z --diff-filter=ACMR | xargs -0 git add --
 fi
 
+echo "Running UI foundation check..."
+bun run check:ui
+
 echo "Running type checks..."
 bun run typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,9 @@ belongs.
 
 ## Do not run repo-wide checks. CI owns the full suite.
 
-Run the narrowest test for what you touched, `biome check <paths>`, and a targeted `tsc` on the
-project you changed. Do not run `bun run check`, `check:desktop`, `test`, or `build-storybook`: each
+Run the narrowest test for what you touched, `biome check <paths>`, `bun run check:ui` if you
+touched `src/renderer` — it scans the whole renderer in 60 ms and is not one of the slow ones — and
+a targeted `tsc` on the project you changed. Do not run `bun run check`, `check:desktop`, `test`, or `build-storybook`: each
 takes minutes, and the desktop suite flakes under load, so a red result tells you nothing about your
 change. CI owns all of it on every push:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,10 @@ belongs.
 ## Do not run repo-wide checks. CI owns the full suite.
 
 Run the narrowest test for what you touched, `biome check <paths>`, `bun run check:ui` if you
-touched `src/renderer` — it scans the whole renderer in 60 ms and is not one of the slow ones — and
-a targeted `tsc` on the project you changed. Do not run `bun run check`, `check:desktop`, `test`, or `build-storybook`: each
-takes minutes, and the desktop suite flakes under load, so a red result tells you nothing about your
-change. CI owns all of it on every push:
+touched `src/renderer` — it scans the whole renderer in 60 ms and is not one of the slow ones —
+and a targeted `tsc` on the project you changed. Do not run `bun run check`, `check:desktop`,
+`test`, or `build-storybook`: each takes minutes, and the desktop suite flakes under load, so a
+red result tells you nothing about your change. CI owns all of it on every push:
 
 | CI job | Runner | Command |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Use `bun run dev:seed --dry-run` to inspect the target and fixture counts withou
 | `bun run dev:reset` | Delete the local app, test-client, and legacy host development state. |
 | `bun run dev:automation` | Drive the running dev app over CDP: `instances`, `pages`, `snapshot`, `screenshot`, `click`/`type` by accessible role. `--page=<target-id\|url-substring>` aims at any window, including embedded browser views; `--wait-for=<role>,<name>` settles on an accessible target instead of polling; mutations need `--allow-mutations` and a named instance (this worktree's record, `--instance=<id>` or `--port=`). |
 | `bun run check` | Run Biome, both typechecks, offline tests, the browser smoke test, and the production build. |
+| `bun run check:ui` | Check the renderer against the design system: shared primitives, Kobalte and Lucide confined to `components/ui`, palette tokens instead of colour, size, radius and transition literals. Reads the whole renderer in 60 ms. |
 | `bun run test:backend` | Run backend tests only. |
 | `bun run test:browser` | Run the local embedded-browser smoke test. |
 | `bun run test:codex` | Probe the real CLI handshake and account without starting a paid turn. |

--- a/biome.json
+++ b/biome.json
@@ -120,6 +120,16 @@
       }
     },
     {
+      "includes": ["src/**/*.ts", "src/**/*.tsx"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUndeclaredDependencies": "error"
+          }
+        }
+      }
+    },
+    {
       "includes": ["**/*.test.ts", "**/*.test.tsx"],
       "plugins": [
         "./tools/biome/anti-slop/rules/no-class-assertions.grit",

--- a/scripts/ui-foundation-check.ts
+++ b/scripts/ui-foundation-check.ts
@@ -22,7 +22,7 @@ function matches(source: string, expression: RegExp): number {
 }
 
 for (const file of filesUnder(rendererRoot).filter((path) => /\.(?:ts|tsx)$/.test(path))) {
-  if (file.startsWith(uiRoot) || file.endsWith(".test.tsx")) continue;
+  if (file.startsWith(uiRoot) || /\.test\.tsx?$/u.test(file)) continue;
   const source = readFileSync(file, "utf8");
   const label = relative(projectRoot, file);
 
@@ -68,13 +68,14 @@ const manualCompositeCount = matches(
 // The palette moved to @openbot/brand, which is now the only file allowed to hold
 // a colour literal, so every stylesheet the renderer owns is scanned whole. This
 // used to slice styles.css after its :root block to spare the palette, which also
-// spared everything else declared in there.
-const styles = readFileSync(resolve(rendererRoot, "styles.css"), "utf8");
-const featureStyles = filesUnder(resolve(rendererRoot, "styles"))
+// spared everything else declared in there. It then named styles.css and styles/
+// explicitly, which spared a stylesheet placed anywhere else - preview/preview.css
+// was outside the scan and nothing said so. The whole renderer tree is the scope,
+// so a new stylesheet is covered by existing there rather than by being listed.
+const legacyStyles = filesUnder(rendererRoot)
   .filter((path) => path.endsWith(".css"))
   .map((path) => readFileSync(path, "utf8"))
   .join("\n");
-const legacyStyles = `${styles}\n${featureStyles}`;
 const colorLiteralCount =
   matches(legacyStyles, /#[\da-f]{3,8}|rgba?\([^)]*\)|hsla?\([^)]*\)/giu) +
   matches(legacyStyles, /(?<![-\w])(?:white|black|red|blue|green|yellow|purple|orange|gray|grey|pink)(?![-\w])/giu);

--- a/src/renderer/AGENTS.md
+++ b/src/renderer/AGENTS.md
@@ -13,6 +13,10 @@ for the component patterns, not the imports.
 - `bun run dev` for integrated work — it starts the local Auth API and the Electron dev app
   together. `bun run dev:api` is for API-only debugging.
 - `bun run storybook` verifies isolated components. CI builds it; do not run `build-storybook`.
+- `bun run check:ui` is the design-system guard for this directory: shared primitives over native
+  controls, Kobalte and Lucide only inside `components/ui`, and palette tokens instead of colour,
+  size, radius and transition literals. It reads the whole renderer in 60 ms, so run it on any
+  change here rather than waiting for CI — its budgets all sit at zero and only ever go down.
 - Never verify UI with `dist/`, a packaged `.app`, a production build, or an ad-hoc preview — those
   are for release verification the user asked for. If the dev app will not start, report the blocker
   instead of falling back to one.


### PR DESCRIPTION
## Dlaczego

`bun run check:ui` czyta cały renderer w 60 ms, ale jego jedynym wywołaniem był `check:desktop` —
jedna z czterech komend, których AGENTS.md każe agentowi nigdy nie uruchamiać, bo pozostałe w niej
trwają minuty. Guard osiągalny wyłącznie przez zakazaną komendę to guard, którego nikt nie odpala
przed CI. Do tego sam skrypt miał dwa martwe pola typu „wzorzec, który nic nie matchuje".

## Co się zmienia

**Osiągalność.** `check:ui` jest teraz wymieniony w zdaniu o wąskich komendach w `AGENTS.md`, w
`src/renderer/AGENTS.md` obok `storybook`, i w tabeli komend w `README.md` — za każdym razem z
kosztem, żeby nie czytał się jak kolejna wolna komenda. `.githooks/pre-commit` uruchamia go między
staged Biome a typecheckami, które hook już robił.

**Dwa martwe pola w skrypcie.**

- Skan CSS wymieniał `styles.css` i `styles/` z nazwy, więc arkusz położony gdziekolwiek indziej był
  poza zasięgiem — `preview/preview.css` był, i nic tego nie mówiło. Zakresem jest teraz całe drzewo
  renderera: nowy arkusz jest pokryty przez to, że tam leży, a nie przez to, że ktoś go dopisał do
  listy.
- Lista pomijanych plików łapała `.test.tsx`, ale nie `.test.ts`, więc 29 plików pod rendererem było
  skanowanych pod kątem reguł JSX, których nie mogą zawierać.

**`noUndeclaredDependencies` na `src/**`.** Reguła jest w domenie `project` Biome i czyta
`package.json` — to jedyny fragment tego, co dałby knip, który Biome umie dziś wyrazić. `src/**`
jest już czyste na 666 plikach, więc włączenie jej nic nie psuje i łapie następny przypadek.

## Czego świadomie nie ruszam

Reguła zostaje wyłączona poza `src/**`. `packages/`, `apps/` i `scripts/` mają razem 10 prawdziwych
znalezisk (`--max-diagnostics=1000`, bo domyślny limit to 20):

- `packages/team-client` — `vitest` niezadeklarowany, 6 plików
- `apps/mobile` — `vitest`, 1 plik
- `apps/auth-api` — `zod` i `@openbot/renderer-preview`
- `scripts/team-webrtc-live-smoke-app` — `electron`

Naprawa oznacza edycję czterech manifestów i lockfile'a. To osobny PR, nie ten.

## Watch it fail

Wstrzyknąłem `.probe { color: #ff0000; }` do `src/renderer/src/preview/preview.css`:

- **nowy** skrypt: `literały kolorów poza paletą: 1 (budżet migracyjny: 0)` → exit 1
- **stary** skrypt (przywrócony przez `git stash`): przechodzi na zielono

Czyli martwe pole było prawdziwe, a nowy zakres łapie dokładnie to, co miał złapać. Plik przywrócony
przez `git checkout` w obu przebiegach; w drzewie roboczym nie ma pozostałości po probe.

Test nie doszedł żaden — guard jest tu mechanizmem, a jego regułę pokrywa reguła 3 z AGENTS.md.

## Powierzchnie

Tooling repozytorium i dokumentacja. Bez zmian w rendererze, mobile, web, kontraktach IPC,
migracjach i schemacie. Renderer jest dotknięty tylko przez to, że guard czyta go szerzej — żaden
plik produktowy się nie zmienia.

## Sprawdzone

`biome check` na zmienionych ścieżkach czysto, `bun run typecheck` (wszystkie projekty) czysto przez
pre-commit hook, `sh -n .githooks/pre-commit` OK, `check:ui` zielony.

Bez `biome-ignore`, `@ts-expect-error`, bez poszerzania typu do `any`/`unknown`, bez wyłączania
reguły w `overrides` — dodany wpis w `biome.json` włącza regułę, nie wyłącza.

Model: Claude Opus 5. Harness: Claude Code CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)