### PR TITLE
docs(agents): drop the four drifted counts in the AGENTS.md guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,10 @@ it walks the workspace dependency graph and asserts a manifest is copied for eac
 
 `remote/scripts` rides along in that same project. `check.ts` and `update.ts` are Bun scripts
 using `Bun.spawn` and `import.meta.dir`, and no `tsconfig` reached them: `tsconfig.node.json` stops
-at the root `scripts/**` and pins `"types": ["node"]`, which is why all thirty root scripts use the
-`Bun` global exactly zero times. Adding `@types/bun` at the root would have made Bun globals
-resolvable repo-wide, including in `src/main`, which runs under Node. Instead `remote/api` already
-had the Bun-typed project the scripts needed, so its `include` carries `../scripts/*.ts` and
+at the root `scripts/**` and pins `"types": ["node"]`, which is why no root script uses the `Bun`
+global at all. Adding `@types/bun` at the root would have made Bun globals resolvable repo-wide,
+including in `src/main`, which runs under Node. Instead `remote/api` already had the Bun-typed
+project the scripts needed, so its `include` carries `../scripts/*.ts` and
 `typecheck:remote` covers both. `update.ts` drains and force-recreates the live coturn container, so
 it is worth a checker.
 

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -21,7 +21,7 @@ mock — so the cost of a change is paid by code you cannot edit.
   update-direction tests, and clear UI text.
 - Malformed known payloads fail closed as `protocol_error`. Unknown optional events are ignored.
 
-## One channel list, four hand-written mirrors
+## One channel list, three hand-written mirrors
 
 `src/ipc-channels.ts` declares every channel. Three files mirror it by hand:
 

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -65,12 +65,13 @@ wrong.
 
 `mailbox-store.ts` is the largest file in this directory, at about 1,700 lines.
 
-The two that used to be larger are both worth copying. `agent-service.ts` was split into eight
-controllers; `openbot-database.ts` was split into nine under `database/`, leaving a ~300-line facade
-that had to keep its class name, instance identity, constructor signature and public surface because
-callers reach past it into `connection` and `dispatch`. The shape in both: one class per file,
-kebab-case, `<Name>Options` + `<Name>`, `readonly #` fields, a constructor that only assigns, and a
-doc comment saying what the class **owns** and that it never imports the facade. No barrel file.
+The two that used to be larger are both worth copying. `agent-service.ts` was split into one
+controller per concern, each injected into the service; `openbot-database.ts` was split into nine
+under `database/`, leaving a ~300-line facade that had to keep its class name, instance identity,
+constructor signature and public surface because callers reach past it into `connection` and
+`dispatch`. The shape in both: one class per file, kebab-case, `<Name>Options` + `<Name>`,
+`readonly #` fields, a constructor that only assigns, and a doc comment saying what the class
+**owns** and that it never imports the facade. No barrel file.
 
 Two rules those controllers depend on and a reader cannot infer. They hold the core object and read
 `.connection` at each use — a cached handle survives `initialize()` and then silently addresses a

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -66,10 +66,10 @@ wrong.
 `mailbox-store.ts` is the largest file in this directory, at about 1,700 lines.
 
 The two that used to be larger are both worth copying. `agent-service.ts` was split into one
-controller per concern, each injected into the service; `openbot-database.ts` was split into nine
-under `database/`, leaving a ~300-line facade that had to keep its class name, instance identity,
-constructor signature and public surface because callers reach past it into `connection` and
-`dispatch`. The shape in both: one class per file, kebab-case, `<Name>Options` + `<Name>`,
+controller per concern, each constructed and owned by the service; `openbot-database.ts` was split
+into nine under `database/`, leaving a ~300-line facade that had to keep its class name, instance
+identity, constructor signature and public surface because callers reach past it into `connection`
+and `dispatch`. The shape in both: one class per file, kebab-case, `<Name>Options` + `<Name>`,
 `readonly #` fields, a constructor that only assigns, and a doc comment saying what the class
 **owns** and that it never imports the facade. No barrel file.
 

--- a/src/main/AGENTS.md
+++ b/src/main/AGENTS.md
@@ -59,8 +59,9 @@ single most expensive edit available in this directory.
 The split is also enforced by path. `biome.json` gives `src/main`, `src/backend` and `src/preload` a
 `noRestrictedImports` group rejecting `**/renderer/**`, and the renderer the mirror of it, so the
 first import across the boundary fails `bun run lint` with the reason rather than passing review as
