### PR TITLE
Fix mobile sidebar swipe over agent rows

### DIFF
--- a/apps/mobile/src/features/agents/components/agent-list-row.tsx
+++ b/apps/mobile/src/features/agents/components/agent-list-row.tsx
@@ -23,6 +23,7 @@ import { AgentPinAvatar } from "@/features/agents/components/agent-pin-avatar";
 import { type AgentAvatarLocation, useAgentPinTransition } from "@/features/agents/components/agent-pin-transition";
 import { BloubAvatar } from "@/features/agents/components/bloub-avatar";
 import { ChatLinkPressable } from "@/features/agents/components/chat-link-pressable";
+import { useAppDrawer } from "@/features/servers/components/app-drawer-shell";
 import { type MobileAgent, useMobileWorkspace } from "@/features/workspace/context/mobile-workspace-context";
 
 const AnimatedRect = Animated.createAnimatedComponent(Rect);
@@ -100,6 +101,7 @@ export function AgentListRow({
 }: AgentListRowProps) {
   const [background, accent, accentForeground] = useThemeColor(["background", "accent", "accent-foreground"]);
   const { unreadAgentIds } = useMobileWorkspace();
+  const { openingGesture } = useAppDrawer();
   const { startAgentNavigationAnimated, toggleAgentPinAnimated, transition } = useAgentPinTransition();
   const pendingPinRef = useRef(false);
   const agentContextMenu = useAgentContextMenu(agent);
@@ -191,6 +193,8 @@ export function AgentListRow({
       onSwipeableClose={handleSwipeableClose}
       overshootFriction={8}
       overshootRight={false}
+      // Rightward drags belong to the drawer; it yields to row actions on leftward drags.
+      requireExternalGestureToFail={openingGesture}
       renderRightActions={(_progress, _translation, swipeable) => (
         <View className="w-[88px] overflow-hidden" style={{ backgroundColor: accent }}>
           <Pressable

--- a/apps/mobile/src/features/servers/components/app-drawer-shell.tsx
+++ b/apps/mobile/src/features/servers/components/app-drawer-shell.tsx
@@ -4,7 +4,7 @@ import { type Href, router, usePathname } from "expo-router";
 import { useThemeColor } from "heroui-native/hooks";
 import { createContext, type PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Pressable, useWindowDimensions, View } from "react-native";
-import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import { Gesture, GestureDetector, type PanGesture } from "react-native-gesture-handler";
 import Animated, {
   interpolate,
   ReduceMotion,
@@ -23,6 +23,7 @@ import { isIOS } from "@/shared/lib/platform";
 interface AppDrawerContextValue {
   openDrawer: () => void;
   closeDrawer: () => void;
+  openingGesture: PanGesture;
 }
 
 const AppDrawerContext = createContext<AppDrawerContextValue | null>(null);
@@ -156,7 +157,10 @@ export function AppDrawerShell({ children }: PropsWithChildren) {
     [closeDrawer],
   );
 
-  const contextValue = useMemo(() => ({ closeDrawer, openDrawer }), [closeDrawer, openDrawer]);
+  const contextValue = useMemo(
+    () => ({ closeDrawer, openDrawer, openingGesture }),
+    [closeDrawer, openDrawer, openingGesture],
+  );
 
   if (!session) {
     return <AppDrawerContext.Provider value={contextValue}>{children}</AppDrawerContext.Provider>;


### PR DESCRIPTION
## What changed

Fixes #285.

On the mobile agent list, swiping right over an agent row now gives the sidebar opening gesture priority. The row waits for that gesture to fail before handling its own swipe; leftward swipes still reveal the Pin action because the drawer rejects leftward motion.

Surface touched: mobile (agent rows and drawer gesture context).

Before: a rightward swipe starting on a row was captured by the row and the sidebar stayed closed.
After: the same swipe opens the sidebar, including when it starts on a row. Sidebar closing behavior remains unchanged.

## Verification

- [x] `bun run lint` passed (8 existing module-mocking warnings in unrelated tests).
- [x] `bun run typecheck` passed across all projects, including mobile.
- [x] `git diff --check` passed.
- [x] No credentials, private data, generated output, or real user files are included.
- [ ] Native device smoke test: not run. Still needs iOS/Android verification of rightward drawer opening, leftward Pin reveal, vertical scrolling, and interrupted/reversed gestures.

No automated gesture regression test was added; native gesture arbitration is not exercised by the existing mobile test setup. The device and regression-coverage acceptance criteria in #285 remain unverified.

## Risk and security impact

Gesture arbitration changes only. No changes to permissions, IPC, persistence, filesystem or network access. Native touch/pointer behavior still needs device verification.

Implemented with GPT-6 in the Codex desktop harness.
