### PR TITLE
fix(browser): prevent sidebar resize feedback loop

### DIFF
--- a/src/renderer/src/App.browser.test.tsx
+++ b/src/renderer/src/App.browser.test.tsx
@@ -1,5 +1,6 @@
 import type { AgentSummary, BrowserTab, ServerSummary } from "@openbot/contracts/ipc";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import { flush } from "solid-js";
 import { expect, it, vi } from "vitest";
 import { App } from "./App";
 import {
@@ -10,10 +11,41 @@ import {
   installOpenbotStub,
   testServer,
 } from "./app-test-harness";
+import { TestResizeObserver } from "./setupTests";
 
 describe("OpenBot connected desktop shell", () => {
   beforeEach(() => {
     installOpenbotStub();
+  });
+
+  it("keeps the dragged browser width when conversation padding changes and restores it after a window resize", async () => {
+    window.localStorage.setItem("openbot:browser-panel-width", "400");
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    await fireEvent.click(screen.getByRole("button", { name: "Open computer" }));
+    const resizer = await screen.findByRole("separator", { name: "Resize right panel" });
+    const conversation = screen.getByRole("main", { name: "Conversation" });
+    const width = vi.spyOn(conversation, "clientWidth", "get").mockReturnValue(1200);
+
+    await fireEvent.pointerDown(resizer, { button: 0, pointerId: 1, clientX: 800 });
+    await fireEvent.pointerMove(window, { pointerId: 1, clientX: 700 });
+    expect(resizer).toHaveAttribute("aria-valuenow", "500");
+    TestResizeObserver.resize(conversation, "content-box");
+    flush();
+    expect(resizer).toHaveAttribute("aria-valuenow", "500");
+    await fireEvent.pointerUp(window, { pointerId: 1, clientX: 700 });
+    expect(window.localStorage.getItem("openbot:browser-panel-width")).toBe("500");
+
+    width.mockReturnValue(300);
+    TestResizeObserver.resize(conversation, "border-box");
+    await waitFor(() => expect(resizer).toHaveAttribute("aria-valuenow", "220"));
+    expect(window.localStorage.getItem("openbot:browser-panel-width")).toBe("500");
+    width.mockReturnValue(1200);
+    TestResizeObserver.resize(conversation, "border-box");
+    await waitFor(() => expect(resizer).toHaveAttribute("aria-valuenow", "500"));
+    await fireEvent.keyDown(resizer, { key: "ArrowLeft" });
+    expect(window.localStorage.getItem("openbot:browser-panel-width")).toBe("512");
+    width.mockRestore();
   });
 
   it("moves the live embedded browser between the sidebar and desktop Picture in Picture", async () => {

--- a/src/renderer/src/components/PanelResizer.tsx
+++ b/src/renderer/src/components/PanelResizer.tsx
@@ -76,7 +76,9 @@ export function PanelResizer(props: PanelResizerProps) {
     const resizeTarget = props.onParentResize ? handle?.parentElement?.parentElement : handle?.parentElement;
     if (resizeTarget) {
       parentResizeObserver = new ResizeObserver(enforceBounds);
-      parentResizeObserver.observe(resizeTarget);
+      // Panel widths also change the parent's padding. Only its outer size
+      // should restore the preferred width, or a drag resets itself.
+      parentResizeObserver.observe(resizeTarget, { box: "border-box" });
     }
     return () => {
       cleanupDrag?.();

--- a/src/renderer/src/setupTests.ts
+++ b/src/renderer/src/setupTests.ts
@@ -15,18 +15,37 @@ export class TestResizeObserver implements ResizeObserver {
    */
   static readonly instances = new Set<TestResizeObserver>();
 
-  readonly #elements = new Set<Element>();
+  readonly #elements = new Map<Element, ResizeObserverBoxOptions>();
 
-  // No constructor: the callback is discarded, because no test drives a resize.
-  // They only assert on `instances`.
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  static resize(element: Element, box: ResizeObserverBoxOptions): void {
+    for (const observer of TestResizeObserver.instances) {
+      if (observer.#elements.get(element) !== box) continue;
+      const bounds = element.getBoundingClientRect();
+      const size = [{ inlineSize: bounds.width, blockSize: bounds.height }];
+      observer.callback(
+        [
+          {
+            target: element,
+            contentRect: bounds,
+            borderBoxSize: size,
+            contentBoxSize: size,
+            devicePixelContentBoxSize: size,
+          },
+        ],
+        observer,
+      );
+    }
+  }
 
   disconnect(): void {
     this.#elements.clear();
     TestResizeObserver.instances.delete(this);
   }
 
-  observe(element: Element): void {
-    this.#elements.add(element);
+  observe(element: Element, options?: ResizeObserverOptions): void {
+    this.#elements.set(element, options?.box ?? "content-box");
     TestResizeObserver.instances.add(this);
   }
 


### PR DESCRIPTION
## What changed

Fixes #184.

Dragging the Browser sidebar changed the conversation's padding. Its content-box ResizeObserver then restored the saved panel width during the drag. The shared panel resizer now observes the parent's border box, so only a change to the outer size restores the preferred width.

Surface touched: desktop renderer, including the shared panel resizer. The regression test covers dragging, width persistence, shrinking and expanding the parent, and keyboard resizing.

| Before | After |
| --- | --- |
| Dragging from 400 px to 500 px reset the panel to 400 px when the content area changed. | The panel stays at 500 px and saves that width when the drag ends. |
| Padding changes could repeatedly reset the drag. | Parent window size changes still clamp the width and restore the saved width when space is available. |

## Verification

- [x] `bun run test:desktop -- src/renderer/src/App.browser.test.tsx` — 21 tests passed. The final test-only change also passed its targeted run.
- [x] Mutation check: restored the old observer call and confirmed the regression test failed because 500 px reset to 400 px. Restored the fix and confirmed it passed.
- [x] `bun run lint` — passed, with 8 existing warnings outside this change.
- [x] `bun run typecheck` and `bun run check:ui` — passed.
- [x] Live isolated development app: dragged 424 → 504 px and 504 → 584 px; checked window widths of 800, 1200, and 1400 px; navigated to Example Domain through the address field after resizing.
- [x] No credentials, private data, generated output, or real user files are included.

Model: GPT-6. Harness: Codex desktop, Vitest with the renderer test harness, and the repository's dev-automation CDP connection to an isolated development instance.

## Risk and security impact

The shared desktop panel resizer now reacts to border-box changes. This also applies to other panels that use it. No IPC, permissions, schema, network, or stored-width format changes.
