### PR TITLE
refactor(main): split three concerns out of index.ts, and check the decoder twins

### DIFF
--- a/src/main/AGENTS.md
+++ b/src/main/AGENTS.md
@@ -99,7 +99,23 @@ not import `electron` in the first place.
 
 ## Size
 
-`index.ts` is the dispatcher plus window and lifecycle code and should not grow handlers again.
+`index.ts` is the dispatcher plus window and lifecycle code and should not grow handlers again. Four
+things that used to live in it now have their own file, and none of them should come back:
+
+| File | What it owns |
+| --- | --- |
+| `main-window-state.ts` | reading, resolving and debounce-writing the window's saved position |
+| `session-configuration.ts` | the renderer CSP, the permission handlers, the attachment/avatar/logo protocols |
+| `renderer-forwarders.ts` | the eleven service events relayed to the renderer |
+| `ipc/register-*-handlers.ts` | every IPC endpoint, one file per domain |
+
+A dependency that may not exist yet when one of these is wired is passed from `index.ts` as a
+**function** - `getAgentService: () => AgentService | null` - and read on every call, because most of
+them are constructed during `app.whenReady()` before the services they reach are assigned, and a
+captured `null` never recovers. A service that is already constructed is passed as the value:
+`configureServerLogoProtocols` takes `remoteServers: RemoteServerManager`, and the IPC registrars
+take their stores directly. Which of the two a dependency needs is the one thing here `tsc` cannot
+decide for you - `() => X | null` and `X | null` both type-check at every call site.
 
 `remote-server-manager.ts` used to be the outlier at 2828 lines. It is now the composition root of a
 flat `remote-server-*` / `remote-*-decoding` family, and each of those files has exactly one reason
@@ -160,3 +176,11 @@ Three things are deliberately not unified, and each says so in its own file head
 decoders and their `FromMain` twins in `src/preload/index.ts` (different trust boundaries), the HTTPS
 V1/V3 and WebRTC V2 wire encodings (released protocols), and the control-plane methods on
 `RemoteTeamDirectory` (a different server from the host).
