### PR TITLE
Let NorbiAI review a fork PR when a maintainer asks

### DIFF
--- a/.github/workflows/norbiai-review.yml
+++ b/.github/workflows/norbiai-review.yml
@@ -32,13 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
-    # The push path stays automatic and skips drafts. The comment path is an explicit
-    # request from someone who can already merge, so it runs on drafts too: `/norbiai review`
-    # means review it now. `github.event.issue.pull_request` is what separates a pull request
-    # comment from an issue comment, and `author_association` is a cheap pre-filter that
-    # keeps a drive-by comment from reaching the permission lookup below. The
-    # same-repository rule is enforced in the review job, because a comment payload carries
-    # no head repository to test here.
+    # The push path stays automatic, skips drafts, and stays same-repository: a fork's
+    # `pull_request` run gets a read-only `GITHUB_TOKEN` whatever the `permissions` block
+    # below says, so it could review and then fail to publish either the comment or the
+    # gate status — and nobody asked for it to try.
+    #
+    # The comment path is an explicit request from someone who can already merge, so it runs
+    # on drafts and on forks too: `/norbiai review` means review it now. `issue_comment`
+    # fires in the base repository, which is what gives that path the write token the push
+    # path cannot have on a fork. `github.event.issue.pull_request` is what separates a pull
+    # request comment from an issue comment, and `author_association` is a cheap pre-filter
+    # that keeps a drive-by comment from reaching the permission lookup below.
     if: >
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -130,19 +134,22 @@ jobs:
           base_sha=${EVENT_BASE_SHA:-}
           head_sha=${EVENT_HEAD_SHA:-}
 
-          # A comment payload carries no SHAs and no head repository, so those come from the
-          # API. The push path deliberately keeps the payload's SHAs: they are the commit the
-          # checkout is for, whereas the API answers with a newer head the moment another push
-          # lands, and the guard below would then fail on a commit this run never fetched.
+          # A comment payload carries no SHAs, so those come from the API. The push path
+          # deliberately keeps the payload's SHAs: they are the commit the checkout is for,
+          # whereas the API answers with a newer head the moment another push lands, and the
+          # guard below would then fail on a commit this run never fetched.
+          #
+          # The head repository is not tested. A fork reaching this job means a maintainer
+          # who can merge asked for it by comment, and the merge ref below is the base
+          # repository's own computation of that fork's head, so it resolves for a fork
+          # exactly as it does for a branch. What keeps the fork's own content from steering
+          # the review is downstream and unchanged: the prompt and the composer are read from
+          # the base commit, the composer runs with an empty bunfig and `--no-install`, and
+          # the reviewer is sandboxed read-only.
           if [ -z "$head_sha" ]; then
