### PR TITLE
docs(skills): add a release upgrade-safety audit skill

### DIFF
--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -74,8 +74,9 @@ Then handle each bucket one of three ways, and say in the Step 3 table which one
 
 - **Dismissed as a bucket**, with the reason stated once. A bucket qualifies only if you can say
   what makes *every* file in it inert. `docs/**`, `tools/**` and `src/renderer/stories/**` are not
-  in the shipped app at all, which is such a reason. "Nothing looked interesting" is not. Two
-  buckets that look dismissible and are not:
+  in the shipped app at all, which is such a reason. "Nothing looked interesting" is not. Three
+  buckets that look dismissible and are not — and note what the second and third have in common:
+  **nothing this audit delegates a check to can be dismissed by the bucket its file lives in.**
   - **`src/renderer/**`** — the renderer writes `localStorage`, that store lives in the user's
     Electron partition, and it outlives the build that wrote it exactly the way a file under
     `userData` does. Route it through gate B.
@@ -89,6 +90,12 @@ Then handle each bucket one of three ways, and say in the Step 3 table which one
     behind the range every future audit starts from. Route a modification or deletion of one
     through the gate that names it and read the hunks. Other `**/*.test.ts` files dismiss as a
     bucket normally.
+  - **`docs/RELEASING.md`**, for the same reason one level up. This audit does not restate the
+    Team API compatibility matrix — gate C points at preflight item 0 and stops there — and it
+    hands the publish itself back to that document at Step 3. Weakening either is invisible to
+    every gate here, because the gate's own text still reads correctly while the thing it defers to
+    no longer says what it assumed. Read its changed hunks under gate C and the handoff. The rest
+    of `docs/**` dismisses as a bucket normally.
 - **Cleared by a derived query.** This is how a large hazard-bearing directory gets honestly
   covered: gate B's `git grep` over `src/main` and `src/backend` names every file that decodes a
   versioned payload, so the other two hundred are cleared by the query having asked the right
@@ -151,6 +158,40 @@ Triggered by any change to that file or to `src/backend/database/`.
   `refreshProviderSessionsForDynamicTools` is currently the migration for 9, 10 and 14 — so a
   one-line edit there rewrites three shipped migrations at once, and the diff shows it as a single
   changed function far from any `version:` line.
+
+  **The `up:` names are the entry points, not the frozen set — take the transitive closure.** A
+  migration body delegates, and the helper it delegates to is as frozen as the body: at the time of
+  writing `migrateToBaselineV8` is four lines of `db.prepare` followed by calls to
+  `compactConversationHistory`, `compactMailboxHistory`, `migrateProviderSessionsForGrok` and
+  `migrateReactionsForActors`, and the first two run `DELETE FROM orchestration_events` and
+  `DELETE FROM projection_thread_activities`. Editing one of those changes what an upgrading
+  database *deletes*, while new installs never execute it at all — they get `LATEST_SCHEMA_SQL` and
+  the entry stamped as applied. The wrapper's own diff stays clean, so the `up:` list alone reports
+  nothing. Two names against nine is the difference this makes; derive it rather than listing it:
+
+  ```bash
+  schema() { git show "${1}:src/backend/openbot-database-schema.ts"; }
+  frozen() {
+    src=$(schema "$1")
+    defs=$(printf '%s\n' "$src" | grep -oE '^function [a-zA-Z0-9_]+' | awk '{print $2}' | sort -u)
+    seen=$(printf '%s\n' "$src" | grep -oE '^[[:space:]]+up: [a-zA-Z0-9_]+' | awk '{print $2}' | sort -u)
+    n=0
+    while [ "$(printf '%s\n' "$seen" | wc -l)" -ne "$n" ]; do
+      n=$(printf '%s\n' "$seen" | wc -l)
+      for f in $(printf '%s\n' "$seen"); do
+        seen="$seen
+  $(printf '%s\n' "$src" | awk "/^function $f\\(/,/^}/" | grep -oE '[a-zA-Z0-9_]+\(' | tr -d '(')"
+      done
+      seen=$(printf '%s\n' "$seen" | sed '/^$/d' | sort -u | grep -Fx -f <(printf '%s\n' "$defs"))
+    done
+    printf '%s\n' "$seen"
+  }
+  frozen <tag>
+  ```
+
+  It iterates to a fixpoint, so a helper added one level deeper is still caught. `for f in $(...)`
+  rather than `for f in $seen`: command substitution splits in both shells, bare parameter expansion
+  splits only in bash. Run it against the tag, not `HEAD` — the question is what was already shipped.
 - **If the migration executes DDL, `LATEST_SCHEMA_SQL` must be extended in the same change.**
   `createLatestDatabase` execs that SQL and then stamps every `MIGRATIONS` entry as applied
   *without running it*, so a DDL migration missing from it ships new installs a database without

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -87,7 +87,13 @@ green and you added DDL, check that you actually added it to `MIGRATIONS`.
 
 ### B. On-disk state outside SQLite — `src/main/index.ts`, `src/backend/*-store.ts`
 
-Triggered by a change to any file in the inventory in `references/surfaces.md`.
+Triggered by a change to `src/main/index.ts`, any `*-store.ts` under `src/main/` or `src/backend/`,
+`src/backend/workspace-paths.ts`, `src/backend/browser-host.ts`,
+`src/main/remote-server-stored-shape.ts`, `src/main/sunshine-moonlight-runtime.ts`, or
+`electron-builder.yml`. The list is here and not in `references/surfaces.md` because you classify
+triggers before you open any reference — a trigger that pointed at the inventory would need the
+inventory read first, and a file you did not already suspect would be classified as not triggered.
+Once this gate fires, open the inventory for the file-by-file detail.
 
 - **Did an on-disk filename constant change?** A rename is silent data loss: the old file is never
   found, never read, and never deleted. The new build starts from its defaults and the user's
@@ -121,24 +127,37 @@ Triggered by a change to any file in the inventory in `references/surfaces.md`.
 
 Triggered by any change under that directory.
 
-First derive the frozen set from the tag rather than hard-coding versions — a protocol released
-since you last read this file is frozen too, and a hard-coded `v1 v2 v3` would never audit it:
+Let git match the frozen set. A protocol released since you last read this file is frozen too, so
+nothing here names a version:
 
 ```bash
-FROZEN=$(git ls-tree --name-only <tag> packages/contracts/src/team-protocol/ \
-  | grep -E '/v[0-9]+\.ts$')
-git diff --stat --diff-filter=MDR <tag>..HEAD -- $FROZEN \
-  packages/contracts/src/team-protocol/fixtures
+git diff --stat --diff-filter=MDR <tag>..HEAD -- \
+  'packages/contracts/src/team-protocol/v*.ts' \
+  'packages/contracts/src/team-protocol/fixtures/**' \
+  ':(exclude)packages/contracts/src/team-protocol/v*.test.ts'
 ```
 
-**This must be empty.** `--diff-filter=MDR` is the point: a released codec or fixture that was
-*modified, deleted or renamed* is a broken contract with every peer still running an older build,
-and the fix is a new protocol version, never an edit. `R` is in that list deliberately — git
-classifies a rename as `R` rather than `M`, so leaving it out lets a frozen fixture be renamed out
-from under the check while the diff still reports clean.
+**This must be empty.** Three things in that command are load-bearing:
 
-An *added* fixture is additive and allowed. Read the additions separately with `--diff-filter=A`
-and confirm each is a genuinely new case rather than the other half of a rename.
+- **Every pathspec is quoted, so git expands it and the shell never sees a glob.** Do not collect
+  the file list into a variable first. An unquoted `$FROZEN` word-splits under bash but *not* under
+  zsh, where the newline-joined list becomes a single path that matches nothing — so the check
+  prints empty and passes while a frozen codec sits modified in the diff. A gate that reports clean
+  for the wrong reason is worse than no gate, and this is the one gate whose whole output is its
+  own emptiness.
+- **`v*.ts` covers the adapters.** `packages/contracts/AGENTS.md` freezes a codec, an adapter, and
+  client and host fixtures for every released protocol, so `v1-adapter.ts`, `v2-adapter.ts`,
+  `v3-adapter.ts` and `v3-webrtc-adapter.ts` are as frozen as `v1.ts`. A pattern anchored on
+  `v[0-9]+\.ts$` matches one frozen file in five and passes while four broken adapters ship.
+- **`--diff-filter=MDR`.** A released file *modified, deleted or renamed* is a broken contract with
+  every peer still running an older build, and the fix is a new protocol version, never an edit.
+  `R` is listed deliberately: git classifies a rename as `R` rather than `M`, so leaving it out
+  lets a frozen fixture be renamed out from under the check while the diff still reports clean.
+  `A` is left out because an added fixture is additive, and `v*.test.ts` is excluded because a test
+  covering a frozen protocol may legitimately gain cases.
+
+Read the additions separately with `--diff-filter=A` and confirm each is a genuinely new case
+rather than the other half of a rename.
 
 If the modified-or-deleted diff is non-empty, read every hunk before calling it a stop. A change
 that provably cannot alter what any encoded payload means — an added `export` keyword, a comment —
@@ -152,10 +171,11 @@ is not a wire change. Anything that touches a key list, a validator, or a projec
   fails validation and returns `null`, and callers read `null` as "nothing to send". `tsc` stays
   green throughout.
 
+List the protocol tests from the tag for the same reason the diff is derived from it, then run
+`bun run test:desktop -- <path>` once per file it prints:
+
 ```bash
-bun run test:desktop -- packages/contracts/src/team-protocol/v1.test.ts
-bun run test:desktop -- packages/contracts/src/team-protocol/v2.test.ts
-bun run test:desktop -- packages/contracts/src/team-protocol/v3.test.ts
+git ls-tree --name-only <tag> packages/contracts/src/team-protocol/ | grep -E 'v[0-9]+\.test\.ts$'
 ```
 
 The full compatibility matrix — older client against new host, new client against older host,

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -21,6 +21,10 @@ This runs *before* `docs/RELEASING.md`, which stays authoritative for the publis
 - It never runs `bun run check`, `check:desktop`, `test`, or `build-storybook` — each takes minutes,
   CI owns them, and the desktop suite flakes under load, so a red result would tell you nothing.
   Run the narrowest test file named by a gate, then `bun run lint` and `bun run typecheck`.
+- **If gate C or D fired, add `bun run mobile:typecheck`.** `bun run typecheck` is `typecheck:*` and
+  the mobile script is named `mobile:typecheck`, so the aggregate misses it — and `apps/mobile`
+  depends on `@openbot/contracts`, which is exactly what those two gates change. A contract export
+  change passes the aggregate and still breaks the mobile app.
 - It never runs `bun run dev:seed` or `dev:reset` — both destroy the developer's own profile — and
   never `pkill -f`, which kills other sessions' work mid-write.
 
@@ -48,9 +52,16 @@ need the exact file, not before.
 
 Triggered by any change to that file or to `src/backend/database/`.
 
-- A new entry in `MIGRATIONS` must be the **next contiguous version after 14**.
-  `validateMigrationRegistry` throws on a gap, so a wrong number is loud — but a *reused* number is
-  a migration that never runs.
+- New entries in `MIGRATIONS` must **continue contiguously from the last version at the release
+  tag**. Read that number, never remember it:
+
+  ```bash
+  git show <tag>:src/backend/openbot-database-schema.ts | grep -E 'version: [0-9]+' | tail -1
+  ```
+
+  A literal written into this file would go stale the first time a migration ships and would then
+  reject the correct number. `validateMigrationRegistry` throws on a gap, so a skipped number is
+  loud — but a *reused* one is a migration that never runs on any database that already applied it.
 - **No shipped `migrateTo*` body may have changed**, including the frozen `migrateToBaselineV8`.
   Read every hunk of the diff, not the stat. A database that already applied version 12 will never
   apply it again, so an edit to it reaches new installs only and the two populations diverge.
@@ -110,19 +121,24 @@ Triggered by a change to any file in the inventory in `references/surfaces.md`.
 
 Triggered by any change under that directory.
 
+First derive the frozen set from the tag rather than hard-coding versions — a protocol released
+since you last read this file is frozen too, and a hard-coded `v1 v2 v3` would never audit it:
+
 ```bash
-git diff --stat --diff-filter=MD <tag>..HEAD -- \
-  packages/contracts/src/team-protocol/v1.ts \
-  packages/contracts/src/team-protocol/v2.ts \
-  packages/contracts/src/team-protocol/v3.ts \
+FROZEN=$(git ls-tree --name-only <tag> packages/contracts/src/team-protocol/ \
+  | grep -E '/v[0-9]+\.ts$')
+git diff --stat --diff-filter=MDR <tag>..HEAD -- $FROZEN \
   packages/contracts/src/team-protocol/fixtures
 ```
 
