### PR TITLE
fix(browser): let WhatsApp Web log in, with one plain Chromium identity

### DIFF
--- a/scripts/browser-smoke-electron.ts
+++ b/scripts/browser-smoke-electron.ts
@@ -1991,9 +1991,13 @@ async function main(): Promise<void> {
       : [];
     const clientHintBrands = getString(identity.requestHeaders, "sec-ch-ua") ?? "";
     const chromiumMajorVersion = process.versions.chrome.split(".")[0];
+    // The page and its requests present plain Chromium: neither the build token nor the app product
+    // token, which `navigator.userAgentData.brands` never carried either. A site that gates on a
+    // browser allowlist reads a product it does not know as an unsupported browser -- WhatsApp Web
+    // refuses to start on it, which blocks the QR login.
     if (
       headerSnapshot.text.includes("Electron/") ||
-      !headerSnapshot.text.includes("OpenBot/") ||
+      headerSnapshot.text.includes("OpenBot/") ||
       !navigatorUserAgent?.includes(`Chrome/${chromiumMajorVersion}`) ||
       getString(identity.requestHeaders, "user-agent") !== navigatorUserAgent ||
       identity.navigatorWebdriver !== false ||

--- a/src/backend/browser-host.ts
+++ b/src/backend/browser-host.ts
@@ -34,7 +34,7 @@ import {
 } from "electron";
 import { BrowserCdpEngine, type BrowserUploadAssignment, type SnapshotReadResult } from "./browser-cdp";
 import { BrowserDiagnostics } from "./browser-diagnostics";
-import { embeddedBrowserUserAgent, embeddedBrowserUserAgentForUrl } from "./browser-identity";
+import { embeddedBrowserUserAgent } from "./browser-identity";
 import { BrowserRecorder } from "./browser-recorder";
 import { isCloseBrowserTabShortcut, isGlobalSearchShortcut, isToggleDevToolsShortcut } from "./browser-shortcuts";
 import {
@@ -360,9 +360,7 @@ export class BrowserHost {
 
   async navigate(tabId: string, direction: BrowserNavigationDirection): Promise<void> {
     await this.#enqueue(tabId, async (tab) => {
-      await navigateAndWait(tab.view.webContents, () =>
-        navigateHistory(tab.view.webContents, direction, this.#session.getUserAgent()),
-      );
+      await navigateAndWait(tab.view.webContents, () => navigateHistory(tab.view.webContents, direction));
     });
   }
 
@@ -476,9 +474,7 @@ export class BrowserHost {
               return;
             case "back":
             case "forward":
-              await navigateAndWait(tab.view.webContents, () =>
-                navigateHistory(tab.view.webContents, action.type, this.#session.getUserAgent()),
-              );
+              await navigateAndWait(tab.view.webContents, () => navigateHistory(tab.view.webContents, action.type));
               return;
             case "reload":
               await navigateAndWait(tab.view.webContents, () => {
@@ -628,9 +624,6 @@ export class BrowserHost {
                 if (url) {
                   const normalizedUrl = normalizeBrowserUrl(url);
                   tab.requestedUrl = normalizedUrl;
-                  tab.view.webContents.setUserAgent(
-                    embeddedBrowserUserAgentForUrl(this.#session.getUserAgent(), normalizedUrl),
-                  );
                   await navigateAndWait(
                     tab.view.webContents,
                     () => tab.view.webContents.loadURL(normalizedUrl, browserLoadOptions()),
@@ -648,7 +641,7 @@ export class BrowserHost {
                 } else if (direction) {
                   await navigateAndWait(
                     tab.view.webContents,
-                    () => navigateHistory(tab.view.webContents, direction, this.#session.getUserAgent()),
+                    () => navigateHistory(tab.view.webContents, direction),
                     operationTimeout,
                   );
                 }
@@ -1008,7 +1001,6 @@ export class BrowserHost {
   ): InternalTab {
     if (this.#destroyPromise) throw new Error("BrowserHost is shutting down.");
     const view = this.#createView();
-    view.webContents.setUserAgent(embeddedBrowserUserAgentForUrl(this.#session.getUserAgent(), requestedUrl));
     this.#mountView(view);
     const diagnostics = new BrowserDiagnostics();
     return {
@@ -1188,19 +1180,11 @@ export class BrowserHost {
       this.#schedulePersist();
     });
     contents.on("will-navigate", (event, url) => {
-      if (!isAllowedMainUrl(url)) {
-        event.preventDefault();
-        return;
-      }
-      contents.setUserAgent(embeddedBrowserUserAgentForUrl(this.#session.getUserAgent(), url));
+      if (!isAllowedMainUrl(url)) event.preventDefault();
     });
     contents.on("will-redirect", (event) => {
       if (!event.isMainFrame) return;
-      if (!isAllowedMainUrl(event.url)) {
-        event.preventDefault();
-        return;
-      }
-      contents.setUserAgent(embeddedBrowserUserAgentForUrl(this.#session.getUserAgent(), event.url));
+      if (!isAllowedMainUrl(event.url)) event.preventDefault();
     });
     contents.setWindowOpenHandler(({ url }) => {
       if (isAllowedMainUrl(url)) void this.open(url, tab.ownerThreadId, tab.ownerAgentId);
@@ -2145,17 +2129,12 @@ function optionalStringArray(value: DynamicRecord, key: string, maximum: number)
   return requiredStringArray(value, key, maximum, 64, "reject-empty");
 }
 
-function navigateHistory(
-  contents: WebContents,
-  direction: BrowserNavigationDirection,
-  sessionUserAgent: string,
-): boolean {
+function navigateHistory(contents: WebContents, direction: BrowserNavigationDirection): boolean {
   const history = contents.navigationHistory;
   const offset = direction === "back" ? -1 : 1;
   if (!history.canGoToOffset(offset)) return false;
   const entry = history.getEntryAtIndex(history.getActiveIndex() + offset);
   if (!entry?.url) return false;
-  contents.setUserAgent(embeddedBrowserUserAgentForUrl(sessionUserAgent, entry.url));
   history.goToOffset(offset);
   return true;
 }

--- a/src/backend/browser-identity.test.ts
+++ b/src/backend/browser-identity.test.ts
@@ -20,6 +20,12 @@ describe("embeddedBrowserUserAgentForUrl", () => {
     );
   });
 
+  it("uses a standard Chromium identity for WhatsApp Web, which refuses an unknown product", () => {
+    expect(embeddedBrowserUserAgentForUrl(userAgent, "https://web.whatsapp.com/")).toBe(
+      "Mozilla/5.0 AppleWebKit/537.36 Chrome/152.0.7977.54 Safari/537.36",
+    );
+  });
+
   it("keeps the embedded app identity for other sites", () => {
     expect(embeddedBrowserUserAgentForUrl(userAgent, "https://accounts.google.com/")).toContain("OpenBot/0.3.5");
   });

--- a/src/backend/browser-identity.test.ts
+++ b/src/backend/browser-identity.test.ts
@@ -1,32 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { embeddedBrowserUserAgent, embeddedBrowserUserAgentForUrl } from "./browser-identity";
+import { embeddedBrowserUserAgent } from "./browser-identity";
 
 describe("embeddedBrowserUserAgent", () => {
-  it("removes Electron while preserving the app product and Chromium version", () => {
+  it("removes the build and product tokens, so a browser allowlist reads plain Chromium", () => {
     expect(
       embeddedBrowserUserAgent(
         "Mozilla/5.0 AppleWebKit/537.36 OpenBot/0.3.5 Chrome/152.0.7977.54 Electron/44.0.0 Safari/537.36",
       ),
-    ).toBe("Mozilla/5.0 AppleWebKit/537.36 OpenBot/0.3.5 Chrome/152.0.7977.54 Safari/537.36");
-  });
-});
-
-describe("embeddedBrowserUserAgentForUrl", () => {
-  const userAgent = "Mozilla/5.0 AppleWebKit/537.36 OpenBot/0.3.5 Chrome/152.0.7977.54 Electron/44.0.0 Safari/537.36";
-
-  it("uses a standard Chromium identity for X", () => {
-    expect(embeddedBrowserUserAgentForUrl(userAgent, "https://x.com/i/flow/login")).toBe(
-      "Mozilla/5.0 AppleWebKit/537.36 Chrome/152.0.7977.54 Safari/537.36",
-    );
-  });
-
-  it("uses a standard Chromium identity for WhatsApp Web, which refuses an unknown product", () => {
-    expect(embeddedBrowserUserAgentForUrl(userAgent, "https://web.whatsapp.com/")).toBe(
-      "Mozilla/5.0 AppleWebKit/537.36 Chrome/152.0.7977.54 Safari/537.36",
-    );
-  });
-
-  it("keeps the embedded app identity for other sites", () => {
-    expect(embeddedBrowserUserAgentForUrl(userAgent, "https://accounts.google.com/")).toContain("OpenBot/0.3.5");
+    ).toBe("Mozilla/5.0 AppleWebKit/537.36 Chrome/152.0.7977.54 Safari/537.36");
   });
 });

--- a/src/backend/browser-identity.ts
+++ b/src/backend/browser-identity.ts
@@ -1,3 +1,8 @@
+// Sites that gate on a browser allowlist and reject an unknown product token: X serves a
+// degraded page, and WhatsApp Web refuses to start with "WhatsApp works with Google Chrome
+// 100+", which blocks the QR login. They get a plain Chromium identity instead.
+const PLAIN_CHROMIUM_DOMAINS = ["x.com", "whatsapp.com"];
+
 export function embeddedBrowserUserAgent(sessionUserAgent: string): string {
   return sessionUserAgent.replace(/\sElectron\/[^\s]+/gu, "");
 }
@@ -5,12 +10,16 @@ export function embeddedBrowserUserAgent(sessionUserAgent: string): string {
 export function embeddedBrowserUserAgentForUrl(sessionUserAgent: string, value: string): string {
   const userAgent = embeddedBrowserUserAgent(sessionUserAgent);
   try {
-    const hostname = new URL(value).hostname;
-    if (hostname === "x.com" || hostname === "www.x.com") {
+    if (needsPlainChromiumIdentity(new URL(value).hostname)) {
       return userAgent.replace(/\sOpenBot\/[^\s]+/gu, "");
     }
   } catch {
     // Keep the embedded identity when the navigation URL is not complete yet.
   }
   return userAgent;
+}
+
+function needsPlainChromiumIdentity(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return PLAIN_CHROMIUM_DOMAINS.some((domain) => host === domain || host.endsWith(`.${domain}`));
 }

--- a/src/backend/browser-identity.ts
+++ b/src/backend/browser-identity.ts
@@ -1,25 +1,10 @@
-// Sites that gate on a browser allowlist and reject an unknown product token: X serves a
-// degraded page, and WhatsApp Web refuses to start with "WhatsApp works with Google Chrome
-// 100+", which blocks the QR login. They get a plain Chromium identity instead.
-const PLAIN_CHROMIUM_DOMAINS = ["x.com", "whatsapp.com"];
-
+/**
+ * The embedded browser presents a plain Chromium identity: no `Electron/` build token, and no app
+ * product token either. `navigator.userAgentData.brands` never carried the product, so a page that
+ * read both saw the two disagree, and a site that gates on a browser allowlist reads that as an
+ * unsupported browser -- X served a degraded page, and WhatsApp Web refused to start at all, which
+ * blocked the QR login. One identity for every site and every subresource, set once on the session.
+ */
 export function embeddedBrowserUserAgent(sessionUserAgent: string): string {
-  return sessionUserAgent.replace(/\sElectron\/[^\s]+/gu, "");
-}
-
-export function embeddedBrowserUserAgentForUrl(sessionUserAgent: string, value: string): string {
-  const userAgent = embeddedBrowserUserAgent(sessionUserAgent);
-  try {
-    if (needsPlainChromiumIdentity(new URL(value).hostname)) {
-      return userAgent.replace(/\sOpenBot\/[^\s]+/gu, "");
-    }
-  } catch {
-    // Keep the embedded identity when the navigation URL is not complete yet.
-  }
-  return userAgent;
-}
-
-function needsPlainChromiumIdentity(hostname: string): boolean {
-  const host = hostname.toLowerCase();
-  return PLAIN_CHROMIUM_DOMAINS.some((domain) => host === domain || host.endsWith(`.${domain}`));
+  return sessionUserAgent.replace(/\s(?:Electron|OpenBot)\/[^\s]+/gu, "");
 }


### PR DESCRIPTION
## Problem

WhatsApp Web cannot be used from the embedded browser. It checks the user agent against a browser allowlist, finds the `OpenBot/<version>` product token, and replaces the whole app with an update prompt. The login page never appears, so there is no way to link a device.

## Change

The embedded browser now presents a plain Chromium identity to every site, set once on the session. The product token was the only place the app name reached a page, and `navigator.userAgentData.brands` never carried it — a page that read both saw the two disagree, which is what a browser allowlist reads as an unsupported browser.

`browser-identity.ts` already dropped the token for X. A per-site exception list grows by bug report, and WhatsApp was the second entry, so the exception became the rule instead. Nothing first-party reads the token: the landing page platform sniff needs the OS part only, and the runtime installer sets its own separate `User-Agent`.

This removes the per-URL identity. `embeddedBrowserUserAgentForUrl` and the five `setUserAgent` calls that followed each navigation — new tab, the `navigate` tool, `will-navigate`, `will-redirect`, history movement — are gone, because one session user agent covers every tab, subresource and redirect. `navigateHistory` loses the parameter it needed only for that. Net 75 lines removed against 23 added.

For X the identity is byte-for-byte what it was. Every other site loses the token, and its subresources stop disagreeing with the page.

Prior art: T3 Code does the same in one place, in `apps/desktop/src/preview/BrowserSession.ts`, with no per-site list.

## Before and after

Captured from a scratch Electron process on a temporary profile, with the same session settings as `BrowserHost`: the `persist:` partition, sandbox, denied permissions, and the no-cache load headers.

Before, with `Mozilla/5.0 (Macintosh; …) OpenBot/0.5.0 Chrome/152.0.7977.54 Safari/537.36`:

> WhatsApp works with Google Chrome 100+ — To use WhatsApp, update Chrome or use Mozilla Firefox, Safari, Microsoft Edge or Opera.

After, with `Mozilla/5.0 (Macintosh; …) Chrome/152.0.7977.54 Safari/537.36`:

> Scan to log in — 1 Scan the QR code with your phone's camera … Stay logged in on this browser — Log in with phone number

The QR page also carried a live `data-ref` pairing reference, which the server issues over the login websocket, so the handshake up to the phone scan works. The second run set the identity on the session only, with no per-tab call, and the tab inherited it — which is the code path this PR ships.

## Surfaces

Desktop embedded browser (`src/backend`) and the desktop smoke script. No IPC contract, no schema, no migration, and no renderer markup, so the mock IPC, `check:ui` and the documentation need no edit.

## Tests

`src/backend/browser-identity.test.ts` keeps one test for the one function; no new file.

- `bun run test:desktop -- src/backend/browser-identity.test.ts src/backend/browser-state.test.ts` and the four neighbouring `browser-*` files — all passed.
- Watched it fail: took `OpenBot` out of the strip and the test went red for the right reason — `Received: "… OpenBot/0.3.5 Chrome/152.0.7977.54 …"`, the token WhatsApp rejects. Then restored it.
- `bun run lint` — 8 warnings, all pre-existing, none in these files. `bun run typecheck` — 11 projects clean.

`scripts/browser-smoke-electron.ts` asserted the opposite on purpose, so its identity check now rejects `OpenBot/` in the page and request identity instead of requiring it. That runs in `check:desktop`, which CI owns; I did not run it locally.

## Not covered

A QR code cannot be scanned from a test, so a completed session was not observed. The login state persists in the `persist:openbot-browser` partition, which the smoke test already covers for cookies, `localStorage` and IndexedDB across processes.

Two related limits stay as they are, because neither blocks login: the session denies every permission request, so WhatsApp notifications and camera or microphone calls do not work in the embedded browser.

Model: Claude Opus 5. Harness: Claude Code in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)