### PR TITLE
ci: check the remote stack's scripts and Compose files, and fix the image's pruned install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,13 @@ jobs:
     # first break at release time rather than on the pull request that broke
     # them. Mobile's typecheck generates `expo-env.d.ts` and the uniwind
     # declarations first - both are gitignored, so a fresh checkout cannot
-    # resolve `global.css`. `remote/api` is typechecked here rather than through
-    # `remote:check`, which also validates both Compose files and so needs
-    # Docker; the workspace's own `check` script needs nothing but Bun, and its
-    # `include` reaches `../scripts/*.ts` so the stack scripts come with it.
+    # resolve `global.css`. `remote/api` is typechecked through the workspace's
+    # own script rather than through `remote:check`, so that the tests it also
+    # runs stay in the Tests job; its `include` reaches `../scripts/*.ts`, so the
+    # stack scripts come with it. `remote:check:compose` is the rest of
+    # `remote:check`: `docker compose config` interpolates client-side and never
+    # opens a socket, so it validates both Compose files on a runner with no
+    # daemon.
     name: Surfaces
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -92,6 +95,9 @@ jobs:
 
       - name: Typecheck remote API
         run: bun run typecheck:remote
+
+      - name: Validate the remote Compose files
+        run: bun run remote:check:compose
 
   api:
     name: API

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
     # declarations first - both are gitignored, so a fresh checkout cannot
     # resolve `global.css`. `remote/api` is typechecked here rather than through
     # `remote:check`, which also validates both Compose files and so needs
-    # Docker; the workspace's own `check` script needs nothing but Bun.
+    # Docker; the workspace's own `check` script needs nothing but Bun, and its
+    # `include` reaches `../scripts/*.ts` so the stack scripts come with it.
     name: Surfaces
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -193,7 +194,11 @@ jobs:
   deploy-production:
     name: Deploy Cloudflare production
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [check, tests, api, storybook]
+    # `surfaces` gates the deploy even though the Worker it ships lives in
+    # `apps/auth-api`, which `api` already covers: mobile, the site router, the
+    # team client and the remote stack all consume the account API, so a red
+    # Surfaces is the signal that this deploy is the thing about to break them.
+    needs: [check, tests, api, storybook, surfaces]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: cloudflare-production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,11 +48,12 @@ gitignored, so the aggregate still leaves your diff alone.
 `remote/api` is in the glob for the same reason, as `typecheck:remote`. Its tests cover ticket
 verification, session revocation and TURN credentials — the Signal service's whole auth boundary —
 and when the workspace arrived nothing ran them, because its only entry point was `remote:check`,
-which also validates both Compose files and so needs Docker that CI does not have. The workspace's
-own `check` needs nothing but Bun and finishes in three seconds, so the two halves are split —
-`typecheck:remote` and `test:remote` — and run in Surfaces and Tests beside the other non-desktop
-surfaces. `remote:check` is still the Docker-inclusive superset; run it when you touch a Compose
-file. Nothing in CI builds the image either, and its Dockerfile installs from a pruned checkout —
+which also validates both Compose files. The workspace's own `check` needs nothing but Bun and
+finishes in three seconds, so the halves are split — `typecheck:remote` and `test:remote` run in
+Surfaces and Tests beside the other non-desktop surfaces, and `remote:check:compose` is the rest.
+`docker compose config` interpolates client-side and never opens a socket, so the Compose half needs
+the docker CLI but no daemon and runs in Surfaces too; `remote:check` remains the local superset.
+Nothing in CI builds the image, though, and its Dockerfile installs from a pruned checkout —
 one `COPY` per workspace — so a `workspace:*` dependency added to the root manifest breaks
 `remote:up` while every job stays green. `scripts/dependency-catalog.test.ts` is what notices now:
 it walks the workspace dependency graph and asserts a manifest is copied for each one it reaches.
@@ -75,7 +76,7 @@ files it reads. CI owns all of it on every push:
 | --- | --- | --- |
 | Check | `macos-14` | `bun run check:desktop` |
 | Tests | `ubuntu-latest` | `bun run test:desktop`, `bun run test:sites`, `bun run test:remote` |