-a convenience. `src/main` importing `src/backend` is the one direction left open, and 38 files use
-it. Share a type through `packages/contracts` instead of reaching for the module.
+a convenience. `src/main` importing `src/backend` is the one direction left open, and the handler
+registrations and the Team API server use it. Share a type through `packages/contracts` instead of
+reaching for the module.
 
 ## Waiting in a main-process test
 


### PR DESCRIPTION
Four exact counts in the `AGENTS.md` files had drifted, and nothing checks them. Agents read these as ground truth, so drift here is more expensive than in a normal comment.

## What was wrong, and what each became

**`src/main/AGENTS.md`** — "`src/main` importing `src/backend` … **38 files** use it." Actual: **19** files, **15** of them non-test. The sentence is about which direction across the boundary is left open, not how many callers walk through it, so the number is gone and the callers are named instead: the IPC handler registrations and the Team API server.

**`src/backend/AGENTS.md`** — "`agent-service.ts` was split into **eight** controllers." Actual: **21** injected controllers (`readonly #` fields on `AgentService`). The paragraph's subject is the *shape* of the split — one class per file, `<Name>Options` + `<Name>`, a constructor that only assigns — which the count added nothing to, so it now reads "one controller per concern, each constructed and owned by the service" — composition, which is what `AgentService`'s constructor actually does (it takes stores and config, then `new`s each controller itself).

**`packages/contracts/AGENTS.md`** — the heading said "**four** hand-written mirrors" over a line saying "**Three** files mirror it by hand" and a three-row table. Heading now says three. The closing "all four files" is correct as written: three mirrors plus `ipc-channels.ts` itself.

**Root `AGENTS.md`** — "all **thirty** root scripts use the `Bun` global exactly zero times." `scripts/` holds **44** non-test `.ts` files today, 64 with tests. The claim the sentence carries is still true: the four files matching `Bun` match it in a comment or a message string, and the global itself is used nowhere. Only the number goes.

## What I checked and left alone

The rest of the numeric claims across the five guides hold, so this is the whole set:

- `typecheck` is **eleven** `tsc` projects — 11 `typecheck:*` scripts.
- Adding a channel touches **four** files — matches the contracts table.
- **Four** places open a transaction unconditionally-or-not — exactly four `BEGIN IMMEDIATE` sites, and they are the four named.
- `openbot-database.ts` split into **nine** under `database/` — nine of the eleven non-test files there export a class; `database-rows.ts` and `legacy-conversation-message.ts` export functions, not controllers.
- `mailbox-store.ts` at about **1,700** lines — 1749.
- `agents-context` having **eighteen** readers — 18.
- `renderer-forwarders.ts` owning **eleven** relayed service events — 11.
- The **five** `data-testid` hooks are already enforced by `check:ui`, which fails on a sixth.
- The past-tense counts (`remote-server-manager.ts` at 2828 lines, eight hand-rolled socket fakes, sixteen standing `no-runtime-typeof` warnings) describe a state that is over. They cannot drift.

## Why no test

None of the four moved into a test. Their counts carry no consequence for a reader at any value — nothing changes at 15 importers versus 38, or 8 controllers versus 21 — so deleting the number is cheaper than checking it, and a test asserting one would go red on every honest refactor.

The contracts count *is* load-bearing, and it is already enforced where it can be. `src/main/ipc-channel-coverage.test.ts` reads both process sources statically and fails on a channel either side is missing, an endpoint registered twice, or an orphan; the `: OpenBotDesktopApi` annotation makes a missing method in `mock-openbot.ts` a `TS2741`. A test asserting the heading says "three" would check the sentence, not the boundary — Tests rule 1 and rule 3 both point the other way.

## Surfaces

Markdown only. No renderer, mobile, web, Signal service, IPC contract, migration or persisted state is touched, and nothing in `scripts/` or `tools/` parses these files — the `AGENTS.md` hits there are diagnostic message strings.

## Checks

`bun run lint`, `bun run typecheck` and `bun run check:ui` pass; the pre-commit hook ran the latter two over the full repo on both commits. No watch-it-fail loop to report: no test changed.

Model: Claude Opus 5. Harness: Claude Code.
