### PR TITLE
feat(dev): generate local Auth API secrets when a fork has no .env.keys

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,4 +1,6 @@
 # Local dotenvx decryption key used by the development Auth API.
 .env.keys
+# Contributor-generated Auth API secrets when the tracked .env.dev cannot be decrypted.
+apps/auth-api/.env.dev.local
 # Local dotenvx decryption key used by the Remote production stack.
 remote/.env.keys

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,9 @@ belongs.
 
 A fresh worktree has no `node_modules`, and every command below dies with `biome: command not found`
 or `Cannot find module '@openbot/logging'` until it does. Run `bun install --frozen-lockfile` first,
-or `bun scripts/prepare-dev-environment.ts`, which adds the local D1 migration and asserts the Bun
-version and the `.env.keys` `.worktreeinclude` carries across.
+or `bun scripts/prepare-dev-environment.ts`, which adds the local D1 migration, asserts the Bun
+version, and either copies `.env.keys` through `.worktreeinclude` or generates contributor-local
+keys and `apps/auth-api/.env.dev.local` when the author's file is not present.
 
 Before you call a task done, run the narrowest test for what you touched, then `bun run lint` and
 `bun run typecheck` — plus `bun run check:ui` if you touched `src/renderer`, which scans the whole

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,9 @@ bun run check
 bun run dev
 ```
 
+`bun run dev` generates ignored local Auth API secrets when `.env.keys` is missing, so a public
+fork can run the app without the author's dotenvx key.
+
 The supported toolchain is pinned in `package.json`. Use stable Bun 1.4.0, TypeScript 5.9, Vite 7, and the
 existing Biome configuration. Biome is the only lint and format tool. Do not add a second linter,
 Prettier, a second state library, or a UI kit without first discussing the architectural cost.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ bun run codex:doctor
 bun run dev
 ```
 
+A fork without the author's ignored `.env.keys` file is fine: `bun run dev` generates a local
+keypair and `apps/auth-api/.env.dev.local`. Those files stay gitignored. Do not commit them.
+Local login returns the one-time code in the API response (`AUTH_EXPOSE_DEVELOPMENT_CODE`).
+
 `codex:doctor` checks the CLI version, App Server handshake, ChatGPT login, and Computer Use plugin
 without starting a model turn.
 
@@ -135,6 +139,7 @@ Use `bun run dev:seed --dry-run` to inspect the target and fixture counts withou
 | Command | Purpose |
 | --- | --- |
 | `bun run dev` | Start the local Auth API, Signal service, and Electron client with renderer HMR on its app profile. |
+| `bun run env:bootstrap` | Generate ignored local `.env.keys` and `apps/auth-api/.env.dev.local` when the author's key is not present. |
 | `bun run preview` | Preview the built Electron client with the green preview icon. |
 | `bun run dev:api` | Start the TanStack Start API and its local D1 database on `127.0.0.1:3100`. |
 | `bun run api:start` | Build and preview the Cloudflare Worker locally. |

--- a/apps/auth-api/README.md
+++ b/apps/auth-api/README.md
@@ -13,6 +13,10 @@ private keys stay in the ignored root `.env.keys` file. Dotenvx decrypts the
 selected file only in process memory. The explicit development flag returns the
 code in the API response. It never writes the code to logs.
 
+A checkout without `.env.keys` (a public fork) generates contributor-local secrets
+on `bun run dev`: a new `.env.keys` and gitignored `apps/auth-api/.env.dev.local`.
+Do not commit either file. They cannot decrypt the tracked production ciphertext.
+
 ```bash
 bun run api:migrate:local
 bun run dev:api
@@ -29,7 +33,7 @@ bun run env:validate:dev
 bun run env:validate:prod
 ```
 
-Commit `.env.dev` and `.env.production`. Never commit `.env.keys`.
+Commit `.env.dev` and `.env.production`. Never commit `.env.keys` or `.env.dev.local`.
 
 ## Email delivery
 

--- a/apps/auth-api/package.json
+++ b/apps/auth-api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "dotenvx run -f .env.dev -fk ../../.env.keys -- vite dev",
+    "dev": "bun ../../scripts/auth-api-dev.ts",
     "start": "bun run build && bun run preview",
     "build": "vite build",
     "preview": "dotenvx run -f .env.production -fk ../../.env.keys -- vite preview --port 3100",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "remote:check:compose": "bun remote/scripts/check.ts --compose",
     "remote:env:validate": "cd remote && bin/dotenvx validate -f .env.production -fk .env.keys",
     "remote:update": "remote/bin/dotenvx run --overload -f remote/.env.production -fk remote/.env.keys -- bun remote/scripts/update.ts",