-| Surfaces | `ubuntu-latest` | `bun run mobile:typecheck`, `bun run typecheck:sites`, `bun run typecheck:team-client`, `bun run typecheck:remote` |
+| Surfaces | `ubuntu-latest` | `bun run mobile:typecheck`, `bun run typecheck:sites`, `bun run typecheck:team-client`, `bun run typecheck:remote`, `bun run remote:check:compose` |
 | API | `ubuntu-latest` | `bun run check:api` |
 | Storybook build | `ubuntu-latest` | `bun run build-storybook` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,10 @@ which also validates both Compose files and so needs Docker that CI does not hav
 own `check` needs nothing but Bun and finishes in three seconds, so the two halves are split —
 `typecheck:remote` and `test:remote` — and run in Surfaces and Tests beside the other non-desktop
 surfaces. `remote:check` is still the Docker-inclusive superset; run it when you touch a Compose
-file.
+file. Nothing in CI builds the image either, and its Dockerfile installs from a pruned checkout —
+one `COPY` per workspace — so a `workspace:*` dependency added to the root manifest breaks
+`remote:up` while every job stays green. `scripts/dependency-catalog.test.ts` is what notices now:
+it walks the workspace dependency graph and asserts a manifest is copied for each one it reaches.
 
 `remote/scripts` rides along in that same project. `check.ts` and `update.ts` are Bun scripts
 using `Bun.spawn` and `import.meta.dir`, and no `tsconfig` reached them: `tsconfig.node.json` stops

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@ own `check` needs nothing but Bun and finishes in three seconds, so the two halv
 surfaces. `remote:check` is still the Docker-inclusive superset; run it when you touch a Compose
 file.
 
+`remote/scripts` rides along in that same project. `check.ts` and `update.ts` are Bun scripts
+using `Bun.spawn` and `import.meta.dir`, and no `tsconfig` reached them: `tsconfig.node.json` stops
+at the root `scripts/**` and pins `"types": ["node"]`, which is why all thirty root scripts use the
+`Bun` global exactly zero times. Adding `@types/bun` at the root would have made Bun globals
+resolvable repo-wide, including in `src/main`, which runs under Node. Instead `remote/api` already
+had the Bun-typed project the scripts needed, so its `include` carries `../scripts/*.ts` and
+`typecheck:remote` covers both. `update.ts` drains and force-recreates the live coturn container, so
+it is worth a checker.
+
 Do not run `bun run check`, `check:desktop`, `test`, or `build-storybook`: each takes minutes, and
 the desktop suite flakes under load, so a red result tells you nothing about your change. That is
 where the line falls — how long a command takes and whether you can trust its result, not how many
@@ -66,6 +75,9 @@ files it reads. CI owns all of it on every push:
 | Surfaces | `ubuntu-latest` | `bun run mobile:typecheck`, `bun run typecheck:sites`, `bun run typecheck:team-client`, `bun run typecheck:remote` |
 | API | `ubuntu-latest` | `bun run check:api` |
 | Storybook build | `ubuntu-latest` | `bun run build-storybook` |
+
+All five gate the Cloudflare production deploy on a push to `main`. Surfaces did not until recently,
+so a red mobile, site-router, team-client or remote typecheck let the deploy through.
 
 `bun run test:desktop -- <path>` runs one desktop file. Need something wider? Ask for it. Permission
 covers the one command named — not another one, not a build, not a packaged app.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Use `bun run dev:seed --dry-run` to inspect the target and fixture counts withou
 | `bun run api:deploy` | Build and deploy the account API to Cloudflare Workers. |
 | `bun run remote:up` | Build and start the self-hosted Signal, coturn, and ACME stack. |
 | `bun run remote:check` | Check the Remote API and both Docker Compose configurations. |
+| `bun run remote:check:compose` | Validate both Docker Compose configurations alone, without a running daemon. |
 | `bun run remote:update` | Update Signal, then drain and update the single coturn instance. |
 | `bun run dev:all` | Start the Auth API, Signal service, and single local Electron instance. |
 | `bun run dev:test-client` | Start the Auth API, Signal service, local instance, and an isolated second client for team testing. |

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "remote:down": "remote/bin/dotenvx run --overload -f remote/.env.production -fk remote/.env.keys -- docker compose -f remote/compose.yaml down",
     "remote:logs": "remote/bin/dotenvx run --overload -f remote/.env.production -fk remote/.env.keys -- docker compose -f remote/compose.yaml logs -f remote-api coturn",
     "remote:check": "bun remote/scripts/check.ts",