+
+Only the first of those three is also *checked*. `ipc-channel-coverage.test.ts` compares the set of
+`decode*FromHost` names under `src/main` against the set of `decode*FromMain` names in the preload
+and fails unless they match exactly, so neither half can lose its twin - which is how the pair gets
+merged in practice: one is deleted, its callers point at the other, and trusted-sender validation
+ends up applied to a remote team server. Adding a decoder to one side means adding it to the other.
+The check enforces the naming bijection and nothing more; two names bound to one decoder still needs
+a reviewer, and the test says so where it is defined.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,15 +3,7 @@ import { readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { extname, isAbsolute, join, relative, resolve } from "node:path";
 import { parseInviteUrl } from "@openbot/contracts/invite-links";
-import {
-  type AgentEvent,
-  type BrowserDisplayState,
-  type CentralAuthState,
-  IPC_CHANNELS,
-  LOCAL_SERVER_ID,
-  type MacPermissionId,
-  type VoiceModelStatus,
-} from "@openbot/contracts/ipc";
+import { type CentralAuthState, IPC_CHANNELS, LOCAL_SERVER_ID, type MacPermissionId } from "@openbot/contracts/ipc";
 import { createOpenBotLogger, toLogValue } from "@openbot/logging";
 import {
   app,
@@ -19,7 +11,6 @@ import {
   type Display,
   dialog,
   Menu,
-  Notification,
   powerMonitor,
   protocol,
   type Rectangle,
@@ -39,7 +30,6 @@ import { SidebarLayoutStore } from "../backend/sidebar-layout-store";
 import { TeamChatStore } from "../backend/team-chat-store";
 import { AgentInitializationGate } from "./agent-initialization";
 import { AgentMarketplaceService } from "./agent-marketplace-service";
-import { notificationForAgentEvent } from "./agent-notifications";
 import { HostAnalytics } from "./analytics";
 import { readAnalyticsPreference } from "./analytics-preference-store";
 import { readAppVariant, resolveAppIconPath } from "./app-icon";
@@ -47,7 +37,6 @@ import { BrowserPictureInPicture } from "./browser-picture-in-picture";
 import { CentralAuthManager, readCentralAuthApiUrl, readMobileConnectApiUrl } from "./central-auth-manager";
 import { ComputerUseMacSetupService } from "./computer-use-mac-setup";
 import { ComputerUseMacSetupWindowController } from "./computer-use-mac-setup-window";
-import { buildContentSecurityPolicy } from "./content-security-policy";
 import { guardDevelopmentOutput } from "./development-output";
 import {
   developmentUserDataName,
@@ -74,11 +63,12 @@ import { registerMemoryIpcHandlers } from "./ipc/register-memory-handlers";
 import { registerProviderIpcHandlers } from "./ipc/register-provider-handlers";
 import { registerRoutineIpcHandlers } from "./ipc/register-routine-handlers";
 import { registerSkillIpcHandlers } from "./ipc/register-skill-handlers";
-import { registerTeamIpcHandlers, withLocalHostSummary } from "./ipc/register-team-handlers";
+import { registerTeamIpcHandlers } from "./ipc/register-team-handlers";
 import { registerUpdateIpcHandlers } from "./ipc/register-update-handlers";
 import { registerVoiceIpcHandlers } from "./ipc/register-voice-handlers";
 import { MacHapticFeedback } from "./mac-haptic-feedback";
 import {
+  createMainWindowBoundsRecorder,
   ensureMacApplicationPresence,
   presentMainWindow,
   readMainWindowBounds,
@@ -92,8 +82,14 @@ import { resolveRemoteDesktopRuntime } from "./remote-desktop-runtime-artifact";
 import { loadOrCreateRemoteDesktopCredentials } from "./remote-desktop-secret-store";
 import { decodeVoid } from "./remote-host-decoding";
 import { type DevelopmentRemoteServerConnection, RemoteServerManager } from "./remote-server-manager";
+import { createRendererForwarders } from "./renderer-forwarders";
 import { sendToRenderer } from "./renderer-ipc";
-import { canCheckRendererPermission, canRequestRendererPermission } from "./renderer-permissions";
+import {
+  configureAttachmentProtocol,
+  configureContentSecurityPolicy,
+  configureRendererPermissions,
+  configureServerLogoProtocols,
+} from "./session-configuration";
 import { readSetupState, writeSetupState } from "./setup-store";
 import { SkillMarketplaceService } from "./skill-marketplace-service";
 import { TeamStore } from "./team-store";
@@ -210,9 +206,6 @@ let isQuitting = false;
 let shutdownStarted = false;
 let systemSessionEnding = false;
 let systemSessionEndFlushStarted = false;
-let mainWindowBounds: Rectangle | null = null;
-let mainWindowBoundsWriteTimer: ReturnType<typeof setTimeout> | null = null;
-let mainWindowBoundsWrite = Promise.resolve();
 let pendingInviteUrl: string | null = findInviteUrl(process.argv);
 let inviteReceiverReady = false;
 
@@ -238,22 +231,40 @@ const CENTRAL_AUTH_FILE = "openbot-central-auth-v1.bin";
 const LEGACY_REMOTE_DESKTOP_CREDENTIAL_FILE = "openbot-remote-desktop-credential-v1.json";
 const REMOTE_DESKTOP_RUNTIME_SECRET_FILE = "openbot-remote-desktop-runtime-v1.json";
 
-function configureContentSecurityPolicy(): void {
-  const policy = buildContentSecurityPolicy(app.isPackaged, process.env.REMOTE_SIGNAL_URL);
-
-  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-    if (details.resourceType !== "mainFrame" || !isTrustedRendererUrl(details.url)) {
-      callback({ responseHeaders: details.responseHeaders });
-      return;
-    }
-    callback({
-      responseHeaders: {
-        ...details.responseHeaders,
-        "Content-Security-Policy": [policy],
-      },
-    });
+// Resolved once, safely: every `app.setPath("userData", ...)` above has already run. `mainWindow`
+// is the one thing that cannot be captured here - it is reassigned whenever the window is rebuilt.
+const mainWindowStatePath = join(app.getPath("userData"), MAIN_WINDOW_STATE_FILE);
+const { restoreMainWindowBounds, currentMainWindowBounds, rememberMainWindowBounds, flushMainWindowBounds } =
+  createMainWindowBoundsRecorder({
+    getMainWindow: () => mainWindow,
+    readBounds: () => readMainWindowBounds(mainWindowStatePath),
+    writeBounds: (bounds) => writeMainWindowBounds(mainWindowStatePath, bounds),
+    reportError: (message, error) => logger.error(message, toLogValue(error)),
   });
-}
+
+// Destructured so every `service.on("event", forwardX)` registration below reads as it always has.
+// `showMainWindow` is a hoisted declaration further down this file; passing it in is what keeps
+// `renderer-forwarders.ts` from importing back into this module.
+const {
+  forwardAgentEvent,
+  forwardBrowserDisplayState,
+  forwardUpdateStatus,
+  forwardVoiceModelStatus,
+  forwardProviderRuntimeStatus,
+  forwardHostStatus,
+  forwardRemoteDesktopSessions,
+  forwardServers,
+  forwardTeamPresence,
+  forwardDirectMessage,
+  forwardDirectTyping,
+} = createRendererForwarders({
+  getMainWindow: () => mainWindow,
+  getAgentService: () => agentService,
+  getHostService: () => hostService,
+  getHostAnalytics: () => hostAnalytics,
+  getRemoteServerManager: () => remoteServerManager,
+  showMainWindow,
+});
 
 interface IpcHandlerDependencies {
   service: AgentService;
@@ -351,7 +362,7 @@ function createWindow(): BrowserWindow {
   let inspectElementModifierPressed = false;
   const cursor = screen.getCursorScreenPoint();
   const bounds = resolveMainWindowBounds(
-    mainWindowBounds,
+    currentMainWindowBounds(),
     screen.getAllDisplays().map((display) => display.workArea),
     screen.getDisplayNearestPoint(cursor).workArea,
     { width: 1200, height: 820 },
@@ -494,35 +505,6 @@ function createWindow(): BrowserWindow {
   });
 
   return window;
-}
-
-function rememberMainWindowBounds(bounds: Rectangle): void {
-  mainWindowBounds = { ...bounds };
-  if (mainWindowBoundsWriteTimer) clearTimeout(mainWindowBoundsWriteTimer);
-  mainWindowBoundsWriteTimer = setTimeout(() => {
-    mainWindowBoundsWriteTimer = null;
-    void queueMainWindowBoundsWrite().catch((error) =>
-      logger.error("Unable to save the main window position:", toLogValue(error)),
-    );
-  }, 250);
-}
-
-function queueMainWindowBoundsWrite(): Promise<void> {
-  if (!mainWindowBounds) return mainWindowBoundsWrite;
-  const bounds = { ...mainWindowBounds };
-  mainWindowBoundsWrite = mainWindowBoundsWrite
-    .catch((error) => logger.error("Unable to save the previous main window position:", toLogValue(error)))
-    .then(() => writeMainWindowBounds(join(app.getPath("userData"), MAIN_WINDOW_STATE_FILE), bounds));
-  return mainWindowBoundsWrite;
-}
-
-async function flushMainWindowBounds(): Promise<void> {
-  if (mainWindow && !mainWindow.isDestroyed()) mainWindowBounds = mainWindow.getNormalBounds();
-  if (mainWindowBoundsWriteTimer) {
-    clearTimeout(mainWindowBoundsWriteTimer);
-    mainWindowBoundsWriteTimer = null;
-  }
-  await queueMainWindowBoundsWrite();
 }
 
 function createDynamicIslandWindow(bounds: Rectangle, _display: Display): BrowserWindow {
@@ -683,90 +665,6 @@ function configureApplicationMenu(service: AgentService, updater: UpdateService)
   );
 }
 
-function forwardAgentEvent(serverId: string, event: AgentEvent, bufferedLive = false): void {
-  if (serverId === LOCAL_SERVER_ID) hostAnalytics?.handleAgentEvent(event);
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(
-    mainWindow,
-    IPC_CHANNELS.agentEvent,
-    bufferedLive ? { serverId, event, bufferedLive } : { serverId, event },
-  );
-  if (mainWindow.isFocused() || !Notification.isSupported()) return;
-
-  const content = notificationForAgentEvent(event, agentService?.listAgents() ?? []);
-  if (!content) return;
-  const notification = new Notification(content);
-  notification.on("click", () => {
-    if (!mainWindow || mainWindow.isDestroyed()) return;
-    showMainWindow(mainWindow);
-  });
-  notification.show();
-}
-
-function forwardBrowserDisplayState(state: BrowserDisplayState): void {
-  for (const window of BrowserWindow.getAllWindows()) {
-    sendToRenderer(window, IPC_CHANNELS.browserDisplayStateEvent, state);
-  }
-}
-
-function forwardUpdateStatus(status: import("@openbot/contracts/ipc").UpdateStatus): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(mainWindow, IPC_CHANNELS.updateEvent, status);
-}
-
-function forwardVoiceModelStatus(status: VoiceModelStatus): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(mainWindow, IPC_CHANNELS.voiceModelStatus, status);
-}
-
-function forwardProviderRuntimeStatus(snapshot: import("@openbot/contracts/ipc").ProviderRuntimeSnapshot): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(mainWindow, IPC_CHANNELS.providerRuntimesEvent, snapshot);
-}
-
-function forwardHostStatus(status: import("@openbot/contracts/ipc").HostStatus): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(mainWindow, IPC_CHANNELS.hostEvent, status);
-  if (remoteServerManager) {
-    sendToRenderer(mainWindow, IPC_CHANNELS.serversEvent, withLocalHostSummary(remoteServerManager.list(), status));
-  }
-}
-
-function forwardRemoteDesktopSessions(sessions: import("@openbot/contracts/ipc").RemoteDesktopSession[]): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(mainWindow, IPC_CHANNELS.remoteDesktopEvent, sessions);
-}
-
-function forwardServers(servers: import("@openbot/contracts/ipc").ServerSummary[]): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(
-    mainWindow,
-    IPC_CHANNELS.serversEvent,
-    hostService ? withLocalHostSummary(servers, hostService.getStatus()) : servers,
-  );
-}
-
-function forwardTeamPresence(serverId: string, snapshot: import("@openbot/contracts/ipc").TeamPresenceSnapshot): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(mainWindow, IPC_CHANNELS.serversPresence, { serverId, snapshot });
-}
-
-function forwardDirectMessage(
-  serverId: string,
-  event: import("@openbot/contracts/ipc").DirectMessageRealtimeEvent,
-): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(mainWindow, IPC_CHANNELS.serversDirectMessage, { serverId, event });
-}
-
-function forwardDirectTyping(
-  serverId: string,
-  event: import("@openbot/contracts/ipc").DirectTypingRealtimeEvent,
-): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  sendToRenderer(mainWindow, IPC_CHANNELS.serversDirectTyping, { serverId, event });
-}
-
 function forwardCentralAuth(state: CentralAuthState): void {
   if (state.status === "signed_in") {
     if (activeAnalyticsPrincipalId && activeAnalyticsPrincipalId !== state.user.id) hostAnalytics?.clear();
@@ -914,12 +812,7 @@ if (!hasSingleInstanceLock) {
       if (process.platform === "darwin") app.dock?.setIcon(appIconPath);
       configureContentSecurityPolicy();
       configureRendererPermissions();
-      mainWindowBounds = await readMainWindowBounds(join(app.getPath("userData"), MAIN_WINDOW_STATE_FILE)).catch(
-        (error) => {
-          logger.error("Unable to restore the main window position:", toLogValue(error));
-          return null;
-        },
-      );
+      await restoreMainWindowBounds();
       mainWindow = createWindow();
       const computerUseMacSetupService = new ComputerUseMacSetupService({
         getIconDataUrl: async (path) => (await app.getFileIcon(path, { size: "normal" })).toDataURL(),
@@ -1038,7 +931,11 @@ if (!hasSingleInstanceLock) {
         async (agentId) => service.refreshAgentRuntime(agentId),
       );
       const agentMarketplace = new AgentMarketplaceService(centralAuthManager, service, skillMarketplace);
-      configureAttachmentProtocol(mailboxStore, service);
+      configureAttachmentProtocol({
+        mailbox: mailboxStore,
+        agents: service,
+        getRemoteServerManager: () => remoteServerManager,
+      });
       const teamStore = new TeamStore(
         join(app.getPath("userData"), TEAM_FILE_V2),
         join(app.getPath("userData"), TEAM_FILE),
@@ -1293,7 +1190,7 @@ if (!hasSingleInstanceLock) {
       } else if (developmentRemoteRole === "client") {
         await connectDevelopmentRemoteServer(remoteServerManager);
       }
-      configureServerLogoProtocols(teamStore);
+      configureServerLogoProtocols({ teamStore, remoteServers: remoteServerManager });
       remoteDesktopManager = new RemoteDesktopManager(remoteServerManager);
       const host = hostService;
       const remoteDesktop = remoteDesktopManager;
@@ -1511,143 +1408,6 @@ async function prepareForShutdown(browserAlreadyDestroyed = false): Promise<void
 
 async function destroyBrowserForShutdown(): Promise<void> {
   await (browserHost?.destroy() ?? Promise.resolve());
-}
-
-function configureRendererPermissions(): void {
-  session.defaultSession.setPermissionCheckHandler((_webContents, permission, requestingOrigin, details) =>
-    canCheckRendererPermission(permission, requestingOrigin, details),
-  );
-  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
-    const mediaTypes = ("mediaTypes" in details ? details.mediaTypes : undefined) ?? [];
-    callback(canRequestRendererPermission(permission, webContents.getURL(), { mediaTypes }));
-  });
-}
-
-function configureAttachmentProtocol(mailbox: MailboxStore, agents: AgentService): void {
-  session.defaultSession.protocol.handle("openbot-attachment", async (request) => {
-    try {
-      const url = new URL(request.url);
-      const id = url.pathname.split("/").filter(Boolean).at(-1);
-      const attachment = id ? await mailbox.resolveAttachment(id) : null;
-      if (!attachment) return new Response("Not found", { status: 404 });
-      return new Response(await readFile(attachment.path), {
-        headers: {
-          "Content-Type": attachment.mimeType,
-          "Cache-Control": "no-store",
-          "Access-Control-Allow-Origin": request.headers.get("Origin") ?? "*",
-          Vary: "Origin",
-          "X-Content-Type-Options": "nosniff",
-          "Content-Disposition": "inline",
-        },
-      });
-    } catch {
-      return new Response("Not found", { status: 404 });
-    }
-  });
-  session.defaultSession.protocol.handle("openbot-remote-attachment", async (request) => {
-    try {
-      const url = new URL(request.url);
-      const serverId = decodeURIComponent(url.hostname);
-      const attachmentId = decodeURIComponent(url.pathname.split("/").filter(Boolean)[0] ?? "");
-      if (!remoteServerManager || !serverId || !attachmentId) {
-        return new Response("Not found", { status: 404 });
-      }
-      const attachment = await remoteServerManager.downloadAttachment(attachmentId, serverId);
-      return new Response(Buffer.from(attachment.bytes), {
-        headers: {
-          "Content-Type": attachment.mimeType,
-          "Cache-Control": "no-store",
-          "Access-Control-Allow-Origin": request.headers.get("Origin") ?? "*",
-          Vary: "Origin",
-          "X-Content-Type-Options": "nosniff",
-          "Content-Disposition": "inline",
-        },
-      });
-    } catch {
-      return new Response("Not found", { status: 404 });
-    }
-  });
-  session.defaultSession.protocol.handle("openbot-avatar", async (request) => {
-    try {
-      const url = new URL(request.url);
-      if (url.hostname !== "agent") return new Response("Not found", { status: 404 });
-      const agentId = decodeURIComponent(url.pathname.split("/").filter(Boolean)[0] ?? "");
-      const avatar = agentId ? agents.resolveAvatar(agentId) : null;
-      if (!avatar || avatar.version !== url.searchParams.get("v")) {
-        return new Response("Not found", { status: 404 });
-      }
-      return new Response(await readFile(avatar.path), {
-        headers: {
-          "Content-Type": avatar.mimeType,
-          "Cache-Control": "private, max-age=31536000, immutable",
-          "X-Content-Type-Options": "nosniff",
-        },
-      });
-    } catch {
-      return new Response("Not found", { status: 404 });
-    }
-  });
-  session.defaultSession.protocol.handle("openbot-remote-avatar", async (request) => {
-    try {
-      const url = new URL(request.url);
-      const serverId = decodeURIComponent(url.hostname);
-      const agentId = decodeURIComponent(url.pathname.split("/").filter(Boolean)[0] ?? "");
-      if (!remoteServerManager || !serverId || !agentId) {
-        return new Response("Not found", { status: 404 });
-      }
-      const version = url.searchParams.get("v");
-      if (!version) return new Response("Not found", { status: 404 });
-      const avatar = await remoteServerManager.downloadAgentAvatar(agentId, serverId, version);
-      return new Response(Buffer.from(avatar.bytes), {
-        headers: {
-          "Content-Type": avatar.mimeType,
-          "Cache-Control": "private, max-age=31536000, immutable",
-          "X-Content-Type-Options": "nosniff",
-        },
-      });
-    } catch {
-      return new Response("Not found", { status: 404 });
-    }
-  });
-}
-
-function configureServerLogoProtocols(teamStore: TeamStore): void {
-  session.defaultSession.protocol.handle("openbot-server-logo", async (request) => {
-    try {
-      const url = new URL(request.url);
-      const logo = teamStore.resolveLogo();
-      if (url.hostname !== LOCAL_SERVER_ID || !logo || logo.version !== url.searchParams.get("v")) {
-        return new Response("Not found", { status: 404 });
-      }
-      return new Response(await readFile(logo.path), {
-        headers: {
-          "Content-Type": logo.mimeType,
-          "Cache-Control": "private, max-age=31536000, immutable",
-          "X-Content-Type-Options": "nosniff",
-        },
-      });
-    } catch {
-      return new Response("Not found", { status: 404 });
-    }
-  });
-  session.defaultSession.protocol.handle("openbot-remote-server-logo", async (request) => {
-    try {
-      const url = new URL(request.url);
-      const serverId = decodeURIComponent(url.hostname);
-      const version = url.searchParams.get("v");
-      if (!remoteServerManager || !serverId || !version) return new Response("Not found", { status: 404 });
-      const logo = await remoteServerManager.downloadServerLogo(serverId, version);
-      return new Response(Buffer.from(logo.bytes), {
-        headers: {
-          "Content-Type": logo.mimeType,
-          "Cache-Control": "private, max-age=31536000, immutable",
-          "X-Content-Type-Options": "nosniff",
-        },
-      });
-    } catch {
-      return new Response("Not found", { status: 404 });
-    }
-  });
 }
 
 function configureApplicationProtocol(): void {

--- a/src/main/ipc-channel-coverage.test.ts
+++ b/src/main/ipc-channel-coverage.test.ts
@@ -76,6 +76,26 @@ const WRAPPER_CHANNEL_PARAMETER = "channel";
 // The call that makes a registration a trusted one.
 const SENDER_CHECK = "isTrustedRendererUrl";
 
+// How many twin decoders the pair currently has. The comparison below is between
+// two sets, so a regex that stopped matching would leave both empty and green;
+// this is the floor that makes that failure loud instead.
+const TWIN_DECODER_FLOOR = 8;
+
+// Every twin in the tree is a `function` today, so the alias check below matches
+// nothing and would stay green even if its pattern stopped working. This is that
+// check's fixture: each line it must reject beside a correct one it must leave
+// alone, the way a rule under `tools/biome/anti-slop/rules` carries one.
+const TWIN_ALIAS_FIXTURE = `
+const decodeAliasedFromMain = decodeAliasedFromHost;
+const decodeAnnotatedFromMain: Decoder<Alias> = shared.decodeAliasedFromHost as Decoder<Alias>;
+const decodeSignedFromMain: (value: unknown) => Alias = decodeAliasedFromHost;
+const decodeBuiltFromHost = guardedDecoder(isBuilt, "built");
+const decodeInlineFromHost = (value: unknown) => (isInline(value) ? value : null);
+function decodeWrittenFromMain(value: unknown): Written | null {
+  return isWritten(value) ? value : null;
+}
+`;
+
 // The preload's agent helpers take the channel as a parameter and pass it on,
 // so the forwarding call names a variable by design. Their own call sites carry
 // the IPC_CHANNELS reference and are what the scan checks, which is why the
@@ -264,6 +284,47 @@ describe("IPC channel coverage", () => {
 
     expect(declared).toEqual([]);
   });
+
+  // `decodeXFromHost` here and `decodeXFromMain` in the preload are deliberately two
+  // functions for one shape: the preload checks what the main process sent the
+  // renderer, which is a trusted sender, while these check a remote team server,
+  // which is not.
+  //
+  // What this enforces is the naming bijection, and only that: neither half may lose
+  // its twin. That catches the way the pair actually gets merged - one is deleted and
+  // its callers point at the other, which reads in review as a tidy deduplication and
+  // passes every other assertion in this file. It does not prove the two names have
+  // separate implementations - the test below covers the one aliasing spelling a
+  // source scan can recognise, and a wrapper that forwards to the other decoder is
+  // still review's job.
+  //
+  // Names only, never the file list: the headers describe four wire-area siblings,
+  // but two of them hold no suffixed decoder at all, so where the twin lives is not
+  // the invariant. Nor is `export` - the preload exports nothing, and one FromHost
+  // decoder is module-private.
+  it("gives every FromHost decoder a FromMain twin, and the reverse", () => {
+    const host = twinDecoders(mainSources, "Host");
+    const main = twinDecoders(preloadSources, "Main");
+
+    expect(host.length).toBeGreaterThanOrEqual(TWIN_DECODER_FLOOR);
+    expect(host).toEqual(main);
+  });
+
+  // The bijection above is satisfied by two names, so it survives
+  // `const decodeXFromMain = decodeXFromHost` - which would hand a remote team
+  // server the validation written for a trusted sender while keeping both names in
+  // place. An initializer that is a bare reference is that merge; an initializer
+  // that calls something is an implementation, which is what keeps the factory
+  // spelling this family already uses (`remote-agent-decoding.ts:162`) accepted.
+  it("declares each twin decoder rather than aliasing the other", () => {
+    expect(aliasedTwinsIn(TWIN_ALIAS_FIXTURE)).toEqual([
+      "decodeAliasedFromMain",
+      "decodeAnnotatedFromMain",
+      "decodeSignedFromMain",
+    ]);
+
+    expect(aliasedTwins([...mainSources, ...preloadSources])).toEqual([]);
+  });
 });
 
 // One occurrence of a known call, with the source text of its channel argument
@@ -291,6 +352,44 @@ function sourceFilesUnder(directory: string): readonly string[] {
 // not the name's other appearance in the dispatcher.
 function callCount(source: string, name: string): number {
   return [...source.matchAll(new RegExp(`\\b${name}\\s*\\(`, "g"))].length;
+}
+
+// Every decoder declared with the given suffix, the suffix removed so the two
+// sides compare directly. `const` counts as well as `function`: the family already
+// builds decoders out of guardedDecoder factories, and a regex blind to that
+// spelling would drop one silently here and fail on the opposite side.
+function twinDecoders(files: readonly string[], side: "Host" | "Main"): readonly string[] {
+  const declaration = new RegExp(`(?:function|const)\\s+(decode[A-Za-z0-9_]*)From${side}\\b`, "g");
+  const names = new Set<string>();
+  for (const file of files) {
+    for (const match of readSource(file).matchAll(declaration)) {
+      const name = match[1];
+      if (name !== undefined) names.add(name);
+    }
+  }
+  return [...names].sort();
+}
+
+// A suffixed decoder bound straight to another name: `= other`, `= module.other`,
+// either of them with a trailing `as T`. An initializer holding a call, an arrow or a
+// body is an implementation and is left alone. The annotation this skips over may itself
+// be a function type, so `=>` has to be consumed there rather than mistaken for the
+// assignment - otherwise `const decodeXFromMain: (value: unknown) => X = other` is read
+// from the arrow onwards and escapes.
+const TWIN_ASSIGNMENT = /const\s+(decode[A-Za-z0-9_]*From(?:Host|Main))\s*(?::(?:[^=;]|=>)+)?=\s*([^;]+);/g;
+const BARE_REFERENCE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s+as\s+[\w$.<>[\], |]+)?$/;
+
+function aliasedTwinsIn(source: string): readonly string[] {
+  const aliases: string[] = [];
+  for (const match of source.matchAll(TWIN_ASSIGNMENT)) {
+    const [, name, initializer] = match;
+    if (name !== undefined && initializer !== undefined && BARE_REFERENCE.test(initializer.trim())) aliases.push(name);
+  }
+  return aliases;
+}
+
+function aliasedTwins(files: readonly string[]): readonly string[] {
+  return files.flatMap((file) => aliasedTwinsIn(readSource(file)).map((name) => `${file} aliases ${name}`));
 }
 
 function readSource(file: string): string {

--- a/src/main/main-window-state.test.ts
+++ b/src/main/main-window-state.test.ts
@@ -3,8 +3,10 @@
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import type { Rectangle } from "electron";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createMainWindowBoundsRecorder,
   ensureMacApplicationPresence,
   presentMainWindow,
   readMainWindowBounds,
@@ -109,5 +111,126 @@ describe("main window state", () => {
 
     await writeFile(path, '{"version":1,"x":"bad"}\n');
     await expect(readMainWindowBounds(path)).resolves.toBeNull();
+  });
+});
+
+describe("main window bounds recorder", () => {
+  // The debounce the recorder is built around, spelled out here rather than imported so that
+  // changing the constant has to be a decision about this contract.
+  const debounceMs = 250;
+  const moved = { x: 10, y: 20, width: 1100, height: 700 };
+  const resized = { x: 10, y: 20, width: 1180, height: 700 };
+  const quitting = { x: 60, y: 70, width: 1300, height: 880 };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Records what the recorder actually persisted. The debounce exists to turn a burst of moves into
+   * one write, and how often it wrote is not observable from the saved file - one write and three
+   * writes leave the same bytes behind.
+   */
+  function recordWrites(): { written: Rectangle[]; writeBounds: (bounds: Rectangle) => Promise<void> } {
+    const written: Rectangle[] = [];
+    return {
+      written,
+      writeBounds: async (bounds) => {
+        written.push(bounds);
+      },
+    };
+  }
+
+  it("coalesces a burst of window moves into one write", async () => {
+    const { written, writeBounds } = recordWrites();
+    const recorder = createMainWindowBoundsRecorder({
+      getMainWindow: () => null,
+      readBounds: async () => null,
+      writeBounds,
+      reportError: () => undefined,
+    });
+
+    recorder.rememberMainWindowBounds(moved);
+    await vi.advanceTimersByTimeAsync(debounceMs - 1);
+    recorder.rememberMainWindowBounds(resized);
+    await vi.advanceTimersByTimeAsync(debounceMs - 1);
+    recorder.rememberMainWindowBounds(quitting);
+    await vi.advanceTimersByTimeAsync(debounceMs);
+
+    expect(written).toEqual([quitting]);
+  });
+
+  it("reopens the window where the last one was left", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-main-window-recorder-"));
+    const statePath = join(root, "state.json");
+    // Wired to the real file the way the main process wires it, so this covers the round trip and
+    // not just the recorder's half of it.
+    const dependencies = {
+      getMainWindow: () => null,
+      readBounds: () => readMainWindowBounds(statePath),
+      writeBounds: (bounds: Rectangle) => writeMainWindowBounds(statePath, bounds),
+      reportError: () => undefined,
+    };
+
+    const recorder = createMainWindowBoundsRecorder(dependencies);
+    recorder.rememberMainWindowBounds(moved);
+    await recorder.flushMainWindowBounds();
+
+    const relaunched = createMainWindowBoundsRecorder(dependencies);
+    await relaunched.restoreMainWindowBounds();
+
+    expect(relaunched.currentMainWindowBounds()).toEqual(moved);
+  });
+
+  it("cancels a pending write before it yields, and saves what the window shows now", async () => {
+    const { written, writeBounds } = recordWrites();
+    const recorder = createMainWindowBoundsRecorder({
+      getMainWindow: () => ({ isDestroyed: () => false, getNormalBounds: () => quitting }),
+      readBounds: async () => null,
+      writeBounds,
+      reportError: () => undefined,
+    });
+
+    recorder.rememberMainWindowBounds(moved);
+    // Windows session-end calls the flush from a synchronous handler and never awaits it, so the
+    // debounce has to be gone by the time the call returns - not by the time the promise settles.
+    const settled = recorder.flushMainWindowBounds();
+    vi.advanceTimersByTime(debounceMs);
+    await settled;
+    await vi.runAllTimersAsync();
+
+    expect(written).toEqual([quitting]);
+  });
+
+  it("keeps saving after a write fails", async () => {
+    const { written, writeBounds } = recordWrites();
+    const reported: string[] = [];
+    let firstWrite = true;
+    const recorder = createMainWindowBoundsRecorder({
+      getMainWindow: () => null,
+      readBounds: async () => null,
+      writeBounds: (bounds) => {
+        if (!firstWrite) return writeBounds(bounds);
+        firstWrite = false;
+        return Promise.reject(new Error("disk full"));
+      },
+      reportError: (message) => {
+        reported.push(message);
+      },
+    });
+
+    recorder.rememberMainWindowBounds(moved);
+    await vi.advanceTimersByTimeAsync(debounceMs);
+    recorder.rememberMainWindowBounds(quitting);
+    await recorder.flushMainWindowBounds();
+
+    expect(written).toEqual([quitting]);
+    expect(reported).toEqual([
+      "Unable to save the main window position:",
+      "Unable to save the previous main window position:",
+    ]);
   });
 });

--- a/src/main/main-window-state.ts
+++ b/src/main/main-window-state.ts
@@ -80,6 +80,93 @@ export async function writeMainWindowBounds(path: string, bounds: Rectangle): Pr
   }
 }
 
