### PR TITLE
Make the composer action buttons perfect circles

### DIFF
--- a/src/renderer/src/features/conversation/ConversationComposer.tsx
+++ b/src/renderer/src/features/conversation/ConversationComposer.tsx
@@ -1,6 +1,7 @@
 import { ATTACHMENT_FILE_ACCEPT, IMAGE_ATTACHMENT_ACCEPT } from "@openbot/contracts/attachment-files";
 import { For, Loading, lazy, Show } from "solid-js";
 import {
+  ArrowUp,
   Button,
   DropdownMenu,
   File,
@@ -9,12 +10,13 @@ import {
   Input,
   LoaderCircle,
   Mic,
+  Plus,
   Puzzle,
 } from "../../components/ui";
 import { fileBadge, formatFileSize } from "./AttachmentCards";
 import { attachmentReferenceTone } from "./AttachmentReference";
 import { ComposerEditor } from "./ComposerEditor";
-import { CloseIcon, MoreIcon, PlusIcon, StopIcon } from "./ConversationIcons";
+import { CloseIcon, MoreIcon, StopIcon } from "./ConversationIcons";
 import { useConversationViewScope } from "./conversation-scope";
 import { RichMessageText } from "./RichMessageText";
 import { formatVoiceDuration, voiceButtonLabel } from "./voice-status";
@@ -229,7 +231,7 @@ export function ConversationComposer() {
                   !agentReady()
                 }
               >
-                <PlusIcon />
+                <Plus aria-hidden="true" />
               </DropdownMenu.Trigger>
               <DropdownMenu.Portal>
                 <DropdownMenu.Content aria-label="Add to prompt">
@@ -288,7 +290,7 @@ export function ConversationComposer() {
                       }
                       fallback={<Mic aria-hidden="true" />}
                     >
-                      <LoaderCircle class="dictation-spinner" aria-hidden="true" />
+                      <LoaderCircle class="composer-spinner" aria-hidden="true" />
                     </Show>
                   </Button>
                 }
@@ -335,7 +337,9 @@ export function ConversationComposer() {
                     }
                     onClick={submitComposer}
                   >
-                    {submitting() ? "…" : "↑"}
+                    <Show when={submitting()} fallback={<ArrowUp aria-hidden="true" />}>
+                      <LoaderCircle class="composer-spinner" aria-hidden="true" />
+                    </Show>
                   </Button>
                 }
               >

--- a/src/renderer/src/features/conversation/conversation.css
+++ b/src/renderer/src/features/conversation/conversation.css
@@ -5832,6 +5832,9 @@ button.chat-action-target:active,
   place-items: center;
   border: 0;
   border-radius: var(--openbot-radius-pill);
+  /* Without this the button primitive's inline padding outgrows the 28px width
+     under border-box sizing and stretches the circle into a pill. */
+  padding: 0;
   background: var(--openbot-hover);
   color: var(--openbot-text-secondary);
   transition:
@@ -5877,6 +5880,7 @@ button.chat-action-target:active,
   place-items: center;
   border: 0;
   border-radius: var(--openbot-radius-pill);
+  padding: 0;
   background: transparent;
   color: var(--openbot-text-primary);
   transition: transform var(--openbot-duration-fast) var(--openbot-ease-out);
@@ -5915,12 +5919,14 @@ button.chat-action-target:active,
   color: var(--openbot-white);
 }
 
