### PR TITLE
Ask NorbiAI for a review with a label

### DIFF
--- a/.github/workflows/norbiai-review.yml
+++ b/.github/workflows/norbiai-review.yml
@@ -8,6 +8,13 @@ on:
   # code to satisfy it.
   issue_comment:
     types: [created]
+  # The other way past the fork token problem, and one click rather than a typed comment:
+  # a review submitted from this repository carries the write token a fork's push run
+  # cannot have. `commented` is deliberately not honoured below — submitting inline notes
+  # is not a request for a review — so the states that reach the gate are the two that are
+  # already a verdict on the pull request.
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   # A comment must never cancel a review, running or queued. Concurrency is resolved for the
@@ -20,7 +27,11 @@ concurrency:
   # each comment run gets a group of its own, where it can neither cancel nor be cancelled;
   # the reviews themselves still serialize on the self-hosted runner. Push runs keep the
   # shared group, where cancelling a review of superseded code is what we want.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event.comment.id }}
+  #
+  # A submitted-review run needs that same private group, and does not inherit it: its
+  # payload carries `pull_request`, so the number resolves and it would land in the shared
+  # push group, where the next push would cancel the recheck it asked for.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event.comment.id || github.event.review.id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -37,12 +48,16 @@ jobs:
     # below says, so it could review and then fail to publish either the comment or the
     # gate status — and nobody asked for it to try.
     #
-    # The comment path is an explicit request from someone who can already merge, so it runs
-    # on drafts and on forks too: `/norbiai review` means review it now. `issue_comment`
-    # fires in the base repository, which is what gives that path the write token the push
-    # path cannot have on a fork. `github.event.issue.pull_request` is what separates a pull
-    # request comment from an issue comment, and `author_association` is a cheap pre-filter
-    # that keeps a drive-by comment from reaching the permission lookup below.
+    # The comment and review paths are an explicit request from someone who can already
+    # merge, so they run on drafts and on forks too: `/norbiai review`, or an approval,
+    # means review it now. Both `issue_comment` and `pull_request_review` fire in the base
+    # repository, which is what gives them the write token the push path cannot have on a
+    # fork. `github.event.issue.pull_request` is what separates a pull request comment from
+    # an issue comment, and `author_association` is a cheap pre-filter that keeps a
+    # drive-by from reaching the permission lookup below.
+    #
+    # `review.state` is lower case in the webhook payload where the REST API spells it
+    # upper; `contains` compares strings case-insensitively, so the gate holds either way.
     if: >
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -50,18 +65,21 @@ jobs:
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
         contains(github.event.comment.body, '/norbiai review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(fromJSON('["approved", "changes_requested"]'), github.event.review.state) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
 
     permissions:
       contents: read
 
     steps:
-      - name: Verify the commenter can merge
-        if: github.event_name == 'issue_comment'
+      - name: Verify the requester can merge
+        if: github.event_name != 'pull_request'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          COMMENTER: ${{ github.event.comment.user.login }}
+          REQUESTER: ${{ github.event.comment.user.login || github.event.review.user.login }}
         run: |
           set -euo pipefail
 
@@ -69,22 +87,22 @@ jobs:
           # with an unknown permission. `maintain` answers `write` here and `triage`
           # answers `read`, so `admin` and `write` are exactly the roles that can merge.
           if ! permission=$(
-            gh api "repos/${GITHUB_REPOSITORY}/collaborators/${COMMENTER}/permission" \
+            gh api "repos/${GITHUB_REPOSITORY}/collaborators/${REQUESTER}/permission" \
               --jq '.permission' 2>/dev/null
           ); then
-            echo "::error title=NorbiAI could not authorize the request::Could not read the repository permission of @${COMMENTER}."
+            echo "::error title=NorbiAI could not authorize the request::Could not read the repository permission of @${REQUESTER}."
             exit 1
           fi
 
           case "$permission" in
             admin | write) ;;
             *)
-              echo "::error title=NorbiAI ignored the request::@${COMMENTER} has ${permission:-no} access to ${GITHUB_REPOSITORY}. Only someone who can merge the pull request can ask for a finding to be rechecked."
+              echo "::error title=NorbiAI ignored the request::@${REQUESTER} has ${permission:-no} access to ${GITHUB_REPOSITORY}. Only someone who can merge the pull request can ask for a review or for a finding to be rechecked."
               exit 1
               ;;
           esac
 