+    "env:bootstrap": "bun scripts/development-secrets.ts",
     "env:encrypt:dev": "bun run --cwd apps/auth-api env:encrypt:dev",
     "env:encrypt:prod": "bun run --cwd apps/auth-api env:encrypt:prod",
     "env:set:smtp": "bun run --cwd apps/auth-api env:set:smtp",

--- a/scripts/auth-api-dev.ts
+++ b/scripts/auth-api-dev.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from "node:child_process";
+import { delimiter, join } from "node:path";
+import { developmentAuthEnvFile, developmentKeysFile, developmentProjectRoot } from "./development-secrets";
+
+const projectRoot = developmentProjectRoot;
+const pathPrefix = join(projectRoot, "node_modules", ".bin");
+const dotenvx = join(pathPrefix, process.platform === "win32" ? "dotenvx.cmd" : "dotenvx");
+const result = spawnSync(
+  dotenvx,
+  ["run", "-f", developmentAuthEnvFile(projectRoot), "-fk", developmentKeysFile(projectRoot), "--", "vite", "dev"],
+  {
+    cwd: join(projectRoot, "apps", "auth-api"),
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      PATH: `${pathPrefix}${delimiter}${process.env.PATH ?? ""}`,
+    },
+  },
+);
+process.exit(result.status ?? 1);

--- a/scripts/dev-services.test.ts
+++ b/scripts/dev-services.test.ts
@@ -11,6 +11,7 @@ import {
   signalOwnedProcess,
   stopOwnedProcesses,
 } from "./dev-services";