+    "remote:check:compose": "bun remote/scripts/check.ts --compose",
     "remote:env:validate": "cd remote && bin/dotenvx validate -f .env.production -fk .env.keys",
     "remote:update": "remote/bin/dotenvx run --overload -f remote/.env.production -fk remote/.env.keys -- bun remote/scripts/update.ts",
     "env:encrypt:dev": "bun run --cwd apps/auth-api env:encrypt:dev",

--- a/remote/api/Dockerfile
+++ b/remote/api/Dockerfile
@@ -5,6 +5,8 @@ COPY patches ./patches
 COPY apps/auth-api/package.json ./apps/auth-api/package.json
 COPY packages/brand/package.json ./packages/brand/package.json
 COPY packages/contracts/package.json ./packages/contracts/package.json
+COPY packages/logging/package.json ./packages/logging/package.json
+COPY packages/team-client/package.json ./packages/team-client/package.json
 COPY remote/api/package.json ./remote/api/package.json
 RUN bun install --production --ignore-scripts --frozen-lockfile --filter @openbot/remote-api
 

--- a/remote/api/tsconfig.json
+++ b/remote/api/tsconfig.json
@@ -8,5 +8,5 @@
     "noEmit": true,
     "types": ["bun"]
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "../scripts/*.ts"]
 }

--- a/remote/scripts/check.ts
+++ b/remote/scripts/check.ts
@@ -22,10 +22,19 @@ const environment = {
   TURN_SHARED_SECRET: process.env.TURN_SHARED_SECRET ?? "t".repeat(32),
 };
 
-await run(["run", "--cwd", "remote/api", "check"]);
+// `docker compose config` parses and interpolates client-side and never opens a
+// socket, so the Compose half runs anywhere the docker CLI exists - including a
+// GitHub runner, which has the CLI but no useful daemon. `--compose` selects that
+// half alone, because CI already runs the workspace's typecheck and tests as
+// their own steps and has no reason to pay for them twice.
+const composeOnly = process.argv.includes("--compose");
+
+if (!composeOnly) await run(["run", "--cwd", "remote/api", "check"]);
 await composeCheck("remote/compose.yaml");
 await composeCheck("remote/compose.dev.yaml");
-console.log("Remote API and Docker Compose configuration are valid.");
+console.log(
+  composeOnly ? "Docker Compose configuration is valid." : "Remote API and Docker Compose configuration are valid.",
+);
 
 async function composeCheck(file: string): Promise<void> {
   const args = ["compose"];

--- a/scripts/dependency-catalog.test.ts
+++ b/scripts/dependency-catalog.test.ts
@@ -164,6 +164,11 @@ describe("remote API Dockerfile", () => {
   });
 });
 
+// Every field, not just `dependencies`, even though the image installs with
+// `--production`. Today every workspace edge in the repo is a plain dependency, so
+// the difference is inert; the bias is deliberate for when it stops being. Naming a
+// workspace the pruned install turns out not to need costs one harmless COPY line,
+// and missing one costs the image.
 function workspaceDependencies(manifest: string): string[] {
   return readDependencies(manifest)
     .filter(([, , version]) => version.startsWith("workspace:"))

--- a/scripts/dependency-catalog.test.ts
+++ b/scripts/dependency-catalog.test.ts
@@ -7,6 +7,9 @@
 // ended up on typescript@5.9.3 while the rest ran 7.0.2, and mobile on a different
 // zod than the desktop app. This test is what keeps the catalog from decaying into
 // a comment.
+//
+// The second describe covers the other fact about these manifests that nothing
+// else enforces: which of them the remote API image has to carry.
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
@@ -121,6 +124,51 @@ describe("dependency catalog", () => {
     expect(conflicting).toEqual([]);
   });
 });
