### PR TITLE
fix(renderer): polish question summaries and align chat input

### DIFF
--- a/src/renderer/src/components/QuestionPromptBubble.tsx
+++ b/src/renderer/src/components/QuestionPromptBubble.tsx
@@ -84,11 +84,6 @@ function CompletedQuestionPrompt(props: { questions: AgentPromptQuestion[]; reso
           {props.resolution.status === "answered" ? <CircleCheck aria-hidden="true" /> : <X aria-hidden="true" />}
           <strong>{title()}</strong>
         </span>
-        <Show when={props.resolution.status === "answered"}>
-          <span class="question-prompt-complete-count">
-            {props.questions.length} of {props.questions.length}
-          </span>
-        </Show>
       </header>
 
       <Show when={props.resolution.status === "answered"}>
@@ -146,8 +141,6 @@ export function QuestionPromptBubble(props: QuestionPromptBubbleProps) {
   });
 
   queueMicrotask(() => {
-    const element = pageElements[0];
-    if (stage && element) stage.style.height = `${element.scrollHeight}px`;
     if (initialQuestion && !initialQuestion.options?.length) customInputs.get(initialQuestion.id)?.focus();
   });
 
@@ -160,7 +153,10 @@ export function QuestionPromptBubble(props: QuestionPromptBubbleProps) {
   );
 
   function transitionTo(content: PageContent, direction: "forward" | "back", after?: () => void): void {
-    if (transitioning()) return;
+    if (transitioning() || !stage) return;
+    const fromHeight = stage.getBoundingClientRect().height;
+    stage.dataset.preparing = "";
+    stage.style.height = `${fromHeight}px`;
     const fromSlot = activeSlot();
     const toSlot: 0 | 1 = fromSlot === 0 ? 1 : 0;
     const fromPageId = direction === "forward" ? 1 : 2;
@@ -181,10 +177,7 @@ export function QuestionPromptBubble(props: QuestionPromptBubbleProps) {
 
     queueMicrotask(() => {
       if (!stage) return;
-      stage.dataset.preparing = "";
-      const fromElement = pageElements[fromSlot];
       const toElement = pageElements[toSlot];
-      if (fromElement) stage.style.height = `${fromElement.scrollHeight}px`;
       void stage.offsetHeight;
       delete stage.dataset.preparing;
       if (toElement) stage.style.height = `${toElement.scrollHeight}px`;
@@ -199,6 +192,7 @@ export function QuestionPromptBubble(props: QuestionPromptBubbleProps) {
         });
         setTransitioning(false);
         transitionTimer = undefined;
+        stage?.style.removeProperty("height");
         after?.();
         const interaction = queuedInteraction;
         queuedInteraction = undefined;

--- a/src/renderer/src/features/conversation/conversation.css
+++ b/src/renderer/src/features/conversation/conversation.css
@@ -5506,7 +5506,7 @@ button.chat-action-target:active,
 .composer-wrap {
   position: relative;
   flex: 0 0 auto;
-  padding: 0 12px 7px;
+  padding: 0 var(--openbot-space-1-5) var(--openbot-space-1-5);
 }
 
 .team-typing-dots {
@@ -5644,7 +5644,7 @@ button.chat-action-target:active,
 
 .composer[data-compact] {
   grid-template-columns: 28px minmax(0, 1fr) auto;
-  min-height: 46px;
+  min-height: 48px;
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
@@ -7167,21 +7167,17 @@ button.chat-action-target:active,
   letter-spacing: var(--openbot-tracking-tight);
 }
 
-.question-prompt-complete-count {
-  color: var(--openbot-text-muted);
-  font-size: var(--openbot-text-sm);
-  line-height: var(--openbot-leading-sm);
-  white-space: nowrap;
-}
-
 .question-prompt-complete-answers.ui-item-group {
-  border-radius: var(--openbot-radius-bubble-inset);
+  gap: var(--openbot-space-3);
+  border: 0;
+  border-radius: 0;
   background: transparent;
 }
 
 .question-prompt-complete-answers .ui-item {
-  min-height: 48px;
-  padding: var(--openbot-space-2) var(--openbot-space-3);
+  min-height: 0;
+  border: 0;
+  padding: 0;
 }
 
 .question-prompt-complete-answers .ui-item-title,
@@ -7189,6 +7185,7 @@ button.chat-action-target:active,
   overflow: visible;
   text-overflow: clip;
   white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .question-prompt-complete-answers .ui-item-title {
@@ -7277,17 +7274,19 @@ button.chat-action-target:active,
 }
 
 .question-prompt-stage {
-  --page-slide-distance: 6px;
-  --page-blur: 5px;
-
   min-width: 0;
   overflow: hidden;
   transition: height var(--page-slide-dur) var(--page-slide-ease);
 }
 
-.question-prompt-page {
+.question-prompt-stage .question-prompt-page {
+  bottom: auto;
   display: grid;
   gap: var(--openbot-space-3);
+}
+
+.question-prompt-stage:not([data-transitioning]) .question-prompt-page:not([aria-hidden="true"]) {
+  position: relative;
 }
 
 .question-prompt-stage[data-preparing],

--- a/src/renderer/stories/QuestionPromptBubble.stories.tsx
+++ b/src/renderer/stories/QuestionPromptBubble.stories.tsx
@@ -335,3 +335,63 @@ export const PersistedExpired: Story = {
   args: { questions: multipleQuestions, resolution: { status: "expired" } },
   render: renderInChat,
 };
+
+export const PersistedSingleAnswer: Story = {
+  args: {
+    questions: singleQuestion,
+    resolution: {
+      status: "answered",
+      responses: { reply: { status: "answered", answers: ["Send that reply"] } },
+    },
+  },
+  render: renderInChat,
+};
+
+export const PersistedPrivateAnswer: Story = {
+  args: {
+    questions: secretQuestion,
+    resolution: {
+      status: "answered",
+      responses: { token: { status: "answered" } },
+    },
+  },
+  render: renderInChat,
+};
+
+export const PersistedLongAnswer: Story = {
+  args: {
+    questions: [
+      {
+        id: "outcome",
+        header: "Outcome",
+        question:
+          "What should the implementation plan include so that the team can review the authentication setup and release it safely?",
+        isSecret: false,
+        options: null,
+      },
+    ],
+    resolution: {
+      status: "answered",
+      responses: {
+        outcome: {
+          status: "answered",
+          answers: [
+            "Prepare a technical brief with the proposed approach, risks, owners, and steps to reverse the release. Include this reference: authentication-session-cookie-configuration-and-release-verification-checklist.",
+          ],
+        },
+      },
+    },
+  },
+  render: renderInChat,
+};
+
+export const PersistedLongAnswerNarrow: Story = {
+  ...PersistedLongAnswer,
+  decorators: [
+    (Story) => (
+      <div class="question-prompt-story-narrow">
+        <Story />
+      </div>
+    ),
+  ],
+};


### PR DESCRIPTION
## What changed

Completed question cards now use their content height after submission, so answers do not retain blank space from the question form. The summary removes the inner border, row dividers, and completed count. Long answers wrap. The compact chat input now matches the account dock at 48 px high, with 6 px side and bottom insets.

The question transition keeps the existing 250 ms slide, fade, and resize timing. Pages use natural height, the fixed stage height is cleared after each transition, and the component uses the shared 8 px slide and 3 px blur defaults. Storybook adds saved single, private, and long answer examples, including a narrow layout.

Surfaces touched: desktop renderer and Storybook. No mobile, public web, Signal service, IPC, persistence, migration, or shared palette changes.

### Before and after

| Before | After |
| --- | --- |
| Completed card could retain the question form height and spread its contents | Submitted and saved summaries use the same natural content height |
| Inner answer box, row dividers, count, and padded rows | One bubble with compact answer pairs and wrapping text |
| 6 px slide and 5 px blur override | Shared 8 px slide and softer 3 px blur |
| Input: 46 px high, 12 px side insets, 7 px bottom inset | Input: 48 px high, 6 px side and bottom insets; top and bottom edges match the dock |

## Verification

- [x] Existing QuestionPromptBubble tests: 10 passed.
- [x] Existing ComposerEditor tests: 31 passed.
- [x] `bun run lint`: passed with eight existing module-mocking warnings in mobile tests. These files are outside this change.
- [x] `bun run typecheck` and `bun run check:ui`: passed.
- [x] Surfaces touched are named above.
- [x] Manual Storybook checks: submission, custom answer entry, reverse navigation, preserved drafts, saved answers, private answers, skipped answers, and narrow long-answer wrapping. Submitted and saved summaries with identical answers both measured 168 px high. The compact input and dock both measured 48 px high with matching top and bottom edges.
- [x] No credentials, private data, generated output, or real user files are included.

No behavior tests were added or changed; visual changes are covered by Storybook examples and manual checks. Desktop uses a dark palette, so light-theme verification does not apply. Before and after screenshots were captured in the Codex task; they are not hosted in this pull request.

Model: GPT-6. Harness: Codex desktop, local Bun/Vitest, and the in-app browser running Storybook.

## Risk and security impact

Low: renderer layout and transition height management only. Existing submission callbacks, private-answer redaction, retry behavior, and reduced-motion handling remain in place. No changes to permissions, IPC, filesystem access, persistence, or network access.