-**This must be empty.** `--diff-filter=MD` is the point: a released codec or fixture that was
-*modified or deleted* is a broken contract with every peer still running an older build, and the
-fix is a new protocol version, never an edit. An *added* fixture is additive and allowed, so read
-the additions separately with `--diff-filter=A` and confirm each is a new case rather than a
-replacement for one that was renamed away.
+**This must be empty.** `--diff-filter=MDR` is the point: a released codec or fixture that was
+*modified, deleted or renamed* is a broken contract with every peer still running an older build,
+and the fix is a new protocol version, never an edit. `R` is in that list deliberately — git
+classifies a rename as `R` rather than `M`, so leaving it out lets a frozen fixture be renamed out
+from under the check while the diff still reports clean.
+
+An *added* fixture is additive and allowed. Read the additions separately with `--diff-filter=A`
+and confirm each is a genuinely new case rather than the other half of a rename.
 
 If the modified-or-deleted diff is non-empty, read every hunk before calling it a stop. A change
 that provably cannot alter what any encoded payload means — an added `export` keyword, a comment —
@@ -149,7 +165,11 @@ restate it.
 
 ### D. IPC channels — `packages/contracts/src/ipc-channels.ts`
 
-Triggered by a change to the channel list.
+Triggered by a change to the channel list **or to any of its mirrors** — `src/main/index.ts`,
+`src/main/ipc/`, `src/preload/index.ts`, `src/renderer/src/preview/mock-openbot.ts`. Deleting a
+handler or an `invoke` breaks a live channel without touching the list at all, and the coverage
+test below is what catches it, so a gate that only watched the list would skip the one run that
+would have found it.
 
 Renderer and main ship in one binary, so a channel rename is **not** an upgrade hazard — nothing
 older ever calls it. The hazard is drift between the list and its hand-written mirrors, which is a
@@ -169,19 +189,34 @@ array is a story that silently shows nothing.
 
 ### E. Account Worker — `apps/auth-api/`
 
-Triggered by a new file in `apps/auth-api/migrations/`, or a change under
-`apps/auth-api/src/routes/` or `apps/auth-api/src/server/`.
+Triggered by **any** addition, modification, deletion or rename under `apps/auth-api/migrations/`,
+or a change under `apps/auth-api/src/routes/` or `apps/auth-api/src/server/`:
 
-Two separate hazards; check both.
+```bash
+git diff --stat --diff-filter=AMDR <tag>..HEAD -- apps/auth-api/migrations
+```
 
+Three separate hazards; check all three.
+
+- **An already-applied migration was edited.** This is a stop, and it is the one that looks
+  harmless. Wrangler records migrations by *name* and never replays a file it has already applied,
+  so an edit leaves production on the old schema while every fresh database executes the new
+  history. The two diverge permanently and nothing reports it. Same rule as `src/backend`: append a
+  new migration, never edit a shipped one — for a different reason, since here it is the applied-name
+  ledger rather than the absence of a backup.
 - **The D1 deploy race.** CI applies migrations **before** deploying the new Worker, so for the
   length of that gap the old Worker runs against the new schema. No `NOT NULL` column without a
   default, no rename, no drop of a column the deployed Worker still reads. A contraction needs the
   two-step release — expand, deploy the Worker that uses it, contract in a later change.
-- **Installed desktop builds never update.** A build from a year ago keeps calling `auth:*` against
-  the current Worker forever. A removed or renamed *response field* in a route handler under
-  `apps/auth-api/src/routes/v1/` or `v2/` breaks those clients, and unlike a D1 mistake that is not
-  recoverable by a redeploy. Diff the route handlers for removed fields, not just the migrations.
+- **Installed desktop builds never update**, in *both* directions. A build from a year ago keeps
+  calling `auth:*` against the current Worker forever, and unlike a D1 mistake that is not
+  recoverable by a redeploy.
+  - *Responses*: a removed or renamed field in a handler under `apps/auth-api/src/routes/v1/` or
+    `v2/` breaks the clients that still read it.
+  - *Requests*: an old build also keeps sending its original routes, methods, headers and bodies.
+    Making an optional request field required, tightening a validator, rejecting a value that used
+    to be accepted, or adding an auth requirement breaks those clients even when every response
+    shape is untouched. Diff the request parsers and route registrations, not only the responses.
 
 ```bash
 bun run --cwd apps/auth-api test:server test/mobile-auth-migration.test.ts

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -273,18 +273,29 @@ array is a story that silently shows nothing.
 ### E. Account Worker — `apps/auth-api/`
 
 Triggered by **any** addition, modification, deletion or rename under `apps/auth-api/migrations/`,
-a change to any non-UI file under `apps/auth-api/src/`, or a change to `.github/workflows/ci.yml`.
+a change to any non-UI file under `apps/auth-api/src/`, or a change to any of the four files that
+decide the deploy order: `.github/workflows/ci.yml`, `scripts/deploy-auth-api.ts`,
+`apps/auth-api/package.json` and `apps/auth-api/wrangler.jsonc`.
 
 The `src/` half is wider than `routes/` and `server/` on purpose: `worker-entry.ts` is the deployed
 Worker's default export and `router.tsx` builds the router from `routeTree.gen.ts`, so a `/v1` or
 `/v2` endpoint can be removed or shadowed there while every file under `routes/` is untouched.
 
-`ci.yml` is in the list because the deploy-race hazard below is a property of the *workflow*, not of
-`apps/auth-api/`. It holds only while "Apply production D1 migrations" runs before the Worker
-deploy in the same job. Reorder those steps, drop the migration step, or move either into another
-workflow, and production runs a Worker against a schema it was never deployed against — with
-nothing under `apps/auth-api/` modified and the gate otherwise reporting "not triggered". Re-read
-the step order every time that file changes; do not assume the order you were told about here.
+The deploy-order files are in the list because the deploy-race hazard below is a property of *how
+the deploy runs*, not of `apps/auth-api/`. **There are two independent paths and they must both
+hold:**
+
+- `.github/workflows/ci.yml` — "Apply production D1 migrations" runs before the Worker deploy in
+  the same job.
+- `scripts/deploy-auth-api.ts` — applies remote D1 migrations, then builds, then runs
+  `wrangler deploy`. `apps/auth-api/package.json` `deploy` and `deploy:test` are its entrypoints,
+  so a change to either can redirect or reorder the whole sequence.
+
+Reorder those operations, drop the migration step, or split them across jobs, and production runs a
+Worker against a schema it was never deployed against — with nothing under `apps/auth-api/src/`
+modified and the gate otherwise reporting "not triggered". Re-read the order in **both** paths every
+time one of these files changes; do not assume the order described here still holds, and do not
+assume fixing one path covers the other.
 
 ```bash
 git diff --stat --diff-filter=AMDR <tag>..HEAD -- apps/auth-api/migrations

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: release-upgrade-safety
+description: Audit a pending OpenBot release for upgrade and data-loss hazards before the version is bumped or tagged. Use when asked to cut a release, create or bump a version, prepare a tag, or check whether a change is safe to ship to installed users.
+---
+
+# Release upgrade safety
+
+Every hazard here is one an installed user pays for and you cannot take back. `openbot.db` is
+migrated in place with no backup, two dozen files under `userData` are rewritten by whichever build
+opens them last, a released Team API adapter is spoken by peers you will never update, and the
+account Worker's D1 migrations are applied before the Worker that needs them. A build that ships
+past one of these does not fail on your machine; it fails on someone else's, once, permanently.
+
+Audit the diff since the last released tag against the seven gates below, then report a verdict.
+This runs *before* `docs/RELEASING.md`, which stays authoritative for the publish itself.
+
+## What this skill does and does not do
+
+- It audits. It does not run `bun run release:patch`, commit a version bump, or push a tag unless
+  you are separately asked to.
+- It never runs `bun run check`, `check:desktop`, `test`, or `build-storybook` — each takes minutes,
+  CI owns them, and the desktop suite flakes under load, so a red result would tell you nothing.
+  Run the narrowest test file named by a gate, then `bun run lint` and `bun run typecheck`.
+- It never runs `bun run dev:seed` or `dev:reset` — both destroy the developer's own profile — and
+  never `pkill -f`, which kills other sessions' work mid-write.
+
+## Step 1 — establish the range
+
+```bash
+git tag --list 'v*' --sort=-v:refname | head -1
+git diff --stat <tag>..HEAD
+```
+
+The audit is over that commit range, not over the working tree: an uncommitted edit is not what
+ships, and a hazard three commits back is. State the tag and the changed-file count up front, and
+run every gate's `git diff` over that same range.
+
+## Step 2 — the seven gates
+
+Each gate is triggered by a path appearing in the diff. Work through all seven. A gate no path
+triggered is reported as **not triggered** — never dropped silently, because "I did not look" and
+"I looked and it was clean" are different verdicts and only one of them is a release gate.
+
+`references/surfaces.md` holds the exhaustive path inventory. Load it when a gate fires and you
+need the exact file, not before.
+
+### A. SQLite schema — `src/backend/openbot-database-schema.ts`
+
+Triggered by any change to that file or to `src/backend/database/`.
+
+- A new entry in `MIGRATIONS` must be the **next contiguous version after 14**.
+  `validateMigrationRegistry` throws on a gap, so a wrong number is loud — but a *reused* number is
+  a migration that never runs.
+- **No shipped `migrateTo*` body may have changed**, including the frozen `migrateToBaselineV8`.
+  Read every hunk of the diff, not the stat. A database that already applied version 12 will never
+  apply it again, so an edit to it reaches new installs only and the two populations diverge.
+- **If the migration executes DDL, `LATEST_SCHEMA_SQL` must be extended in the same change.**
+  `createLatestDatabase` execs that SQL and then stamps every `MIGRATIONS` entry as applied
+  *without running it*, so a DDL migration missing from it ships new installs a database without
+  the column upgraded installs have. Today `LATEST_SCHEMA_SQL` is derived by `substituteOnce`,
+  which replaces exactly one table in the v8 baseline (the v12 reactions table) and throws on zero
+  or two matches. A second DDL migration must change that mechanism, not append to it.
+- Data-preservation fixtures for every shipped source schema, plus failure, rollback, retry,
+  downgrade, missing-version, foreign-key and integrity coverage, per `src/backend/AGENTS.md`.
+- Confirm the downgrade guard still names the new `LATEST_SCHEMA_VERSION` — the test is
+  "rejects a database created by a newer application" in `src/backend/openbot-database.test.ts`.
+
+```bash
+bun run test:desktop -- src/backend/openbot-database-schema-parity.test.ts
+bun run test:desktop -- src/backend/openbot-database.test.ts
+```
+
+The parity test builds a database both ways and compares normalised `sqlite_master` and
+`PRAGMA table_info`, so an unmirrored DDL migration is red rather than a support ticket. If it is
+green and you added DDL, check that you actually added it to `MIGRATIONS`.
+
+### B. On-disk state outside SQLite — `src/main/index.ts`, `src/backend/*-store.ts`
+
+Triggered by a change to any file in the inventory in `references/surfaces.md`.
+
+- **Did an on-disk filename constant change?** A rename is silent data loss: the old file is never
+  found, never read, and never deleted. The new build starts from its defaults and the user's
+  setup, servers or window state are simply gone.
+- **Did a stored payload `version` bump?** Every shipped previous shape needs a read path. Three
+  working precedents to copy, in descending order of care:
+  - `src/main/remote-server-stored-shape.ts` — reads v1 and v2 as a re-tag of v3, preserves entries
+    it cannot parse rather than dropping them, and **refuses an unknown version outright** so it
+    never overwrites a file a newer build can still read.
+  - `src/main/team-store.ts` — keeps `openbot-team-server-v1.json` and `-v2.json` on disk together,
+    so a user who downgrades still finds their host.
+  - `src/main/dynamic-island-preference-store.ts` — reads `version === 1` and `=== 2` into 3.
+  - Known gap, re-check every release: `src/main/setup-store.ts` accepts only `version === 2` and
+    falls back to defaults on anything else, silently. Bumping it to 3 without a read path re-runs
+    setup for every installed user.
+- **The permanent names are permanent.** The four legacy path prefixes in
+  `src/backend/workspace-paths.ts`, `bots.json` (`LEGACY_AGENTS_STATE_FILE` in
+  `src/backend/agent-store.ts`), `mailbox.json`, and the `legacy-import:bots:v1` command id are
+  spellings a shipped release already wrote to the user's disk. A database restored from the user's
+  own file copy never ran migration v13, so `bot-<uuid>` ids and `~/OpenBot/Bots` paths are still
+  live values.
+- **`legacy-backup-v1/` is not a general backup.** `DatabaseCore.backupLegacyFile` copies a single
+  named file, once, with `COPYFILE_EXCL`, and it is used for the two legacy JSON imports only.
+  Nothing else on disk is ever copied before being rewritten.
+- **`safeStorage` files become undecryptable** if the macOS signing identity, team ID or `appId`
+  changes: `openbot-central-auth-v1.bin` and the remote-desktop secret files are encrypted against
+  the keychain entry those identify. Diff `electron-builder.yml` for `appId`, `ElectronTeamID`, and
+  the `publish` block — this overlaps gate F on purpose, because one field breaks two things.
+
+### C. Team API wire — `packages/contracts/src/team-protocol/`
+
+Triggered by any change under that directory.
+
+```bash
+git diff --stat --diff-filter=MD <tag>..HEAD -- \
+  packages/contracts/src/team-protocol/v1.ts \
+  packages/contracts/src/team-protocol/v2.ts \
+  packages/contracts/src/team-protocol/v3.ts \
+  packages/contracts/src/team-protocol/fixtures
+```
+
+**This must be empty.** `--diff-filter=MD` is the point: a released codec or fixture that was
+*modified or deleted* is a broken contract with every peer still running an older build, and the
+fix is a new protocol version, never an edit. An *added* fixture is additive and allowed, so read
+the additions separately with `--diff-filter=A` and confirm each is a new case rather than a
+replacement for one that was renamed away.
+
+If the modified-or-deleted diff is non-empty, read every hunk before calling it a stop. A change
+that provably cannot alter what any encoded payload means — an added `export` keyword, a comment —
+is not a wire change. Anything that touches a key list, a validator, or a projected value is.
+
+- Every shipped protocol is still registered, and the negotiation maximum only ever grows. Age and
+  SemVer distance are not reasons to drop an adapter (`packages/contracts/AGENTS.md`).
+- A new additive capability belongs in `current.ts`, never in a frozen codec.
+- **Any new key needs a `current-agent-keys.ts` decision.** The failure is silent, not loud: the
+  frozen codecs project through a key allowlist, an unmapped key is *dropped*, the encode then
+  fails validation and returns `null`, and callers read `null` as "nothing to send". `tsc` stays
+  green throughout.
+
+```bash
+bun run test:desktop -- packages/contracts/src/team-protocol/v1.test.ts
+bun run test:desktop -- packages/contracts/src/team-protocol/v2.test.ts
+bun run test:desktop -- packages/contracts/src/team-protocol/v3.test.ts
+```
+
+The full compatibility matrix — older client against new host, new client against older host,
+matching versions, no shared protocol, capability omission, unknown optional events, malformed
+known events — stays where it is, in `docs/RELEASING.md` preflight item 0. Point at it; do not
+restate it.
+
+### D. IPC channels — `packages/contracts/src/ipc-channels.ts`
+
+Triggered by a change to the channel list.
+
+Renderer and main ship in one binary, so a channel rename is **not** an upgrade hazard — nothing
+older ever calls it. The hazard is drift between the list and its hand-written mirrors, which is a
+runtime rejection in the build you are about to sign. Confirm all of them moved together, per the
+table in `packages/contracts/AGENTS.md`: the `handleTrusted` registrations in `src/main/index.ts`
+and `src/main/ipc/`, the `invoke` calls in `src/preload/index.ts`, and
+`src/renderer/src/preview/mock-openbot.ts`, the second implementation Storybook and the preview run
+against.
+
+```bash
+bun run test:desktop -- src/main/ipc-channel-coverage.test.ts
+```
+
+That test links main and preload. The mock is covered by `tsc` in both directions, so what is left
+for you to judge is its *behaviour* — a mock method that satisfies the type by returning an empty
+array is a story that silently shows nothing.
+
+### E. Account Worker — `apps/auth-api/`
+
+Triggered by a new file in `apps/auth-api/migrations/`, or a change under
+`apps/auth-api/src/routes/` or `apps/auth-api/src/server/`.
+
+Two separate hazards; check both.
+
+- **The D1 deploy race.** CI applies migrations **before** deploying the new Worker, so for the
+  length of that gap the old Worker runs against the new schema. No `NOT NULL` column without a
+  default, no rename, no drop of a column the deployed Worker still reads. A contraction needs the
+  two-step release — expand, deploy the Worker that uses it, contract in a later change.
+- **Installed desktop builds never update.** A build from a year ago keeps calling `auth:*` against
+  the current Worker forever. A removed or renamed *response field* in a route handler under
+  `apps/auth-api/src/routes/v1/` or `v2/` breaks those clients, and unlike a D1 mistake that is not
+  recoverable by a redeploy. Diff the route handlers for removed fields, not just the migrations.
+
+```bash
+bun run --cwd apps/auth-api test:server test/mobile-auth-migration.test.ts
+```
+
+`apps/auth-api` has its own vitest config, so `bun run test:desktop` does not reach it. Run the
+sibling `*-migration.test.ts` files in `apps/auth-api/test/` that cover what you touched.
+`bun run check:api` is CI's job, not yours.
+
+### F. The updater itself — `electron-builder.yml`, `src/main/update-service.ts`, `package.json`
+
+Triggered by a change to any of those, or to `package.json` dependencies.
+
+- `appId`, the `publish` owner and repo, `artifactName` and `electronUpdaterCompatibility` are
+  unchanged. A changed `appId` breaks the update feed and the `safeStorage` files at once — the
+  users who lose their credentials are exactly the ones who successfully updated.
+- **An `electron-updater` version bump means re-verifying the four non-public behaviours**
+  documented on `UpdateAdapter` in `src/main/update-service.ts`: `MacUpdater.updateDownloaded` only
+  asks Squirrel to stage while `autoInstallOnAppQuit` is on, `MacUpdater.quitAndInstall` stages on
+  demand, every available check mints and returns a cancellation token, and
+  `BaseUpdater.quitAndInstall` can return without quitting. Then update `VERIFIED_VERSION` in
+  `src/main/electron-updater-assumptions.test.ts`. Retyping that version without re-verifying is
+  the exact failure the test exists to catch, and issue #152 is what it cost last time.
+- New `extraResources` or a bundled model breaks the size gates:
+  `scripts/verify-update-artifacts.ts` rejects an update artifact over 700 MiB and a DMG over
+  750 MiB, and `.github/workflows/release.yml` additionally rejects a macOS ZIP that is not smaller
+  than the `v0.1.21` ZIP it downloads to compare against.
+
+```bash
+bun run test:desktop -- src/main/electron-updater-assumptions.test.ts
+```
+
+### G. Reverse states and the changelog
+
+Always triggered. There is no path that exempts a release from these.
+
+- **Any state this release lets a user enter but not leave is a bug, not a release note.** Snooze
+  needs unsnooze, pause resume, revoke reconnect, mute unmute. Walk the new user-facing states in
+  the diff and name the exit for each.
+- **Anything requiring a user action after upgrade goes in the `CHANGELOG.md` entry in bold.** The
+  precedent is the paired-phones note currently under `## [Unreleased]`: it states the action, why
+  the upgrade forced it, and what is *not* lost. Copy that shape. A user who has to act and is not
+  told files a data-loss bug.
+
+## Step 3 — report and hand off
+
+Report a table:
+
+| Gate | Triggered by | Verdict |
+| --- | --- | --- |
+| A. SQLite schema | *path, or "not triggered"* | pass / stop / needs a human |
+
+Then state the stops explicitly. Any one of these means **the version is not cuttable yet**:
+
+- a modified or deleted frozen Team API codec or fixture;
+- a DDL migration not mirrored into `LATEST_SCHEMA_SQL`;
+- a renamed on-disk file, or a bumped stored `version`, with no read path for the old one;
+- a D1 contraction without the two-step release;
+- a changed `appId`, `ElectronTeamID`, or `publish` target.
+
+If every gate passes, say so and hand off: `docs/RELEASING.md` owns the publish — the preflight
+checklist, the compatibility matrix, signing, notarization, the canary update and the size gates.

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -87,13 +87,26 @@ green and you added DDL, check that you actually added it to `MIGRATIONS`.
 
 ### B. On-disk state outside SQLite — `src/main/index.ts`, `src/backend/*-store.ts`
 