+/**
+ * The window the recorder reads. Structural, like `MainWindowPresentationTarget` above, so this
+ * module still imports no Electron value and its tests still need no mock.
+ */
+interface MainWindowBoundsSource {
+  isDestroyed(): boolean;
+  getNormalBounds(): Rectangle;
+}
+
+export interface MainWindowBoundsDependencies {
+  /**
+   * Read on every call, never captured: the `closed` handler drops the main window and a later
+   * relaunch builds a new one, so a captured reference would flush a destroyed window.
+   */
+  getMainWindow: () => MainWindowBoundsSource | null;
+  /**
+   * The recorder decides *when* to persist; the caller decides *where*. Both of these are
+   * `readMainWindowBounds` / `writeMainWindowBounds` above bound to a path in production - they are
+   * parameters so that this file's own tests can observe how often a write actually happens, which
+   * is the whole point of the debounce and is not otherwise visible from outside.
+   */
+  readBounds: () => Promise<Rectangle | null>;
+  writeBounds: (bounds: Rectangle) => Promise<void>;
+  reportError: (message: string, error: unknown) => void;
+}
+
+export interface MainWindowBoundsRecorder {
+  restoreMainWindowBounds: () => Promise<void>;
+  currentMainWindowBounds: () => Rectangle | null;
+  rememberMainWindowBounds: (bounds: Rectangle) => void;
+  flushMainWindowBounds: () => Promise<void>;
+}
+
+/** Long enough that a drag-resize writes once, short enough to survive a quit that follows it. */
+const BOUNDS_WRITE_DELAY_MS = 250;
+
+export function createMainWindowBoundsRecorder({
+  getMainWindow,
+  readBounds,
+  writeBounds,
+  reportError,
+}: MainWindowBoundsDependencies): MainWindowBoundsRecorder {
+  let bounds: Rectangle | null = null;
+  let writeTimer: ReturnType<typeof setTimeout> | null = null;
+  let write = Promise.resolve();
+
+  // One shared chain, with the `.catch` before the `.then` so a rejected write is absorbed instead
+  // of poisoning every write queued after it.
+  function queueWrite(): Promise<void> {
+    if (!bounds) return write;
+    const pending = { ...bounds };
+    write = write
+      .catch((error) => reportError("Unable to save the previous main window position:", error))
+      .then(() => writeBounds(pending));
+    return write;
+  }
+
+  return {
+    async restoreMainWindowBounds() {
+      bounds = await readBounds().catch((error) => {
+        reportError("Unable to restore the main window position:", error);
+        return null;
+      });
+    },
+    currentMainWindowBounds: () => bounds,
+    rememberMainWindowBounds(next) {
+      bounds = { ...next };
+      if (writeTimer) clearTimeout(writeTimer);
+      writeTimer = setTimeout(() => {
+        writeTimer = null;
+        void queueWrite().catch((error) => reportError("Unable to save the main window position:", error));
+      }, BOUNDS_WRITE_DELAY_MS);
+    },
+    async flushMainWindowBounds() {
+      const window = getMainWindow();
+      if (window && !window.isDestroyed()) bounds = window.getNormalBounds();
+      // Cleared before the first await: Windows session-end calls this from a synchronous handler
+      // it never awaits, so a pending timer left here can outlive the decision to quit.
+      if (writeTimer) {
+        clearTimeout(writeTimer);
+        writeTimer = null;
+      }
+      await queueWrite();
+    },
+  };
+}
+
 export function resolveMainWindowBounds(
   stored: Rectangle | null,
   workAreas: Rectangle[],

--- a/src/main/remote-host-decoding.ts
+++ b/src/main/remote-host-decoding.ts
@@ -5,7 +5,8 @@
 // not the same function: a remote team server is an untrusted sender, so these enumerate what the
 // preload's twin is content to accept as a string. The suffix is there so a later reader does not
 // merge them onto whichever is looser. The convention only works while both halves keep the suffix,
-// because it is what lets a reader find the twin at all.
+// because it is what lets a reader find the twin at all - which is why
+// `src/main/ipc-channel-coverage.test.ts` compares the two sets name for name.
 //
 // The decoders sit in four sibling files by wire area — `remote-agent-decoding.ts`,
 // `remote-conversation-decoding.ts`, `remote-team-decoding.ts`, `remote-device-decoding.ts` — and this

--- a/src/main/renderer-forwarders.ts
+++ b/src/main/renderer-forwarders.ts
@@ -1,0 +1,163 @@
+/**
+ * The eleven service events the main process relays to the renderer. They live here rather than in
+ * the entry point because every one of them is the same three lines around a different channel, and
+ * because they are the part of the entry point most likely to be edited by two agents at once.
+ *
+ * Every dependency is a **function**, never a nullable value. Most of these are subscribed before
+ * the service they read exists, so `getHostService()` and `hostService` behave differently at run
+ * time - and `() => HostService | null` and `HostService | null` both type-check at every call site,
+ * so `tsc` cannot tell you which one you passed. A function-typed field makes the wrong one an error.
+ *
+ * `showMainWindow` is injected for a second reason: importing it from the entry point would be an
+ * import cycle, which Biome rejects, and is forbidden by `src/main/AGENTS.md`.
+ */
+
+import {
+  type AgentEvent,
+  type BrowserDisplayState,
+  IPC_CHANNELS,
+  LOCAL_SERVER_ID,
+  type VoiceModelStatus,
+} from "@openbot/contracts/ipc";
+import { BrowserWindow, Notification } from "electron";
+import type { AgentService } from "../backend/agent-service";
+import { notificationForAgentEvent } from "./agent-notifications";
+import type { HostAnalytics } from "./analytics";
+import type { HostService } from "./host-service";
+import { withLocalHostSummary } from "./ipc/register-team-handlers";
+import type { RemoteServerManager } from "./remote-server-manager";
+import { sendToRenderer } from "./renderer-ipc";
+
+export interface RendererForwarderDependencies {
+  getMainWindow: () => BrowserWindow | null;
+  getAgentService: () => AgentService | null;
+  getHostService: () => HostService | null;
+  getHostAnalytics: () => HostAnalytics | null;
+  getRemoteServerManager: () => RemoteServerManager | null;
+  showMainWindow: (window: BrowserWindow) => void;
+}
+
+/**
+ * Returns the forwarders as an object so the entry point can destructure it and keep every
+ * `service.on("event", forwardX)` registration exactly as it was.
+ */
+export function createRendererForwarders({
+  getMainWindow,
+  getAgentService,
+  getHostService,
+  getHostAnalytics,
+  getRemoteServerManager,
+  showMainWindow,
+}: RendererForwarderDependencies) {
+  function forwardAgentEvent(serverId: string, event: AgentEvent, bufferedLive = false): void {
+    if (serverId === LOCAL_SERVER_ID) getHostAnalytics()?.handleAgentEvent(event);
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    sendToRenderer(
+      window,
+      IPC_CHANNELS.agentEvent,
+      bufferedLive ? { serverId, event, bufferedLive } : { serverId, event },
+    );
+    if (window.isFocused() || !Notification.isSupported()) return;
+
+    const content = notificationForAgentEvent(event, getAgentService()?.listAgents() ?? []);
+    if (!content) return;
+    const notification = new Notification(content);
+    notification.on("click", () => {
+      // Re-read rather than reuse the local above: a notification can be clicked long after it was
+      // shown, by which time the window may have been closed and a new one built.
+      const current = getMainWindow();
+      if (!current || current.isDestroyed()) return;
+      showMainWindow(current);
+    });
+    notification.show();
+  }
+
+  function forwardBrowserDisplayState(state: BrowserDisplayState): void {
+    for (const window of BrowserWindow.getAllWindows()) {
+      sendToRenderer(window, IPC_CHANNELS.browserDisplayStateEvent, state);
+    }
+  }
+
+  function forwardUpdateStatus(status: import("@openbot/contracts/ipc").UpdateStatus): void {
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    sendToRenderer(window, IPC_CHANNELS.updateEvent, status);
+  }
+
+  function forwardVoiceModelStatus(status: VoiceModelStatus): void {
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    sendToRenderer(window, IPC_CHANNELS.voiceModelStatus, status);
+  }
+
+  function forwardProviderRuntimeStatus(snapshot: import("@openbot/contracts/ipc").ProviderRuntimeSnapshot): void {
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    sendToRenderer(window, IPC_CHANNELS.providerRuntimesEvent, snapshot);
+  }
+
+  function forwardHostStatus(status: import("@openbot/contracts/ipc").HostStatus): void {
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    sendToRenderer(window, IPC_CHANNELS.hostEvent, status);
+    const remoteServers = getRemoteServerManager();
+    if (remoteServers) {
+      sendToRenderer(window, IPC_CHANNELS.serversEvent, withLocalHostSummary(remoteServers.list(), status));
+    }
+  }
+
+  function forwardRemoteDesktopSessions(sessions: import("@openbot/contracts/ipc").RemoteDesktopSession[]): void {
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    sendToRenderer(window, IPC_CHANNELS.remoteDesktopEvent, sessions);
+  }
+
+  function forwardServers(servers: import("@openbot/contracts/ipc").ServerSummary[]): void {
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    const host = getHostService();
+    sendToRenderer(window, IPC_CHANNELS.serversEvent, host ? withLocalHostSummary(servers, host.getStatus()) : servers);
+  }
+
+  function forwardTeamPresence(
+    serverId: string,
+    snapshot: import("@openbot/contracts/ipc").TeamPresenceSnapshot,
+  ): void {
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    sendToRenderer(window, IPC_CHANNELS.serversPresence, { serverId, snapshot });
+  }
+
+  function forwardDirectMessage(
+    serverId: string,
+    event: import("@openbot/contracts/ipc").DirectMessageRealtimeEvent,
+  ): void {
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    sendToRenderer(window, IPC_CHANNELS.serversDirectMessage, { serverId, event });
+  }
+
+  function forwardDirectTyping(
+    serverId: string,
+    event: import("@openbot/contracts/ipc").DirectTypingRealtimeEvent,
+  ): void {
+    const window = getMainWindow();
+    if (!window || window.isDestroyed()) return;
+    sendToRenderer(window, IPC_CHANNELS.serversDirectTyping, { serverId, event });
+  }
+
+  return {
+    forwardAgentEvent,
+    forwardBrowserDisplayState,
+    forwardUpdateStatus,
+    forwardVoiceModelStatus,
+    forwardProviderRuntimeStatus,
+    forwardHostStatus,
+    forwardRemoteDesktopSessions,
+    forwardServers,
+    forwardTeamPresence,
+    forwardDirectMessage,
+    forwardDirectTyping,
+  };
+}

--- a/src/main/session-configuration.ts
+++ b/src/main/session-configuration.ts
@@ -1,0 +1,200 @@
+/**
+ * Everything that configures the default Electron session: the renderer's Content-Security-Policy,
+ * its permission handlers, and the custom protocols that serve attachments, avatars and server
+ * logos.
+ *
+ * **This module body must stay side-effect free.** The main entry point imports it, and an import
+ * evaluates before the entry point's own statements - which is where `app.setPath("userData", ...)`
+ * and `app.enableSandbox()` run. Anything executed at this module's top level would therefore run
+ * against the wrong profile and an unsandboxed default. Every function here touches
+ * `session.defaultSession` only when called, and each is called from inside `app.whenReady()`.
+ */
+
+import { readFile } from "node:fs/promises";
+import { LOCAL_SERVER_ID } from "@openbot/contracts/ipc";
+import { app, session } from "electron";
+import type { AgentService } from "../backend/agent-service";
+import type { MailboxStore } from "../backend/mailbox-store";
+import { buildContentSecurityPolicy } from "./content-security-policy";
+import type { RemoteServerManager } from "./remote-server-manager";
+import { canCheckRendererPermission, canRequestRendererPermission } from "./renderer-permissions";
+import type { TeamStore } from "./team-store";
+import { isTrustedRendererUrl } from "./trusted-renderer";
+
+export function configureContentSecurityPolicy(): void {
+  const policy = buildContentSecurityPolicy(app.isPackaged, process.env.REMOTE_SIGNAL_URL);
+
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    if (details.resourceType !== "mainFrame" || !isTrustedRendererUrl(details.url)) {
+      callback({ responseHeaders: details.responseHeaders });
+      return;
+    }
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        "Content-Security-Policy": [policy],
+      },
+    });
+  });
+}
+
+export function configureRendererPermissions(): void {
+  session.defaultSession.setPermissionCheckHandler((_webContents, permission, requestingOrigin, details) =>
+    canCheckRendererPermission(permission, requestingOrigin, details),
+  );
+  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
+    const mediaTypes = ("mediaTypes" in details ? details.mediaTypes : undefined) ?? [];
+    callback(canRequestRendererPermission(permission, webContents.getURL(), { mediaTypes }));
+  });
+}
+
+export interface AttachmentProtocolDependencies {
+  mailbox: MailboxStore;
+  agents: AgentService;
+  /**
+   * A getter, not a value, and the one place in this file that needs to be. This runs during
+   * `app.whenReady()` while `remoteServerManager` is still null, so the null branches below are
+   * that startup window rather than defensive padding. Both shapes type-check at every call site,
+   * so `tsc` cannot tell a value passed here from a getter - only this comment can.
+   */
+  getRemoteServerManager: () => RemoteServerManager | null;
+}
+
+export function configureAttachmentProtocol({
+  mailbox,
+  agents,
+  getRemoteServerManager,
+}: AttachmentProtocolDependencies): void {
+  session.defaultSession.protocol.handle("openbot-attachment", async (request) => {
+    try {
+      const url = new URL(request.url);
+      const id = url.pathname.split("/").filter(Boolean).at(-1);
+      const attachment = id ? await mailbox.resolveAttachment(id) : null;
+      if (!attachment) return new Response("Not found", { status: 404 });
+      return new Response(await readFile(attachment.path), {
+        headers: {
+          "Content-Type": attachment.mimeType,
+          "Cache-Control": "no-store",
+          "Access-Control-Allow-Origin": request.headers.get("Origin") ?? "*",
+          Vary: "Origin",
+          "X-Content-Type-Options": "nosniff",
+          "Content-Disposition": "inline",
+        },
+      });
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+  });
+  session.defaultSession.protocol.handle("openbot-remote-attachment", async (request) => {
+    try {
+      const url = new URL(request.url);
+      const serverId = decodeURIComponent(url.hostname);
+      const attachmentId = decodeURIComponent(url.pathname.split("/").filter(Boolean)[0] ?? "");
+      const remoteServers = getRemoteServerManager();
+      if (!remoteServers || !serverId || !attachmentId) {
+        return new Response("Not found", { status: 404 });
+      }
+      const attachment = await remoteServers.downloadAttachment(attachmentId, serverId);
+      return new Response(Buffer.from(attachment.bytes), {
+        headers: {
+          "Content-Type": attachment.mimeType,
+          "Cache-Control": "no-store",
+          "Access-Control-Allow-Origin": request.headers.get("Origin") ?? "*",
+          Vary: "Origin",
+          "X-Content-Type-Options": "nosniff",
+          "Content-Disposition": "inline",
+        },
+      });
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+  });
+  session.defaultSession.protocol.handle("openbot-avatar", async (request) => {
+    try {
+      const url = new URL(request.url);
+      if (url.hostname !== "agent") return new Response("Not found", { status: 404 });
+      const agentId = decodeURIComponent(url.pathname.split("/").filter(Boolean)[0] ?? "");
+      const avatar = agentId ? agents.resolveAvatar(agentId) : null;
+      if (!avatar || avatar.version !== url.searchParams.get("v")) {
+        return new Response("Not found", { status: 404 });
+      }
+      return new Response(await readFile(avatar.path), {
+        headers: {
+          "Content-Type": avatar.mimeType,
+          "Cache-Control": "private, max-age=31536000, immutable",
+          "X-Content-Type-Options": "nosniff",
+        },
+      });
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+  });
+  session.defaultSession.protocol.handle("openbot-remote-avatar", async (request) => {
+    try {
+      const url = new URL(request.url);
+      const serverId = decodeURIComponent(url.hostname);
+      const agentId = decodeURIComponent(url.pathname.split("/").filter(Boolean)[0] ?? "");
+      const remoteServers = getRemoteServerManager();
+      if (!remoteServers || !serverId || !agentId) {
+        return new Response("Not found", { status: 404 });
+      }
+      const version = url.searchParams.get("v");
+      if (!version) return new Response("Not found", { status: 404 });
+      const avatar = await remoteServers.downloadAgentAvatar(agentId, serverId, version);
+      return new Response(Buffer.from(avatar.bytes), {
+        headers: {
+          "Content-Type": avatar.mimeType,
+          "Cache-Control": "private, max-age=31536000, immutable",
+          "X-Content-Type-Options": "nosniff",
+        },
+      });
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+  });
+}
+
+export interface ServerLogoProtocolDependencies {
+  teamStore: TeamStore;
+  /** Not a getter: unlike the pair above, this runs after `remoteServerManager` is constructed. */
+  remoteServers: RemoteServerManager;
+}
+
+export function configureServerLogoProtocols({ teamStore, remoteServers }: ServerLogoProtocolDependencies): void {
+  session.defaultSession.protocol.handle("openbot-server-logo", async (request) => {
+    try {
+      const url = new URL(request.url);
+      const logo = teamStore.resolveLogo();
+      if (url.hostname !== LOCAL_SERVER_ID || !logo || logo.version !== url.searchParams.get("v")) {
+        return new Response("Not found", { status: 404 });
+      }
+      return new Response(await readFile(logo.path), {
+        headers: {
+          "Content-Type": logo.mimeType,
+          "Cache-Control": "private, max-age=31536000, immutable",
+          "X-Content-Type-Options": "nosniff",
+        },
+      });
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+  });
+  session.defaultSession.protocol.handle("openbot-remote-server-logo", async (request) => {
+    try {
+      const url = new URL(request.url);
+      const serverId = decodeURIComponent(url.hostname);
+      const version = url.searchParams.get("v");
+      if (!serverId || !version) return new Response("Not found", { status: 404 });
+      const logo = await remoteServers.downloadServerLogo(serverId, version);
+      return new Response(Buffer.from(logo.bytes), {
+        headers: {
+          "Content-Type": logo.mimeType,
+          "Cache-Control": "private, max-age=31536000, immutable",
+          "X-Content-Type-Options": "nosniff",
+        },
+      });
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+  });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -168,7 +168,8 @@ async function importFiles(files: File[]): Promise<void> {
 // its four wire-area siblings, and is deliberately not the same function: this side is checking what
 // the main process sent the renderer, which is a trusted sender, while that side is checking a remote
 // team server, which is not. The suffix is there so a later reader does not merge them onto whichever
-// is looser.
+// is looser. `src/main/ipc-channel-coverage.test.ts` checks the two sets name for name, so dropping a
+// suffix or deleting one half is a red test rather than a comment nobody read.
 function decodeBrowserPreviewFromMain(value: unknown): BrowserPreview {
   const preview = decodeRecord(value, "browser preview");
   const dataUrl = requiredString(preview, "dataUrl");


### PR DESCRIPTION
## What this does

`src/main/index.ts` is the file every IPC change has to open, and with several agents working in
parallel worktrees on one machine it is also the highest-probability merge-conflict surface — which
is where an agent with no memory of the other agent's intent does the most damage. It goes from
1704 to 1461 lines, into three modules that each have one reason to change:

| New/changed module | What moved into it |
| --- | --- |
| `src/main/main-window-state.ts` (existing) | the window-bounds recorder: the 250 ms debounce, the shared write chain, the shutdown flush |
| `src/main/session-configuration.ts` (new) | the renderer CSP, the permission handlers, and the attachment / avatar / server-logo protocols |
| `src/main/renderer-forwarders.ts` (new) | the eleven service events relayed to the renderer |

Window bounds went into the **existing** `main-window-state.ts` rather than a new file, because that
file imports only `type Rectangle` from electron — so the moved code needed no electron mock and is
now the first *tested* part of this area.

Separately, `ipc-channel-coverage.test.ts` gains one check: the set of `decode*FromHost` names under
`src/main` must equal the set of `decode*FromMain` names in the preload. The two families
deliberately differ — `FromMain` validates what the trusted main process sent the renderer,
`FromHost` validates an untrusted remote team server. Merging a pair onto whichever is looser
type-checks, passes every other assertion in that file, and reads in review as a tidy deduplication,
while silently applying trusted-sender validation to a remote host. Until now a suffix and two file
comments were the whole guard.

## Behaviour

No intended behaviour change outside the tests. The moved handler bodies are byte-identical to what
they replaced; I diffed them mechanically against the previous `index.ts` rather than by eye. All 17
existing `service.on("event", forwardX)` registration sites are byte-identical too — the forwarders
come back as an object that `index.ts` destructures at module scope.

**Every injected dependency is typed as a function**, never as a nullable value
(`getHostService: () => HostService | null`). Most of these forwarders are subscribed before the
service they read is constructed, so getter-vs-value is a correctness question here, not a style
one — and `() => X | null` and `X | null` both type-check at every call site, so `tsc` is blind to
exactly the mistake this refactor invites. A function-typed field makes the wrong form a TS2322.

Four hazards the moves had to respect, all documented in the new file headers:

- `session-configuration.ts` has a **side-effect-free module body**. `index.ts` imports it, and an
  import evaluates before the entry point's own `app.setPath("userData", …)` and `app.enableSandbox()`.
- The window-bounds recorder takes `readBounds` / `writeBounds` rather than a path, so it decides
  *when* to persist and the caller decides *where*. That matches how `ensureMacApplicationPresence`
  and `presentMainWindow` in the same file already take their effects, and it is what makes "how
  often did it write" — the entire point of the debounce, and not visible from the saved file —
  observable to a test.
- `flushMainWindowBounds` still clears the debounce **before its first `await`** — Windows
  `query-session-end` calls it from a synchronous handler and never awaits it. There is now a test
  for that ordering specifically.
- `configureAttachmentProtocol` runs while `remoteServerManager` is still null; the null branches
  inside its handlers are that window, not defensive padding, so the read stays inside the async
  handler at the position it was at.

## Three things I deliberately did not move

Each was in scope and cut on safety grounds:

1. **`forwardCentralAuth`** — not a forwarder but an account-transition state machine. It is
   registered while `hostService`, `hostAnalytics` and `remoteServerManager` are *all* still null,
   and its `++centralAuthGeneration` protects "only the account the renderer was last told about may
   have its host activated" — a data-exposure invariant on a Non-negotiable boundary. The generation
   counter itself is untested: `centralAuthGeneration` appears in `index.ts` and nowhere else in the
   repo. (`host-service.test.ts` does cover the HostService side of the transition — `unbind`, and
   re-binding the same account — with a helper modelled on this function, so the gap is the counter
   rather than the whole flow.) It should move as a tested coordinator, in a PR that adds the
   coverage for the counter first, and that needs it out of the unimportable entry point to test at
   all.
2. **`protocol.registerSchemesAsPrivileged`** — rollup evaluates a sibling module's top level before
   `index.ts`'s body, so moving it would relocate the call above `app.setPath` / `app.enableSandbox`,
   and would falsify an invariant stated in both `src/main/AGENTS.md` and this test file's own header.
3. **`configureApplicationProtocol`** — unverifiable in dev (`loadRenderer` uses
   `ELECTRON_RENDERER_URL`, so `openbot-app://` is never requested) and it holds the renderer
   path-traversal guard. Untested security code that cannot be smoke-checked should not move in a
   no-behaviour-change PR.

## Tests

Four new cases in `main-window-state.test.ts`, on fake timers: a burst of moves coalescing into one
write, the position surviving a relaunch, the flush cancelling a pending write before it yields, and
the write chain surviving a failed write. Plus the one decoder-bijection case in
`ipc-channel-coverage.test.ts`, with a floor assertion so a regex that stops matching goes red
instead of passing with two empty sets.

**Watched them fail**, each for its own reason:

| Break | Result |
| --- | --- |
| rename `decodeBrowserPreviewFromMain` → `decodeBrowserPreview` | red, naming the orphaned `FromHost` twin in the set diff |
| break the decoder regex to `xdecode` | red on the floor: `expected 0 to be greater than or equal to 8` |
| raise `BOUNDS_WRITE_DELAY_MS` to 2500 | coalescing case red (no write inside the window) |
| drop the `clearTimeout` from `rememberMainWindowBounds` | coalescing case red with all three writes listed: `expected [ { x: 10, … }, …(2) ] to deeply equal [ { x: 60, … } ]` |
| move the timer clear *after* the first `await` in `flushMainWindowBounds` | ordering case red: two writes where one was expected — the pending debounce fired and queued a second |
| drop the absorbing `.catch` before the chain's `.then` | "keeps saving after a write fails" red |

All restored afterwards; 14/14 and 11/11 green. Re-verified after the review changes, since the
recorder's test seam changed.

## Surfaces touched

**Desktop main process only.** Not the renderer, not mobile, not the public web, not
`packages/contracts`, not the IPC channel list, not migrations, not the mock in
`src/renderer/src/preview/mock-openbot.ts`. Docs updated: `src/main/AGENTS.md` (what index.ts owns
now, and that the decoder split is enforced rather than merely commented), plus the header comments
in `src/preload/index.ts` and `src/main/remote-host-decoding.ts`.

## Review round 1

`NorbiAI` raised three findings; all three had their facts right. Two are fixed here:

- **P3, the state-path getter solved an ordering problem that does not exist.** Correct — I had
  placed the construction site below both `app.setPath` and `MAIN_WINDOW_STATE_FILE` precisely to
  avoid the hazard, then kept the getter and its now-false rationale. Replaced with injected
  `readBounds` / `writeBounds` and a path resolved once.
- **P3, the speculative server-manager getter on `configureServerLogoProtocols`.** Correct —
  `remoteServerManager` is assigned once at `index.ts:1091`, never reset to null, and the logo
  protocols are configured at 1190, so that null branch was unreachable. It now takes the manager
  directly. This reverses a line in the plan I was working from, which asked for the getter to keep
  the two functions symmetric; the comment on `configureAttachmentProtocol` now carries that reason
  where it is actually load-bearing instead.
- **P2, direct aliases evade the guard.** The hole is real: `const decodeXFromMain = sharedDecoder`
  keeps both names and stays green. In round 1 I only corrected the test's own comment, which had
  overclaimed, and argued against the suggested fix. Round 2 changed that — see below.

## Review round 2

Both P3s from round 1 came back resolved. One finding remained and one was new; I took both.

- **P2, direct aliases (now fixed).** My round-1 objection was to rejecting `const` wholesale,
  because `remote-agent-decoding.ts:162` legitimately spells a decoder
  `const decodeRoutine = guardedDecoder(...)`. The refined suggestion is narrower than that and my
  objection does not reach it: reject a suffixed `const` whose **initializer is a bare reference**,
  and every factory call stays accepted. That distinction is lexical, so a source scan can make it.
  New test, `declares each twin decoder rather than aliasing the other`.

  It needed one thing the reviewer did not ask for. Every twin in the tree is a `function`, so this
  pattern matches nothing today, and `AGENTS.md` is explicit that a pattern matching nothing is green
  and enforces nothing — that is how a rule stayed blind to `querySelector<HTMLElement>` for months.
  So the test carries an inline fixture the way a rule under `tools/biome/anti-slop/rules` does:
  two alias spellings it must reject beside three correct declarations it must leave alone.

  Still not covered, and the test says so: a wrapper that forwards to the other decoder. That is
  review's job.

## Review round 3

- **P2, the same finding, one real hole left in my fix.** The annotation the scan skips over can
  itself be a function type, so `const decodeXFromMain: (value: unknown) => X = other` was read from
  the arrow onwards and escaped. I had seen this case while writing the pattern and judged it
  fails-open-and-therefore-fine; that was the wrong call for a guard whose whole job is to close the
  cheap spelling. The annotation now consumes `=>`, and `decodeSignedFromMain` is a fourth fixture
  line. Watch-it-fail: reverting just that alternation goes red naming `decodeSignedFromMain` and
  nothing else.
- **P3, the blanket dependency rule in `src/main/AGENTS.md`.** Correct and my own overreach — I wrote
  that these modules take every dependency as a function, in the same PR that changed
  `configureServerLogoProtocols` to take a value on the reviewer's round-1 advice. The rule now
  covers only a dependency that may not exist yet when the module is wired, and names
  `configureServerLogoProtocols` and the IPC registrars as the counter-case, so it can no longer be
  read as an argument for the speculative getter this PR removed.

## Verification gaps

Ran: `bun run typecheck`, `bun run lint`, `bun run test:desktop -- src/main/ipc-channel-coverage.test.ts`
(15 pass), `bun run test:desktop -- src/main/main-window-state.test.ts` (11 pass). CI owns the wide
suites.

Watch-it-fail on the decoder-alias test, both halves: aliasing a real twin in the preload
(`const decodeBrowserPreviewFromMain = decodeBrowserPreviewFromHost`) went red naming the file, and
narrowing the pattern to `export const` went red on the fixture instead — so neither half is a
costume.

I have **not** smoke-checked this on a running app. Worth knowing which parts a manual check could
not have covered anyway: 7 of the 11 forwarders have no achievable local check —
`forwardUpdateStatus` needs a packaged build, `forwardVoiceModelStatus` a model download, and the
remote-desktop / presence / direct-message forwarders a second peer. The three `openbot-remote-*`
protocol paths need a joined remote server. So the exact code paths getter injection is most likely
to break are the ones that cannot be verified locally — which is the argument for the
function-typed-dependency rule above, and the reason to read those five getters closely in review.

## Approvability

No `biome-ignore`, `@ts-expect-error`, `@ts-ignore`, `biome.json` override, or widening to `any` or
`unknown`. `bun run lint` reports the same 5 pre-existing warnings as `main` (all in
`apps/mobile/.../mobile-auth.test.ts`).

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