-          echo "@${COMMENTER} has ${permission} access."
+          echo "@${REQUESTER} has ${permission} access."
 
   review:
     # Gated by `authorize`, which carries the event filter: a skipped or refused
@@ -105,19 +123,27 @@ jobs:
 
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-      # Empty on a comment run. Both are SHAs, not free text.
-      EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      # Empty on a comment or review run, which resolves the pair from the API instead. A
+      # review payload does carry both, and honouring them would be wrong: they are the head
+      # as of the review, while the checkout below is the merge ref fetched now. A push
+      # landing in between would leave this run reviewing the superseded commit and
+      # publishing the gate status on it — and on a fork that push gets no run of its own to
+      # correct the newest commit. Both are SHAs, not free text.
+      EVENT_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+      EVENT_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       STATUS_CONTEXT: NorbiAI review
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # A comment run has no pull request ref of its own and would land on the default
-          # branch, where neither the base nor the head commit need exist. The merge ref is
-          # what the push path already gets by default, and it reaches both parents.
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
+          # A comment or review run has no pull request ref of its own and would land on the
+          # default branch, where neither the base nor the head commit need exist. The merge
+          # ref is what the push path already gets by default, and it reaches both parents.
+          # Written as a negation so the push path keeps the empty default: an expression of
+          # the form `cond && '' || format(...)` picks the format branch every time, because
+          # the empty string is falsy.
+          ref: ${{ github.event_name != 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number || github.event.issue.number) || '' }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -179,6 +205,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TRIGGER_COMMENT_ID: ${{ github.event.comment.id }}
+          TRIGGER_REVIEW_ID: ${{ github.event.review.id }}
         run: |
           set -euo pipefail
 
@@ -343,6 +370,37 @@ jobs:
               }
             ' "$responses_raw" > "$responses_file"
           fi