-.dictation-button svg {
-  width: 14px;
-  height: 14px;
+.composer-button svg,
+.dictation-button svg,
+.voice-button svg {
+  width: 16px;
+  height: 16px;
 }
 
-.dictation-spinner {
+.composer-spinner {
   animation: ui-spin 720ms linear infinite;
 }
 

--- a/src/renderer/src/features/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/features/onboarding/OnboardingFlow.tsx
@@ -8,11 +8,10 @@ import type {
 } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, For, Match, onCleanup, Show, Switch } from "solid-js";
 import { ProviderPicker, type ProviderPickerOption } from "../../components/ProviderPicker";
-import { Button } from "../../components/ui";
+import { ArrowUp, Button, Plus } from "../../components/ui";
 import { errorMessage } from "../../error-message";
 import { AgentAvatar } from "../agents/AgentAvatar";
 import { ComputerUseMacSetup } from "../computer-use/ComputerUseMacSetup";
-import { PlusIcon } from "../conversation/ConversationIcons";
 import { fallbackProviderState } from "./onboarding-provider-state";
 
 export interface OnboardingFlowProps {
@@ -335,7 +334,7 @@ export function OnboardingFlow(props: OnboardingFlowProps) {
                       aria-label="Add to prompt"
                       disabled
                     >
-                      <PlusIcon />
+                      <Plus aria-hidden="true" />
                     </Button>
                     <div class="composer-primary-actions">
                       <Button
@@ -346,7 +345,7 @@ export function OnboardingFlow(props: OnboardingFlowProps) {
                         aria-label="Send message"
                         disabled
                       >
-                        ↑
+                        <ArrowUp aria-hidden="true" />
                       </Button>
                     </div>
                   </div>


### PR DESCRIPTION
## What

The composer's mic and send buttons rendered as **32×28 pills, not circles**. Both are `Button` primitives, and `:where(.ui-button)`'s `padding: 0 var(--openbot-space-4)` outgrew the declared `28px` width under `box-sizing: border-box`, so the *used* width became the padding. The plus button escaped it only because it is a Kobalte trigger that never picks up `.ui-button`, and the onboarding copy escaped it only because it passes `size="xs"`, whose narrower padding still fits inside 28px.

Zeroing the padding on the shared rule puts all three at 28×28. `.voice-recording-stop` had the identical bug (20px box, primitive padding) and is fixed the same way.

While in there, the icons: 14px → 16px across plus, mic and send, and the hand-rolled 1.3-stroke plus SVG and the bare `↑` glyph are replaced with lucide `Plus` and `ArrowUp` — so the three read as one family at one stroke weight instead of a thin SVG, a lucide icon and a text character. The send button's `submitting()` state was the text `…`; it is now the `LoaderCircle` spinner the mic already used, which also keeps the circle intact (CSS class renamed `dictation-spinner` → `composer-spinner`, since both buttons use it now).

## Before / after

Measured live in the browser on the `conversation-conversation--empty` story:

| | plus | mic | send |
| --- | --- | --- | --- |
| before | 28×28, 14px icon | **32×28**, 14px icon | **32×28**, `↑` glyph |
| after | 28×28, 16px icon | 28×28, 16px icon | 28×28, 16px icon |

Confirmed the diagnosis rather than assuming it: forcing `padding: 0 var(--openbot-space-4)` back onto the fixed send button re-inflated it to 32×28, and removing it returned it to 28×28.

Visually (Storybook, composer zoomed 3×): three even circles, icons centred and filling more of each button.

## Surfaces touched

Desktop renderer only. Mobile's composer send/mic is already `size-10 rounded-full` with 21px lucide icons and needed nothing. No IPC, contracts, migrations or persisted state. `OnboardingFlow.tsx` renders a static copy of the same composer markup, so it got the same icon swap.

## Tests

No test added — this is styling and icon choice, which per AGENTS belongs in a story, not an assertion; the circle geometry has no consequence a user or caller can observe beyond the visual. The existing suites query these buttons by accessible role and name, which the icon swap leaves unchanged.

Ran `bun run test:desktop -- src/renderer/src/App.voice.test.tsx` (11 passed) and `bun run test:desktop -- src/renderer/src/App.queue.test.tsx` (22 passed), plus `bun run lint` (5 warnings, all pre-existing mobile module-mock warnings), `bun run typecheck` and `bun run check:ui`. The wider suites are CI's.

## Model and harness

Claude Opus 5 (`claude-opus-5`) in T3 Code via the Claude Code harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