+import { developmentAuthEnvFile } from "./development-secrets";
 
 describe("development service runner", () => {
   it("runs the normal API and app in a stable order", () => {
@@ -37,7 +38,7 @@ describe("development service runner", () => {
   it("builds the local Signal command with the Auth API development keys", () => {
     const spec = createDevelopmentServiceSpec("remote", { REMOTE_SIGNAL_PORT: "3101" });
 
-    expect(spec.args).toContain(`${projectRoot}/apps/auth-api/.env.dev`);
+    expect(spec.args).toContain(developmentAuthEnvFile(projectRoot));
     expect(spec.args).toContain(`${projectRoot}/remote/api`);
     expect(spec.env.REMOTE_SIGNAL_PORT).toBe("3101");
   });

--- a/scripts/dev-services.ts
+++ b/scripts/dev-services.ts
@@ -12,6 +12,7 @@ import {
   removeDevInstanceRecord,
   writeDevInstanceRecord,
 } from "./dev-automation/instance-registry";
+import { developmentAuthEnvFile, developmentKeysFile } from "./development-secrets";
 import { prepareDevelopmentEnvironment } from "./prepare-dev-environment";
 
 const logger = createOpenBotLogger("dev-services");
@@ -96,9 +97,9 @@ export function createDevelopmentServiceSpec(
         "--redact",
         "--strict",
         "-f",
-        join(projectRoot, "apps", "auth-api", ".env.dev"),
+        developmentAuthEnvFile(projectRoot),
         "-fk",
-        join(projectRoot, ".env.keys"),
+        developmentKeysFile(projectRoot),
         "--",
         process.execPath,
         "run",

--- a/scripts/development-secrets.test.ts
+++ b/scripts/development-secrets.test.ts
@@ -1,0 +1,132 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createContributorDevelopmentSecrets,
+  developmentAuthEnvFile,
+  developmentRemoteTicketKeyId,
+  ensureDevelopmentSecrets,
+  hasDevelopmentKeys,
+  serializeEnvFile,
+} from "./development-secrets";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("contributor development secrets", () => {
+  it("generates a local key file and Auth API overlay when none exist", () => {
+    const root = createTemporaryRoot();
+
+    ensureDevelopmentSecrets(root, {
+      encrypt: ({ keysFile }) => {
+        writeFileSync(keysFile, "DOTENV_PRIVATE_KEY_DEV_LOCAL=test-key\n");
+      },
+    });
+
+    expect(hasDevelopmentKeys(root)).toBe(true);
+    expect(developmentAuthEnvFile(root)).toBe(join(root, "apps", "auth-api", ".env.dev.local"));
+    const values = parseEnvFile(readFileSync(join(root, "apps", "auth-api", ".env.dev.local"), "utf8"));
+    expect(values.AUTH_EXPOSE_DEVELOPMENT_CODE).toBe("true");
+    expect(values.EMAIL_SMTP_PASSWORD).toBe("unused-local-development");
+    expect(values.REMOTE_TICKET_KEY_ID).toBe(developmentRemoteTicketKeyId);
+    expect(values.SITE_REPORT_HASH_SECRET?.length).toBeGreaterThanOrEqual(32);
+    expect(values.REMOTE_AUTH_WEBHOOK_SECRET?.length).toBeGreaterThanOrEqual(32);
+    const privateJwk = JSON.parse(values.REMOTE_TICKET_PRIVATE_JWK ?? "");
+    const publicJwks = JSON.parse(values.REMOTE_TICKET_PUBLIC_JWKS ?? "");
+    expect(privateJwk).toMatchObject({ kty: "EC", crv: "P-256", kid: developmentRemoteTicketKeyId, alg: "ES256" });
+    expect(privateJwk.d).toEqual(expect.any(String));
+    expect(publicJwks.keys).toEqual([
+      expect.objectContaining({ kty: "EC", crv: "P-256", kid: developmentRemoteTicketKeyId, use: "sig" }),
+    ]);
+  });
+
+  it("leaves an existing .env.keys file alone", () => {
+    const root = createTemporaryRoot();
+    writeFileSync(join(root, ".env.keys"), "DOTENV_PRIVATE_KEY_DEV=existing\n");
+
+    ensureDevelopmentSecrets(root, {
+      encrypt: () => {
+        throw new Error("must not encrypt when keys already exist");
+      },
+    });
+
+    expect(readFileSync(join(root, ".env.keys"), "utf8")).toBe("DOTENV_PRIVATE_KEY_DEV=existing\n");
+    expect(developmentAuthEnvFile(root)).toBe(join(root, "apps", "auth-api", ".env.dev"));
+  });
+
+  it("rewrites a contributor overlay whose ticket JWKS is not JSON", () => {
+    const root = createTemporaryRoot();
+    mkdirSync(join(root, "apps", "auth-api"), { recursive: true });
+    writeFileSync(join(root, ".env.keys"), "DOTENV_PRIVATE_KEY_DEV_LOCAL=existing\n");
+    writeFileSync(
+      join(root, "apps", "auth-api", ".env.dev.local"),
+      'REMOTE_TICKET_PUBLIC_JWKS=\'{\\"keys\\":[]}\'\nREMOTE_TICKET_PRIVATE_JWK=\'{\\"kty\\":\\"EC\\"}\'\n',
+    );
+
+    ensureDevelopmentSecrets(root, { encrypt: () => undefined });
+
+    const values = parseEnvFile(readFileSync(join(root, "apps", "auth-api", ".env.dev.local"), "utf8"));
+    expect(JSON.parse(values.REMOTE_TICKET_PUBLIC_JWKS ?? "").keys).toEqual([
+      expect.objectContaining({ kty: "EC", kid: developmentRemoteTicketKeyId }),
+    ]);
+    expect(readFileSync(join(root, ".env.keys"), "utf8")).toBe("DOTENV_PRIVATE_KEY_DEV_LOCAL=existing\n");
+  });
+
+  it("prefers the contributor overlay over the tracked development file", () => {
+    const root = createTemporaryRoot();
+    mkdirSync(join(root, "apps", "auth-api"), { recursive: true });
+    writeFileSync(join(root, "apps", "auth-api", ".env.dev"), "AUTH_EXPOSE_DEVELOPMENT_CODE=false\n");
+    writeFileSync(join(root, "apps", "auth-api", ".env.dev.local"), "AUTH_EXPOSE_DEVELOPMENT_CODE=true\n");
+
+    expect(developmentAuthEnvFile(root)).toBe(join(root, "apps", "auth-api", ".env.dev.local"));
+  });
+
+  it("serializes JSON secrets so dotenvx can decrypt them as JSON", () => {
+    const values = createContributorDevelopmentSecrets();
+    const serialized = serializeEnvFile({
+      AUTH_EXPOSE_DEVELOPMENT_CODE: values.AUTH_EXPOSE_DEVELOPMENT_CODE,
+      REMOTE_TICKET_PRIVATE_JWK: values.REMOTE_TICKET_PRIVATE_JWK,
+      EMAIL_SMTP_PASSWORD: values.EMAIL_SMTP_PASSWORD,
+    });
+
+    expect(serialized).toContain("AUTH_EXPOSE_DEVELOPMENT_CODE=true\n");
+    expect(serialized).toContain("REMOTE_TICKET_PRIVATE_JWK='{");
+    expect(serialized).not.toContain("\\");
+    const parsed = parseEnvFile(serialized);
+    expect(JSON.parse(parsed.REMOTE_TICKET_PRIVATE_JWK ?? "")).toEqual(JSON.parse(values.REMOTE_TICKET_PRIVATE_JWK));
+    expect(parsed.EMAIL_SMTP_PASSWORD).toBe("unused-local-development");
+  });
+});
+
+function createTemporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "openbot-dev-secrets-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function parseQuotedEnvValue(raw: string): string {
+  const parsed = JSON.parse(raw);
+  if (typeof parsed !== "string") throw new Error(`Expected a quoted string env value, received ${typeof parsed}.`);
+  return parsed;
+}
+
+function parseEnvFile(contents: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const line of contents.split("\n")) {
+    if (!line || line.startsWith("#")) continue;
+    const separator = line.indexOf("=");
+    if (separator < 1) continue;
+    const name = line.slice(0, separator);
+    const raw = line.slice(separator + 1);
+    if (raw.startsWith("'") && raw.endsWith("'")) {
+      values[name] = raw.slice(1, -1);
+      continue;
+    }
+    values[name] = raw.startsWith('"') ? parseQuotedEnvValue(raw) : raw;
+  }
+  return values;
+}

--- a/scripts/development-secrets.ts
+++ b/scripts/development-secrets.ts
@@ -1,0 +1,211 @@
+import { execFileSync } from "node:child_process";
+import { generateKeyPairSync, randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptsRoot = dirname(fileURLToPath(import.meta.url));
+export const developmentProjectRoot = dirname(scriptsRoot);
+
+export const contributorAuthEnvFileName = ".env.dev.local";
+export const developmentRemoteTicketKeyId = "openbot-remote-1";
+export const developmentSmtpPasswordPlaceholder = "unused-local-development";
+
+const unquotedEnvValue = /^[A-Za-z0-9._-]+$/u;
+
+export type DevelopmentSecretEncryptor = (input: { envFile: string; keysFile: string; projectRoot: string }) => void;
+
+export function developmentKeysFile(projectRoot: string): string {
+  return join(projectRoot, ".env.keys");
+}
+
+export function developmentAuthEnvFile(projectRoot: string): string {
+  const contributorFile = join(projectRoot, "apps", "auth-api", contributorAuthEnvFileName);
+  if (isNonEmptyFile(contributorFile)) return contributorFile;
+  return join(projectRoot, "apps", "auth-api", ".env.dev");
+}
+
+export function hasDevelopmentKeys(projectRoot: string): boolean {
+  return isNonEmptyFile(developmentKeysFile(projectRoot));
+}
+
+export function ensureDevelopmentSecrets(
+  projectRoot: string,
+  options: { encrypt?: DevelopmentSecretEncryptor } = {},
+): void {
+  const envFile = join(projectRoot, "apps", "auth-api", contributorAuthEnvFileName);
+  if (hasDevelopmentKeys(projectRoot) && !isNonEmptyFile(envFile)) return;
+  if (hasDevelopmentKeys(projectRoot) && !contributorOverlayNeedsRepair(projectRoot, envFile)) return;
+
+  mkdirSync(dirname(envFile), { recursive: true });
+  writeFileSync(envFile, serializeEnvFile(createContributorDevelopmentSecrets()));
+  (options.encrypt ?? encryptContributorDevelopmentSecrets)({
+    envFile,
+    keysFile: developmentKeysFile(projectRoot),
+    projectRoot,
+  });
+
+  if (!hasDevelopmentKeys(projectRoot)) {
+    throw new Error("Failed to create .env.keys for local development.");
+  }
+}
+
+export function createContributorDevelopmentSecrets(): Record<string, string> {
+  const ticket = createDevelopmentRemoteTicketKeys();
+  return {
+    AUTH_EXPOSE_DEVELOPMENT_CODE: "true",
+    EMAIL_SMTP_PASSWORD: developmentSmtpPasswordPlaceholder,
+    SKILLS_ADMIN_TOKEN: randomBytes(32).toString("hex"),
+    SITE_REPORT_HASH_SECRET: randomBytes(32).toString("hex"),
+    REMOTE_TICKET_PRIVATE_JWK: ticket.privateJwk,
+    REMOTE_TICKET_PUBLIC_JWKS: ticket.publicJwks,
+    REMOTE_TICKET_KEY_ID: developmentRemoteTicketKeyId,
+    REMOTE_AUTH_WEBHOOK_SECRET: randomBytes(32).toString("hex"),
+  };
+}
+
+export function createDevelopmentRemoteTicketKeys(): { privateJwk: string; publicJwks: string } {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  const privateJwk = {
+    ...privateKey.export({ format: "jwk" }),
+    kid: developmentRemoteTicketKeyId,
+    alg: "ES256",
+  };
+  const publicJwk = {
+    ...publicKey.export({ format: "jwk" }),
+    kid: developmentRemoteTicketKeyId,
+    use: "sig",
+    alg: "ES256",
+  };
+  return {
+    privateJwk: JSON.stringify(privateJwk),
+    publicJwks: JSON.stringify({ keys: [publicJwk] }),
+  };
+}
+
+export function serializeEnvFile(values: Record<string, string>): string {
+  const lines = Object.entries(values).map(([name, value]) => `${name}=${serializeEnvValue(value)}`);
+  return `${lines.join("\n")}\n`;
+}
+
+export function contributorOverlayNeedsRepair(projectRoot: string, envFile: string): boolean {
+  if (!isNonEmptyFile(envFile)) return false;
+  const contents = readFileSync(envFile, "utf8");
+  const values = parseDotenvAssignments(contents);
+  const privateJwk = resolveOverlaySecret(
+    projectRoot,
+    envFile,
+    "REMOTE_TICKET_PRIVATE_JWK",
+    values.REMOTE_TICKET_PRIVATE_JWK,
+  );
+  const publicJwks = resolveOverlaySecret(
+    projectRoot,
+    envFile,
+    "REMOTE_TICKET_PUBLIC_JWKS",
+    values.REMOTE_TICKET_PUBLIC_JWKS,
+  );
+  return !isRemoteTicketJson(privateJwk, publicJwks);
+}
+
+function serializeEnvValue(value: string): string {
+  if (unquotedEnvValue.test(value)) return value;
+  if (value.includes("'") || value.includes("\n")) {
+    throw new Error("Development secret values must not contain single quotes or newlines.");
+  }
+  return `'${value}'`;
+}
+
+function parseDotenvAssignments(contents: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const line of contents.split("\n")) {
+    if (!line || line.startsWith("#")) continue;
+    const separator = line.indexOf("=");
+    if (separator < 1) continue;
+    const name = line.slice(0, separator);
+    const raw = line.slice(separator + 1);
+    if (raw.startsWith("'") && raw.endsWith("'")) {
+      values[name] = raw.slice(1, -1);
+      continue;
+    }
+    if (raw.startsWith('"') && raw.endsWith('"')) {
+      values[name] = raw.slice(1, -1);
+      continue;
+    }
+    values[name] = raw;
+  }
+  return values;
+}
+
+function resolveOverlaySecret(
+  projectRoot: string,
+  envFile: string,
+  name: string,
+  raw: string | undefined,
+): string | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw.startsWith("encrypted:")) return raw;
+  const dotenvx = dotenvxExecutable(projectRoot);
+  if (!dotenvx) return undefined;
+  try {
+    return execFileSync(dotenvx, ["get", name, "-f", envFile, "-fk", developmentKeysFile(projectRoot)], {
+      cwd: projectRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function isRemoteTicketJson(privateJwk: string | undefined, publicJwks: string | undefined): boolean {
+  try {
+    return isEcPrivateJwk(JSON.parse(privateJwk ?? "")) && isPublicJwks(JSON.parse(publicJwks ?? ""));
+  } catch {
+    return false;
+  }
+}
+
+function isEcPrivateJwk(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  if (!("kty" in value) || !("d" in value)) return false;
+  return value.kty === "EC" && typeof value.d === "string";
+}
+
+function isPublicJwks(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  if (!("keys" in value)) return false;
+  return Array.isArray(value.keys);
+}
+
+function encryptContributorDevelopmentSecrets(input: { envFile: string; keysFile: string; projectRoot: string }): void {
+  const dotenvx = dotenvxExecutable(input.projectRoot);
+  if (dotenvx) {
+    execFileSync(dotenvx, ["encrypt", "-f", input.envFile, "-fk", input.keysFile], {
+      cwd: input.projectRoot,
+      stdio: "inherit",
+    });
+  }
+  if (!isNonEmptyFile(input.keysFile)) {
+    writeFileSync(
+      input.keysFile,
+      `# Contributor-local dotenvx key. Do not commit.\nDOTENV_PRIVATE_KEY_DEV_LOCAL="${randomBytes(32).toString("hex")}"\n`,
+    );
+  }
+}
+
+function dotenvxExecutable(projectRoot: string): string | undefined {
+  const path = join(projectRoot, "node_modules", ".bin", process.platform === "win32" ? "dotenvx.cmd" : "dotenvx");
+  return existsSync(path) ? path : undefined;
+}
+
+function isNonEmptyFile(path: string): boolean {
+  try {
+    return statSync(path).isFile() && statSync(path).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+if (import.meta.main) {
+  ensureDevelopmentSecrets(developmentProjectRoot);
+}

--- a/scripts/prepare-dev-environment.test.ts
+++ b/scripts/prepare-dev-environment.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { hasDevelopmentKeys } from "./development-secrets";
 import {
   assertDevelopmentSecrets,
   assertSupportedBunVersion,
@@ -24,10 +25,29 @@ describe("development environment preparation", () => {
     expect(() => assertSupportedBunVersion(version)).toThrow("OpenBot development requires stable Bun 1.4.0");
   });
 
-  it("fails with an actionable error when worktree secrets were not copied", () => {
+  it("generates contributor secrets after install when worktree keys are missing", () => {
     const root = createTemporaryRoot();
+    const calls: string[][] = [];
+    const run: DevelopmentCommandRunner = (_executable, args) => calls.push(args);
 
-    expect(() => assertDevelopmentSecrets(root)).toThrow("Missing or empty .env.keys");
+    prepareDevelopmentEnvironment({
+      projectRoot: root,
+      executable: "bun",
+      bunVersion: "1.4.0",
+      run,
+      encrypt: ({ keysFile }) => {
+        writeFileSync(keysFile, "DOTENV_PRIVATE_KEY_DEV_LOCAL=generated\n");
+      },
+    });
+
+    expect(hasDevelopmentKeys(root)).toBe(true);
+    expect(readFileSync(join(root, "apps", "auth-api", ".env.dev.local"), "utf8")).toContain(
+      "AUTH_EXPOSE_DEVELOPMENT_CODE",
+    );
+    expect(calls).toEqual([
+      ["install", "--frozen-lockfile"],
+      ["run", "api:migrate:local"],
+    ]);
   });
 
   it("installs dependencies and migrates the local API in order", () => {
@@ -42,6 +62,12 @@ describe("development environment preparation", () => {
       ["install", "--frozen-lockfile"],
       ["run", "api:migrate:local"],
     ]);
+  });
+
+  it("fails with an actionable error when secret generation did not create .env.keys", () => {
+    const root = createTemporaryRoot();
+
+    expect(() => assertDevelopmentSecrets(root)).toThrow("Missing or empty .env.keys");
   });
 });
 

--- a/scripts/prepare-dev-environment.ts
+++ b/scripts/prepare-dev-environment.ts
@@ -1,10 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { statSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import {
+  type DevelopmentSecretEncryptor,
+  developmentProjectRoot,
+  ensureDevelopmentSecrets,
+  hasDevelopmentKeys,
+} from "./development-secrets";
 
-const scriptsRoot = dirname(fileURLToPath(import.meta.url));
-export const developmentProjectRoot = dirname(scriptsRoot);
+export { developmentProjectRoot };
 
 export type DevelopmentCommandRunner = (
   executable: string,
@@ -15,17 +17,24 @@ export type DevelopmentCommandRunner = (
 export const supportedBunVersion = "1.4.0";
 
 export function prepareDevelopmentEnvironment(
-  input: { projectRoot?: string; executable?: string; bunVersion?: string; run?: DevelopmentCommandRunner } = {},
+  input: {
+    projectRoot?: string;
+    executable?: string;
+    bunVersion?: string;
+    run?: DevelopmentCommandRunner;
+    encrypt?: DevelopmentSecretEncryptor;
+  } = {},
 ): void {
   const projectRoot = input.projectRoot ?? developmentProjectRoot;
   assertSupportedBunVersion(input.bunVersion ?? process.versions.bun ?? "unknown");
-  assertDevelopmentSecrets(projectRoot);
 
   const executable = input.executable ?? process.execPath;
   const run = input.run ?? execDevelopmentCommand;
   const options = { cwd: projectRoot, stdio: "inherit" as const };
 
   run(executable, ["install", "--frozen-lockfile"], options);
+  ensureDevelopmentSecrets(projectRoot, { encrypt: input.encrypt });
+  assertDevelopmentSecrets(projectRoot);
   run(executable, ["run", "api:migrate:local"], options);
 }
 
@@ -38,18 +47,10 @@ export function assertSupportedBunVersion(version: string): void {
 }
 
 export function assertDevelopmentSecrets(projectRoot: string): void {
-  const keyPath = join(projectRoot, ".env.keys");
-  let hasKeys = false;
-  try {
-    hasKeys = statSync(keyPath).isFile() && statSync(keyPath).size > 0;
-  } catch {
-    // The actionable error below is the same for a missing or unreadable key file.
-  }
-  if (!hasKeys) {
-    throw new Error(
-      "Missing or empty .env.keys. Add it to the local checkout so Codex can copy it through .worktreeinclude.",
-    );
-  }
+  if (hasDevelopmentKeys(projectRoot)) return;
+  throw new Error(
+    "Missing or empty .env.keys. Forked checkouts generate one on bun run dev; if this is a worktree, copy it through .worktreeinclude.",
+  );
 }
 
 function execDevelopmentCommand(executable: string, args: string[], options: { cwd: string; stdio: "inherit" }): void {


### PR DESCRIPTION
Public checkouts cannot decrypt the tracked dotenvx files, so bun run dev now writes gitignored contributor keys and an overlay instead of failing closed.

When trying to run `bun run dev` on a fresh clone (following setup instructions) I stumbled on:

```
2026-09-06T20:44:32.032Z ERROR [dev-services] Missing or empty .env.keys. Add it to the local checkout so Codex can copy it through .worktreeinclude.
```

<img width="611" height="917" alt="Screenshot 2026-09-07 at 12 20 07" src="https://github.com/user-attachments/assets/9f902681-0bf7-44ca-8899-850824f7d442" />

## What changed

`bun run dev` no longer requires the author's ignored `.env.keys`. A public fork generates gitignored contributor keys and `apps/auth-api/.env.dev.local` (local login code, ticket JWKS, placeholder SMTP secret) so the Auth API and Signal service can start. Tracked production ciphertext is left alone. JSON secrets are single-quoted so dotenvx decrypts them as JSON, not `\"`-escaped text.

Surfaces: `apps/auth-api` local env loading, local Signal dotenvx path, README / CONTRIBUTING / Auth API docs. Not renderer, mobile, IPC contracts, or migrations.

## Verification

- [x] Narrow checks for what changed: `biome check <paths>`, a targeted `tsc`, and the affected test files — CI owns the full suite
  - `bun run test:desktop -- scripts/development-secrets.test.ts scripts/prepare-dev-environment.test.ts scripts/dev-services.test.ts`
  - `bun run lint` and `bun run typecheck`
  - Watch-it-fail: overlay generation without `AUTH_EXPOSE_DEVELOPMENT_CODE=true`; JSON.stringify quoting left `\\` in JWKS and dotenvx could not parse it
- [x] Surfaces touched are named under "What changed": renderer, mobile, `apps/auth-api`, the three `--openbot-*` palettes, IPC contracts and `mock-openbot.ts`, reverse states, migrations and the latest schema, documentation
- [x] Relevant manual smoke test completed, or not applicable — `dotenvx run --strict` on the overlay parses ticket JWKS; `bun run dev` injects the local env and starts the API
- [x] No credentials, private data, generated output, or real user files are included

## Risk and security impact

None for the renderer-to-main trust boundary. Contributor secrets stay gitignored and cannot decrypt the tracked production files. Local development exposes the one-time login code in the API response (`AUTH_EXPOSE_DEVELOPMENT_CODE`), matching the existing tracked `.env.dev` intent.