+
+          # A review run's request is the review body, and a review is not an issue comment,
+          # so none of the lookups above can see it: without this, approving with a rebuttal
+          # written in it asks for a recheck and hands the reviewer no argument. Prepending
+          # keeps the promise the comment path makes — the request that asked for this review
+          # comes first and whole. `authorize` already proved this author can merge, and an
+          # approval with no body adds nothing rather than an empty block. Digits only, so
+          # the id can only ever be an id, and the body goes to a file so nothing in it has
+          # to survive a delimiter.
+          case "${TRIGGER_REVIEW_ID:-}" in
+            "") ;;
+            *[!0-9]*)
+              echo "::warning title=NorbiAI ignored a malformed review id::Not reading the triggering review"
+              ;;
+            *)
+              trigger_review="$RUNNER_TEMP/norbiai-trigger-review.txt"
+              if ! gh api \
+                "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews/${TRIGGER_REVIEW_ID}" \
+                --jq 'if (.body // "" | test("\\S"))
+                  then "### @\(.user.login) at \(.submitted_at)\n\(.body)\n"
+                  else "" end' > "$trigger_review" 2>/dev/null
+              then
+                echo "::warning title=NorbiAI request unavailable::Could not read the review that asked for this run"
+              elif grep -q '[^[:space:]]' "$trigger_review"; then
+                combined="$RUNNER_TEMP/norbiai-author-responses-combined.txt"
+                head -c 20000 "$trigger_review" > "$combined"
+                cat "$responses_file" >> "$combined"
+                mv "$combined" "$responses_file"
+              fi
+              ;;
+          esac
 
           {
             echo "previous_file=$previous_file"

--- a/.github/workflows/norbiai-review.yml
+++ b/.github/workflows/norbiai-review.yml
@@ -8,13 +8,15 @@ on:
   # code to satisfy it.
   issue_comment:
     types: [created]
-  # The other way past the fork token problem, and one click rather than a typed comment:
-  # a review submitted from this repository carries the write token a fork's push run
-  # cannot have. `commented` is deliberately not honoured below — submitting inline notes
-  # is not a request for a review — so the states that reach the gate are the two that are
-  # already a verdict on the pull request.
-  pull_request_review:
-    types: [submitted]
+  # One click instead of a typed comment, and the only shape that can be either. The
+  # `pull_request_review` events cannot: GitHub groups them with `pull_request`, running the
+  # workflow file from the pull request's own merge commit and handing a fork a read-only
+  # token, so an approval would review and then fail to publish exactly as the push path
+  # would — and a fork's edited copy of this file would be what ran, on the self-hosted
+  # runner. `pull_request_target` is the counterpart built for this: the base branch's
+  # workflow, with a write token.
+  pull_request_target:
+    types: [labeled]
 
 concurrency:
   # A comment must never cancel a review, running or queued. Concurrency is resolved for the
@@ -28,10 +30,12 @@ concurrency:
   # the reviews themselves still serialize on the self-hosted runner. Push runs keep the
   # shared group, where cancelling a review of superseded code is what we want.
   #
-  # A submitted-review run needs that same private group, and does not inherit it: its
-  # payload carries `pull_request`, so the number resolves and it would land in the shared
-  # push group, where the next push would cancel the recheck it asked for.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event.comment.id || github.event.review.id }}
+  # A labelled run needs that same private group and does not inherit it: its payload
+  # carries `pull_request`, so the number resolves and it would land in the shared push
+  # group, where the next push cancels the review it asked for. Keyed on the run rather than
+  # the event, which is unique for every request path and empty only on a push. Written as a
+  # negation because `cond && '' || x` picks `x` every time — the empty string is falsy.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name != 'pull_request' && github.run_id || '' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -48,16 +52,19 @@ jobs:
     # below says, so it could review and then fail to publish either the comment or the
     # gate status — and nobody asked for it to try.
     #
-    # The comment and review paths are an explicit request from someone who can already
-    # merge, so they run on drafts and on forks too: `/norbiai review`, or an approval,
-    # means review it now. Both `issue_comment` and `pull_request_review` fire in the base
-    # repository, which is what gives them the write token the push path cannot have on a
-    # fork. `github.event.issue.pull_request` is what separates a pull request comment from
-    # an issue comment, and `author_association` is a cheap pre-filter that keeps a
-    # drive-by from reaching the permission lookup below.
+    # The comment and label paths are an explicit request from someone who can already
+    # merge, so they run on drafts and on forks too: `/norbiai review`, or the label, means
+    # review it now. `issue_comment` and `pull_request_target` both run the base
+    # repository's own copy of this file, which is what gives them the write token the push
+    # path cannot have on a fork. `github.event.issue.pull_request` is what separates a pull
+    # request comment from an issue comment, and `author_association` is a cheap pre-filter
+    # that keeps a drive-by comment from reaching the permission lookup below.
     #
-    # `review.state` is lower case in the webhook payload where the REST API spells it
-    # upper; `contains` compares strings case-insensitively, so the gate holds either way.
+    # The label path needs no such pre-filter and cannot use one: `author_association` in
+    # that payload describes the pull request's author, not whoever applied the label.
+    # GitHub is the pre-filter instead — applying a label already requires triage or above,
+    # which is a narrower gate than any association, and the lookup below is what turns that
+    # into the permission to merge.
     if: >
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -66,9 +73,8 @@ jobs:
         github.event.issue.pull_request != null &&
         contains(github.event.comment.body, '/norbiai review') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' &&
-        contains(fromJSON('["approved", "changes_requested"]'), github.event.review.state) &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
+      (github.event_name == 'pull_request_target' &&
+        github.event.label.name == 'norbiai')
 
     permissions:
       contents: read
@@ -79,7 +85,8 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          REQUESTER: ${{ github.event.comment.user.login || github.event.review.user.login }}
+          # The commenter, or whoever applied the label.
+          REQUESTER: ${{ github.event.comment.user.login || github.event.sender.login }}
         run: |
           set -euo pipefail
 
@@ -123,9 +130,9 @@ jobs:
 
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-      # Empty on a comment or review run, which resolves the pair from the API instead. A
-      # review payload does carry both, and honouring them would be wrong: they are the head
-      # as of the review, while the checkout below is the merge ref fetched now. A push
+      # Empty on a comment or label run, which resolves the pair from the API instead. A
+      # labelled payload does carry both, and honouring them would be wrong: they are the
+      # head as of the label, while the checkout below is the merge ref fetched now. A push
       # landing in between would leave this run reviewing the superseded commit and
       # publishing the gate status on it — and on a fork that push gets no run of its own to
       # correct the newest commit. Both are SHAs, not free text.
@@ -137,7 +144,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # A comment or review run has no pull request ref of its own and would land on the
+          # A comment or label run has no pull request ref of its own and would land on the
           # default branch, where neither the base nor the head commit need exist. The merge
           # ref is what the push path already gets by default, and it reaches both parents.
           # Written as a negation so the push path keeps the empty default: an expression of
@@ -205,7 +212,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TRIGGER_COMMENT_ID: ${{ github.event.comment.id }}
-          TRIGGER_REVIEW_ID: ${{ github.event.review.id }}
         run: |
           set -euo pipefail
 
@@ -370,37 +376,6 @@ jobs:
               }
             ' "$responses_raw" > "$responses_file"
           fi
