### PR TITLE
fix(renderer): align island avatar with text

### DIFF
--- a/src/renderer/src/features/dynamic-island/dynamic-island-surface.css
+++ b/src/renderer/src/features/dynamic-island/dynamic-island-surface.css
@@ -198,8 +198,7 @@ body:has(.dynamic-island-surface),
 }
 
 .dynamic-island-surface-avatar {
-  --agent-avatar-optical-offset: -2px;
-  --agent-avatar-optical-offset-x: 1px;
+  --agent-avatar-optical-offset: -3px;
   width: 20px;
   height: 20px;
   flex: 0 0 auto;


### PR DESCRIPTION
The Dynamic Island avatar sat slightly below and to the right of the agent name. Move the avatar graphic 1 px up and 1 px left to align it with the text.

| Before | After |
| --- | --- |
| Vertical optical offset: `-2px`; horizontal offset: `1px`. | Vertical optical offset: `-3px`; horizontal offset: default `0`. |

Surface: desktop renderer, including built-in and external display islands.

Validation: checked the single-agent working story in Storybook before and after the change, including expansion and collapse. All 7 tests in `OpenBotDynamicIsland.test.tsx` passed. `bun run lint`, `bun run typecheck`, and `bun run check:ui` passed. Lint reported 8 existing warnings in mobile tests. No new tests were added for this visual change.

Storybook component documentation generation stalled during startup. Visual checks used a temporary configuration with documentation generation disabled; the repository configuration is unchanged.

Model: GPT-6. Harness: Codex desktop, with the in-app browser and local Storybook.