+
+// The remote API image installs from a pruned checkout: the Dockerfile copies the
+// root manifest and lockfile, then one manifest per workspace, and runs
+// `bun install --frozen-lockfile --filter @openbot/remote-api`. Bun refuses that
+// install unless every workspace the remaining ones depend on is on disk, so a new
+// `workspace:*` entry in the root manifest breaks the production image while every
+// job in CI stays green - none of them builds this image. That is not hypothetical:
+// the root package gained `@openbot/logging` and `@openbot/team-client` without the
+// matching COPY lines, and `bun run remote:up` had been failing on
+// `the root package depends on workspace "@openbot/logging" (packages/logging),
+// which is listed in bun.lock but not on disk`.
+describe("remote API Dockerfile", () => {
+  it("copies a manifest for every workspace the pruned install needs", () => {
+    const directoryOf = new Map(
+      workspaces.map((directory) => [readManifest(`${directory}/package.json`).name, directory]),
+    );
+    const required = new Set<string>();
+    const pending: unknown[] = [...workspaceDependencies("package.json"), "@openbot/remote-api"];
+    while (pending.length > 0) {
+      const name = pending.pop();
+      if (!isString(name) || required.has(name)) continue;
+      required.add(name);
+      const directory = directoryOf.get(name);
+      if (isString(directory)) pending.push(...workspaceDependencies(`${directory}/package.json`));
+    }
+
+    // Extra COPY lines are harmless - bun prunes whatever nothing depends on - so
+    // this asserts the set that must be present, never the exact list.
+    const dockerfile = readFileSync(join(repositoryRoot, "remote/api/Dockerfile"), "utf8");
+    const copied = [...dockerfile.matchAll(/^COPY (\S+\/package\.json) /gm)].map((match) => match[1]);
+    const missing = [...required]
+      .map((name) => directoryOf.get(name))
+      .filter(isString)
+      .filter((directory) => !copied.includes(`${directory}/package.json`))
+      .sort();
+
+    expect(missing).toEqual([]);
+  });
+});
+
+function workspaceDependencies(manifest: string): string[] {
+  return readDependencies(manifest)
+    .filter(([, , version]) => version.startsWith("workspace:"))
+    .map(([, name]) => name);
+}
 
 function readManifest(path: string): DynamicRecord {
   const parsed = JSON.parse(readFileSync(join(repositoryRoot, path), "utf8"));


### PR DESCRIPTION
Follow-up to #249, which wired `remote/api`'s typecheck and tests into CI. Auditing the neighbourhood turned up three more gaps in the same area, one of them a live bug on `main`.

> **Note on reading this PR:** the description below replaces an earlier one. The first approach here added a `remote/scripts` workspace with its own `package.json`, `tsconfig.json`, `typecheck:remote-scripts` script, catalog entry and CI step. A review finding pointed out that `remote/api` already had the Bun-typed project those files needed, and it was right — all seven of those artifacts were reverted in favour of one line. None of that machinery is in this diff.

## 1. `remote/scripts` had no checker

`check.ts` and `update.ts` use `Bun.spawn` and `import.meta.dir`, and no `tsconfig` reached them. They cannot join `tsconfig.node.json`, which pins `"types": ["node"]`:

```
remote/scripts/check.ts(4,34): error TS2339: Property 'dir' does not exist on type 'ImportMeta'.
remote/scripts/check.ts(33,19): error TS2868: Cannot find name 'Bun'.
```

That pin is load-bearing — it is why all thirty root scripts use the `Bun` global exactly zero times — and adding `@types/bun` at the root would make Bun globals resolvable in `src/main`, which runs under Node. `remote/api` already had a `"types": ["bun"]` project one directory over, so its `include` now carries `../scripts/*.ts` and `typecheck:remote` covers both. One line.

## 2. Surfaces did not gate the production deploy

`deploy-production` was `needs: [check, tests, api, storybook]`. On a push to `main`, a red mobile, site-router, team-client or remote typecheck did not stop the Cloudflare deploy. Added, with a comment on why a job typechecking non-Worker surfaces gates a Worker deploy: they are all consumers of the account API being shipped.

## 3. The remote API image could not build — a live bug on `main`

`remote/api/Dockerfile` installs from a pruned checkout: root manifest and lockfile, one `package.json` per workspace, then `bun install --frozen-lockfile --filter @openbot/remote-api`. It copied four manifests, but the root package depends on `@openbot/logging` and `@openbot/team-client` via `workspace:*`, and bun refuses a pruned checkout missing a workspace its remaining workspaces depend on:

```
error: the root package depends on workspace "@openbot/logging" (packages/logging),
which is listed in bun.lock but not on disk
```

So `bun run remote:up` was broken, and reproduces identically on `origin/main` — this predates both this PR and #249. No CI job builds this image, which is why nothing noticed.

Fixed with two `COPY` lines. Docker's daemon was unavailable locally, so I verified by replaying the dependency stage as a script that reads the COPY list out of the Dockerfile itself, so it cannot drift from the real one: before, 4 manifests and exit 1 on the error above; after, 6 manifests and exit 0 with 25 packages installed.

The guard extends `scripts/dependency-catalog.test.ts`, which already parses every workspace manifest and owns the helpers this needs, rather than adding a file. It walks the `workspace:*` graph from the root package and `@openbot/remote-api` and asserts the Dockerfile copies a manifest for each workspace reached. It asserts a required *set*, never the exact list — extra `COPY` lines are harmless, since bun prunes what nothing depends on.

## 4. The Compose files were checkable in CI all along

#249 and the first version of this PR both claimed `remote:check` "needs Docker that CI does not have." That is wrong, and I wrote it. `composeCheck` is `docker compose config --quiet`, which interpolates and validates client-side and never opens a socket. With the daemon down:

```
$ docker info >/dev/null 2>&1 && echo UP || echo DOWN
DOWN
$ docker compose -f remote/compose.yaml config --quiet ; echo $?
0
$ docker compose -f remote/compose.dev.yaml config --quiet ; echo $?
0
```

`ubuntu-latest` ships the docker CLI, so `remote:check:compose` (a `--compose` flag on the existing script) now runs in Surfaces — and passed there on this PR, which is the real confirmation. The flag exists so Surfaces does not re-run the typecheck and tests it already runs as separate steps, and so the twelve env defaults those files interpolate stay in the script instead of being copied into the workflow. `remote:check` is unchanged as the local superset.

## Watch it fail

Every check added here was broken deliberately and confirmed red for the intended reason, then restored.

**The typecheck**, broken through `Bun.spawn` and `import.meta.dir` specifically, so this also proves the Bun types resolve rather than the project silently matching no files:

```
../scripts/check.ts(42,7): error TS2322: Type 'number' is not assignable to type 'string'.
../scripts/update.ts(37,7): error TS2322: Type 'number' is not assignable to type 'string'.
```

**The Dockerfile guard**, in both directions — the second matters more, since it is the regression the test actually exists to stop:

- revert the Dockerfile → `expected [ 'packages/logging', 'packages/team-client' ] to deeply equal []`
- keep the fix, add a fake root `"@openbot/site-router": "workspace:*"` → `expected [ 'apps/site-router' ] to deeply equal []`

**The Compose validation**, once per file, because a second call that never runs enforces half of what it claims:

- bogus key in `compose.yaml` → `validating .../remote/compose.yaml: services.acme additional properties 'not_a_real_key' not allowed`, exit 1
- bogus key in `compose.dev.yaml` only → `validating .../remote/compose.dev.yaml: services.remote-api.build additional properties 'bogus_field' not allowed`, exit 1

## Checked, no change needed

- **No dangling symlinks in the image.** `remote/api` declares no `@openbot/*` dependency and imports none, so stage two needs no workspace directories on disk. The manifests matter only for install-time validation, which is what the guard models.
- **The guard's model.** It walks the graph from the root package, matching the error bun emits. If bun instead required the deps of every workspace present on disk it would under-cover, since `apps/auth-api` is copied without the root depending on it — but the root requires `{brand, contracts, logging, team-client}`, a superset of every workspace's deps in this repo, so the two models are currently indistinguishable. I could not construct a separating case without editing a manifest, which `--frozen-lockfile` rejects for an unrelated reason. Left as is rather than adding a branch I cannot watch fail.
- **`remote/coturn/Dockerfile`** runs no install, and both Compose files build from the one Dockerfile fixed here.

## Still not covered

Nothing builds the image. `docker build -f remote/api/Dockerfile .` in CI would catch this class outright rather than by proxy, for roughly 1–2 minutes a run. That is a CI-minutes decision, so it is not in this PR.

## Surfaces touched

CI configuration, build configuration, one deployment Dockerfile, one tooling test, and documentation (`AGENTS.md`, and the `README.md` command table for the new script). No product code — `check.ts`'s runtime behaviour is unchanged when the flag is absent. No renderer, mobile, IPC contract, migration, or Team API wire change.

## Checks

- `bun run lint` — clean. 5 warnings, all pre-existing `no-module-mocking` in `apps/mobile/src/features/auth/api/mobile-auth.test.ts`, untouched here.
- `bun run typecheck` — green across all eleven projects.
- `bun run remote:check` — typecheck, 21 tests, both Compose files.
- `bun run test:desktop -- scripts/dependency-catalog.test.ts` — 6 passed.
- All CI checks green, including the new Compose step in Surfaces.

Auto-approvable: no `biome-ignore`, no `@ts-expect-error`, no `overrides` entry, no widened type.

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)