-            IFS=$'\t' read -r head_repo base_sha head_sha < <(
-              gh api "$api" --jq '[.head.repo.full_name // "", .base.sha, .head.sha] | @tsv'
+            IFS=$'\t' read -r base_sha head_sha < <(
+              gh api "$api" --jq '[.base.sha, .head.sha] | @tsv'
             )
-
-            if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
-              echo "::error title=NorbiAI does not review forks::Head repository ${head_repo:-unknown} is not ${GITHUB_REPOSITORY}."
-              exit 1
-            fi
           fi
 
           for sha in "$base_sha" "$head_sha"; do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,11 @@ state, `.env` files, credentials, real conversations, or user attachments.
 
 ### Answering the NorbiAI review
 
-Every push runs the automated reviewer and it blocks the merge on an unresolved P0 or P1 finding.
-Two ways past one:
+Every push to a branch in this repository runs the automated reviewer, and it blocks the merge on
+an unresolved P0 or P1 finding. A pull request from a fork is the exception: GitHub gives a fork's
+push run a read-only token, so it could not publish a review even if it produced one. Ask a
+maintainer to comment `/norbiai review` — that path runs in this repository and can publish, and
+the same comment re-runs the review after each push. Two ways past a finding:
 
 1. Fix it and push. The next review classifies the finding `[RESOLVED]`.
 2. Show it is wrong. Comment the concrete reason — the guard it misses, the line that already
@@ -58,10 +61,11 @@ Two ways past one:
 
 A rebuttal needs something checkable in it. "Intended", "out of scope", or a promise to fix it
 later leaves the finding `[REMAINS]`, and the reviewer says which part it could not verify. Only
-comments from someone who can merge the pull request are read — organization membership on its
-own is not enough — and only those written after the review being answered, plus the comment that
-asked for the recheck whatever its timestamp says. That one is passed to the reviewer whole; the
-older responses share a size budget and are dropped from the oldest end.
+comments from someone who can merge the pull request are read — organization membership on its own
+is not enough, and on a fork that means the recheck has to be asked for by a maintainer rather than
+by you — and only those written after the review being answered, plus the comment that asked for
+the recheck whatever its timestamp says. That one is passed to the reviewer whole; the older
+responses share a size budget and are dropped from the oldest end.
 
 ## Security-sensitive changes
 


### PR DESCRIPTION
## Why

A pull request from a fork gets no NorbiAI review at all. On #262 both jobs skipped in zero
seconds, so the `NorbiAI review` status never appeared — and where branch protection requires that
status, no action by anyone could satisfy it. Approving the workflow run does not help: the run
starts and then skips itself, because the block is a fork condition rather than the approval gate.

Two separate guards refused a fork. `authorize` refused the push path via its `if`, and
`Resolve pull request` refused a fork again at runtime, which is the one that closed the comment
path too.

## What changed

The comment path is unlocked for forks. `issue_comment` fires in the base repository, so it carries
a write token and can publish both the review comment and the gate status on a fork head SHA, and
`authorize` already resolves the commenter's permission through the API and refuses anyone who
cannot merge. Removing the second guard leaves a fork review gated on a maintainer asking for it by
name with `/norbiai review`.

`head_repo` is dropped from the `jq` in that step, since nothing reads it now.

**The push path stays same-repository, deliberately.** That clause is not a policy preference:
GitHub forces `GITHUB_TOKEN` to read-only for a `pull_request` run from a fork whatever the
`permissions` block says. Letting one through would spend fifteen minutes on the self-hosted runner
and then 403 on the comment and the status both. The comment in the file now says so, so the next
reader does not "fix" it.

Nothing about what a fork's own content can influence changes. The prompt and the composer are
still read from the base commit, the composer still runs with an empty bunfig and `--no-install`,
and the reviewer is still sandboxed read-only.

`CONTRIBUTING.md` claimed "every push runs the automated reviewer", which was never true for a
fork. It now says a fork PR needs a maintainer to comment `/norbiai review`, and that on a fork the
rebuttal recheck has to be asked for by a maintainer rather than by the author.

## Surfaces touched

CI workflow and documentation only. No renderer, mobile, web, Signal service, IPC contract,
migration or schema change.

## Verification

- Simulated the changed `Resolve pull request` step against fork PR #262 for real:
  `refs/pull/262/merge` exists in `nightly-labs/openbot`, and after fetching it both the base
  (`4c6210d2`) and the fork head (`0d134fad`) are reachable — so the `git cat-file -e` guard passes
  and `git diff base...head` resolves on a fork exactly as on a branch. That was the one thing that
  could have failed silently.
- YAML parses; all seven `run:` blocks pass `bash -n`.
- Grepped for any other fork gate. The `authorize` push-path clause is the only one left.
- `bun run typecheck` (all 11 projects) and `bun run check:ui` green via the pre-commit hook.

No test added: there is no harness for workflow YAML in this repo, and the change is a deletion of a
guard plus comments. The behavioural check that mattered is the merge-ref simulation above.

Not verified: the `POST /statuses/{head_sha}` call, since testing it means writing a status onto a
contributor's PR. It should work — a fork PR's head commit is present in the base repository as
`refs/pull/N/head`, which is what that API requires.

## Note for whoever merges

`issue_comment` workflows always run the copy of the file on the default branch, so `/norbiai
review` will not work on #262 until this lands on `main`.

## Approvability

No `biome-ignore`, no `@ts-expect-error`, no `biome.json` override, no widened type or assertion.

---

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
