### PR TITLE
Update review workflow to use GPT-6 Astra

### DIFF
--- a/.github/workflows/norbiai-review.yml
+++ b/.github/workflows/norbiai-review.yml
@@ -458,7 +458,7 @@ jobs:
             --ephemeral \
             --ignore-user-config \
             --sandbox read-only \
-            --model gpt-5.6-sol \
+            --model gpt-6-astra \
             --config 'model_reasoning_effort="medium"' \
             --color never \
             --output-last-message "$last_message_file" \


### PR DESCRIPTION
## Summary

- Switch the NorbiAI review workflow from `gpt-5.6-sol` to `gpt-6-astra`.
- Keep the existing medium reasoning effort and read-only sandbox configuration.

## Testing

- Not run (workflow configuration-only change).