### PR TITLE
fix: recover chat history after provider sessions become inactive

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -166,6 +166,11 @@ SQLite migration history starts at the frozen version 8 compatibility baseline. 
 schema unchanged, append every later migration in numeric order, and update the separate latest
 schema used for new databases. Never remove or rewrite a migration that may have shipped.
 
+At startup, chat recovery reads all saved provider sessions for each thread, including inactive
+sessions from an upgrade or a provider change. It uses each session's provider and merges the
+messages into SQLite without activating the old session. A failed read reports an error, keeps
+the saved messages, and can be tried again when the provider connects or the app restarts.
+
 ## Team API compatibility boundary
 
 Current remote connections use Team API protocol v3 over three ordered WebRTC DataChannels: `rpc`,

--- a/src/backend/agent-service-test-harness.ts
+++ b/src/backend/agent-service-test-harness.ts
@@ -97,6 +97,7 @@ export class FakeAgentClient extends EventEmitter implements AgentClient {
   running = false;
   responseError: Error | null = null;
   modelList: ((params: unknown) => unknown) | undefined;
+  threadRead: ((params: unknown) => unknown) | undefined;
   accountRateLimits: unknown = { rateLimits: null, rateLimitsByLimitId: null };
 
   constructor(
@@ -171,7 +172,7 @@ export class FakeAgentClient extends EventEmitter implements AgentClient {
       result = { thread: { id: stringParam(params, "threadId") } };
     }
     if (method === "thread/read") {
-      result = { thread: { id: stringParam(params, "threadId"), turns: [] } };
+      result = this.threadRead?.(params) ?? { thread: { id: stringParam(params, "threadId"), turns: [] } };
     }
     if (method === "thread/compact/start" || method === "turn/interrupt") result = {};
     if (method === "turn/steer") {

--- a/src/backend/agent-service.restart.test.ts
+++ b/src/backend/agent-service.restart.test.ts
@@ -139,6 +139,87 @@ describe.sequential("AgentService: restart", () => {
     });
   });
 
+  it("recovers history from sessions retired by an upgrade and retries failed reads without losing local messages", async () => {
+    const { store } = stores(root);
+    await store.initialize();
+    await store.getOrCreate("chief");
+    const threadId = await store.ensureThreadId("chief");
+    store.bindProviderSession("chief", "old-session");
+    const local = {
+      id: "local-message",
+      author: "user" as const,
+      text: "Keep this local message",
+      createdAt: "2026-08-01T12:00:00.000Z",
+      status: "completed" as const,
+    };
+    store.database.persistConversation(
+      { agentId: "chief", threadId, activeTurnId: null, revision: 0, messages: [local] },
+      "test.saved-before-upgrade",
+    );
+    // Version 14 changes session state only. Reopen the version 13 database to run the shipped upgrade.
+    store.database.connection.prepare("DELETE FROM schema_migrations WHERE version = 14").run();
+    store.database.close();
+
+    let failRead = true;
+    const events: AgentEvent[] = [];
+    const createService = () => {
+      const restored = stores(root);
+      const next = new AgentService(restored.store, restored.mailbox, fakeBrowser(), 30_000, "codex", (provider) => {
+        const client = new FakeAgentClient(provider);
+        client.threadRead = () => {
+          if (failRead) throw new Error("Saved provider history is unavailable. Try again.");
+          return {
+            thread: {
+              id: "old-session",
+              turns: [
+                {
+                  id: "old-turn",
+                  status: "completed",
+                  startedAt: 1785585600,
+                  items: [{ id: "old-reply", type: "agentMessage", text: "Reply saved before the update" }],
+                },
+              ],
+            },
+          };
+        };
+        return client;
+      });
+      next.on("event", (event) => events.push(event));
+      return { next, restored };
+    };
+    const first = createService();
+    service = first.next;
+    await service.initialize();
+    await waitFor(() =>
+      events.some((event) => event.type === "error" && event.code === "provider_history_backfill_pending"),
+    );
+    expect((await service.readConversation("chief")).messages).toEqual([expect.objectContaining(local)]);
+    expect(first.restored.store.activeProviderSession("chief")).toBeNull();
+    await service.stop();
+    first.restored.store.database.close();
+
+    failRead = false;
+    for (let restart = 0; restart < 2; restart += 1) {
+      const { next, restored } = createService();
+      service = next;
+      await service.initialize();
+      await waitFor(async () =>
+        (await next.readConversation("chief")).messages.some((message) => message.id === "old-reply"),
+      );
+      const recovered = await service.readConversation("chief");
+      expect(recovered.threadId).toBe(threadId);
+      expect(recovered.messages).toEqual([
+        expect.objectContaining(local),
+        expect.objectContaining({ id: "old-reply", text: "Reply saved before the update" }),
+      ]);
+      expect(restored.store.database.listProviderSessions(threadId)).toEqual([
+        expect.objectContaining({ externalSessionId: "old-session", state: "inactive" }),
+      ]);
+      await service.stop();
+      restored.store.database.close();
+    }
+  });
+
   it("does not persist unchanged provider history after repeated restarts", async () => {
     const clients: FakeAgentClient[] = [];
     const { store, mailbox } = stores(root);

--- a/src/backend/agent/boot-recovery.ts
+++ b/src/backend/agent/boot-recovery.ts
@@ -139,35 +139,37 @@ export class BootRecovery {
   async backfillProviderHistory(): Promise<void> {
     for (const agent of this.#store.list()) {
       if (!agent.threadId) continue;
-      const session = this.#store.activeProviderSession(agent.id);
-      const client = this.#providers.clientForAgent(agent);
-      if (!session || !client) continue;
-      try {
-        const response = await client.request(
-          "thread/read",
-          { threadId: session.externalSessionId, includeTurns: true },
-          decodeThreadResponse,
-        );
-        const imported = snapshotFromThread(agent.id, response.thread, (deliveryId) =>
-          this.#mailbox.getDelivery(deliveryId),
-        );
-        imported.threadId = agent.threadId;
-        const current = this.#store.database.readConversation(agent.id, agent.threadId);
-        const merged = mergeProviderHistory(current, imported);
-        this.#mailboxSync.syncMailboxMessages(merged);
-        if (conversationContentSignature(merged) === conversationContentSignature(current)) {
+      // Inactive sessions still own history after an upgrade or provider switch.
+      for (const session of this.#store.database.listProviderSessions(agent.threadId)) {
+        const client = this.#providers.clientFor(session.provider);
+        if (!client) continue;
+        try {
+          const response = await client.request(
+            "thread/read",
+            { threadId: session.externalSessionId, includeTurns: true },
+            decodeThreadResponse,
+          );
+          const imported = snapshotFromThread(agent.id, response.thread, (deliveryId) =>
+            this.#mailbox.getDelivery(deliveryId),
+          );
+          imported.threadId = agent.threadId;
+          const current = this.#store.database.readConversation(agent.id, agent.threadId);
+          const merged = mergeProviderHistory(current, imported);
+          this.#mailboxSync.syncMailboxMessages(merged);
+          if (conversationContentSignature(merged) === conversationContentSignature(current)) {
+            const live = this.#conversation.snapshot(agent.id);
+            if (!live?.activeTurnId) this.#conversation.setSnapshot(agent.id, current);
+            continue;
+          }
+          const persisted = this.#store.database.persistConversation(merged, "provider-history.backfilled", {
+            provider: session.provider,
+            externalSessionId: session.externalSessionId,
+          });
           const live = this.#conversation.snapshot(agent.id);
-          if (!live?.activeTurnId) this.#conversation.setSnapshot(agent.id, current);
-          continue;
+          if (!live?.activeTurnId) this.#conversation.setSnapshot(agent.id, persisted);
+        } catch (error) {
+          this.#hooks.emitError("provider_history_backfill_pending", error, agent.id);
         }
-        const persisted = this.#store.database.persistConversation(merged, "provider-history.backfilled", {
-          provider: session.provider,
-          externalSessionId: session.externalSessionId,
-        });
-        const live = this.#conversation.snapshot(agent.id);
-        if (!live?.activeTurnId) this.#conversation.setSnapshot(agent.id, persisted);
-      } catch (error) {
-        this.#hooks.emitError("provider_history_backfill_pending", error, agent.id);
       }
     }
   }


### PR DESCRIPTION
## What changed

An upgrade marks old provider sessions inactive, but startup recovery read only the active session. Messages still held by an old provider session could therefore remain absent from the local chat. Recovery now reads all saved sessions with each session's provider and merges the messages into the existing SQLite thread. It does not activate old sessions. Failed reads keep local messages, report an error, and can be retried on restart or provider connection.

Surfaces changed: desktop backend recovery and architecture documentation. No renderer, mobile, public web, Signal service, IPC contract, or schema changes. The exact `OpenBot_Posty` report lacks version and data details; this fixes a reproduced upgrade recovery failure.

Fixes #298.

## Verification

- [x] `bun run test:desktop -- src/backend/agent-service.restart.test.ts` — 9 tests passed.
- [x] `bun run lint` — passed with 8 existing module-mocking warnings in unchanged mobile tests.
- [x] `bun run typecheck` — passed across all projects.
- [x] Regression test runs migration 14 from its version 13 source state, checks failed-read preservation, retries recovery, and checks persistence across restarts.
- [x] Mutation check: temporarily skipping inactive sessions made the regression test fail because recovery never reported the failed history read. Restored the fix and reran the file successfully.
- [x] Manual UI smoke test: not applicable; no UI changes.
- [x] No credentials, private data, generated output, or real user files included.

Model and harness: GPT-6 in Codex desktop; Vitest with the existing `FakeAgentClient` harness.

## Risk and security impact

Startup can read more saved provider sessions. Successful reads merge into the existing local conversation; failed reads leave local messages intact. Released migrations, session activation, permissions, IPC, and storage paths are unchanged.
