### PR TITLE
refactor(renderer): import the copied helpers instead of redeclaring them

### DIFF
--- a/src/renderer/src/components/ProviderModelPicker.tsx
+++ b/src/renderer/src/components/ProviderModelPicker.tsx
@@ -412,7 +412,7 @@ function displayModelName(name: string | undefined, fallback: string): string {
   return name?.replace(/^[\s:–—-]+/, "") || fallback;
 }
 
-function reasoningLabel(effort: AgentReasoningEffort): string {
+export function reasoningLabel(effort: AgentReasoningEffort): string {
   if (effort === "xhigh") return "Extra high";
   return `${effort.slice(0, 1).toUpperCase()}${effort.slice(1)}`;
 }

--- a/src/renderer/src/components/ui/dynamic-island.tsx
+++ b/src/renderer/src/components/ui/dynamic-island.tsx
@@ -1,7 +1,7 @@
 import type { DynamicIslandNotchSize } from "@openbot/contracts/ipc";
 import type { JSX } from "@solidjs/web";
 import { createEffect, createSignal, createUniqueId, onCleanup, onSettled, Show, untrack } from "solid-js";
-import { cx, prefersReducedMotion } from "./utils";
+import { cx, mix, prefersReducedMotion } from "./utils";
 
 export type DynamicIslandViewState = "compact" | "expanded";
 export type DynamicIslandHoverBehavior = "none" | "grow" | "expand";
@@ -879,10 +879,6 @@ function springKeyframes(spring: Spring, frame: (progress: number) => Keyframe):
     const progress = index === sampleCount ? 1 : rawProgress / finalProgress;
     return { ...frame(progress), offset };
   });
