### PR TITLE
test(tooling): widen the mobile vitest glob to the whole app

### DIFF
--- a/scripts/test-collection.test.ts
+++ b/scripts/test-collection.test.ts
@@ -1,0 +1,82 @@
+// A test file no runner collects is green forever. `vitest run` never imports it, no
+// report names it, and the only signal is a number nobody has a baseline for. The root
+// config's include list is an allowlist of directories, so a test written outside one
+// passes locally by never running: that is how the mobile glob stayed pinned to
+// `apps/mobile/src/features/auth/api` while reading like it covered the app. The next one
+// is `apps/mobile/src/foo.test.tsx`, which matches the node project's `*.test.ts` never
+// and the renderer project's `src/renderer` root never.
+//
+// So the tracked tree is the source of truth and `vitest list` is asked what it collects.
+// Every tracked test file is accounted for by exactly one of three answers: the root run
+// collects it, a workspace with its own test script owns it, or it is a fixture that is
+// read rather than run.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = resolve(import.meta.dirname, "..");
+
+// Workspaces the root run leaves alone because they have a runner of their own, which CI
+// invokes as `test:sites`, `test:remote` and `check:api`. Each entry is checked below to
+// still have that script, so a workspace cannot lose its runner and keep its exemption.
+const delegatedWorkspaces = ["apps/auth-api", "apps/site-router", "remote/api"];
+
+// Input to scripts/ui-foundation-check.test.ts, which reads these as text to prove the
+// check skips test files. They assert nothing, so collecting them would be meaningless.
+const readNotRun = ["tools/ui-foundation/fixtures/"];
+
+// `--others --exclude-standard` adds the files git would accept but has not been given
+// yet, so the test a developer is writing right now is checked before it is committed,
+// while .gitignore still keeps node_modules and every build directory out.
+function trackedTestFiles(): string[] {
+  const tracked = execFileSync("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  });
+  return tracked.split("\0").filter((path) => /\.test\.tsx?$/u.test(path));
+}
+
+// `--filesOnly` globs the include patterns without importing a single test file, so this
+// costs a subprocess and no test run. Lines are `[project] path/from/the/repository/root`.
+function collectedTestFiles(): string[] {
+  const listed = execFileSync(join(repositoryRoot, "node_modules/.bin/vitest"), ["list", "--filesOnly"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  });
+  return listed
+    .split("\n")
+    .map((line) => line.replace(/^\[[^\]]+\]\s+/u, "").trim())
+    .filter((line) => line.length > 0);
+}
+
+// The one field this file reads out of a package manifest.
+type WorkspaceManifest = { scripts?: { test?: string } };
+
+function hasOwnRunner(workspace: string): boolean {
+  const manifest: WorkspaceManifest = JSON.parse(readFileSync(join(repositoryRoot, workspace, "package.json"), "utf8"));
+  return typeof manifest.scripts?.test === "string";
+}
+
+describe("test collection", () => {
+  const tracked = trackedTestFiles();
+
+  it("hands every tracked test file to a runner", () => {
+    // Without this the assertion below passes on an empty list, which is the failure it
+    // exists to catch: a check that enforces nothing because it found nothing.
+    expect(tracked.length).toBeGreaterThan(100);
+
+    const collected = new Set(collectedTestFiles());
+    const exempt = [...delegatedWorkspaces.map((workspace) => `${workspace}/`), ...readNotRun];
+    const uncollected = tracked.filter(
+      (path) => !collected.has(path) && !exempt.some((prefix) => path.startsWith(prefix)),
+    );
+
+    expect(uncollected).toEqual([]);
+  });
+
+  it("keeps a runner of its own in every workspace the root run skips", () => {
+    expect(delegatedWorkspaces.filter((workspace) => !hasOwnRunner(workspace))).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
             "packages/contracts/**/*.test.ts",
             "packages/logging/**/*.test.ts",
             "packages/team-client/**/*.test.ts",
-            "apps/mobile/src/features/auth/api/*.test.ts",
+            "apps/mobile/src/**/*.test.ts",
           ],
           exclude: [...configDefaults.exclude, "**/*.dom.test.ts"],
         },


### PR DESCRIPTION
## What

`vitest.config.ts` included `apps/mobile/src/features/auth/api/*.test.ts` in the `node` project. That glob is exact today only because `mobile-auth.test.ts` is the only mobile test — a test added anywhere else under `apps/mobile` would pass locally by never running, with nothing reporting it. Every other entry in that include list is already `<root>/**/*.test.ts`; the mobile one now matches.

```diff
-            "apps/mobile/src/features/auth/api/*.test.ts",
+            "apps/mobile/src/**/*.test.ts",
```

## Watch it fail

Not a new test, so the check is on collection rather than on a red assertion. I dropped a throwaway `apps/mobile/src/glob-probe.test.ts` outside the auth directory and ran `bunx vitest list apps/mobile` against both configs:

- old glob: 0 occurrences of `glob-probe` — the file silently never ran, which is the bug;
- new glob: collected, and `apps/mobile/src/features/auth/api/mobile-auth.test.ts` still collected in full.

Probe file removed. `apps/mobile/node_modules` cannot leak in — `configDefaults.exclude` still filters it, and `*.test.tsx` still routes to the `renderer` project, which only includes `src/renderer`.

## Surfaces

Build and test configuration only. No renderer, mobile, public web, Signal service, IPC contract, migration or documentation change.

## Checks

`bun run lint` and `bun run typecheck` pass. Lint's 5 warnings are pre-existing and in unrelated mobile source. The pre-commit `check:staged` (biome, `check:ui`, all eleven `typecheck` projects) passed.

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: the NorbiAI P2, fixed in `89905f44`

The review was right that widening the glob fixed the one pinned file without closing the hole — `apps/mobile/src/foo.test.tsx` still matches the node project's `*.test.ts` never and the renderer project's `src/renderer` root never, so it would be green forever by never running.

I took the second of the two remedies the finding offered — the collection guard, not a mobile Vitest project. A React Native test project with its own transform and setup, for a surface with zero component tests, is infrastructure guessed ahead of its first user; the guard closes the whole class instead, mobile included, and fires on `packages/brand/x.test.ts` just as well.

`scripts/test-collection.test.ts` takes the tracked tree as the source of truth and asks `vitest list --filesOnly` what the root run actually collects — no second glob matcher to drift from the config. Every test file must be accounted for by one of three answers: the root run collects it, a workspace with its own `test` script owns it (`apps/auth-api`, `apps/site-router`, `remote/api` — each verified to still have that script, so a workspace cannot lose its runner and keep its exemption), or it is a `tools/ui-foundation/fixtures` file read as text rather than run. `git ls-files --others --exclude-standard` includes the file a developer has not committed yet, so it fires before the commit rather than in CI.

Today the arithmetic is exact: 248 tracked test files, 37 delegated or fixture, 211 collected.

### Watch it fail

- Dropped `apps/mobile/src/probe.test.tsx` — the exact file from the finding: `expected [ 'apps/mobile/src/probe.test.tsx' ] to deeply equal []`. Reported by name.
- Deleted `apps/site-router`'s `test` script — `expected [ 'apps/site-router' ] to deeply equal []`, rather than quietly excusing its 1 test file.
- The `toBeGreaterThan(100)` line is there because the interesting failure of a check like this is enumerating nothing and passing.

Both probes reverted. `bun run test:desktop -- scripts/test-collection.test.ts` passes in 395 ms; the subprocess globs include patterns without importing a test file.