-Triggered by a change to `src/main/index.ts`, any `*-store.ts` under `src/main/` or `src/backend/`,
-`src/backend/workspace-paths.ts`, `src/backend/browser-host.ts`,
-`src/main/remote-server-stored-shape.ts`, `src/main/sunshine-moonlight-runtime.ts`, or
-`electron-builder.yml`. The list is here and not in `references/surfaces.md` because you classify
-triggers before you open any reference — a trigger that pointed at the inventory would need the
-inventory read first, and a file you did not already suspect would be classified as not triggered.
-Once this gate fires, open the inventory for the file-by-file detail.
+Triggered by a change to `src/main/index.ts`, `src/backend/workspace-paths.ts`,
+`src/main/sunshine-moonlight-runtime.ts`, `electron-builder.yml`, or **any file that decodes a
+versioned payload**. Derive that last set instead of trusting a list — a serialization owner is not
+always a `*-store.ts`, and `central-auth-manager.ts`, `main-window-state.ts` and
+`skill-marketplace-service.ts` are three that are not:
+
+```bash
+git grep -lE 'version *(!==|===) *[0-9]' HEAD -- 'src/main/*.ts' 'src/backend/*.ts' \
+  ':(exclude)*.test.ts'
+```
+
+The gate fires if the release diff touches any file that prints. Note the absent `\b`: `git grep -E`
+is POSIX ERE, where `\b` matches nothing at all, so writing the pattern the natural way returns an
+empty list and reports that the release changed no serialization owner. Same failure as gate C —
+a check that answers the wrong question and calls the silence a pass.
+
+The trigger lives here rather than in `references/surfaces.md` because you classify triggers before
+you open any reference; a trigger that pointed at the inventory would need the inventory read first,
+and a file you did not already suspect would be classified as not triggered. Once this gate fires,
+open the inventory for the file-by-file detail.
 
 - **Did an on-disk filename constant change?** A rename is silent data loss: the old file is never
   found, never read, and never deleted. The new build starts from its defaults and the user's
@@ -109,6 +122,20 @@ Once this gate fires, open the inventory for the file-by-file detail.
   - Known gap, re-check every release: `src/main/setup-store.ts` accepts only `version === 2` and
     falls back to defaults on anything else, silently. Bumping it to 3 without a read path re-runs
     setup for every installed user.
+- **A read path is only the upgrade half — check the downgrade too.** Proving the new build reads
+  every old shape says nothing about the old build reading the *new* one, and every file here is
+  rewritten in place by whichever build opens it last. A user who rolls back to the previous
+  release, or runs an older install beside the new one, hands the file to a reader that predates
+  the bump. `src/main/dynamic-island-preference-store.ts` treats an unknown version as defaults and
+  then rewrites the file at its own version, so shipping a `version: 4` under that filename means
+  the older build silently discards the user's setting rather than leaving it alone. Before reusing
+  a filename, read the reader **at the release tag** and confirm it refuses an unknown version
+  instead of defaulting — `src/main/remote-server-stored-shape.ts` does, which is what makes it safe
+  to bump. If it does not, keep the old file and write the new version beside it under a new name,
+  the way `src/main/team-store.ts` keeps `-v1.json` and `-v2.json`.
+  - The same asymmetry applies to `central-auth-manager.ts`, which is stricter still: an unknown
+    shape *throws*, and `#initialize` catches that into `#clearStoredSession()`. The user is signed
+    out, and because the file is `safeStorage`-encrypted there is nothing to recover by hand.
 - **The permanent names are permanent.** The four legacy path prefixes in
   `src/backend/workspace-paths.ts`, `bots.json` (`LEGACY_AGENTS_STATE_FILE` in
   `src/backend/agent-store.ts`), `mailbox.json`, and the `legacy-import:bots:v1` command id are
