### PR TITLE
Fix automatic ChatGPT, Claude, and Grok model discovery

### DIFF
--- a/src/backend/agent-service-test-harness.ts
+++ b/src/backend/agent-service-test-harness.ts
@@ -95,6 +95,7 @@ export class FakeAgentClient extends EventEmitter implements AgentClient {
   #threadCounter = 0;
   running = false;
   responseError: Error | null = null;
+  modelList: ((params: unknown) => unknown) | undefined;
   accountRateLimits: unknown = { rateLimits: null, rateLimitsByLimitId: null };
 
   constructor(
@@ -145,9 +146,7 @@ export class FakeAgentClient extends EventEmitter implements AgentClient {
       result = {
         data:
           this.provider === "codex"
-            ? // The uncurated ids are advertised on purpose, the way the real CLI
-              // does: CURATED_CODEX_MODEL_IDS has to drop them again.
-              [
+            ? [
                 "gpt-5.6-luna",
                 "gpt-5.6-terra",
                 "gpt-5.6-sol",
@@ -161,6 +160,7 @@ export class FakeAgentClient extends EventEmitter implements AgentClient {
               : ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"].map((model) => ({ model })),
       };
     }
+    if (method === "model/list" && this.modelList) result = this.modelList(params);
     if (method === "plugin/list") result = { marketplaces: [] };
     if (method === "thread/start") {
       this.#threadCounter += 1;

--- a/src/backend/agent/provider-runtime.test.ts
+++ b/src/backend/agent/provider-runtime.test.ts
@@ -16,6 +16,8 @@ import {
   waitFor,
 } from "../agent-service-test-harness";
 
+import { getString } from "../protocol";
+
 let root: string;
 let service: AgentService | null = null;
 
@@ -81,15 +83,138 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
 
     expect(availableOrder).toEqual(["claude", "grok", "codex"]);
 
-    // The fake advertises gpt-5.5, gpt-5.4, gpt-5.4-mini and gpt-5.3-codex-spark
-    // alongside the curated three, so CURATED_CODEX_MODEL_IDS has to drop four.
     expect(
       service
         .listModels()
         .filter((model) => model.provider === "codex")
         .map((model) => model.id),
-    ).toEqual(["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]);
+    ).toEqual([
+      "gpt-5.6-luna",
+      "gpt-5.6-terra",
+      "gpt-5.6-sol",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.3-codex-spark",
+    ]);
   });
+  it("uses startup fallbacks when provider discovery is unavailable", async () => {
+    process.env.OPENBOT_CLAUDE_PATH = await createFakeClaude(root);
+    const { store, mailbox } = stores(root);
+    service = new AgentService(store, mailbox, fakeBrowser(), 30_000, "codex", (provider) => {
+      const client = new FakeAgentClient(provider);
+      client.modelList = () => {
+        throw new Error("Discovery unavailable");
+      };
+      return client;
+    });
+    const fallback = service.listModels();
+    await service.initialize();
+    expect(service.listModels()).toEqual(fallback);
+  });
+
+  it.each(["codex", "claude"] as const)(
+    "discovers and refreshes %s models without losing the catalog on failure",
+    async (provider) => {
+      process.env.OPENBOT_CLAUDE_PATH = await createFakeClaude(root);
+      const { store, mailbox } = stores(root);
+      const client = new FakeAgentClient(provider);
+      const id = provider === "codex" ? "gpt-6-astra" : "claude-future-model";
+      let response: unknown = {
+        data: [
+          {
+            model: id,
+            displayName: "Discovered model",
+            defaultReasoningEffort: "high",
+            supportedReasoningEfforts: [{ reasoningEffort: "high" }],
+          },
+          { model: "hidden-model", hidden: true },
+        ],
+      };
+      let failure = false;
+      let queried = false;
+      client.modelList = () => {
+        queried = true;
+        if (failure) throw new Error("Discovery unavailable");
+        return response;
+      };
+      service = new AgentService(store, mailbox, fakeBrowser(), 30_000, provider, (candidate) =>
+        candidate === provider ? client : new FakeAgentClient(candidate),
+      );
+      await service.initialize();
+      const catalog = () => service?.listModels().filter((model) => model.provider === provider);
+      expect(catalog()).toEqual([
+        {
+          provider,
+          id,
+          name: "Discovered model",
+          description: expect.any(String),
+          defaultReasoningEffort: "high",
+          supportedReasoningEfforts: ["high"],
+        },
+      ]);
+
+      const refresh = async () => {
+        queried = false;
+        const current = service;
+        if (!current) throw new Error("Service not initialized");
+        const published = new Promise<void>((resolve) => {
+          const listener = (event: { type: string }) => {
+            if (event.type !== "status" || !queried) return;
+            current.off("event", listener);
+            resolve();
+          };
+          current.on("event", listener);
+        });
+        await current.refreshProviders();
+        await published;
+      };
+      failure = true;
+      await refresh();
+      expect(catalog()?.map((model) => model.id)).toEqual([id]);
+      failure = false;
+      response = { data: [{ model: id }, { model: "newly-available" }] };
+      await refresh();
+      expect(catalog()?.map((model) => model.id)).toEqual([id, "newly-available"]);
+      response = { data: [] };
+      await refresh();
+      expect(catalog()).toEqual([]);
+      failure = true;
+      await refresh();
+      expect(catalog()).toEqual([]);
+    },
+  );
+
+  it("collects all ChatGPT pages and keeps the previous catalog when pagination fails", async () => {
+    const { store, mailbox } = stores(root);
+    const client = new FakeAgentClient("codex");
+    let repeat = false;
+    client.modelList = (params) => {
+      const cursor = getString(params, "cursor");
+      return cursor
+        ? { data: [{ model: "gpt-6-astra" }, { model: "gpt-5.6-sol" }], nextCursor: repeat ? "page-2" : null }
+        : { data: [{ model: repeat ? "partial-result" : "gpt-5.6-sol" }], nextCursor: "page-2" };
+    };
+    service = new AgentService(store, mailbox, fakeBrowser(), 30_000, "codex", () => client);
+    await service.initialize();
+    expect(
+      service
+        .listModels()
+        .filter((model) => model.provider === "codex")
+        .map((model) => model.id),
+    ).toEqual(["gpt-5.6-sol", "gpt-6-astra"]);
+    expect(client.requests).toContainEqual({
+      method: "model/list",
+      params: { limit: 100, includeHidden: false, cursor: "page-2" },
+    });
+    const previous = service.listModels();
+    repeat = true;
+    // initialize awaits metadata discovery, unlike the background provider Refresh action.
+    await service.stop();
+    await service.initialize();
+    expect(service.listModels()).toEqual(previous);
+  });
+
   it("connects ChatGPT through the Codex App Server and promotes the authenticated client", async () => {
     const { store, mailbox } = stores(root);
     const codexClients: FakeAgentClient[] = [];

--- a/src/backend/agent/provider-runtime.test.ts
+++ b/src/backend/agent/provider-runtime.test.ts
@@ -113,13 +113,14 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
     expect(service.listModels()).toEqual(fallback);
   });
 
-  it.each(["codex", "claude"] as const)(
+  it.each(["codex", "claude", "grok"] as const)(
     "discovers and refreshes %s models without losing the catalog on failure",
     async (provider) => {
       process.env.OPENBOT_CLAUDE_PATH = await createFakeClaude(root);
+      process.env.OPENBOT_GROK_PATH = await createFakeGrok(root);
       const { store, mailbox } = stores(root);
       const client = new FakeAgentClient(provider);
-      const id = provider === "codex" ? "gpt-6-astra" : "claude-future-model";
+      const id = provider === "codex" ? "gpt-6-astra" : `${provider}-future-model`;
       let response: unknown = {
         data: [
           {

--- a/src/backend/agent/provider-runtime.ts
+++ b/src/backend/agent/provider-runtime.ts
@@ -1079,7 +1079,7 @@ export class ProviderRuntime implements ProviderPort {
         BUILT_IN_PROVIDER_DRIVERS.map(async ({ id: provider }): Promise<AgentModelOption[]> => {
           const previous = this.#models.filter((model) => model.provider === provider);
           const client = this.#clients.get(provider);
-          if (!client) return provider === "grok" ? [] : previous;
+          if (!client) return previous;
           try {
             const serverModels = new Map<string, ModelListResponse["data"][number]>();
             const cursors = new Set<string>();
@@ -1123,7 +1123,7 @@ export class ProviderRuntime implements ProviderPort {
             }
             return models;
           } catch {
-            return client.provider === "grok" ? [] : previous;
+            return previous;
           }
         }),
       )

--- a/src/backend/agent/provider-runtime.ts
+++ b/src/backend/agent/provider-runtime.ts
@@ -8,7 +8,6 @@ import type {
   AgentSummary,
 } from "@openbot/contracts/ipc";
 import { isReasoningEffort } from "@openbot/contracts/ipc";
-import { isString } from "@openbot/contracts/runtime-values";
 import type { AgentClient, AgentProvider } from "./../agent-client";
 import { CodexAppServerClient } from "./../app-server-client";
 import { type AgentCliInfo, CodexCliError, type CodexCliInfo, resolveCodexCli } from "./../cli";
@@ -22,6 +21,7 @@ import {
   decodeRecordResponse,
   getArray,
   isRecord,
+  type ModelListResponse,
 } from "./../protocol";
 import { BUILT_IN_PROVIDER_DRIVERS, type CliLoginCommand, requireProviderDriver } from "./../provider-drivers";
 import { normalizeAccountUsage } from "./account-usage";
@@ -148,10 +148,6 @@ const FALLBACK_MODELS: AgentModelOption[] = [
     supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
   },
 ];
-
-const CURATED_CODEX_MODEL_IDS = new Set(
-  FALLBACK_MODELS.filter((model) => model.provider === "codex").map((model) => model.id),
-);
 
 /**
  * Owns provider processes, their CLIs, accounts, login flows and the derived AgentStatus.
@@ -1080,23 +1076,31 @@ export class ProviderRuntime implements ProviderPort {
   async #refreshModelCatalog(): Promise<void> {
     const discovered = (
       await Promise.all(
-        [...this.#clients.values()].map(async (client): Promise<AgentModelOption[]> => {
+        BUILT_IN_PROVIDER_DRIVERS.map(async ({ id: provider }): Promise<AgentModelOption[]> => {
+          const previous = this.#models.filter((model) => model.provider === provider);
+          const client = this.#clients.get(provider);
+          if (!client) return provider === "grok" ? [] : previous;
           try {
-            const response = await client.request(
-              "model/list",
-              { limit: 100, includeHidden: false },
-              decodeModelListResponse,
-              5_000,
-            );
-            const serverModels = new Map(
-              response.data
-                .filter((item): item is typeof item & { model: string } => !item.hidden && isString(item.model))
-                .map((item) => [item.model, item] as const),
-            );
+            const serverModels = new Map<string, ModelListResponse["data"][number]>();
+            const cursors = new Set<string>();
+            let cursor: string | undefined;
+            do {
+              const response = await client.request(
+                "model/list",
+                { limit: 100, includeHidden: false, ...(cursor ? { cursor } : {}) },
+                decodeModelListResponse,
+                5_000,
+              );
+              for (const item of response.data) {
+                if (!item.hidden && item.model?.trim()) serverModels.set(item.model, item);
+              }
+              cursor = client.provider === "codex" ? response.nextCursor : undefined;
+              if (cursor && cursors.has(cursor)) throw new Error("Model discovery repeated a pagination cursor.");
+              if (cursor) cursors.add(cursor);
+            } while (cursor);
             const models: AgentModelOption[] = [];
             for (const server of serverModels.values()) {
               if (!server.model) continue;
-              if (client.provider === "codex" && !CURATED_CODEX_MODEL_IDS.has(server.model)) continue;
               const fallback = FALLBACK_MODELS.find(
                 (candidate) => candidate.provider === client.provider && candidate.id === server.model,
               );
@@ -1119,24 +1123,12 @@ export class ProviderRuntime implements ProviderPort {
             }
             return models;
           } catch {
-            return client.provider === "grok"
-              ? []
-              : FALLBACK_MODELS.filter((model) => model.provider === client.provider);
+            return client.provider === "grok" ? [] : previous;
           }
         }),
       )
     ).flat();
-    const discoveredById = new Map(discovered.map((model) => [`${model.provider}:${model.id}`, model]));
-    const staticModels = FALLBACK_MODELS.map(
-      (fallback) => discoveredById.get(`${fallback.provider}:${fallback.id}`) ?? fallback,
-    );
-    this.#models = [
-      ...staticModels,
-      ...discovered.filter(
-        (model) =>
-          !FALLBACK_MODELS.some((fallback) => fallback.provider === model.provider && fallback.id === model.id),
-      ),
-    ];
+    this.#models = discovered;
   }
 
   async #probeComputerUse(client: AgentClient): Promise<"ready" | "setup-required" | "unavailable"> {

--- a/src/backend/grok-client.test.ts
+++ b/src/backend/grok-client.test.ts
@@ -222,6 +222,30 @@ describe.sequential("GrokAgentClient", () => {
     );
   });
 
+  it("rediscovers Grok models without restarting and closes discovery sessions", async () => {
+    process.env.OPENBOT_FAKE_GROK_MODE = "refresh-models";
+    client = new GrokAgentClient({ executable, version: "1.0.13" }, 5_000);
+    client.start();
+    await client.request("initialize", {}, decodeRecordResponse);
+    const models = await client.request("model/list", {}, decodeModelListResponse);
+    expect(models.data).toContainEqual(expect.objectContaining({ model: "grok-future-2", displayName: "Future Grok" }));
+    expect(await readLog()).toContainEqual({ method: "session/close", sessionId: "grok-session-2" });
+    await expect(client.request("model/list", {}, decodeModelListResponse)).rejects.toThrow("Discovery unavailable");
+    const refreshed = await client.request("model/list", {}, decodeModelListResponse);
+    expect(refreshed.data.map((model) => model.model)).toEqual(["grok-4.5", "grok-fast", "grok-future-4"]);
+    expect(await readLog()).toContainEqual({ method: "session/close", sessionId: "grok-session-4" });
+  });
+
+  it("bounds Grok model discovery by the caller timeout", async () => {
+    process.env.OPENBOT_FAKE_GROK_MODE = "hung-models";
+    client = new GrokAgentClient({ executable, version: "1.0.13" }, 5_000);
+    client.start();
+    await client.request("initialize", {}, decodeRecordResponse);
+    await expect(client.request("model/list", {}, decodeModelListResponse, 10)).rejects.toThrow(
+      "Grok request timed out: model/list",
+    );
+  });
+
   it("uses one neutral effort when thought_level is not advertised", async () => {
     process.env.OPENBOT_FAKE_GROK_MODE = "no-thought";
     client = new GrokAgentClient({ executable, version: "1.0.5" }, 5_000);
@@ -384,6 +408,7 @@ const modelConfig = () => {
       { value: "grok-fast", name: "Grok Fast", description: "Fast" },
     ],
   }];
+  if (mode === "refresh-models" && sessionCounter > 1) options[0].options.push({ value: "grok-future-" + sessionCounter, name: "Future Grok" });
   if (mode !== "no-thought") options.push({
     id: "thought",
     name: "Thought level",
@@ -476,6 +501,11 @@ createInterface({ input: process.stdin }).on("line", (line) => {
   }
   if (message.method === "session/new") {
     sessionCounter += 1;
+    if (mode === "hung-models" && sessionCounter > 1) return;
+    if (mode === "refresh-models" && sessionCounter === 3) {
+      write({ id: message.id, error: { code: -32603, message: "Discovery unavailable" } });
+      return;
+    }
     const sessionId = "grok-session-" + sessionCounter;
     log({ method: message.method, sessionId, mcpAuthorization: message.params.mcpServers?.some((server) => server.headers?.some((header) => header.name.toLowerCase() === "authorization" && header.value.startsWith("Bearer "))) });
     const result = mode === "model-metadata"

--- a/src/backend/grok-client.ts
+++ b/src/backend/grok-client.ts
@@ -189,6 +189,8 @@ export class GrokAgentClient extends EventEmitter<ClientEvents> {
           ),
         );
       case "model/list":
+        await this.#ensureInitialized();
+        if (this.#signedIn) this.#models = await this.#discoverModels(timeoutMs);
         return decoder({
           data: this.#models.map((model) => ({
             model: model.id,
@@ -271,13 +273,11 @@ export class GrokAgentClient extends EventEmitter<ClientEvents> {
       advertised.find((method) => method.id === "cached_token");
     try {
       if (selected) await connection.authenticate({ methodId: selected.id });
-      const probe = await connection.newSession({ cwd: process.cwd(), mcpServers: [] });
-      this.#models = modelsFromSessionSetup(probe);
+      this.#models = await this.#discoverModels();
       if (this.#models.length === 0) {
         throw new Error("Grok CLI did not advertise any ACP models. OpenBot will not guess a fallback model.");
       }
       this.#signedIn = true;
-      await connection.closeSession({ sessionId: probe.sessionId }).catch(() => undefined);
     } catch (error) {
       if (isAuthenticationError(error)) {
         this.#signedIn = false;
@@ -285,6 +285,22 @@ export class GrokAgentClient extends EventEmitter<ClientEvents> {
       }
       throw error;
     }
+  }
+
+  async #discoverModels(timeoutMs = this.#requestTimeoutMs): Promise<GrokModel[]> {
+    const connection = this.#requireConnection();
+    return withTimeout(
+      (async () => {
+        const probe = await connection.newSession({ cwd: process.cwd(), mcpServers: [] });
+        try {
+          return modelsFromSessionSetup(probe);
+        } finally {
+          await connection.closeSession({ sessionId: probe.sessionId }).catch(() => undefined);
+        }
+      })(),
+      timeoutMs,
+      "Grok request timed out: model/list",
+    );
   }
 
   async #startThread(params: unknown, resume: boolean): Promise<{ thread: { id: string } }> {

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -129,6 +129,7 @@ export interface TurnResponse {
 export type ResponseDecoder<T> = (value: unknown) => T;
 
 export interface ModelListResponse {
+  nextCursor?: string;
   data: Array<{
     model?: string;
     displayName?: string;
@@ -140,7 +141,9 @@ export interface ModelListResponse {
 
 export function decodeModelListResponse(value: unknown): ModelListResponse {
   const data = getArray(value, "data");
+  const nextCursor = getString(value, "nextCursor");
   return {
+    ...(nextCursor ? { nextCursor } : {}),
     data: data.filter(isRecord).map((item) => ({
       ...(isString(item.model) ? { model: item.model } : {}),
       ...(isString(item.displayName) ? { displayName: item.displayName } : {}),

--- a/src/renderer/stories/ProviderModelPicker.stories.tsx
+++ b/src/renderer/stories/ProviderModelPicker.stories.tsx
@@ -88,3 +88,20 @@ export const ProviderDownloadsOpen: Story = {
   },
   play: Opens.play,
 };
+
+export const DiscoveredModels: Story = {
+  args: {
+    modelOptions: [
+      ...STORY_MODELS,
+      {
+        provider: "codex",
+        id: "gpt-6-astra",
+        name: "GPT-6 Astra",
+        description: "Codex model discovered from the local CLI.",
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+      },
+    ],
+  },
+  play: Opens.play,
+};


### PR DESCRIPTION
When the ChatGPT CLI advertised Astra, OpenBot discarded it because its picker allowed only Luna, Terra, and Sol. The picker now accepts every visible discovered model for ChatGPT, Claude, and Grok, including future IDs, and follows ChatGPT pagination.

Successful discovery replaces that provider’s catalog, including empty results. Failed discovery retains the last in-memory catalog, with existing ChatGPT/Claude static fallbacks available at startup. Grok has no guessed fallback models. Existing startup, connection, and provider Refresh flows trigger discovery; saved selections and defaults are unchanged.

Grok now re-probes its ACP model catalog on model-list requests instead of returning only its initialization cache. Discovery honors the caller timeout and closes temporary probe sessions, including late responses after a timeout.

Before/after: `Conversation/ProviderModelPicker/Opens` shows the existing catalog; the new `DiscoveredModels` story adds GPT-6 Astra. Screenshot verification could not be completed: the browser runtime reported no available browsers, and the sandbox blocked the attempted Storybook listener. These are fixture examples, not evidence of account-specific Astra availability.

Validation:
- The original 34 targeted tests passed across provider-runtime, Claude client, and Grok client. After extending Grok, all 23 runtime/Grok tests passed. New Grok refresh, timeout, and failure-retention regressions were first run against the old implementation and all three failed for the intended reasons.
- Restored the old allowlist temporarily: Astra and pagination regressions failed for missing models. Removed failure preservation temporarily: startup fallback and both providers’ retention tests failed. Restored implementation and reran successfully.
- `bun run lint`, `bun run typecheck`, `bun run check:ui`, and `git diff --check` passed. Lint reports five pre-existing module-mocking warnings in mobile auth tests; left unrelated native-boundary mocks unchanged.

Surfaces: backend provider discovery and a desktop renderer Storybook example. Existing IPC and Team API model-list consumers receive the updated catalog without wire changes. No mobile, public web, Signal service, database, or privacy changes.

Model/harness: GPT-6 Astra in Codex; Vitest provider fakes and a SolidJS Storybook fixture.