-
-          # A review run's request is the review body, and a review is not an issue comment,
-          # so none of the lookups above can see it: without this, approving with a rebuttal
-          # written in it asks for a recheck and hands the reviewer no argument. Prepending
-          # keeps the promise the comment path makes — the request that asked for this review
-          # comes first and whole. `authorize` already proved this author can merge, and an
-          # approval with no body adds nothing rather than an empty block. Digits only, so
-          # the id can only ever be an id, and the body goes to a file so nothing in it has
-          # to survive a delimiter.
-          case "${TRIGGER_REVIEW_ID:-}" in
-            "") ;;
-            *[!0-9]*)
-              echo "::warning title=NorbiAI ignored a malformed review id::Not reading the triggering review"
-              ;;
-            *)
-              trigger_review="$RUNNER_TEMP/norbiai-trigger-review.txt"
-              if ! gh api \
-                "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews/${TRIGGER_REVIEW_ID}" \
-                --jq 'if (.body // "" | test("\\S"))
-                  then "### @\(.user.login) at \(.submitted_at)\n\(.body)\n"
-                  else "" end' > "$trigger_review" 2>/dev/null
-              then
-                echo "::warning title=NorbiAI request unavailable::Could not read the review that asked for this run"
-              elif grep -q '[^[:space:]]' "$trigger_review"; then
-                combined="$RUNNER_TEMP/norbiai-author-responses-combined.txt"
-                head -c 20000 "$trigger_review" > "$combined"
-                cat "$responses_file" >> "$combined"
-                mv "$combined" "$responses_file"
-              fi
-              ;;
-          esac
 
           {
             echo "previous_file=$previous_file"
@@ -791,3 +766,25 @@ jobs:
             -f description="$description" \
             -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" \
             > /dev/null
+
+      - name: Remove the request label
+        # Left in place, the label makes every re-run two clicks: remove, then re-apply.
+        # Removing it here means one click asks for a review, every time. `always()` so a
+        # timed-out or refused review is still re-requestable — the gate step above fails
+        # the job on an unresolved finding, and that must not strand the label.
+        if: always() && github.event_name == 'pull_request_target'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LABEL: ${{ github.event.label.name }}
+        run: |
+          set -uo pipefail
+
+          # A warning, not a failure. The label is a request that has now been served, so
+          # losing the race with someone removing it by hand changes nothing about the
+          # review that already published.
+          if ! gh api --method DELETE \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/${LABEL}" > /dev/null 2>&1
+          then
+            echo "::warning title=NorbiAI could not remove the label::Remove \`${LABEL}\` by hand before asking for another review."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,14 @@ state, `.env` files, credentials, real conversations, or user attachments.
 Every push to a branch in this repository runs the automated reviewer, and it blocks the merge on
 an unresolved P0 or P1 finding. A pull request from a fork is the exception: GitHub gives a fork's
 push run a read-only token, so it could not publish a review even if it produced one. Ask a
-maintainer, who has two ways to start one from this repository, where the token can publish:
-approving the pull request or requesting changes on it, or commenting `/norbiai review`. Either
-can be repeated to re-run the review after a push. Two ways past a finding:
+maintainer to add the `norbiai` label, or to comment `/norbiai review`. Both run this
+repository's own copy of the workflow, where the token can publish, and either can be repeated
+after a push — the label is removed once the review runs, so re-applying it asks again. Two ways
+past a finding:
 
 1. Fix it and push. The next review classifies the finding `[RESOLVED]`.
 2. Show it is wrong. Comment the concrete reason — the guard it misses, the line that already
-   handles it — and include `/norbiai review` anywhere in the same comment. A maintainer can write
-   the same argument in the body of an approval or a change request instead. The reviewer rechecks
+   handles it — and include `/norbiai review` anywhere in the same comment. The reviewer rechecks
    that finding against your argument and marks it `[WITHDRAWN]`, which stops blocking and stays
    recorded under `## Withdrawn Findings` so a later push does not raise it again.
 
@@ -65,9 +65,10 @@ A rebuttal needs something checkable in it. "Intended", "out of scope", or a pro
 later leaves the finding `[REMAINS]`, and the reviewer says which part it could not verify. Only
 comments from someone who can merge the pull request are read — organization membership on its own
 is not enough, and on a fork that means the recheck has to be asked for by a maintainer rather than
-by you — and only those written after the review being answered, plus the comment or review body
-that asked for the recheck whatever its timestamp says. That one is passed to the reviewer whole;
-the older responses share a size budget and are dropped from the oldest end.
+by you — and only those written after the review being answered, plus the comment that asked for
+the recheck whatever its timestamp says. That one is passed to the reviewer whole; the older
+responses share a size budget and are dropped from the oldest end. A label carries no argument of
+its own, so write the rebuttal as a comment first and label afterwards.
 
 ## Security-sensitive changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,14 @@ state, `.env` files, credentials, real conversations, or user attachments.
 Every push to a branch in this repository runs the automated reviewer, and it blocks the merge on
 an unresolved P0 or P1 finding. A pull request from a fork is the exception: GitHub gives a fork's
 push run a read-only token, so it could not publish a review even if it produced one. Ask a
-maintainer to comment `/norbiai review` — that path runs in this repository and can publish, and
-the same comment re-runs the review after each push. Two ways past a finding:
+maintainer, who has two ways to start one from this repository, where the token can publish:
+approving the pull request or requesting changes on it, or commenting `/norbiai review`. Either
+can be repeated to re-run the review after a push. Two ways past a finding:
 
 1. Fix it and push. The next review classifies the finding `[RESOLVED]`.
 2. Show it is wrong. Comment the concrete reason — the guard it misses, the line that already
-   handles it — and include `/norbiai review` anywhere in the same comment. The reviewer rechecks
+   handles it — and include `/norbiai review` anywhere in the same comment. A maintainer can write
+   the same argument in the body of an approval or a change request instead. The reviewer rechecks
    that finding against your argument and marks it `[WITHDRAWN]`, which stops blocking and stays
    recorded under `## Withdrawn Findings` so a later push does not raise it again.
 
@@ -63,9 +65,9 @@ A rebuttal needs something checkable in it. "Intended", "out of scope", or a pro
 later leaves the finding `[REMAINS]`, and the reviewer says which part it could not verify. Only
 comments from someone who can merge the pull request are read — organization membership on its own
 is not enough, and on a fork that means the recheck has to be asked for by a maintainer rather than
-by you — and only those written after the review being answered, plus the comment that asked for
-the recheck whatever its timestamp says. That one is passed to the reviewer whole; the older
-responses share a size budget and are dropped from the oldest end.
+by you — and only those written after the review being answered, plus the comment or review body
+that asked for the recheck whatever its timestamp says. That one is passed to the reviewer whole;
+the older responses share a size budget and are dropped from the oldest end.
 
 ## Security-sensitive changes
 


### PR DESCRIPTION
## Why

A fork's pull request can only reach NorbiAI through a typed `/norbiai review` comment. [#273](https://github.com/nightly-labs/openbot/pull/273) sat unreviewed for exactly that reason — both of its `pull_request` runs skipped, and nobody knew to type the comment.

Adding the `norbiai` label now asks for a review. One click, and it works on forks and drafts.

## What changed

`.github/workflows/norbiai-review.yml` gains a third trigger:

```yaml
pull_request_target:
  types: [labeled]
```

`pull_request_target` runs the **base branch's** copy of the workflow with a write token, which is what makes it able to publish on a fork's pull request. The gate is `github.event.label.name == 'norbiai'` plus the same `admin`-or-`write` permission lookup the comment path already uses, on `github.event.sender.login`.

That path takes no `author_association` pre-filter, and cannot: in a `labeled` payload `author_association` describes the pull request's *author*, not whoever applied the label. GitHub is the pre-filter instead — applying a label already requires triage or above, which is narrower than any association — and the lookup turns that into permission to merge.

Four supporting changes, each because the labelled payload differs from the comment payload rather than because the trigger needed them:

| Change | Why |
| --- | --- |
| Concurrency group keys on `github.run_id` for every non-push path | A labelled payload carries `pull_request`, so the number resolves and the run lands in the shared push group — where the next push cancels the review it asked for. That is the exact failure the group was split to prevent. Replaces the `comment.id` key, which was unique per run in the same way but covered only one path. |
| Base and head SHAs come from the API | The payload carries both, but they are the head as of the label while the checkout is the merge ref fetched now. A push landing in between would review the superseded commit and publish the gate status on it, and on a fork that push gets no run of its own to correct the newest commit. |
| Checkout takes the merge ref | `pull_request_target` sets `GITHUB_REF` to the default branch, same as `issue_comment`, where neither the base nor the head commit need exist. Written `!= 'pull_request' && format(…) || ''` rather than the reverse, because `cond && '' \|\| format(…)` picks `format` every time — the empty string is falsy. |
| The label is removed when the run finishes | Left in place it makes every re-run two clicks. `always()`, so a timed-out or refused review is still re-requestable; the gate step fails the job on an unresolved finding and must not strand the label. A failed removal warns rather than failing the job — the request has already been served. |

The `norbiai` label [already exists](https://github.com/nightly-labs/openbot/labels/norbiai) in the repository. `CONTRIBUTING.md` documents both routes, and that a label carries no argument so a rebuttal is still a comment.

## What this PR tried first, and why it was wrong

The first commit used `pull_request_review: [submitted]`, so that approving would start a review. **NorbiAI's P1 on that commit was correct.** `pull_request_review` is not a base-repository event: GitHub groups it with `pull_request` — "it runs the workflow file from the merge commit of the pull request… GitHub restricts these events to a read-only `GITHUB_TOKEN`" ([docs](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)). An approval on a fork PR would have reviewed and then 403'd on both the comment and the status.

Two further consequences that commit had backwards:

- `GITHUB_REF` for that event is already `refs/pull/N/merge`, not the default branch, so its checkout change was justified by a false reason.
- Because the workflow file comes from the merge commit, a fork's **own edited copy of this file** would have run — on `runs-on: [self-hosted]`, with the `authorize` gate deletable.

Its P2 was correct too: the triggering review body was truncated at 20,000 bytes while the comment above it promised the request whole. A label carries no argument, so that code and its contradiction are both gone.

## Noticed while verifying — separate from this PR

This repository's fork-PR approval policy is `first_time_contributors`, so a **returning** contributor's fork PR runs workflows without approval. Combined with the shipped `pull_request` trigger taking the workflow file from the merge commit and `runs-on: [self-hosted]`, a returning contributor can already run their own edited workflow on the self-hosted runner. That is pre-existing and not touched here, but it probably wants either `all_external_contributors` or a hosted runner for the fork path.

## Surfaces touched

CI workflow and contributor documentation only. No renderer, mobile, web, Signal service, IPC contract, migration, or schema change.

## Risk

Adding any label now starts a workflow run, filtered to the `norbiai` label by the `authorize` job on a hosted runner, so the self-hosted runner is never allocated for another label.

The trust boundary is unchanged, and `pull_request_target` keeps it where `pull_request_review` would not have: the workflow, the prompt and the composer all come from the base branch, the composer runs with an empty bunfig and `--no-install`, and the reviewer runs `--ephemeral --ignore-user-config --sandbox read-only`.

No test. There is no harness for a GitHub Actions trigger in this repo, and the security-relevant half — the merge-permission lookup — is unchanged code now reached by one more event.

## Verification

- `bun run lint` — clean (5 pre-existing `no-module-mocking` warnings in `apps/mobile`, none in the changed files).
- `bun run typecheck` — 11 projects pass, via the pre-commit hook.
- `check:staged` and `check:ui` — pass.
- YAML parses, and all 8 `run:` blocks pass `bash -n` after extraction from the parsed document.
- The read-only-token and `GITHUB_REF` claims above are quoted from GitHub's docs, not from memory — that is what the first commit got wrong.

Not verifiable before merge: `pull_request_target` runs the workflow from the **base** branch, so the label does nothing until this is on `main`. #273 still needs a `/norbiai review` comment today.

## Model and harness

Claude Opus 5 (`claude-opus-5`) via T3 Code on the Claude Code harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