@@ -210,7 +237,10 @@ array is a story that silently shows nothing.
 ### E. Account Worker — `apps/auth-api/`
 
 Triggered by **any** addition, modification, deletion or rename under `apps/auth-api/migrations/`,
-or a change under `apps/auth-api/src/routes/` or `apps/auth-api/src/server/`:
+or a change to any non-UI file under `apps/auth-api/src/`. That is wider than `routes/` and
+`server/` on purpose: `worker-entry.ts` is the deployed Worker's default export, and `router.tsx`
+builds the router from `routeTree.gen.ts`. Those three decide what is actually served, so a `/v1` or
+`/v2` endpoint can be removed or shadowed there while every file under `routes/` is untouched.
 
 ```bash
 git diff --stat --diff-filter=AMDR <tag>..HEAD -- apps/auth-api/migrations

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -73,11 +73,22 @@ git diff --name-only <tag>..HEAD | cut -d/ -f1-2 | sort | uniq -c | sort -rn
 Then handle each bucket one of three ways, and say in the Step 3 table which one you used:
 
 - **Dismissed as a bucket**, with the reason stated once. A bucket qualifies only if you can say
-  what makes *every* file in it inert. `**/*.test.ts`, `docs/**`, `tools/**` and
-  `src/renderer/stories/**` are not in the shipped app at all, which is such a reason. "Nothing
-  looked interesting" is not. **`src/renderer/**` does not qualify** — the renderer writes
-  `localStorage`, that store lives in the user's Electron partition, and it outlives the build that
-  wrote it exactly the way a file under `userData` does. Route it through gate B instead.
+  what makes *every* file in it inert. `docs/**`, `tools/**` and `src/renderer/stories/**` are not
+  in the shipped app at all, which is such a reason. "Nothing looked interesting" is not. Two
+  buckets that look dismissible and are not:
+  - **`src/renderer/**`** — the renderer writes `localStorage`, that store lives in the user's
+    Electron partition, and it outlives the build that wrote it exactly the way a file under
+    `userData` does. Route it through gate B.
+  - **The tests a gate relies on.** "Not in the shipped app" is true of every test and irrelevant
+    for these, because a gate that delegates its check to a test inherits that test's weakening.
+    `openbot-database-schema-parity.test.ts` is the whole mechanical half of gate A's DDL rule;
+    `openbot-database.test.ts` carries the downgrade guard; `ipc-channel-coverage.test.ts` is gate
+    D's only static link between main and preload; `electron-updater-assumptions.test.ts` pins the
+    updater behaviour gate F rests on; the `v*.test.ts` files are gate C's. A change that makes one
+    of those assertions vacuous passes every later gate, and once it is tagged the weakening is
+    behind the range every future audit starts from. Route a modification or deletion of one
+    through the gate that names it and read the hunks. Other `**/*.test.ts` files dismiss as a
+    bucket normally.
 - **Cleared by a derived query.** This is how a large hazard-bearing directory gets honestly
   covered: gate B's `git grep` over `src/main` and `src/backend` names every file that decodes a
   versioned payload, so the other two hundred are cleared by the query having asked the right
@@ -188,28 +199,66 @@ far less than the file inventory in `references/surfaces.md`, the pattern is bro
 release clean. Step 1 is what actually guarantees an unmatched file gets looked at — a persistence
 change spelled in a way no pattern anticipates is caught by having to dismiss the file by name.
 
-**The renderer persists too, and its store is not on any of the lists above.** `localStorage` lives
-in the user's Electron partition, so it survives an upgrade exactly the way a file under `userData`
-does — sidebar pins, collapsed sections, people order, panel widths and the completion-sound
-preference are all kept there. The query above never reaches it, because the renderer keys its state
-by string rather than guarding a `version` field. Run the key inventory as a second derived list:
+**Three surfaces persist outside `userData` and none of them is on the lists above.** The renderer's
+`localStorage` lives in the user's Electron partition; the mobile app's `SecureStore` and
+`AsyncStorage` live on the phone; `packages/team-client` writes workspace preferences through a
+storage interface both of them supply. All three outlive the build that wrote them exactly the way a
+file under `userData` does, and the query above reaches none of them — it is scoped to `src/main`
+and `src/backend`, and these keep state under a string key rather than guarding a `version` field.
+
+Widen the first query's pathspec to include `'apps/mobile/src/*.ts'` and
+`'packages/team-client/src/*.ts'` — that is what catches `workspace-preferences.ts`, which does
+guard `value.version !== 1`. Then run the key inventory as a second derived list:
 
 ```bash
