### PR TITLE
chore(tooling): show every lint finding instead of the first 20

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,12 @@ version and the `.env.keys` `.worktreeinclude` carries across.
 Before you call a task done, run the narrowest test for what you touched, then `bun run lint` and
 `bun run typecheck` — plus `bun run check:ui` if you touched `src/renderer`, which scans the whole
 renderer in 60 ms. All three read more than you changed on purpose and none is expensive: `lint` is
-`biome check .` across every file in about six seconds, `typecheck` is eleven `tsc` projects in about
-four. The wide typecheck is the more useful one — a change in `packages/contracts` surfaces as an
-error in `src/renderer` or `src/main`, which a single `tsc -p` on the project you edited never sees.
+`biome check --max-diagnostics=none .` across every file in about six seconds, `typecheck` is eleven
+`tsc` projects in about four. The wide typecheck is the more useful one — a change in
+`packages/contracts` surfaces as an error in `src/renderer` or `src/main`, which a single `tsc -p`
+on the project you edited never sees. The `lint` flag is load-bearing: Biome caps a report at 20
+diagnostics by default, and it prints the honest total but not the findings past the cap, so a
+cleanup pass without it costs one full-repo run per 20.
 
 `bun run typecheck` is `typecheck:*`, and `typecheck:mobile` is in that glob, so `apps/mobile` is
 checked with everything else — it depends on `@openbot/brand`, `@openbot/contracts` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,10 +89,10 @@ so a red mobile, site-router, team-client or remote typecheck let the deploy thr
 `bun run test:desktop -- <path>` runs one desktop file. Need something wider? Ask for it. Permission
 covers the one command named — not another one, not a build, not a packaged app.
 
-`bun run format` is the one fast command to leave alone: it is `biome check --write .`, so it
-rewrites files your task never touched and puts them in your diff. Fix what you changed with
-`biome check --write <paths>`, or let the pre-commit hook's `bun run check:staged` do it over the
-staged set.
+`bun run format` is the one fast command to leave alone: it is
+`biome check --write --max-diagnostics=none .`, so it rewrites files your task never touched and
+puts them in your diff. Fix what you changed with `biome check --write <paths>`, or let the
+pre-commit hook's `bun run check:staged` do it over the staged set.
 
 ## Hit every surface
 

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -43,7 +43,7 @@ bun run doctor               # diagnose dependency and config issues
 bunx expo install --fix      # fix incompatible package versions
 ```
 
-Both are scoped to this app: `lint` is `biome check src` and `typecheck` runs `codegen` before `tsc`. See "Execution and verification limits" above for when to run them, and `AGENTS.md` "CI owns the minutes-long suites" for the repository-wide commands worth avoiding and why.
+Both are scoped to this app: `lint` is `biome check --max-diagnostics=none src` and `typecheck` runs `codegen` before `tsc`. See "Execution and verification limits" above for when to run them, and `AGENTS.md` "CI owns the minutes-long suites" for the repository-wide commands worth avoiding and why.
 
 ## Navigation & Routing
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -77,7 +77,7 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "lint": "biome check src",
+    "lint": "biome check --max-diagnostics=none src",
     "codegen": "expo customize tsconfig.json && uniwind generate-artifacts --css ./global.css --dts ./src/uniwind-types.d.ts",
     "typecheck": "bun run codegen && tsc --noEmit",
     "doctor": "bunx expo-doctor@latest"

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "typecheck:mobile": "bun run --cwd apps/mobile typecheck",
     "typecheck:remote": "bun run --cwd remote/api typecheck",
     "typecheck": "bun run --parallel 'typecheck:*'",
-    "lint": "biome check .",
+    "lint": "biome check --max-diagnostics=none .",
     "format": "biome check --write .",
     "check:staged": "biome check --write --staged --files-ignore-unknown=true --no-errors-on-unmatched",
     "test": "bun run test:desktop && bun run test:api && bun run test:sites && bun run test:remote",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "typecheck:remote": "bun run --cwd remote/api typecheck",
     "typecheck": "bun run --parallel 'typecheck:*'",
     "lint": "biome check --max-diagnostics=none .",
-    "format": "biome check --write .",
+    "format": "biome check --write --max-diagnostics=none .",
     "check:staged": "biome check --write --staged --files-ignore-unknown=true --no-errors-on-unmatched",
     "test": "bun run test:desktop && bun run test:api && bun run test:sites && bun run test:remote",
     "test:desktop": "vitest run",


### PR DESCRIPTION
## What changed

`bun run lint` is `biome check .`, which inherits Biome's `--max-diagnostics` default of **20**. Biome 2.5.9 does print the honest total (`Diagnostics not shown: 61.` / `Found 81 errors.`), so nobody was misled about *how many* — but findings 21+ are never shown, so a cleanup pass costs one six-second full-repo round trip per 20 findings. `--max-diagnostics=none` makes it one.

Three commands change:

- **`lint`** — the main case above.
- **`apps/mobile`'s scoped `lint`** (`biome check src`), which `mobile:lint` delegates to. Same cap, same fix.
- **`format`** — `--write` fixes what it can and *reports what it cannot*, and that second half was capped at 20 exactly like `lint`. Verified the flag is display-only: with and without it, `--write` produces byte-identical files, while the unfixable findings it reports go from 20 to 40.

**`check:staged` stays capped.** It runs in the pre-commit hook over the staged set, where output volume is a cost rather than a help.

Both `AGENTS.md` files describe what these commands run, so they are updated to match, plus one sentence saying why the flag is there — otherwise the next reader trims it back as noise. Prose is rewrapped to each file's own width.

**Surfaces touched:** repository tooling (root `package.json`), the mobile app's manifest (`apps/mobile/package.json`), documentation (`AGENTS.md`, `apps/mobile/AGENTS.md`). No renderer, IPC contract, migration, schema or palette change, and no reverse state involved — so no test: this is a flag on a command, and a test asserting the string in `package.json` would restate the manifest without naming a consequence anyone would see.

`CHANGELOG.md` is deliberately untouched — it tracks user-visible product change, and the last six `chore(tooling)`/`ci:`/`test(tooling)` commits touch it zero times.

## Verification

- [x] Narrow checks for what changed: `bun run lint` — 1126 files in 6s, 5 warnings, no errors, the same 5 that predate the change. `typecheck` and `check:ui` green in the pre-commit hook.
- [x] Surfaces touched are named under "What changed"
- [x] Manual smoke test — probed each claim against a 40-violation file rather than assuming:

  | | capped (default) | `--max-diagnostics=none` |
  | --- | --- | --- |
  | `biome check` diagnostics printed | 20 | 40 |
  | `biome check --write` diagnostics printed | 20 | 40 |
  | `biome check --write` bytes written | identical | identical |
  | `--reporter=json` diagnostics | 40 | 40 |
  | `Found N errors.` | `Found 40 errors.` | `Found 40 errors.` |
  | exit code | 1 | 1 |

  The JSON row matters: `scripts/anti-slop-rules.test.ts` parses `--reporter=json` and asserts exact line equality per fixture, so I checked whether it was ever truncated. It was not — the JSON reporter is uncapped — so that test needed no change. Probe files deleted; none are in this diff. `--max-diagnostics=<none|NUMBER>` is documented in the 2.5.9 `--help`.
- [x] No credentials, private data, generated output, or real user files are included

## Risk and security impact

None. No permissions, IPC, filesystem, browser, persistence or network behaviour changes — this only widens how much of a report is printed. The findings Biome computes, the bytes `--write` writes, and the exit codes are all unchanged, each verified above.

---

Model: Claude Opus 5. Harness: Claude Code.