-}
-
-function mix(start: number, end: number, progress: number): number {
-  return start + (end - start) * progress;
 }
 
 function resizeSpring(

--- a/src/renderer/src/components/ui/dynamic-island.tsx
+++ b/src/renderer/src/components/ui/dynamic-island.tsx
@@ -1,7 +1,7 @@
 import type { DynamicIslandNotchSize } from "@openbot/contracts/ipc";
 import type { JSX } from "@solidjs/web";
 import { createEffect, createSignal, createUniqueId, onCleanup, onSettled, Show, untrack } from "solid-js";
-import { cx } from "./utils";
+import { cx, prefersReducedMotion } from "./utils";
 
 export type DynamicIslandViewState = "compact" | "expanded";
 export type DynamicIslandHoverBehavior = "none" | "grow" | "expand";
@@ -1084,10 +1084,6 @@ function animateIslandBlur(targets: HTMLElement[], endBlur: number, options: Isl
 
 function captureIslandBlurs(targets: HTMLElement[]): Map<HTMLElement, number> {
   return new Map(targets.map((target) => [target, computedBlur(getComputedStyle(target).filter)]));
-}
-
-function prefersReducedMotion(): boolean {
-  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 }
 
 function computedScale(transform: string): number {

--- a/src/renderer/src/components/ui/utils.ts
+++ b/src/renderer/src/components/ui/utils.ts
@@ -42,3 +42,22 @@ export function truncateMiddle(value: string, maxLength: number): string {
 export function prefersReducedMotion(): boolean {
   return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 }
+
+/**
+ * Whether the pointer is coarse and hoverless - a touch screen. Sibling of
+ * `prefersReducedMotion` on purpose: both are one-line media-query reads, and splitting
+ * them across two modules is how the second one gets copied by someone who found the first.
+ */
+export function usesTouchLayout(): boolean {
+  return window.matchMedia?.("(hover: none), (pointer: coarse)").matches ?? false;
+}
+
+/** Constrains `value` to the inclusive range. */
+export function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+/** Linear interpolation from `start` to `end`, for a `progress` an animation drives from 0 to 1. */
+export function mix(start: number, end: number, progress: number): number {
+  return start + (end - start) * progress;
+}

--- a/src/renderer/src/components/ui/utils.ts
+++ b/src/renderer/src/components/ui/utils.ts
@@ -24,3 +24,21 @@ export function truncateMiddle(value: string, maxLength: number): string {
   const endLength = visibleLength - startLength;
   return `${value.slice(0, startLength)}…${value.slice(-endLength)}`;
 }
+
+/**
+ * Whether the user has asked the system for less animation. Import this rather than
+ * declaring it again: eight modules held their own byte-identical copy - five spelled
+ * `prefersReducedMotion`, plus `shouldReduceMotion`, `prefersReducedStreamingMotion` and
+ * `reducedMotion` - so a change to how the preference is read, a fallback or a cached
+ * MediaQueryList, would have reached one animation and not the other seven.
+ *
+ * A handful of call sites still read the media query inline, because they want a duration
+ * rather than a boolean (`return 0`) or a `ScrollBehavior`, and one holds the MediaQueryList
+ * to subscribe to it. Those are a different shape, not another copy of this one.
+ *
+ * `matchMedia` is optional because jsdom does not implement it, and a test that renders a
+ * component with an entrance animation must not throw on the way in.
+ */
+export function prefersReducedMotion(): boolean {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+}

--- a/src/renderer/src/error-message.ts
+++ b/src/renderer/src/error-message.ts
@@ -1,0 +1,16 @@
+/**
+ * The message to show a user for a rejected promise, or `fallback` when the rejection
+ * carries nothing readable.
+ *
+ * Six call sites across four features had their own byte-identical copy - five named
+ * `errorMessage`, one `messageForError` - so what a user sees when a command fails was
+ * six decisions that only happened to agree. It stays a renderer module: `src/main` has
+ * the same three lines in `central-auth-manager.ts` and cannot import them, because
+ * nothing behind the trust boundary reaches into the renderer.
+ *
+ * `fallback` rather than `String(error)` on purpose. A thrown non-Error stringifies to
+ * "[object Object]" or "undefined", which is worse than a sentence the feature wrote.
+ */
+export function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}

--- a/src/renderer/src/features/account/OtpInput.tsx
+++ b/src/renderer/src/features/account/OtpInput.tsx
@@ -1,6 +1,7 @@
 import { ONE_TIME_CODE_ALPHABET, ONE_TIME_CODE_LENGTH } from "@openbot/contracts/validation";
 import { createEffect, createMemo, createSignal, createUniqueId, For, Show, untrack } from "solid-js";
 import { Input } from "../../components/ui";
+import { prefersReducedMotion } from "../../components/ui/utils";
 
 export type OtpInputStatus = "idle" | "verifying" | "error" | "success";
 
@@ -57,7 +58,7 @@ export function OtpInput(props: OtpInputProps) {
   createEffect(
     () => status(),
     (nextStatus, previousStatus) => {
-      if (nextStatus !== "error" || previousStatus === "error" || shouldReduceMotion() || !slotsElement) return;
+      if (nextStatus !== "error" || previousStatus === "error" || prefersReducedMotion() || !slotsElement) return;
       slotsElement.animate?.(
         [
           { transform: "translateX(0)" },
@@ -296,8 +297,4 @@ function toSlots(value: string): string[] {
 function firstEmptySlot(slots: string[]): number {
   const index = slots.findIndex((character) => !character);
   return index === -1 ? ONE_TIME_CODE_LENGTH - 1 : index;
-}
-
-function shouldReduceMotion(): boolean {
-  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 }

--- a/src/renderer/src/features/agents/AgentAvatar.tsx
+++ b/src/renderer/src/features/agents/AgentAvatar.tsx
@@ -2,6 +2,7 @@ import { type Block, BloubBot, defaultCycle, makeBlock, POSES, type StateId } fr
 import type { AvatarHue } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, onSettled, Show } from "solid-js";
 import { type AvatarMotion, bloubAvatarProfile, type SupportedAvatarSilhouetteId } from "../../bloub-avatar";
+import { prefersReducedMotion } from "../../components/ui/utils";
 import type { AgentProfile } from "../../data";
 
 const DEFAULT_CYCLE: Block[] = defaultCycle().blocks;
@@ -175,8 +176,4 @@ function offsetCycle(blocks: Block[], offset: number): Block[] {
   const start = ((Math.trunc(offset) % blocks.length) + blocks.length) % blocks.length;
   if (start === 0) return blocks;
   return [...blocks.slice(start), ...blocks.slice(0, start)];
-}
-
-function prefersReducedMotion(): boolean {
-  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 }

--- a/src/renderer/src/features/computer-use/ComputerUseMacSetup.tsx
+++ b/src/renderer/src/features/computer-use/ComputerUseMacSetup.tsx
@@ -26,6 +26,7 @@ import {
   TriangleAlert,
   toast,
 } from "../../components/ui";
+import { errorMessage } from "../../error-message";
 
 export interface ComputerUseMacSetupProps {
   platform: DesktopPlatform;
@@ -257,8 +258,4 @@ function PermissionGroup(props: {
       </For>
     </ItemGroup>
   );
-}
-
-function errorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback;
 }

--- a/src/renderer/src/features/computer-use/ComputerUseSetupSurface.tsx
+++ b/src/renderer/src/features/computer-use/ComputerUseSetupSurface.tsx
@@ -9,6 +9,7 @@ import {
   MousePointer2,
   TriangleAlert,
 } from "../../components/ui";
+import { errorMessage } from "../../error-message";
 
 const PERMISSION_COPY: Record<MacPermissionId, { title: string; icon: typeof Monitor }> = {
   "screen-recording": { title: "Screen Recording", icon: Monitor },
@@ -142,8 +143,4 @@ export function ComputerUseSetupSurface() {
       </footer>
     </main>
   );
-}
-
-function errorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback;
 }

--- a/src/renderer/src/features/conversation/AgentRoutinesSettings.tsx
+++ b/src/renderer/src/features/conversation/AgentRoutinesSettings.tsx
@@ -4,6 +4,7 @@ import { createEffect, createSignal, For, onCleanup, onSettled, Show } from "sol
 import { type DesktopAnalyticsScope, desktopAnalytics } from "../../analytics";
 import { createScrollFades } from "../../components/createScrollFades";
 import { Button, CirclePause, Clock3, Dialog, Input, Plus, Switch, Textarea } from "../../components/ui";
+import { errorMessage } from "../../error-message";
 import { BackIcon, SettingsForwardIcon } from "./ConversationIcons";
 import { RoutineRunHistory } from "./RoutineRunHistory";
 import { RoutineScheduleEditor } from "./RoutineScheduleEditor";
@@ -67,7 +68,7 @@ export function AgentRoutinesSettings(props: AgentRoutinesSettingsProps) {
       if (selected?.id && !next.some((routine) => routine.id === selected.id)) closeEditor();
     } catch (caught) {
       setRoutinesLoaded(false);
-      setError(messageForError(caught, "Could not load routines."));
+      setError(errorMessage(caught, "Could not load routines."));
     } finally {
       setLoading(false);
     }
@@ -83,7 +84,7 @@ export function AgentRoutinesSettings(props: AgentRoutinesSettingsProps) {
         }),
       );
     } catch (caught) {
-      setError(messageForError(caught, "Could not load run history."));
+      setError(errorMessage(caught, "Could not load run history."));
     }
   }
 
@@ -277,7 +278,7 @@ export function AgentRoutinesSettings(props: AgentRoutinesSettingsProps) {
       trackRoutineAction(analytics, action, current.schedule, startedAt, "succeeded");
     } catch (caught) {
       trackRoutineAction(analytics, action, current.schedule, startedAt, "failed");
-      setError(messageForError(caught, "Could not save this routine."));
+      setError(errorMessage(caught, "Could not save this routine."));
     } finally {
       setSaving(false);
     }
@@ -305,7 +306,7 @@ export function AgentRoutinesSettings(props: AgentRoutinesSettingsProps) {
       trackRoutineAction(analytics, "delete", current.schedule, startedAt, "succeeded");
     } catch (caught) {
       trackRoutineAction(analytics, "delete", current.schedule, startedAt, "failed");
-      setError(messageForError(caught, "Could not delete this routine."));
+      setError(errorMessage(caught, "Could not delete this routine."));
     }
   }
 
@@ -325,7 +326,7 @@ export function AgentRoutinesSettings(props: AgentRoutinesSettingsProps) {
       await loadRuns(current.id);
     } catch (caught) {
       trackRoutineAction(analytics, "test", current.schedule, startedAt, "failed");
-      setError(messageForError(caught, "Could not start the test run."));
+      setError(errorMessage(caught, "Could not start the test run."));
     } finally {
       setTesting(false);
     }
@@ -545,9 +546,6 @@ function validDraft(draft: RoutineDraft): boolean {
 
 function isBlankNewDraft(draft: RoutineDraft): boolean {
   return draft.id === null && !draft.name.trim() && !draft.instruction.trim();
-}
-function messageForError(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback;
 }
 
 function trackRoutineAction(

--- a/src/renderer/src/features/conversation/AgentSettingsPanel.tsx
+++ b/src/renderer/src/features/conversation/AgentSettingsPanel.tsx
@@ -14,7 +14,7 @@ import { createEffect, createMemo, createSignal, createStore, For, onSettled, Sh
 import { normalizeAvatarFile } from "../../avatar-image";
 import { AVATAR_HUE_OPTIONS, avatarCandidateSeeds, avatarHueSwatch } from "../../bloub-avatar";
 import { PanelResizer, readPanelWidth, savePanelWidth } from "../../components/PanelResizer";
-import { ProviderModelPicker } from "../../components/ProviderModelPicker";
+import { ProviderModelPicker, reasoningLabel } from "../../components/ProviderModelPicker";
 import {
   Button,
   ChevronRight,
@@ -840,9 +840,4 @@ function sameRuntimeSettings(current: AgentRuntimeSettings, settings: AgentRunti
     current.model === settings.model &&
     current.reasoningEffort === settings.reasoningEffort
   );
-}
-
-function reasoningLabel(effort: AgentReasoningEffort): string {
-  if (effort === "xhigh") return "Extra high";
-  return `${effort.slice(0, 1).toUpperCase()}${effort.slice(1)}`;
 }

--- a/src/renderer/src/features/conversation/AnchoredTooltip.tsx
+++ b/src/renderer/src/features/conversation/AnchoredTooltip.tsx
@@ -1,5 +1,6 @@
 import { Portal } from "@solidjs/web";
 import { createSignal, onSettled } from "solid-js";
+import { clamp } from "../../components/ui/utils";
 
 const TOOLTIP_GAP = 8;
 const TOOLTIP_VIEWPORT_MARGIN = 8;
@@ -96,8 +97,4 @@ export function AnchoredTooltip(props: { id: string; anchor: HTMLElement; conten
       </span>
     </Portal>
   );
-}
-
-function clamp(value: number, minimum: number, maximum: number): number {
-  return Math.min(maximum, Math.max(minimum, value));
 }

--- a/src/renderer/src/features/conversation/ComposerEditor.tsx
+++ b/src/renderer/src/features/conversation/ComposerEditor.tsx
@@ -6,6 +6,7 @@ import { Portal } from "@solidjs/web";
 import { createEffect, createMemo, createSignal, createUniqueId, Show } from "solid-js";
 import { createStaticAvatarSvg } from "../../bloub-avatar";
 import { Listbox, Puzzle } from "../../components/ui";
+import { usesTouchLayout } from "../../components/ui/utils";
 import type { AgentProfile } from "../../data";
 import { AgentAvatar } from "../agents/AgentAvatar";
 import { AnchoredTooltip } from "./AnchoredTooltip";
@@ -687,10 +688,6 @@ function createAttachmentToken(attachment: DraftAttachment, actions: AttachmentT
     actions.open(attachment, usesTouchLayout());
   });
   return token;
-}
-
-function usesTouchLayout(): boolean {
-  return window.matchMedia?.("(hover: none), (pointer: coarse)").matches ?? false;
 }
 
 function createMentionToken(agent: AgentProfile): HTMLSpanElement {

--- a/src/renderer/src/features/conversation/MessageRendering.tsx
+++ b/src/renderer/src/features/conversation/MessageRendering.tsx
@@ -2,6 +2,7 @@ import type { AttachmentSummary, InstalledSkill, MessageReaction } from "@openbo
 import { MESSAGE_REACTIONS, MORE_MESSAGE_REACTIONS } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, For, onCleanup, Show, untrack } from "solid-js";
 import { Button, DropdownMenu } from "../../components/ui";
+import { prefersReducedMotion } from "../../components/ui/utils";
 import type { AgentMessage, AgentProfile } from "../../data";
 import { AttachmentCards } from "./AttachmentCards";
 import { CodeBlock } from "./CodeBlock";
@@ -27,10 +28,6 @@ function nextStreamingText(current: string, target: string, streaming: boolean):
   return streaming ? current : target;
 }
 
-function prefersReducedStreamingMotion(): boolean {
-  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-}
-
 function streamingTextGapMs(): number {
   const value = getComputedStyle(document.documentElement).getPropertyValue("--stream-gap").trim();
   if (!value) return STREAMING_TEXT_GAP_FALLBACK_MS;
@@ -45,7 +42,7 @@ function createStreamingBody(message: () => AgentMessage) {
     initialMessage.author === "agent" &&
     initialMessage.streaming === true &&
     initialMessage.animate === true &&
-    !prefersReducedStreamingMotion();
+    !prefersReducedMotion();
   let targetBody = initialMessage.body;
   let targetStreaming = initialMessage.author === "agent" && initialMessage.streaming === true;
   const [body, setBody] = createSignal(animateInitialText ? "" : initialMessage.body);
@@ -103,7 +100,7 @@ function createStreamingBody(message: () => AgentMessage) {
         keepHeightSmoothingActive();
       }
       const current = untrack(body);
-      if (prefersReducedStreamingMotion() || !nextBody.startsWith(current) || (!streaming && !smoothingActive)) {
+      if (prefersReducedMotion() || !nextBody.startsWith(current) || (!streaming && !smoothingActive)) {
         clearRevealTimer();
         setAnimateTail(false);
         setBody(nextBody);

--- a/src/renderer/src/features/conversation/QueuePanel.tsx
+++ b/src/renderer/src/features/conversation/QueuePanel.tsx
@@ -3,6 +3,7 @@ import type { InstalledSkill, QueueDelivery } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, createUniqueId, For, onCleanup, Show, untrack } from "solid-js";
 import { createVerticalDragPreview } from "../../components/createVerticalDragPreview";
 import { Button } from "../../components/ui";
+import { prefersReducedMotion } from "../../components/ui/utils";
 import type { AgentProfile } from "../../data";
 import { AnchoredTooltip } from "./AnchoredTooltip";
 import { fileBadge } from "./AttachmentCards";
@@ -96,7 +97,7 @@ export function QueuePanel(props: QueuePanelProps) {
 
       setHiddenEditingId(null);
       setEditingExitId(editingId);
-      if (reducedMotion()) {
+      if (prefersReducedMotion()) {
         setHiddenEditingId(editingId);
         setEditingExitId(null);
         return;
@@ -144,7 +145,7 @@ export function QueuePanel(props: QueuePanelProps) {
           });
           continue;
         }
-        if (reducedMotion()) continue;
+        if (prefersReducedMotion()) continue;
         retainedExits.push({ delivery, index });
         if (externalRemovalTimers.has(delivery.id)) continue;
         setRemovingIds((ids) => new Set([...ids, delivery.id]));
@@ -201,10 +202,6 @@ export function QueuePanel(props: QueuePanelProps) {
       callback();
     }, delay);
     animationTimers.add(timer);
-  }
-
-  function reducedMotion(): boolean {
-    return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
   }
 
   function dragStep(deliveryId: string): number {
@@ -337,7 +334,7 @@ export function QueuePanel(props: QueuePanelProps) {
   function requestCancel(deliveryId: string) {
     if (removingIds().has(deliveryId)) return;
     setRemovingIds((current) => new Set([...current, deliveryId]));
-    scheduleAnimationCleanup(() => props.onCancel(deliveryId), reducedMotion() ? 0 : 200);
+    scheduleAnimationCleanup(() => props.onCancel(deliveryId), prefersReducedMotion() ? 0 : 200);
   }
 
   function messagePreview(delivery: QueueDelivery): string {

--- a/src/renderer/src/features/conversation/RichMessageText.tsx
+++ b/src/renderer/src/features/conversation/RichMessageText.tsx
@@ -3,6 +3,7 @@ import type { AttachmentSummary, InstalledSkill } from "@openbot/contracts/ipc";
 import type { JSX } from "@solidjs/web";
 import { createMemo, createSignal, createUniqueId, For, onCleanup, Show } from "solid-js";
 import { Button, Puzzle } from "../../components/ui";
+import { usesTouchLayout } from "../../components/ui/utils";
 import type { AgentProfile, MessageCitation } from "../../data";
 import { AgentAvatar } from "../agents/AgentAvatar";
 import { AnchoredTooltip } from "./AnchoredTooltip";
@@ -286,10 +287,6 @@ export function MessageLink(props: {
       {props.children}
     </a>
   );
-}
-
-function usesTouchLayout(): boolean {
-  return window.matchMedia?.("(hover: none), (pointer: coarse)").matches ?? false;
 }
 
 interface RichMessagePart {

--- a/src/renderer/src/features/conversation/SelectionActions.tsx
+++ b/src/renderer/src/features/conversation/SelectionActions.tsx
@@ -3,6 +3,7 @@ import { Portal } from "@solidjs/web";
 import type { Element as SolidElement } from "solid-js";
 import { createEffect, createMemo, createSignal, For, onSettled, Show } from "solid-js";
 import { Button, Input } from "../../components/ui";
+import { clamp } from "../../components/ui/utils";
 
 const MESSAGE_TEXT_SELECTOR = ".message-copy[data-selection-message-id]";
 const INTERACTIVE_SELECTOR =
@@ -599,10 +600,6 @@ function rectValue(rect: DOMRect): SelectionRect {
     width: rect.width,
     height: rect.height,
   };
-}
-
-function clamp(value: number, minimum: number, maximum: number): number {
-  return Math.min(maximum, Math.max(minimum, value));
 }
 
 function SelectionIcon(props: { children: SolidElement }) {

--- a/src/renderer/src/features/conversation/createSmoothHeightResize.ts
+++ b/src/renderer/src/features/conversation/createSmoothHeightResize.ts
@@ -1,4 +1,5 @@
 import { onCleanup, onSettled } from "solid-js";
+import { prefersReducedMotion } from "../../components/ui/utils";
 
 interface SmoothHeightResizeOptions {
   container: () => HTMLElement | undefined;
@@ -60,10 +61,6 @@ export function createSmoothHeightResize(options: SmoothHeightResizeOptions): vo
   });
 
   onCleanup(cancelAnimation);
-}
-
-function prefersReducedMotion(): boolean {
-  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 }
 
 function resizeDuration(): number {

--- a/src/renderer/src/features/dynamic-island/OpenBotDynamicIsland.tsx
+++ b/src/renderer/src/features/dynamic-island/OpenBotDynamicIsland.tsx
@@ -1055,7 +1055,7 @@ function QuestionContent(props: {
       return;
     }
     questionAnimations = exitAnimations;
-    await waitForQuestionAnimations(questionAnimations);
+    await waitForAnimations(questionAnimations);
     if (questionDisposed || transitionVersion !== questionTransitionVersion) return;
     setQuestionHidden(elements);
     cancelQuestionAnimations();
@@ -1064,7 +1064,7 @@ function QuestionContent(props: {
     await nextAnimationFrame();
     if (questionDisposed || transitionVersion !== questionTransitionVersion) return;
     questionAnimations = animateQuestionElements(elements, "enter") ?? [];
-    await waitForQuestionAnimations(questionAnimations);
+    await waitForAnimations(questionAnimations);
     if (questionDisposed || transitionVersion !== questionTransitionVersion) return;
     clearQuestionHidden(elements);
     cancelQuestionAnimations();
@@ -1220,7 +1220,7 @@ function QuestionProgress(props: { current: number; total: number }): JSX.Elemen
         ),
       ];
 
-      void waitForQuestionAnimations(animations).then(() => {
+      void waitForAnimations(animations).then(() => {
         if (version !== transitionVersion) return;
         cancelTransition();
       });
@@ -1273,10 +1273,6 @@ function animateQuestionElements(elements: HTMLElement[], phase: QuestionSwapPha
     );
   }
   return animations;
-}
-
-function waitForQuestionAnimations(animations: Animation[]): Promise<undefined[]> {
-  return Promise.all(animations.map((animation) => animation.finished.then(() => undefined).catch(() => undefined)));
 }
 
 function setQuestionHidden(elements: HTMLElement[]): void {

--- a/src/renderer/src/features/dynamic-island/OpenBotDynamicIsland.tsx
+++ b/src/renderer/src/features/dynamic-island/OpenBotDynamicIsland.tsx
@@ -38,6 +38,7 @@ import {
   OctagonX,
   Spinner,
 } from "../../components/ui";
+import { prefersReducedMotion } from "../../components/ui/utils";
 import { AgentAvatar } from "../agents/AgentAvatar";
 import {
   animateModeLayers,
@@ -49,7 +50,6 @@ import {
   type ModeSwapSize,
   modeSourceAnchors,
   modeSwapElementSize,
-  prefersReducedMotion,
   primeCompactModeLayerPositions,
   restoreModeTransitionFocus,
   waitForAnimations,

--- a/src/renderer/src/features/dynamic-island/openbot-dynamic-island-motion.ts
+++ b/src/renderer/src/features/dynamic-island/openbot-dynamic-island-motion.ts
@@ -1,4 +1,5 @@
 import type { DynamicIslandPresentation } from "@openbot/contracts/ipc";
+import { mix } from "../../components/ui/utils";
 
 const MODE_SWAP_EXIT_DURATION = 160;
 const MODE_SWAP_STATIC_DURATION = 240;
@@ -233,21 +234,21 @@ function modeSwapEntranceKeyframes(
   spatialOffset: ModeSwapPoint,
 ): Keyframe[] {
   return modeSwapSpringKeyframes((progress) => ({
-    opacity: mixModeSwapValue(startOpacity, 1, progress),
+    opacity: mix(startOpacity, 1, progress),
     transform: preserveSpatialPosition
       ? "none"
       : modeSwapTransform(
           {
-            x: mixModeSwapValue(spatialOffset.x, 0, progress),
-            y: mixModeSwapValue(spatialOffset.y, 0, progress),
+            x: mix(spatialOffset.x, 0, progress),
+            y: mix(spatialOffset.y, 0, progress),
           },
-          mixModeSwapValue(startScale, 1, progress),
+          mix(startScale, 1, progress),
         ),
   }));
 }
 
 function modeSwapBlurEntranceKeyframes(startBlur: number): Keyframe[] {
-  return modeSwapSpringKeyframes((progress) => ({ filter: `blur(${mixModeSwapValue(startBlur, 0, progress)}px)` }));
+  return modeSwapSpringKeyframes((progress) => ({ filter: `blur(${mix(startBlur, 0, progress)}px)` }));
 }
 
 function modeSwapSpringKeyframes(frame: (progress: number) => Keyframe): Keyframe[] {
@@ -263,10 +264,6 @@ function modeSwapSpringKeyframes(frame: (progress: number) => Keyframe): Keyfram
 function criticalModeSwapSpringProgress(offset: number): number {
   const phase = 2 * Math.PI * offset;
   return 1 - Math.exp(-phase) * (1 + phase);
-}
-
-function mixModeSwapValue(start: number, end: number, progress: number): number {
-  return start + (end - start) * progress;
 }
 
 function modeLayerAnchor(layer: HTMLElement): ModeSwapPoint | undefined {

--- a/src/renderer/src/features/dynamic-island/openbot-dynamic-island-motion.ts
+++ b/src/renderer/src/features/dynamic-island/openbot-dynamic-island-motion.ts
@@ -198,10 +198,6 @@ export function waitForAnimations(animations: Animation[]): Promise<undefined[]>
   return Promise.all(animations.map((animation) => animation.finished.then(() => undefined).catch(() => undefined)));
 }
 
-export function prefersReducedMotion(): boolean {
-  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-}
-
 function modeSwapEnterDuration(
   expanded: boolean,
   geometryChanged: boolean,

--- a/src/renderer/src/features/onboarding/InitialSetup.tsx
+++ b/src/renderer/src/features/onboarding/InitialSetup.tsx
@@ -11,6 +11,7 @@ import type {
 import { createEffect, createMemo, createSignal, onSettled, Show, untrack } from "solid-js";
 import { ProviderPicker, type ProviderPickerOption } from "../../components/ProviderPicker";
 import { Button, Dialog, Textarea } from "../../components/ui";
+import { errorMessage } from "../../error-message";
 import { ComputerUseMacSetup } from "../computer-use/ComputerUseMacSetup";
 import { InvitePreviewCard } from "../servers/JoinServerDialog";
 
@@ -385,8 +386,4 @@ function providerName(provider: AgentProviderId | null): "Claude" | "Codex" | "G
 
 function fallbackProviderState(status: AgentStatus): AgentProviderState {
   return status.phase === "starting" || status.phase === "restarting" ? "checking" : "error";
-}
-
-function errorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback;
 }

--- a/src/renderer/src/features/onboarding/InitialSetup.tsx
+++ b/src/renderer/src/features/onboarding/InitialSetup.tsx
@@ -1,7 +1,6 @@
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type {
   AgentProviderId,
-  AgentProviderState,
   AgentStatus,
   AppSetupState,
   DesktopPlatform,
@@ -14,6 +13,7 @@ import { Button, Dialog, Textarea } from "../../components/ui";
 import { errorMessage } from "../../error-message";
 import { ComputerUseMacSetup } from "../computer-use/ComputerUseMacSetup";
 import { InvitePreviewCard } from "../servers/JoinServerDialog";
+import { fallbackProviderState } from "./onboarding-provider-state";
 
 interface InitialSetupProps {
   reviewing?: boolean;
@@ -382,8 +382,4 @@ function providerName(provider: AgentProviderId | null): "Claude" | "Codex" | "G
   if (provider === "claude") return "Claude";
   if (provider === "grok") return "Grok";
   return "Codex";
-}
-
-function fallbackProviderState(status: AgentStatus): AgentProviderState {
-  return status.phase === "starting" || status.phase === "restarting" ? "checking" : "error";
 }

--- a/src/renderer/src/features/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/features/onboarding/OnboardingFlow.tsx
@@ -1,6 +1,5 @@
 import type {
   AgentProviderId,
-  AgentProviderState,
   AgentStatus,
   AppSetupState,
   AvatarHue,
@@ -14,6 +13,7 @@ import { errorMessage } from "../../error-message";
 import { AgentAvatar } from "../agents/AgentAvatar";
 import { ComputerUseMacSetup } from "../computer-use/ComputerUseMacSetup";
 import { PlusIcon } from "../conversation/ConversationIcons";
+import { fallbackProviderState } from "./onboarding-provider-state";
 
 export interface OnboardingFlowProps {
   state: AppSetupState;
@@ -540,10 +540,6 @@ export function OnboardingFlow(props: OnboardingFlowProps) {
       </div>
     </main>
   );
-}
-
-function fallbackProviderState(status: AgentStatus): AgentProviderState {
-  return status.phase === "starting" || status.phase === "restarting" ? "checking" : "error";
 }
 
 function createOnboardingAvatarVariants(): OnboardingAvatarVariants {

--- a/src/renderer/src/features/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/features/onboarding/OnboardingFlow.tsx
@@ -10,6 +10,7 @@ import type {
 import { createEffect, createMemo, createSignal, For, Match, onCleanup, Show, Switch } from "solid-js";
 import { ProviderPicker, type ProviderPickerOption } from "../../components/ProviderPicker";
 import { Button } from "../../components/ui";
+import { errorMessage } from "../../error-message";
 import { AgentAvatar } from "../agents/AgentAvatar";
 import { ComputerUseMacSetup } from "../computer-use/ComputerUseMacSetup";
 import { PlusIcon } from "../conversation/ConversationIcons";
@@ -543,10 +544,6 @@ export function OnboardingFlow(props: OnboardingFlowProps) {
 
 function fallbackProviderState(status: AgentStatus): AgentProviderState {
   return status.phase === "starting" || status.phase === "restarting" ? "checking" : "error";
-}
-
-function errorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback;
 }
 
 function createOnboardingAvatarVariants(): OnboardingAvatarVariants {

--- a/src/renderer/src/features/onboarding/onboarding-provider-state.ts
+++ b/src/renderer/src/features/onboarding/onboarding-provider-state.ts
@@ -1,0 +1,13 @@
+import type { AgentProviderState, AgentStatus } from "@openbot/contracts/ipc";
+
+/**
+ * The provider state to show while `AgentStatus` carries no per-provider entry.
+ *
+ * Both onboarding screens ask this, and both had their own copy, so a build that is
+ * still starting could read as "checking" on one screen and "error" on the other.
+ * Onboarding is the only reader, which is why it lives here rather than beside the
+ * provider context.
+ */
+export function fallbackProviderState(status: AgentStatus): AgentProviderState {
+  return status.phase === "starting" || status.phase === "restarting" ? "checking" : "error";
+}

--- a/src/renderer/src/features/servers/JoinServerDialog.tsx
+++ b/src/renderer/src/features/servers/JoinServerDialog.tsx
@@ -18,6 +18,8 @@ import {
   Text,
   X,
 } from "../../components/ui";
+import { prefersReducedMotion } from "../../components/ui/utils";
+import { errorMessage } from "../../error-message";
 
 interface JoinServerDialogProps {
   inviteUrl: string;
@@ -391,17 +393,9 @@ function shakeDuration(): number {
   return motionDuration("--shake-dur-a", 80) * 2 + motionDuration("--shake-dur-b", 60) * 2;
 }
 
-function prefersReducedMotion(): boolean {
-  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-}
-
 function formatInviteDate(value: string): string {
   const date = new Date(value);
   return Number.isNaN(date.getTime())
     ? "Unknown"
     : new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date);
-}
-
-function errorMessage(cause: unknown, fallback: string): string {
-  return cause instanceof Error ? cause.message : fallback;
 }


### PR DESCRIPTION
Eight helpers had between two and eight byte-identical declarations each, so a change to any of them — a fallback, a cached `MediaQueryList`, a label — would have reached one call site and not the rest. **20 declarations become 8.**

**Surface touched: desktop renderer only.** No IPC contract, no migration, no `mock-openbot.ts`, no reverse state, no doc change.

Six of the twenty were renames, which is why a grep for the name finds fewer than exist. A body-hash scan over `src/renderer` — including `stories/` and `preview/`, which sit outside `src/renderer/src` — is what found them, and re-running it after this change leaves exactly one pair, deliberately deferred below.

## What moved where

| Helper | Copies | Home | Renamed copies folded in |
| --- | --- | --- | --- |
| `prefersReducedMotion` | 8 | `components/ui/utils.ts` | `shouldReduceMotion`, `prefersReducedStreamingMotion`, `reducedMotion` |
| `errorMessage` | 6 renderer | `src/renderer/src/error-message.ts` | `messageForError` |
| `usesTouchLayout` | 2 | `components/ui/utils.ts` | — |
| `clamp` | 2 | `components/ui/utils.ts` | — |
| `mix` | 2 | `components/ui/utils.ts` | `mixModeSwapValue` |
| `waitForAnimations` | 2 | already exported from `openbot-dynamic-island-motion.ts` | `waitForQuestionAnimations` |
| `reasoningLabel` | 2 | exported from `components/ProviderModelPicker.tsx` | — |
| `fallbackProviderState` | 2 | `features/onboarding/onboarding-provider-state.ts` | — |

## The placement decisions

**`prefersReducedMotion` could not stay where one copy was already exported.** `features/dynamic-island/openbot-dynamic-island-motion.ts` exported it, but `components/ui/dynamic-island.tsx` is one of its readers, and the shared layer importing sideways out of a feature is the wrong direction. `components/ui/utils.ts` is the existing home for exactly this — not in the barrel, already read from `features/` by `SettingsDialogShell` and `ServerSettingsModal`.

**`usesTouchLayout` goes there too, against the letter of the placement rule.** Both its readers are in `features/conversation/`, so "a cluster earns a directory when the feature is the only thing that reads it" would put it there. It is the same one-line `window.matchMedia?.(…).matches ?? false` as its new neighbour, on a different query, and splitting the pair across two modules is how the second one gets copied by someone who found the first. `clamp` and `mix` are generic math with no domain and go to the same place.

**`reasoningLabel` is the one that could have shipped a visible bug** rather than only costing maintenance. It is product copy — `if (effort === "xhigh") return "Extra high"` — duplicated across `AgentSettingsPanel.tsx` and `ProviderModelPicker.tsx`, two surfaces that can label the same reasoning effort differently. `AgentSettingsPanel` already imports `ProviderModelPicker`, so exporting it adds no new import edge and points the right way, feature → shared component. Same shape as `InitialSetup` reading `InvitePreviewCard` out of `JoinServerDialog`.

**`waitForAnimations` was free.** It was already exported from `openbot-dynamic-island-motion.ts`, and `OpenBotDynamicIsland.tsx` already imports six other names from that exact module — then declared `waitForQuestionAnimations` with the identical body anyway.

**`errorMessage` stays a renderer module.** `src/main/central-auth-manager.ts:1278` keeps its own copy: nothing behind the trust boundary imports renderer code, and it is a single declaration there, so there is nothing left to consolidate on that side.

## Left inline on purpose

Eleven call sites still read `(prefers-reduced-motion: reduce)` inline, because they want a duration (`return 0`) or a `ScrollBehavior` rather than a boolean, and one holds the `MediaQueryList` to subscribe to it. Those are a different shape, not another copy. The helper's doc comment says so, rather than claiming to be the only reader and rotting the first time someone greps.

## Checks

`bun run check:ui`, `bun run lint` and all eleven `bun run typecheck` projects pass; the pre-commit hook re-ran all three on both commits. Every desktop test file covering a touched file passes — 18 files, 236 tests:

`dynamic-island.test.tsx`, `OpenBotDynamicIsland.test.tsx`, `DynamicIslandSurface.test.tsx`, `ComputerUseMacSetup.test.tsx`, `ComputerUseSetupSurface.test.tsx`, `OnboardingFlow.test.tsx`, `AgentRoutinesSettings.test.tsx`, `MessageRendering.test.tsx`, `QueuePanel.test.tsx`, `OtpInput.test.tsx`, `AccountLogin.test.tsx`, `ServerSettingsModal.test.tsx`, `SelectionActions.test.tsx`, `RichMessageText.test.tsx`, `ComposerEditor.test.tsx`, `ProviderModelPicker.test.tsx`, `AgentSettingsPanel.test.tsx`, `App.test.tsx`, `App.queue.test.tsx`.

**No test added, and none needed the watch-it-fail loop.** Per the Tests section rule 3, `tsc` already enforces this mechanically: a deleted declaration without its import is a compile error. Nothing here changes behaviour, so there is no new consequence to name.

No UI change to show before and after — every call site keeps its existing behaviour, and every body folded in was byte-identical.

## Approvability

Auto-approvable. No `biome-ignore`, `@ts-expect-error` or `@ts-ignore`; no `biome.json` `overrides` entry or unregistered plugin; no widening to `any`/`unknown` and no assertion past a checker.

## Not in this PR

**One duplicate pair remains, and it is a domain decision rather than a mechanical dedup.** `features/dynamic-island/dynamic-island-coordinator.ts:386` reimplements `agentMessageKey` and `deleteAgentMessageBodies` from `features/conversation/conversation-keys.ts`, without the comment that documents why a NUL separator makes the parts unambiguous. Sharing them crosses two features, and `src/renderer/AGENTS.md` says something shared by two domains goes flat rather than being imported sideways out of one — so the honest fix moves them out of `conversation-keys.ts` and touches every existing importer. Different shape, separate PR.

**A `check:ui` duplicate-helper budget.** Nothing mechanical stops this recurring; writing a local three-line helper stays cheaper than finding the existing export. That is a repo-wide ratchet on all future renderer work and needs both `tools/ui-foundation/fixtures` trees, so it is its own decision — but after this PR the budget could start at one, which was the argument for doing the sweep first.

---

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)