-git grep -hoE '"openbot:[a-z0-9:-]+"' <tag> -- 'src/renderer/src/**' \
-  ':(exclude)*.test.ts' ':(exclude)*.test.tsx' | sort -u > /tmp/keys-tag.txt
-git grep -hoE '"openbot:[a-z0-9:-]+"' HEAD -- 'src/renderer/src/**' \
-  ':(exclude)*.test.ts' ':(exclude)*.test.tsx' | sort -u > /tmp/keys-head.txt
-diff /tmp/keys-tag.txt /tmp/keys-head.txt
+keys() { git grep -hoE '"openbot[.:][a-zA-Z0-9.:_-]+"' "$1" -- \
+  'src/renderer/src/**' 'apps/mobile/src/**' 'packages/team-client/src/**' \
+  ':(exclude)*.test.ts' ':(exclude)*.test.tsx' | sort -u; }
+diff <(keys <tag>) <(keys HEAD)
 ```
 
-A key that disappears from the tag side is the renderer's version of a renamed filename constant:
+Process substitution rather than two files in `/tmp`: several agents work in worktrees on this
+machine at once, and a fixed temporary name lets one audit read another range's inventory and call
+a renamed key clean. **`openbot[.:]` covers both spellings** — the renderer uses colons
+(`openbot:sidebar-pins:v1`), mobile and team-client use dots (`openbot.mobile.session.v1`), and a
+pattern written for one silently returns half the set. It still only sees string literals, and two
+keys are built in templates and never appear at all — `workspace-preferences.ts` composes
+`openbot.workspace.v1.${scope}.${fingerprint}` and `trusted-host-keys.ts` composes
+`openbot.host-key.v1.${scope}.${fingerprint}`, the second holding per-host trust. Widen the pattern
+when you meet a third spelling rather than trusting this one, and treat the key diff as necessary
+rather than sufficient.
+
+A key that disappears from the tag side is these surfaces' version of a renamed filename constant:
 the old entry is never read again, never cleaned up, and the user's state is silently back to
-defaults. Three keys already carry their own version suffix — `openbot:sidebar-pins:v1`,
-`openbot:sidebar-collapsed:v1`, `openbot:sidebar-people-order:v1` — so bumping one to `:v2` is a
-deliberate reset and needs the same justification as a `userData` version bump, plus a
-`CHANGELOG.md` note under gate G if the user has to redo anything. Moving a file between directories
-does not rename its key, so expect the owner list to churn while the key list stays still; it is the
-`diff` that matters, not which file holds the literal.
+defaults. Several keys carry their own version suffix — `openbot:sidebar-pins:v1`,
+`openbot.mobile.session.v1`, `openbot.mobile.device-id.v1` — so bumping one is a deliberate reset
+needing the same justification as a `userData` version bump, plus a `CHANGELOG.md` note under gate G.
+
+**An unchanged key list is not a clean result — read the owners too.** The value under a key can
+change shape while the key never moves, and that is the more likely half: it is a schema tightened,
+an enum member renamed, an id format rewritten. Derive the owners the same way, union both
+revisions, and read the hunks of any that the release touched:
+
+```bash
+git grep -lE '"openbot[.:]|localStorage|SecureStore|AsyncStorage' <tag> HEAD -- \
+  'src/renderer/src/**' 'apps/mobile/src/**' 'packages/team-client/src/**' \
+  ':(exclude)*.test.ts' ':(exclude)*.test.tsx' | sed 's/^[^:]*://' | sort -u
+```
+
+**No one of these three passes is sufficient, and they fail in different directions.** Check that
+each of the two files with a templated key lands somewhere: `trusted-host-keys.ts` appears here
+because it names `SecureStore`, and is invisible to both other passes; `workspace-preferences.ts`
+appears in *neither* the key list nor this one — it takes its storage as an injected parameter and
+names no API — and is reached only by the widened `version` query above. If a file you know persists
+is missing from all three, the patterns are what is broken.
+
+Expect this list to churn when files move between directories while the key list stays still — it is
+the *hunks* that matter here, not the paths. `sidebar-pins.ts` is the worked example, and it is the
+reason this paragraph exists: the release that renamed the product concept left
+`openbot:sidebar-pins:v1` and its Zod schema untouched and added `reownSidebarPinnedItems`, which
+rewrites every stored `bot-<uuid>` pin to the matching `agent-<uuid>`. All of the migration lived
+inside the value. Had it been forgotten, every user's pins would point at ids the app no longer
+knows and would be dropped on the next read — and the key diff above would still print nothing.
 
 The trigger lives here rather than in `references/surfaces.md` because you classify triggers before
 you open any reference; a trigger that pointed at the inventory would need the inventory read first,

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -49,9 +49,32 @@ git diff --name-status <tag>..HEAD
 Each gate names the paths that obviously belong to it. Treat those as a starting point and never as
 the authority: they are written by hand, they go stale, and a release can touch a file nobody
 thought to list. The question a gate actually asks is "does this file carry the hazard I own", and
-only the file in front of you answers that. A file matched by no gate has to be dismissed out loud,
-with its reason, in the Step 3 table — "it was not on a trigger list" is not a reason, "it is a
-renderer component with no persisted state" is.
+only the file in front of you answers that.
+
+**Account for every file, but clear directories with a query and reserve prose for the residue.** A
+release here runs to hundreds of files — the range audited when this skill was written was 942, of
+which 212 were under `src/main` and `src/backend` alone. A rule demanding a sentence per file is a
+rule you will skip, and skipping it is the one failure Step 1 exists to prevent. Bucket first:
+
+```bash
+git diff --name-only <tag>..HEAD | cut -d/ -f1-2 | sort | uniq -c | sort -rn
+```
+
+Then handle each bucket one of three ways, and say in the Step 3 table which one you used:
+
+- **Dismissed as a bucket**, with the reason stated once. A bucket qualifies only if you can say
+  what makes *every* file in it inert — `src/renderer/**` and `apps/mobile/**` ship in the same
+  binary as their callers and write nothing a later build reads; `**/*.test.ts`, `docs/**` and
+  `tools/**` are not in the shipped app at all. "Nothing looked interesting" is not a reason.
+- **Cleared by a derived query.** This is how a large hazard-bearing directory gets honestly
+  covered: gate B's `git grep` over `src/main` and `src/backend` names every file that decodes a
+  versioned payload, so the other two hundred are cleared by the query having asked the right
+  question of all of them. A bucket cleared this way inherits that gate's obligation — if the query
+  returns nothing, the pattern is broken, not the bucket clean.
+- **Named individually.** What is left: a file in a hazard-bearing directory that no bucket
+  dismissal covers and no gate's query reached. This residue should be small. If it is not, that is
+  itself the finding — report the count and say you could not account for it, rather than writing a
+  dismissal you did not earn.
 
 Work this way round because the failure this skill exists to prevent is almost never a hazard that
 was examined and misjudged. It is one that was never looked at, because nothing pointed at it.
@@ -79,15 +102,32 @@ Triggered by any change to that file or to `src/backend/database/`.
   tag**. Read that number, never remember it:
 
   ```bash
-  git show <tag>:src/backend/openbot-database-schema.ts | grep -E 'version: [0-9]+' | tail -1
+  git show "<tag>:src/backend/openbot-database-schema.ts" | grep -E 'version: [0-9]+' | tail -1
   ```
 
   A literal written into this file would go stale the first time a migration ships and would then
   reject the correct number. `validateMigrationRegistry` throws on a gap, so a skipped number is
   loud — but a *reused* one is a migration that never runs on any database that already applied it.
-- **No shipped `migrateTo*` body may have changed**, including the frozen `migrateToBaselineV8`.
-  Read every hunk of the diff, not the stat. A database that already applied version 12 will never
-  apply it again, so an edit to it reaches new installs only and the two populations diverge.
+
+  **Quote the whole `<rev>:<path>` argument, and quote it even after you put the tag in a variable.**
+  In zsh `$T:src/...` parses as the `:s` substitution modifier and dies with `bad substitution`
+  before git runs — and only for paths starting `s`, so `$T:packages/...` works and teaches you the
+  wrong lesson. The aborted command prints nothing, which is indistinguishable from a clean read.
+  `"${T}:src/..."` is safe in both shells.
+- **No shipped migration body may have changed.** Do not grep for `migrateTo` — only
+  `migrateToBaselineV8` is spelled that way, so the grep comes back empty on a release that rewrote
+  every other one. Derive the bodies from the registry instead:
+
+  ```bash
+  git show "<tag>:src/backend/openbot-database-schema.ts" | grep -E '^\s+up: [a-zA-Z]' | sort -u
+  ```
+
+  Read every hunk of the diff for each function it names, not the stat. A database that already
+  applied version 12 will never apply it again, so an edit to it reaches new installs only and the
+  two populations diverge. **One body can be `up:` for several versions** —
+  `refreshProviderSessionsForDynamicTools` is currently the migration for 9, 10 and 14 — so a
+  one-line edit there rewrites three shipped migrations at once, and the diff shows it as a single
+  changed function far from any `version:` line.
 - **If the migration executes DDL, `LATEST_SCHEMA_SQL` must be extended in the same change.**
   `createLatestDatabase` execs that SQL and then stamps every `MIGRATIONS` entry as applied
   *without running it*, so a DDL migration missing from it ships new installs a database without
@@ -197,7 +237,15 @@ git diff --stat --diff-filter=MDR <tag>..HEAD -- \
   ':(exclude)packages/contracts/src/team-protocol/v*.test.ts'
 ```
 
-**This must be empty.** Three things in that command are load-bearing:
+**Empty is the clean answer, but do not treat non-empty as rare.** The release audited when this
+skill was written modified all four adapters and `v1.ts`, legitimately: renaming the product concept
+forced the encode and decode halves apart, because they had shared one implementation only for as
+long as the wire vocabulary and the app vocabulary were the same words. Expect to read hunks. What
+the emptiness of this command actually buys you is that nothing frozen changed *without* you
+noticing — so a non-empty result is the start of the work, and an empty one is only trustworthy if
+you have proved the command can still speak.
+
+Three things in that command are load-bearing:
 
 - **Every pathspec is quoted, so git expands it and the shell never sees a glob.** Do not build the
   list into a variable: an unquoted expansion splits in bash and not in zsh, and the check then
@@ -314,6 +362,18 @@ Three separate hazards; check all three.
   length of that gap the old Worker runs against the new schema. No `NOT NULL` column without a
   default, no rename, no drop of a column the deployed Worker still reads. A contraction needs the
   two-step release — expand, deploy the Worker that uses it, contract in a later change.
+  - **Indexes and triggers race too, and they are the ones that get missed** — the list above is
+    about columns, and a migration can leave every column compatible while changing what the old
+    Worker's writes *do*. A `CREATE TRIGGER` fires on statements the old Worker is already issuing.
+    Swapping a `UNIQUE` index is worse: if the replacement is partial and predicated on a column the
+    old Worker does not know to populate, its rows fall outside the new index and the constraint it
+    was relying on silently stops being enforced for the length of the gap.
+    `0018_remote_device_sessions.sql` is the worked example: it drops
+    `remote_sessions_one_active_per_user_host` for a new index predicated on
+    `auth_session_hash IS NOT NULL`, then keeps the old guarantee alive with a second
+    `..._legacy_user_host` index covering exactly the rows the old Worker still writes. Copy that
+    shape — when you narrow a unique index, add the legacy one beside it rather than assuming the
+    gap is short.
 - **Installed desktop builds never update**, in *both* directions. A build from a year ago keeps
   calling `auth:*` against the current Worker forever, and unlike a D1 mistake that is not
   recoverable by a redeploy.

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -28,7 +28,7 @@ This runs *before* `docs/RELEASING.md`, which stays authoritative for the publis
 - It never runs `bun run dev:seed` or `dev:reset` — both destroy the developer's own profile — and
   never `pkill -f`, which kills other sessions' work mid-write.
 
-## Step 1 — establish the range
+## Step 1 — establish the range, then account for every file in it
 
 ```bash
 git tag --list 'v*' --sort=-v:refname | head -1
@@ -38,6 +38,23 @@ git diff --stat <tag>..HEAD
 The audit is over that commit range, not over the working tree: an uncommitted edit is not what
 ships, and a hazard three commits back is. State the tag and the changed-file count up front, and
 run every gate's `git diff` over that same range.
+
+**The diff drives the audit, not the trigger lists.** Take the whole changed-file list and assign
+every entry to a gate or dismiss it by name:
+
+```bash
+git diff --name-status <tag>..HEAD
+```
+
+Each gate names the paths that obviously belong to it. Treat those as a starting point and never as
+the authority: they are written by hand, they go stale, and a release can touch a file nobody
+thought to list. The question a gate actually asks is "does this file carry the hazard I own", and
+only the file in front of you answers that. A file matched by no gate has to be dismissed out loud,
+with its reason, in the Step 3 table — "it was not on a trigger list" is not a reason, "it is a
+renderer component with no persisted state" is.
+
+Work this way round because the failure this skill exists to prevent is almost never a hazard that
+was examined and misjudged. It is one that was never looked at, because nothing pointed at it.
 
 ## Step 2 — the seven gates
 
@@ -85,7 +102,7 @@ The parity test builds a database both ways and compares normalised `sqlite_mast
 `PRAGMA table_info`, so an unmirrored DDL migration is red rather than a support ticket. If it is
 green and you added DDL, check that you actually added it to `MIGRATIONS`.
 
-### B. On-disk state outside SQLite — `src/main/index.ts`, `src/backend/*-store.ts`
+### B. On-disk state outside SQLite — every decoder of a versioned file
 
 Triggered by a change to `src/main/index.ts`, `src/backend/workspace-paths.ts`,
 `src/main/sunshine-moonlight-runtime.ts`, `electron-builder.yml`, or **any file that decodes a
@@ -94,14 +111,27 @@ always a `*-store.ts`, and `central-auth-manager.ts`, `main-window-state.ts` and
 `skill-marketplace-service.ts` are three that are not:
 
 ```bash
-git grep -lE 'version *(!==|===) *[0-9]' HEAD -- 'src/main/*.ts' 'src/backend/*.ts' \
-  ':(exclude)*.test.ts'
+git grep -lE 'version *(!==|===) *[0-9]|version: *z\.literal' <tag> HEAD -- \
+  'src/main/*.ts' 'src/backend/*.ts' ':(exclude)*.test.ts' | sed 's/^[^:]*://' | sort -u
 ```
 
-The gate fires if the release diff touches any file that prints. Note the absent `\b`: `git grep -E`
-is POSIX ERE, where `\b` matches nothing at all, so writing the pattern the natural way returns an
-empty list and reports that the release changed no serialization owner. Same failure as gate C —
-a check that answers the wrong question and calls the silence a pass.
+The gate fires if the release diff touches any file that prints. Three deliberate details:
+
+- **Both revisions, unioned.** Searching only `HEAD` means that *removing* a version guard removes
+  the file from the result, so the one change most worth auditing is the one that hides the file.
+  Searching only the tag misses a serialization owner the release adds. The tag side also carries
+  the pre-rename filename, which is what you need to find the rename.
+- **`z.literal` is a second spelling.** `remote-desktop-secret-store.ts` validates with
+  `z.object({ version: z.literal(1), ... })` and matches no comparison operator at all. Any decoder
+  that pins a version by schema rather than by `===` is the same hazard; when you meet a third
+  spelling, widen the pattern rather than trusting this one.
+- **No `\b`.** `git grep -E` is POSIX ERE, where `\b` matches nothing, so the natural spelling of
+  this pattern returns an empty list and reports that the release changed no serialization owner.
+  Same failure as gate C — a check that answers the wrong question and calls the silence a pass.
+
+The list is still only a starting point. Step 1 is what guarantees an unmatched file gets looked
+at: a persistence change spelled in a way no pattern here anticipates is caught by having to
+dismiss the file by name, not by this command.
 
 The trigger lives here rather than in `references/surfaces.md` because you classify triggers before
 you open any reference; a trigger that pointed at the inventory would need the inventory read first,
@@ -237,10 +267,18 @@ array is a story that silently shows nothing.
 ### E. Account Worker — `apps/auth-api/`
 
 Triggered by **any** addition, modification, deletion or rename under `apps/auth-api/migrations/`,
-or a change to any non-UI file under `apps/auth-api/src/`. That is wider than `routes/` and
-`server/` on purpose: `worker-entry.ts` is the deployed Worker's default export, and `router.tsx`
-builds the router from `routeTree.gen.ts`. Those three decide what is actually served, so a `/v1` or
+a change to any non-UI file under `apps/auth-api/src/`, or a change to `.github/workflows/ci.yml`.
+
+The `src/` half is wider than `routes/` and `server/` on purpose: `worker-entry.ts` is the deployed
+Worker's default export and `router.tsx` builds the router from `routeTree.gen.ts`, so a `/v1` or
 `/v2` endpoint can be removed or shadowed there while every file under `routes/` is untouched.
+
+`ci.yml` is in the list because the deploy-race hazard below is a property of the *workflow*, not of
+`apps/auth-api/`. It holds only while "Apply production D1 migrations" runs before the Worker
+deploy in the same job. Reorder those steps, drop the migration step, or move either into another
+workflow, and production runs a Worker against a schema it was never deployed against — with
+nothing under `apps/auth-api/` modified and the gate otherwise reporting "not triggered". Re-read
+the step order every time that file changes; do not assume the order you were told about here.
 
 ```bash
 git diff --stat --diff-filter=AMDR <tag>..HEAD -- apps/auth-api/migrations
@@ -278,7 +316,12 @@ sibling `*-migration.test.ts` files in `apps/auth-api/test/` that cover what you
 
 ### F. The updater itself — `electron-builder.yml`, `src/main/update-service.ts`, `package.json`
 
-Triggered by a change to any of those, or to `package.json` dependencies.
+Triggered by a change to any of those, to `package.json` dependencies, or to the two files that
+enforce this gate at release time: `scripts/verify-update-artifacts.ts` and
+`.github/workflows/release.yml`. A change that relaxes a size limit, drops a manifest or blockmap
+check, or alters what gets published is exactly the change this gate should stop, and neither file
+lives under the paths above — so without them listed, weakening the safeguard reads as "not
+triggered". Diff the thresholds and the checks themselves, not only the code they guard.
 
 - `appId`, the `publish` owner and repo, `artifactName` and `electronUpdaterCompatibility` are
   unchanged. A changed `appId` breaks the update feed and the `safeStorage` files at once — the
@@ -321,7 +364,9 @@ Report a table:
 
 Then state the stops explicitly. Any one of these means **the version is not cuttable yet**:
 
-- a modified or deleted frozen Team API codec or fixture;
+- a frozen Team API codec, adapter or fixture that was deleted, renamed, or modified **in a way
+  that can change what an encoded payload means** — the narrow exception gate C allows, a hunk that
+  provably cannot alter the wire, is not a stop, and gate C is where that call gets made;
 - a DDL migration not mirrored into `LATEST_SCHEMA_SQL`;
 - a renamed on-disk file, or a bumped stored `version`, with no read path for the old one;
 - a D1 contraction without the two-step release;

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -65,6 +65,12 @@ triggered is reported as **not triggered** — never dropped silently, because "
 `references/surfaces.md` holds the exhaustive path inventory. Load it when a gate fires and you
 need the exact file, not before.
 
+**Some checks below pass by producing no output. Prove the command can still speak before you trust
+its silence** — run it over a range you know contains a hit, or confirm a list you expect to be long
+is not empty. An empty result means "nothing is wrong" and "I asked the wrong question" equally
+well, and the second is the more common of the two. This is not hypothetical: it is how `check:ui`
+lost two checks (`AGENTS.md`, Tests) and why the repo deleted `no-runtime-typeof`.
+
 ### A. SQLite schema — `src/backend/openbot-database-schema.ts`
 
 Triggered by any change to that file or to `src/backend/database/`.
@@ -117,21 +123,18 @@ git grep -lE 'version *(!==|===) *[0-9]|version: *z\.literal' <tag> HEAD -- \
 
 The gate fires if the release diff touches any file that prints. Three deliberate details:
 
-- **Both revisions, unioned.** Searching only `HEAD` means that *removing* a version guard removes
-  the file from the result, so the one change most worth auditing is the one that hides the file.
-  Searching only the tag misses a serialization owner the release adds. The tag side also carries
-  the pre-rename filename, which is what you need to find the rename.
-- **`z.literal` is a second spelling.** `remote-desktop-secret-store.ts` validates with
-  `z.object({ version: z.literal(1), ... })` and matches no comparison operator at all. Any decoder
-  that pins a version by schema rather than by `===` is the same hazard; when you meet a third
-  spelling, widen the pattern rather than trusting this one.
-- **No `\b`.** `git grep -E` is POSIX ERE, where `\b` matches nothing, so the natural spelling of
-  this pattern returns an empty list and reports that the release changed no serialization owner.
-  Same failure as gate C — a check that answers the wrong question and calls the silence a pass.
+- **Both revisions, unioned.** Searching `HEAD` alone means *removing* a version guard removes the
+  file from the result, hiding the change most worth auditing. The tag alone misses an owner the
+  release adds, and the tag side carries the pre-rename filename you need to spot a rename.
+- **`z.literal` is a second spelling** — `remote-desktop-secret-store.ts` pins its version by schema
+  and matches no comparison operator. Widen the pattern when you meet a third spelling rather than
+  trusting this one.
+- **No `\b`** — `git grep -E` is POSIX ERE, where it matches nothing and the list comes back empty.
 
-The list is still only a starting point. Step 1 is what guarantees an unmatched file gets looked
-at: a persistence change spelled in a way no pattern here anticipates is caught by having to
-dismiss the file by name, not by this command.
+The list is still only a starting point, and it is short enough to eyeball: if it prints nothing, or
+far less than the file inventory in `references/surfaces.md`, the pattern is broken rather than the
+release clean. Step 1 is what actually guarantees an unmatched file gets looked at — a persistence
+change spelled in a way no pattern anticipates is caught by having to dismiss the file by name.
 
 The trigger lives here rather than in `references/surfaces.md` because you classify triggers before
 you open any reference; a trigger that pointed at the inventory would need the inventory read first,
@@ -196,12 +199,10 @@ git diff --stat --diff-filter=MDR <tag>..HEAD -- \
 
 **This must be empty.** Three things in that command are load-bearing:
 
-- **Every pathspec is quoted, so git expands it and the shell never sees a glob.** Do not collect
-  the file list into a variable first. An unquoted `$FROZEN` word-splits under bash but *not* under
-  zsh, where the newline-joined list becomes a single path that matches nothing — so the check
-  prints empty and passes while a frozen codec sits modified in the diff. A gate that reports clean
-  for the wrong reason is worse than no gate, and this is the one gate whose whole output is its
-  own emptiness.
+- **Every pathspec is quoted, so git expands it and the shell never sees a glob.** Do not build the
+  list into a variable: an unquoted expansion splits in bash and not in zsh, and the check then
+  prints empty for the wrong reason. This gate's entire signal is its own emptiness, so before
+  trusting a clean result, run it once over a range you know modifies a frozen file.
 - **`v*.ts` covers the adapters.** `packages/contracts/AGENTS.md` freezes a codec, an adapter, and
   client and host fixtures for every released protocol, so `v1-adapter.ts`, `v2-adapter.ts`,
   `v3-adapter.ts` and `v3-webrtc-adapter.ts` are as frozen as `v1.ts`. A pattern anchored on

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -228,12 +228,18 @@ is not a wire change. Anything that touches a key list, a validator, or a projec
   fails validation and returns `null`, and callers read `null` as "nothing to send". `tsc` stays
   green throughout.
 
-List the protocol tests from the tag for the same reason the diff is derived from it, then run
+List the protocol tests for the same reason the diff is derived rather than typed, then run
 `bun run test:desktop -- <path>` once per file it prints:
 
 ```bash
-git ls-tree --name-only <tag> packages/contracts/src/team-protocol/ | grep -E 'v[0-9]+\.test\.ts$'
+{ git ls-tree --name-only <tag> packages/contracts/src/team-protocol/
+  git ls-tree --name-only HEAD packages/contracts/src/team-protocol/; } \
+  | grep -E 'v[0-9]+\.test\.ts$' | sort -u
 ```
+
+Union both revisions, as gate B does. The tag alone would skip a protocol the release *adds* — a
+new `v4.test.ts` would never run, and the one codec with no shipped history is the one this audit
+has the least other evidence about. `HEAD` alone would hide a frozen test the release *deleted*.
 
 The full compatibility matrix — older client against new host, new client against older host,
 matching versions, no shared protocol, capability omission, unknown optional events, malformed

--- a/.agents/skills/release-upgrade-safety/SKILL.md
+++ b/.agents/skills/release-upgrade-safety/SKILL.md
@@ -31,13 +31,23 @@ This runs *before* `docs/RELEASING.md`, which stays authoritative for the publis
 ## Step 1 — establish the range, then account for every file in it
 
 ```bash
+git status --porcelain
 git tag --list 'v*' --sort=-v:refname | head -1
 git diff --stat <tag>..HEAD
 ```
 
-The audit is over that commit range, not over the working tree: an uncommitted edit is not what
-ships, and a hazard three commits back is. State the tag and the changed-file count up front, and
-run every gate's `git diff` over that same range.
+**Stop if the tree is not clean.** The audit is over the commit range, not the working tree, and
+that is only sound if the working tree is empty — otherwise the range you audit and the range that
+ships are different sets. Nothing upstream of you enforces this: `scripts/prepare-release.ts` writes
+the version bump without looking at `git status`, and its closing instruction is "Review, commit,
+push, run preflight, then tag it", so following it sweeps whatever was uncommitted into the release.
+`scripts/release-preflight.ts` does check `git status --porcelain`, but it runs *after* that commit,
+by which point the tree is clean and the unaudited work is inside the tag. Commit or stash first,
+then establish the range.
+
+State the tag and the changed-file count up front, and run every gate's `git diff` over that same
+range. A hazard three commits back is in scope; the file you have open is not, unless it is
+committed.
 
 **The diff drives the audit, not the trigger lists.** Take the whole changed-file list and assign
 every entry to a gate or dismiss it by name:
@@ -63,9 +73,11 @@ git diff --name-only <tag>..HEAD | cut -d/ -f1-2 | sort | uniq -c | sort -rn
 Then handle each bucket one of three ways, and say in the Step 3 table which one you used:
 
 - **Dismissed as a bucket**, with the reason stated once. A bucket qualifies only if you can say
-  what makes *every* file in it inert — `src/renderer/**` and `apps/mobile/**` ship in the same
-  binary as their callers and write nothing a later build reads; `**/*.test.ts`, `docs/**` and
-  `tools/**` are not in the shipped app at all. "Nothing looked interesting" is not a reason.
+  what makes *every* file in it inert. `**/*.test.ts`, `docs/**`, `tools/**` and
+  `src/renderer/stories/**` are not in the shipped app at all, which is such a reason. "Nothing
+  looked interesting" is not. **`src/renderer/**` does not qualify** — the renderer writes
+  `localStorage`, that store lives in the user's Electron partition, and it outlives the build that
+  wrote it exactly the way a file under `userData` does. Route it through gate B instead.
 - **Cleared by a derived query.** This is how a large hazard-bearing directory gets honestly
   covered: gate B's `git grep` over `src/main` and `src/backend` names every file that decodes a
   versioned payload, so the other two hundred are cleared by the query having asked the right
@@ -175,6 +187,29 @@ The list is still only a starting point, and it is short enough to eyeball: if i
 far less than the file inventory in `references/surfaces.md`, the pattern is broken rather than the
 release clean. Step 1 is what actually guarantees an unmatched file gets looked at — a persistence
 change spelled in a way no pattern anticipates is caught by having to dismiss the file by name.
+
+**The renderer persists too, and its store is not on any of the lists above.** `localStorage` lives
+in the user's Electron partition, so it survives an upgrade exactly the way a file under `userData`
+does — sidebar pins, collapsed sections, people order, panel widths and the completion-sound
+preference are all kept there. The query above never reaches it, because the renderer keys its state
+by string rather than guarding a `version` field. Run the key inventory as a second derived list:
+
+```bash
+git grep -hoE '"openbot:[a-z0-9:-]+"' <tag> -- 'src/renderer/src/**' \
+  ':(exclude)*.test.ts' ':(exclude)*.test.tsx' | sort -u > /tmp/keys-tag.txt
+git grep -hoE '"openbot:[a-z0-9:-]+"' HEAD -- 'src/renderer/src/**' \
+  ':(exclude)*.test.ts' ':(exclude)*.test.tsx' | sort -u > /tmp/keys-head.txt
+diff /tmp/keys-tag.txt /tmp/keys-head.txt
+```
+
+A key that disappears from the tag side is the renderer's version of a renamed filename constant:
+the old entry is never read again, never cleaned up, and the user's state is silently back to
+defaults. Three keys already carry their own version suffix — `openbot:sidebar-pins:v1`,
+`openbot:sidebar-collapsed:v1`, `openbot:sidebar-people-order:v1` — so bumping one to `:v2` is a
+deliberate reset and needs the same justification as a `userData` version bump, plus a
+`CHANGELOG.md` note under gate G if the user has to redo anything. Moving a file between directories
+does not rename its key, so expect the owner list to churn while the key list stays still; it is the
+`diff` that matters, not which file holds the literal.
 
 The trigger lives here rather than in `references/surfaces.md` because you classify triggers before
 you open any reference; a trigger that pointed at the inventory would need the inventory read first,

--- a/.agents/skills/release-upgrade-safety/agents/openai.yaml
+++ b/.agents/skills/release-upgrade-safety/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release upgrade safety"
+  short_description: "Audit a pending OpenBot release for upgrade and data-loss hazards"
+  default_prompt: "Use $release-upgrade-safety to audit the changes since the last released tag before this version is bumped or tagged."

--- a/.agents/skills/release-upgrade-safety/references/surfaces.md
+++ b/.agents/skills/release-upgrade-safety/references/surfaces.md
@@ -58,7 +58,7 @@ All in `src/backend/openbot-database-schema.ts`:
 | Constant | Value or meaning |
 | --- | --- |
 | `BASELINE_SCHEMA_VERSION` | `8` — the frozen baseline, `BASELINE_V8_SCHEMA_SQL` |
-| `MIGRATIONS` | versions 8 through 14; a new one is 15 |
+| `MIGRATIONS` | one contiguous entry per version from 8 up; read the last one from the release tag, never from here — a number written down here is stale the next time a migration ships |
 | `LATEST_SCHEMA_VERSION` | derived from the last `MIGRATIONS` entry |
 | `LATEST_SCHEMA_SQL` | `substituteOnce(BASELINE_V8_SCHEMA_SQL, BASELINE_REACTIONS_TABLE_SQL, V12_REACTIONS_TABLE_SQL)` |
 | `substituteOnce` | throws unless the search string appears **exactly once**; handles one table substitution and no more |
@@ -70,6 +70,9 @@ Tests: `src/backend/openbot-database-schema-parity.test.ts` (the two build paths
 application").
 
 ## Team API protocol
+
+The versions below are the ones that existed when this file was written. Match the frozen set with
+the pathspecs in gate C rather than reading a version number off this table.
 
 | Path | Status |
 | --- | --- |

--- a/.agents/skills/release-upgrade-safety/references/surfaces.md
+++ b/.agents/skills/release-upgrade-safety/references/surfaces.md
@@ -43,6 +43,27 @@ the marketplace skills installed into that workspace and is unrelated to the rep
 Derive this set rather than reading it off the table — see the `git grep` in gate B. The table is a
 snapshot, and a serialization owner added after it was written will not be in it.
 
+## Renderer `localStorage`
+
+Kept in the Electron partition under `userData`, so it outlives the build that wrote it. Keyed by
+string, not guarded by a `version` field, which is why the `git grep` in gate B does not reach it —
+use the key-inventory diff there instead. Derive the set rather than reading it off this table.
+
+| Key | Owner |
+| --- | --- |
+| `openbot:sidebar-pins:v1` | `src/renderer/src/features/sidebar/sidebar-pins.ts` |
+| `openbot:sidebar-collapsed:v1` | `src/renderer/src/features/sidebar/sidebar-sections.ts` |
+| `openbot:sidebar-people-order:v1` | `src/renderer/src/features/sidebar/sidebar-people-order.ts` |
+| `openbot:left-panel-collapsed`, `openbot:left-panel-width` | `src/renderer/src/layout.tsx`, `layout-constants.ts` |
+| `openbot:browser-panel-width`, `openbot:browser-pip-native-bounds` | `src/renderer/src/features/conversation/BrowserPanel.tsx` |
+| `openbot:settings-panel-width` | `src/renderer/src/features/settings/settings-context.tsx` |
+| `openbot:completion-sound-enabled` | `src/renderer/src/completion-sound.ts` |
+| `openbot:analytics-app-version` | `src/renderer/src/App.tsx` |
+| `openbot:landing-preview-ready`, `openbot:landing-preview-start` | `src/renderer/src/preview/landing-demo-messages.ts` |
+
+The three `:v1` suffixes are the renderer's own version handling: bumping one to `:v2` abandons the
+old entry rather than migrating it, so it resets that state for every installed user.
+
 ## `~/OpenBot`
 
 Built in the `AgentStore` constructor, `src/backend/agent-store.ts`:

--- a/.agents/skills/release-upgrade-safety/references/surfaces.md
+++ b/.agents/skills/release-upgrade-safety/references/surfaces.md
@@ -64,6 +64,30 @@ use the key-inventory diff there instead. Derive the set rather than reading it 
 The three `:v1` suffixes are the renderer's own version handling: bumping one to `:v2` abandons the
 old entry rather than migrating it, so it resets that state for every installed user.
 
+`sidebar-pins.ts` also carries `reownSidebarPinnedItems`, which rewrites a stored `bot-<uuid>` pin to
+the matching `agent-<uuid>`. It is the reason gate B reads owners and not only keys: that migration
+changed the value under an unchanged key, so a key-only diff reports it as clean.
+
+## Mobile and shared team-client
+
+The phone and the shared client keep their own state, on their own storage, with their own upgrade
+cycle. Keys here are dot-separated, not colon-separated like the renderer's.
+
+| Key | Owner | Note |
+| --- | --- | --- |
+| `openbot.mobile.session.v1` | `apps/mobile/src/features/auth/api/mobile-auth.ts` | `SecureStore`; an undecodable session is **deleted** (`deleteItemAsync`), signing the user out |
+| `openbot.mobile.device-id.v1` | `apps/mobile/src/features/auth/api/mobile-auth.ts` | `SecureStore`; losing it abandons the device identity |
+| `openbot.host-key.v1.<scope>.<fingerprint>` | `apps/mobile/src/features/workspace/model/trusted-host-keys.ts` | `SecureStore`; host trust, so resetting it re-prompts for every host |
+| `openbot.workspace.v1.<scope>.<fingerprint>` | `packages/team-client/src/workspace-preferences.ts` | guards `value.version !== 1` |
+| `openbot.remote-desktop.signal.v1` | `packages/team-client/src/remote-peer.ts`, `src/renderer/src/features/team/team-webrtc.ts` | shared by the desktop renderer, not mobile-only |
+
+The middle two are built with a template literal, so **no key-literal query returns them** — they are
+the standing reason gate B reads owner files as well as keys.
+
+The paired-phones note under `## [Unreleased]` in `CHANGELOG.md` is what this surface looks like when
+it breaks: agent identifiers changed, the phone still held the old ones, and the only remedy was for
+the user to re-pair. Gate B is what should catch the next one before gate G has to apologise for it.
+
 ## `~/OpenBot`
 
 Built in the `AgentStore` constructor, `src/backend/agent-store.ts`:

--- a/.agents/skills/release-upgrade-safety/references/surfaces.md
+++ b/.agents/skills/release-upgrade-safety/references/surfaces.md
@@ -120,6 +120,13 @@ untouched — they already spell the agent `agent` on both sides.
 | `apps/auth-api/src/routes/v1/`, `v2/` | the response shapes installed desktop builds keep reading forever |
 | `apps/auth-api/src/server/` | the handlers behind those routes |
 | `apps/auth-api/test/*-migration.test.ts` | `email-challenge-delivery-migration`, `marketplace-migration`, `mobile-auth-migration` |
+| `.github/workflows/ci.yml` | the CI deploy path: "Apply production D1 migrations" before the Worker deploy, one job |
+| `scripts/deploy-auth-api.ts` | the manual deploy path: remote D1 migrations, build, then `wrangler deploy` |
+| `apps/auth-api/package.json` | `deploy` and `deploy:test` — the entrypoints into that script |
+| `apps/auth-api/wrangler.jsonc` | the D1 binding and environments both paths deploy against |
+
+Two deploy paths, both ordered migrations-then-deploy. Neither one covers the other, and the
+deploy-race reasoning in gate E only holds while *both* keep that order.
 
 `auth:*` channels in `packages/contracts/src/ipc-channels.ts` are the desktop side of this contract.
 

--- a/.agents/skills/release-upgrade-safety/references/surfaces.md
+++ b/.agents/skills/release-upgrade-safety/references/surfaces.md
@@ -1,0 +1,123 @@
+# Upgrade surfaces
+
+The path inventory behind the gates in `SKILL.md`. Facts and locations only — the judgement about
+what a change to one of these costs stays in `SKILL.md`.
+
+## `userData` files
+
+Every one of these is read and rewritten in place by whichever build opens it last. Nothing copies
+any of them before an upgrade. A renamed constant means the old file is never read again; a bumped
+`version` with no read path means the old file is read as garbage and replaced with defaults.
+
+| File | Constant | Version handling |
+| --- | --- | --- |
+| `openbot.db` | `DatabaseCore` in `src/backend/database/database-core.ts` | `schema_migrations`, gate A |
+| `openbot-setup-v2.json` | `SETUP_FILE`, `src/main/index.ts` | `src/main/setup-store.ts` accepts only `version === 2`, silent default otherwise |
+| `openbot-analytics-preference-v1.json` | `ANALYTICS_PREFERENCE_FILE`, `src/main/index.ts` | `src/main/analytics-preference-store.ts` |
+| `openbot-update-preference-v1.json` | `UPDATE_PREFERENCE_FILE`, `src/main/index.ts` | `src/main/update-preference-store.ts` |
+| `openbot-dynamic-island-preference-v1.json` | `DYNAMIC_ISLAND_PREFERENCE_FILE`, `src/main/index.ts` | `src/main/dynamic-island-preference-store.ts` reads `version` 1 and 2 forward into 3 |
+| `openbot-main-window-state-v1.json` | `MAIN_WINDOW_STATE_FILE`, `src/main/index.ts` | — |
+| `openbot-browser-state-v1.json` | `BROWSER_STATE_FILE`, `src/main/index.ts` | `BrowserHost` in `src/backend/browser-host.ts` |
+| `openbot-sidebar-layout-v1.json` | `SIDEBAR_LAYOUT_FILE`, `src/main/index.ts` | `src/backend/sidebar-layout-store.ts` |
+| `openbot-team-server-v1.json` | `TEAM_FILE`, `src/main/index.ts` | frozen as the last pre-accounts build left it |
+| `openbot-team-server-v2.json` | `TEAM_FILE_V2`, `src/main/index.ts` | `src/main/team-store.ts`; both files coexist so a downgrade still finds its host |
+| `openbot-remote-servers-v1.json` | `REMOTE_SERVERS_FILE`, `src/main/index.ts` | `src/main/remote-server-stored-shape.ts` reads v1/v2 as v3, preserves unreadable entries, refuses unknown versions |
+| `openbot-central-auth-v1.bin` | `CENTRAL_AUTH_FILE`, `src/main/index.ts` | `safeStorage`-encrypted; undecryptable if `appId` or the signing identity changes |
+| `openbot-remote-desktop-credential-v1.json` | `LEGACY_REMOTE_DESKTOP_CREDENTIAL_FILE`, `src/main/index.ts` | legacy, still read |
+| `openbot-remote-desktop-runtime-v1.json` | `REMOTE_DESKTOP_RUNTIME_SECRET_FILE`, `src/main/index.ts` | `safeStorage`-encrypted; `src/main/remote-desktop-secret-store.ts` accepts only `version: 1` |
+| `openbot-dev-remote-connection-v1.json` | `DEVELOPMENT_REMOTE_CONNECTION_FILE`, `src/main/index.ts` | development only |
+| `bots.json` | `LEGACY_AGENTS_STATE_FILE`, `src/backend/agent-store.ts` | permanent name; imported once under command id `legacy-import:bots:v1` |
+| `mailbox.json` | `src/backend/mailbox-store.ts` | permanent name |
+| `sunshine-credentials.json`, `sunshine-state.json`, `sunshine-apps.json`, `moonlight-config.json`, `moonlight-data.json` | `src/main/sunshine-moonlight-runtime.ts` | written by the vendored runtimes, not by OpenBot |
+| `avatars/agents/`, `agent-duplications/` | `src/backend/agent-store.ts` | directories under `userData` |
+| `legacy-backup-v1/` | `DatabaseCore.backupLegacyFile` | one copy per named legacy file, `COPYFILE_EXCL`; **not** a general backup |
+
+`openbot-data.json` in `src/main/maintenance-service.ts` is the user-initiated export manifest, not
+persisted state.
+
+## `~/OpenBot`
+
+Built in the `AgentStore` constructor, `src/backend/agent-store.ts`:
+
+| Directory | Note |
+| --- | --- |
+| `~/OpenBot/Agents/<agent-id>` | the current workspace root |
+| `~/OpenBot/Bots/<bot-id>` | the pre-rename root; permanent, still live after a v13-less restore |
+| `~/OpenBot/Shared` | |
+| `~/OpenBot/Downloads` | |
+
+`src/backend/workspace-paths.ts` resolves four permanent prefixes — `~/OpenBot/Agents/<id>/`,
+`OpenBot/Agents/<id>/`, `~/OpenBot/Bots/<legacy-id>/`, `OpenBot/Bots/<legacy-id>/` — and
+`rebaseLegacyWorkspacePath` rebases in both directions, because migration v13's directory move gives
+up on `EXDEV` or a permission error while the message paths have already been rewritten.
+
+## Migration constants
+
+All in `src/backend/openbot-database-schema.ts`:
+
+| Constant | Value or meaning |
+| --- | --- |
+| `BASELINE_SCHEMA_VERSION` | `8` — the frozen baseline, `BASELINE_V8_SCHEMA_SQL` |
+| `MIGRATIONS` | versions 8 through 14; a new one is 15 |
+| `LATEST_SCHEMA_VERSION` | derived from the last `MIGRATIONS` entry |
+| `LATEST_SCHEMA_SQL` | `substituteOnce(BASELINE_V8_SCHEMA_SQL, BASELINE_REACTIONS_TABLE_SQL, V12_REACTIONS_TABLE_SQL)` |
+| `substituteOnce` | throws unless the search string appears **exactly once**; handles one table substitution and no more |
+| `validateMigrationRegistry` | throws on a non-contiguous version |
+| `createLatestDatabase` | execs `LATEST_SCHEMA_SQL`, then stamps every `MIGRATIONS` entry as applied without running it |
+
+Tests: `src/backend/openbot-database-schema-parity.test.ts` (the two build paths must agree),
+`src/backend/openbot-database.test.ts` (including "rejects a database created by a newer
+application").
+
+## Team API protocol
+
+| Path | Status |
+| --- | --- |
+| `packages/contracts/src/team-protocol/v1.ts`, `v2.ts`, `v3.ts` | frozen codecs |
+| `packages/contracts/src/team-protocol/v1-adapter.ts`, `v2-adapter.ts`, `v3-adapter.ts`, `v3-webrtc-adapter.ts` | registered adapters |
+| `packages/contracts/src/team-protocol/fixtures/v1/` | `client-http-request.json`, `client-scope.json`, `host-compatibility.json`, `host-event.json`, `host-http-response.json` |
+| `packages/contracts/src/team-protocol/fixtures/v2/` | `client-scope.json`, `event.json`, `file-open.json`, `host-compatibility.json`, `host-event.json`, `host-http-response.json`, `request.json` |
+| `packages/contracts/src/team-protocol/fixtures/v3/` | `client-http-request.json`, `host-http-response.json` |
+| `packages/contracts/src/team-protocol/current.ts` | where an additive capability goes |
+| `packages/contracts/src/team-protocol/current-agent-keys.ts` | the only wire-to-app vocabulary translator |
+
+`current-agent-keys.ts` maps keys (`bot`/`botId`/`bots`/`ownerBotId`/`recipientBotId`/
+`recipientBotIds`/`senderBotId`/`typingBotId`), discriminant *values* (`kind: "bot"`, `origin:
+"bot"`, `type: "bots-changed"`), and reverses the mapping inside `marketplaceSource`, where
+`agentId` names a listing rather than the product agent. Sidebar layout payloads pass through
+untouched — they already spell the agent `agent` on both sides.
+
+## IPC channel list and its mirrors
+
+`packages/contracts/src/ipc-channels.ts` declares every channel. Per the table in
+`packages/contracts/AGENTS.md`:
+
+| Mirror | What it is |
+| --- | --- |
+| `src/main/index.ts` and `src/main/ipc/` | the `handleTrusted` registrations, one file per domain |
+| `src/preload/index.ts` | the `invoke` calls the renderer reaches |
+| `src/renderer/src/preview/mock-openbot.ts` | the second implementation Storybook and the preview run against |
+
+`src/main/ipc-channel-coverage.test.ts` links main and preload statically. The mock is covered by
+`tsc` in both directions because it is annotated `: OpenBotDesktopApi`.
+
+## Account Worker
+
+| Path | Note |
+| --- | --- |
+| `apps/auth-api/migrations/` | `0001` to `0018`; applied **before** the new Worker deploys |
+| `apps/auth-api/src/routes/v1/`, `v2/` | the response shapes installed desktop builds keep reading forever |
+| `apps/auth-api/src/server/` | the handlers behind those routes |
+| `apps/auth-api/test/*-migration.test.ts` | `email-challenge-delivery-migration`, `marketplace-migration`, `mobile-auth-migration` |
+
+`auth:*` channels in `packages/contracts/src/ipc-channels.ts` are the desktop side of this contract.
+
+## Updater and packaging
+
+| Path | Fields that matter |
+| --- | --- |
+| `electron-builder.yml` | `appId` (`app.openbot.desktop`), `artifactName`, `electronUpdaterCompatibility`, `publish` owner/repo, `mac.extendInfo.ElectronTeamID` (`ZTRDTUL87R`), `extraResources` |
+| `src/main/update-service.ts` | the four `UpdateAdapter` behaviours, documented on the type |
+| `src/main/electron-updater-assumptions.test.ts` | `VERIFIED_VERSION` |
+| `scripts/verify-update-artifacts.ts` | 700 MiB update artifact, 750 MiB DMG, manifest, blockmap, no Whisper model |
+| `.github/workflows/release.yml` | macOS ZIP must be under 800,000,000 bytes **and** smaller than the `v0.1.21` ZIP |

--- a/.agents/skills/release-upgrade-safety/references/surfaces.md
+++ b/.agents/skills/release-upgrade-safety/references/surfaces.md
@@ -16,13 +16,13 @@ any of them before an upgrade. A renamed constant means the old file is never re
 | `openbot-analytics-preference-v1.json` | `ANALYTICS_PREFERENCE_FILE`, `src/main/index.ts` | `src/main/analytics-preference-store.ts` |
 | `openbot-update-preference-v1.json` | `UPDATE_PREFERENCE_FILE`, `src/main/index.ts` | `src/main/update-preference-store.ts` |
 | `openbot-dynamic-island-preference-v1.json` | `DYNAMIC_ISLAND_PREFERENCE_FILE`, `src/main/index.ts` | `src/main/dynamic-island-preference-store.ts` reads `version` 1 and 2 forward into 3 |
-| `openbot-main-window-state-v1.json` | `MAIN_WINDOW_STATE_FILE`, `src/main/index.ts` | — |
+| `openbot-main-window-state-v1.json` | `MAIN_WINDOW_STATE_FILE`, `src/main/index.ts` | `src/main/main-window-state.ts` accepts only `version === 1` |
 | `openbot-browser-state-v1.json` | `BROWSER_STATE_FILE`, `src/main/index.ts` | `BrowserHost` in `src/backend/browser-host.ts` |
 | `openbot-sidebar-layout-v1.json` | `SIDEBAR_LAYOUT_FILE`, `src/main/index.ts` | `src/backend/sidebar-layout-store.ts` |
 | `openbot-team-server-v1.json` | `TEAM_FILE`, `src/main/index.ts` | frozen as the last pre-accounts build left it |
 | `openbot-team-server-v2.json` | `TEAM_FILE_V2`, `src/main/index.ts` | `src/main/team-store.ts`; both files coexist so a downgrade still finds its host |
 | `openbot-remote-servers-v1.json` | `REMOTE_SERVERS_FILE`, `src/main/index.ts` | `src/main/remote-server-stored-shape.ts` reads v1/v2 as v3, preserves unreadable entries, refuses unknown versions |
-| `openbot-central-auth-v1.bin` | `CENTRAL_AUTH_FILE`, `src/main/index.ts` | `safeStorage`-encrypted; undecryptable if `appId` or the signing identity changes |
+| `openbot-central-auth-v1.bin` | `CENTRAL_AUTH_FILE`, `src/main/index.ts` | `safeStorage`-encrypted; `src/main/central-auth-manager.ts` **throws** on anything but `version === 2` and `#initialize` catches that into `#clearStoredSession()`, so a bad shape signs the user out; undecryptable if `appId` or the signing identity changes |
 | `openbot-remote-desktop-credential-v1.json` | `LEGACY_REMOTE_DESKTOP_CREDENTIAL_FILE`, `src/main/index.ts` | legacy, still read |
 | `openbot-remote-desktop-runtime-v1.json` | `REMOTE_DESKTOP_RUNTIME_SECRET_FILE`, `src/main/index.ts` | `safeStorage`-encrypted; `src/main/remote-desktop-secret-store.ts` accepts only `version: 1` |
 | `openbot-dev-remote-connection-v1.json` | `DEVELOPMENT_REMOTE_CONNECTION_FILE`, `src/main/index.ts` | development only |
@@ -34,6 +34,14 @@ any of them before an upgrade. A renamed constant means the old file is never re
 
 `openbot-data.json` in `src/main/maintenance-service.ts` is the user-initiated export manifest, not
 persisted state.
+
+One versioned file lives outside `userData`: `.openbot/skills-lock.json` under each agent workspace,
+written by `src/main/skill-marketplace-service.ts`, which accepts only `version === 1`. It records
+the marketplace skills installed into that workspace and is unrelated to the repository's own
+`.agents/skills/`.
+
+Derive this set rather than reading it off the table — see the `git grep` in gate B. The table is a
+snapshot, and a serialization owner added after it was written will not be in it.
 
 ## `~/OpenBot`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,10 @@ and each says what its own boundary costs and how to wait in its tests.
 Read the one for the directory you are changing before you change it. `docs/ARCHITECTURE.md`
 "Change rules" says where a change belongs when it is not obvious.
 
+One file is scoped to a task rather than a directory: `.agents/skills/release-upgrade-safety/` audits
+the diff since the last released tag for the upgrade and data-loss hazards an installed user cannot
+undo, and nothing opens it for you — reach for it when a version is about to be bumped or tagged.
+
 ## Tests
 
 1. **The default answer is no test.** Prefer changing an existing test to adding one. A new test

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -138,6 +138,11 @@ the Whisper model is present, or if the application contains a second native Cla
 If a release is bad, publish a newer patch version. Do not replace an already published version with
 different binaries.
 
+Before working this checklist, audit the changes since the last released tag with the
+`.agents/skills/release-upgrade-safety/` skill: it covers the upgrade and data-loss hazards an
+installed user cannot undo — the in-place database migration, the `userData` files nothing backs up,
+the frozen Team API adapters, and the D1 migrations that race their own deploy.
+
 ## Preflight checklist
 
 Before creating the first tag or any later release:


### PR DESCRIPTION
## Why

Nothing auto-loads `docs/RELEASING.md`, and every `AGENTS.md` in the repo is **directory-scoped** — it fires when you open a file under it, never when you say "cut a version". The hazards that misses are exactly the irreversible ones: `openbot.db` migrates in place with no backup, the `userData` files are rewritten by whichever build opens them last, released Team API adapters are permanent, and the account Worker's D1 migrations race their own deploy against desktop builds that will never update.

This adds a task-triggered skill that audits the diff since the last released tag against those hazards and reports a verdict. It does not replace `docs/RELEASING.md` — it runs before it, and hands off at the end.

## What

- `.agents/skills/release-upgrade-safety/SKILL.md` — frontmatter, a three-step procedure, seven gates
- `.agents/skills/release-upgrade-safety/agents/openai.yaml` — the `interface:` sidecar every sibling skill carries
- `.agents/skills/release-upgrade-safety/references/surfaces.md` — the exhaustive path inventory, loaded only when a gate fires
- `AGENTS.md` — one sentence in **Where the rest of this lives**, marked as the one task-scoped file among the directory-scoped ones
- `docs/RELEASING.md` — one sentence above `## Preflight checklist`

Placement is `.agents/skills/`, the open location this repo already uses, read by Claude Code, Codex and anything else honouring it — not `.claude/skills/`.

The seven gates: **A** SQLite schema, **B** on-disk state outside SQLite, **C** Team API wire, **D** IPC channels, **E** account Worker, **F** the updater, **G** reverse states and the changelog. Each states what triggers it, the question, how to verify, and what a failure means. A gate no path triggered is reported as *not triggered*, never dropped.

### No `skills-lock.json` entry

Every entry there has a `source`/`computedHash` pair describing an upstream GitHub sync; a repo-authored skill has no upstream. **This is the first unlocked directory under `.agents/skills`.** Nothing in this repo reads the root lock file — the only `skills-lock.json` in code is an unrelated per-workspace file in `src/main/skill-marketplace-service.ts` — so no repo tooling can prune it. Whether the *external* skills CLI prunes directories missing from the lock is the one thing I could not test here; if it does, the fallback is `.claude/skills/` plus a pointer, which loses portability.

## Surfaces touched

Documentation only. No renderer, mobile, public web, IPC contract, migration or reverse-state change — the skill *describes* those surfaces, it does not alter them.

## Verification

**Every cited path and symbol resolves.** 47 repo-relative paths extracted from the two new markdown files, all present. Every cited symbol checked too — `substituteOnce`, `validateMigrationRegistry`, `createLatestDatabase`, `LEGACY_AGENTS_STATE_FILE`, `VERIFIED_VERSION`, the 12 filename constants in `src/main/index.ts`, all 14 protocol fixtures.

**The gates bite.** Run against `aad6b1ec^..aad6b1ec`, the commit that added migration v13 (`rewriteGeneratedAgentIds`):

- Gate A surfaces `+version: 12/13/14` **and** `LATEST_SCHEMA_SQL` changing from `BASELINE_V8_SCHEMA_SQL` to the `substituteOnce` call — exactly the DDL-mirroring pairing the gate exists to catch.
- Gate B surfaces the `bots.json` constant.

Neither reports "not triggered". This is the watch-it-fail equivalent for a file that ships no test: a gate that stays quiet on the range containing the most dangerous migration in the repo would be a costume.

**Every command the skill tells an agent to run passes today** — both database tests, the three protocol tests, IPC coverage, updater assumptions, and the auth-api migration test.

`bun run lint` clean (5 pre-existing `no-module-mocking` warnings in `apps/mobile/.../mobile-auth.test.ts`, untouched). `bun run typecheck` green. `bun run check`, `check:desktop`, `test` and `build-storybook` not run — CI owns those.

## Three corrections against the original plan

- **Gate C's unconditional "must be empty" would have fired falsely.** The real `v0.4.3..HEAD` diff on the frozen set is *not* empty: an added `export` keyword on `teamProtocolV1HttpRoute` (classification only, exported for a coverage test) and four **new** v2 fixture files. Neither is a wire change. The gate now uses `--diff-filter=MD` — modified-or-deleted must be empty, additions are read separately — and tells you to read the hunks before calling a stop.
- **The paired-phones changelog precedent is under `## [Unreleased]`, not `0.4.3`.** Cited correctly.
- **Gate E's test command.** `apps/auth-api` has its own vitest config, so `bun run test:desktop -- apps/auth-api/...` matches nothing. It is `bun run --cwd apps/auth-api test:server test/<file>`, verified working.

## Approvability

Auto-approvable. No `biome-ignore`, `@ts-expect-error` or `@ts-ignore`; no `overrides` entry or unregistered GritQL plugin; no widening to `any`/`unknown` and no assertion past a checker. No TypeScript changes at all.

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
