### PR TITLE
Use one OpenBot tool catalog for all providers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -286,7 +286,10 @@ conversation. `openbot.create_agent` creates a persistent teammate with instruct
 task; `openbot.update_profile` changes an existing agent's name, title, instructions, or generated
 avatar. Both run through the existing agent service and validate arguments before changing state.
 Codex and Grok receive the dynamic tool definitions; Claude exposes the same operations through
-its SDK MCP bridge. There is no separate prompt-generation button or review dialog.
+its SDK MCP bridge. `src/backend/openbot-tools.ts` owns the tool names, descriptions, and Zod
+argument shapes used by both declarations. It reuses the profile, section, and routine schemas.
+Claude uses the SDK’s `AskUserQuestion` flow instead of the `ask_user` MCP tool.
+There is no separate prompt-generation button or review dialog.
 
 Agents can organize teammates into flat sidebar sections through `list_sections`, `create_section`,
 `rename_section`, `delete_section`, and `assign_agent_section`. Assignment accepts a null section

--- a/packages/contracts/src/ipc-agent-identity.ts
+++ b/packages/contracts/src/ipc-agent-identity.ts
@@ -40,8 +40,10 @@ export function isReasoningEffort(value: unknown): value is AgentReasoningEffort
   return isOneOf(AGENT_REASONING_EFFORTS, value);
 }
 
+export const AVATAR_SEED_PATTERN = /^[a-z0-9:-]{1,128}$/;
+
 export function isAvatarSeed(value: unknown): value is string {
-  return isString(value) && /^[a-z0-9:-]{1,128}$/.test(value);
+  return isString(value) && AVATAR_SEED_PATTERN.test(value);
 }
 
 export function isAvatarHue(value: unknown): value is AvatarHue {

--- a/src/backend/agent/profile-tools.ts
+++ b/src/backend/agent/profile-tools.ts
@@ -1,13 +1,13 @@
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
-import { AVATAR_HUES, isAvatarSeed } from "@openbot/contracts/ipc";
+import { AVATAR_HUES, AVATAR_SEED_PATTERN } from "@openbot/contracts/ipc";
 import { z } from "zod";
 
 const profileFields = {
   name: z.string().trim().min(1).max(INPUT_LIMITS.agentName),
   title: z.string().max(INPUT_LIMITS.agentTitle),
   description: z.string().max(INPUT_LIMITS.agentDescription),
-  avatarSeed: z.string().refine(isAvatarSeed, "Invalid avatar seed."),
-  avatarHue: z.union(AVATAR_HUES.map((hue) => z.literal(hue))).nullable(),
+  avatarSeed: z.string().regex(AVATAR_SEED_PATTERN, "Invalid avatar seed."),
+  avatarHue: z.literal(AVATAR_HUES).nullable(),
 };
 
 export const createAgentToolSchema = z

--- a/src/backend/claude-client.test.ts
+++ b/src/backend/claude-client.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import type { CanUseTool, ModelInfo, SDKUserMessage, SessionMessage } from "@anthropic-ai/claude-agent-sdk";
 import { type DynamicRecord, isDynamicRecord, isString } from "@openbot/contracts/runtime-values";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { ClaudeAgentClient } from "./claude-client";
 import { OPENBOT_DYNAMIC_TOOLS } from "./openbot-tools";
 import {
@@ -211,17 +212,20 @@ fi
       const openbotServer = mcpServers?.openbot;
       const serverInstance = isDynamicRecord(openbotServer) ? openbotServer.instance : null;
       const registeredTools = isDynamicRecord(serverInstance) ? serverInstance._registeredTools : null;
-      // Codex and Grok read OPENBOT_DYNAMIC_TOOLS; Claude gets this hand-written MCP mirror, so the
-      // two lists drift unless the mirror is held to the catalogue. Set equality, not arrayContaining:
-      // a tool missing here is one the developer instructions promise and Claude cannot call, and a
-      // Claude-only tool is one no other provider or handler knows about.
-      const claudeOnlySdkTools = new Set(["ask_user"]); // Claude uses the SDK's AskUserQuestion instead.
-      const expectedTools = OPENBOT_DYNAMIC_TOOLS.tools
-        .map((dynamicTool) => dynamicTool.name)
-        .filter((name) => !claudeOnlySdkTools.has(name));
+      // Compare the declarations passed to the providers, including schema constraints and guidance.
+      // Claude uses the SDK's AskUserQuestion instead of the ask_user MCP tool.
+      const expectedTools = OPENBOT_DYNAMIC_TOOLS.tools.filter((dynamicTool) => dynamicTool.name !== "ask_user");
       expect((isDynamicRecord(registeredTools) ? Object.keys(registeredTools) : []).toSorted()).toEqual(
-        expectedTools.toSorted(),
+        expectedTools.map((dynamicTool) => dynamicTool.name).toSorted(),
       );
+      for (const dynamicTool of expectedTools) {
+        const registered = isDynamicRecord(registeredTools) ? registeredTools[dynamicTool.name] : null;
+        const inputSchema = isDynamicRecord(registered) ? registered.inputSchema : null;
+        expect(isDynamicRecord(registered) ? registered.description : null).toBe(dynamicTool.description);
+        expect(
+          inputSchema instanceof z.core.$ZodObject ? z.toJSONSchema(inputSchema, { target: "draft-7" }) : null,
+        ).toEqual(dynamicTool.inputSchema);
+      }
       return generator;
     });
     const notifications: Array<{ method: string; params: unknown }> = [];

--- a/src/backend/claude-client.ts
+++ b/src/backend/claude-client.ts
@@ -13,19 +13,11 @@ import {
   tool,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import { type DynamicRecord, isDynamicRecord, isNumber, isOneOf, isString } from "@openbot/contracts/runtime-values";
-import { z } from "zod";
-import { createAgentToolSchema, updateProfileToolSchema } from "./agent/profile-tools";
-import {
-  assignAgentSectionToolSchema,
-  createSectionToolSchema,
-  deleteSectionToolSchema,
-  renameSectionToolSchema,
-} from "./agent/sidebar-tools";
 import type { AgentProvider } from "./agent-client";
 import { BROWSER_TOOL_DEFINITIONS, OPENBOT_BROWSER_NAMESPACE } from "./browser-tools";
 import type { ClaudeCliInfo } from "./cli";
+import { OPENBOT_TOOL_DEFINITIONS } from "./openbot-tools";
 import {
   type AccountRateLimitsReadResult,
   type AccountRateLimitWindowResult,
@@ -41,7 +33,6 @@ import {
   type ThreadResponse,
   type TurnResponse,
 } from "./protocol";
-import { routineScheduleZodSchema } from "./routine-tool-schema";
 
 const execFileAsync = promisify(execFile);
 const CLAUDE_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
@@ -744,170 +735,12 @@ export class ClaudeAgentClient extends EventEmitter<ClientEvents> {
       openbot: createSdkMcpServer({
         name: "openbot",
         version: "0.1.0",
-        tools: [
-          tool("list_sites", "List static sites hosted by the signed-in OpenBot user.", {}, (args) =>
-            call("openbot", "list_sites", args),
+        // Claude uses the SDK's AskUserQuestion permission flow.
+        tools: OPENBOT_TOOL_DEFINITIONS.filter((definition) => definition.name !== "ask_user").map((definition) =>
+          tool(definition.name, definition.description, definition.shape, (args) =>
+            call("openbot", definition.name, args),
           ),
-          tool(
-            "publish_site",
-            "Publish a static site only after the user explicitly asks to publish it.",
-            {
-              sourcePath: z.string().min(1).max(INPUT_LIMITS.path),
-              title: z.string().min(1).max(120),
-              description: z.string().min(1).max(500),
-              spaFallback: z.boolean().optional(),
-            },
-            (args) => call("openbot", "publish_site", args),
-          ),
-          tool(
-            "replace_site",
-            "Replace an owned static site only after the user explicitly asks. The URL stays the same.",
-            {
-              siteId: z.string().min(1).max(INPUT_LIMITS.identifier),
-              sourcePath: z.string().min(1).max(INPUT_LIMITS.path),
-              title: z.string().min(1).max(120),
-              description: z.string().min(1).max(500),
-              spaFallback: z.boolean().optional(),
-            },
-            (args) => call("openbot", "replace_site", args),
-          ),
-          tool(
-            "delete_site",
-            "Delete an owned static site only after the user explicitly asks to delete it.",
-            { siteId: z.string().min(1).max(INPUT_LIMITS.identifier) },
-            (args) => call("openbot", "delete_site", args),
-          ),
-          tool(
-            "attach_files_to_response",
-            "Attach existing local files to the current response for the user. Use this for screenshots, charts, diagrams, reports, and other files that the user should receive.",
-            { paths: z.array(z.string().min(1).max(INPUT_LIMITS.path)).min(1).max(INPUT_LIMITS.attachments) },
-            (args) => call("openbot", "attach_files_to_response", args),
-          ),
-          tool(
-            "list_sections",
-            "List sidebar sections (folders), their stable ids, and agent assignments before grouping agents.",
-            {},
-            (args) => call("openbot", "list_sections", args),
-          ),
-          tool(
-            "create_section",
-            "Create a sidebar section (folder) to group existing agents. List sections first and reuse an existing matching section.",
-            createSectionToolSchema.shape,
-            (args) => call("openbot", "create_section", args),
-          ),
-          tool("rename_section", "Rename an existing custom sidebar section.", renameSectionToolSchema.shape, (args) =>
-            call("openbot", "rename_section", args),
-          ),
-          tool(
-            "delete_section",
-            "Delete a custom sidebar section without deleting its agents; its agents become ungrouped.",
-            deleteSectionToolSchema.shape,
-            (args) => call("openbot", "delete_section", args),
-          ),
-          tool(
-            "assign_agent_section",
-            "Move an existing agent into a sidebar section. Pass null for sectionId to ungroup it.",
-            assignAgentSectionToolSchema.shape,
-            (args) => call("openbot", "assign_agent_section", args),
-          ),
-          tool("list_agents", "List OpenBot agents that can receive local messages.", {}, (args) =>
-            call("openbot", "list_agents", args),
-          ),
-          tool(
-            "create_agent",
-            "Create a persistent local teammate from the user's request, with a profile and first task.",
-            createAgentToolSchema.shape,
-            (args) => call("openbot", "create_agent", args),
-          ),
-          tool(
-            "update_profile",
-            "Change an existing local agent's profile or generated avatar from the user's request.",
-            updateProfileToolSchema.shape,
-            (args) => call("openbot", "update_profile", args),
-          ),
-          tool(
-            "list_routines",
-            "List routines for this agent, or for another local agent when agentId is provided.",
-            { agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional() },
-            (args) => call("openbot", "list_routines", args),
-          ),
-          tool(
-            "create_routine",
-            "Create a scheduled routine for this agent, or for another local agent when agentId is provided.",
-            {
-              agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional(),
-              name: z.string().min(1).max(INPUT_LIMITS.routineName),
-              instruction: z.string().min(1).max(INPUT_LIMITS.routineInstruction),
-              schedule: routineScheduleZodSchema,
-              active: z.boolean().optional(),
-              timezone: z.string().min(1).max(128).optional(),
-            },
-            (args) => call("openbot", "create_routine", args),
-          ),
-          tool(
-            "update_routine",
-            "Update, pause, or resume an existing routine for this agent, or for another local agent when agentId is provided.",
-            {
-              agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional(),
-              routineId: z.string().min(1).max(INPUT_LIMITS.identifier),
-              name: z.string().min(1).max(INPUT_LIMITS.routineName).optional(),
-              instruction: z.string().min(1).max(INPUT_LIMITS.routineInstruction).optional(),
-              schedule: routineScheduleZodSchema.optional(),
-              active: z.boolean().optional(),
-            },
-            (args) => call("openbot", "update_routine", args),
-          ),
-          tool(
-            "delete_routine",
-            "Delete an existing routine for this agent, or for another local agent when agentId is provided.",
-            {
-              agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional(),
-              routineId: z.string().min(1).max(INPUT_LIMITS.identifier),
-            },
-            (args) => call("openbot", "delete_routine", args),
-          ),
-          tool(
-            "test_routine",
-            "Queue one manual test run of an existing routine for this agent, or for another local agent when agentId is provided.",
-            {
-              agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional(),
-              routineId: z.string().min(1).max(INPUT_LIMITS.identifier),
-            },
-            (args) => call("openbot", "test_routine", args),
-          ),
-          tool(
-            "remember",
-            "Stage one durable memory for this agent. Use memoryId to update an existing memory.",
-            {
-              text: z.string().min(1).max(500),
-              memoryId: z.string().optional(),
-            },
-            (args) => call("openbot", "remember", args),
-          ),
-          tool(
-            "forget_memory",
-            "Stage deletion of one saved memory when the user asks you to forget it.",
-            { memoryId: z.string().min(1) },
-            (args) => call("openbot", "forget_memory", args),
-          ),
-          tool(
-            "react_to_user_message",
-            "Add one emoji reaction for an obvious positive or negative emotional moment such as a win, affection, gratitude, humor, sadness, disappointment, frustration, empathy, or strong approval. Inline emoji do not count as reactions. Skip neutral messages and always provide the same complete normal answer.",
-            { emoji: z.string().min(1).max(64) },
-            (args) => call("openbot", "react_to_user_message", args),
-          ),
-          tool(
-            "send_message",
-            "Send an asynchronous message or local files to OpenBot teammates.",
-            {
-              recipientAgentIds: z.array(z.string()).min(1).max(32),
-              text: z.string().min(1).max(100_000),
-              paths: z.array(z.string()).max(10).optional(),
-              replyToMessageId: z.string().nullable().optional(),
-            },
-            (args) => call("openbot", "send_message", args),
-          ),
-        ],
+        ),
       }),
     };
   }

--- a/src/backend/openbot-tools.test.ts
+++ b/src/backend/openbot-tools.test.ts
@@ -1,11 +1,11 @@
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import { AVATAR_HUES, isAvatarSeed } from "@openbot/contracts/ipc";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createAgentToolSchema, updateProfileToolSchema } from "./agent/profile-tools";
 import { OPENBOT_DYNAMIC_TOOLS } from "./openbot-tools";
 
-describe("OpenBot hosting tools", () => {
-  // OPENBOT_DYNAMIC_TOOLS is `as const` with no annotation, so the compiler
-  // infers whatever the literal says instead of requiring these fields:
-  // dropping one narrows the type and still typechecks, while the provider
-  // would start omitting site identity or source metadata at runtime.
+describe("OpenBot tool declarations", () => {
   it("requires site identity and local source details for mutations", () => {
     const publish = OPENBOT_DYNAMIC_TOOLS.tools.find((tool) => tool.name === "publish_site");
     const replace = OPENBOT_DYNAMIC_TOOLS.tools.find((tool) => tool.name === "replace_site");
@@ -13,5 +13,80 @@ describe("OpenBot hosting tools", () => {
     expect(publish?.inputSchema).toMatchObject({ required: ["sourcePath", "title", "description"] });
     expect(replace?.inputSchema).toMatchObject({ required: ["siteId", "sourcePath", "title", "description"] });
     expect(remove?.inputSchema).toMatchObject({ required: ["siteId"] });
+  });
+
+  it.each([
+    ["remember", { text: "A short memory" }, true],
+    ["remember", { text: "x".repeat(INPUT_LIMITS.agentMemoryText + 1) }, false],
+    ["attach_files_to_response", { paths: [] }, false],
+    ["attach_files_to_response", { paths: ["/tmp/report.pdf"] }, true],
+    [
+      "attach_files_to_response",
+      { paths: Array.from({ length: INPUT_LIMITS.attachments + 1 }, () => "/tmp/report.pdf") },
+      false,
+    ],
+    ["assign_agent_section", { agentId: "agent-1", sectionId: null }, true],
+    ["assign_agent_section", { agentId: "agent-1" }, false],
+    ["update_profile", { agentId: "agent-1", avatarSeed: "agent:1", avatarHue: null }, true],
+    ["update_profile", { agentId: "agent-1", avatarSeed: "INVALID" }, false],
+    ["update_profile", { agentId: "agent-1", avatarSeed: "x".repeat(129) }, false],
+    ["update_profile", { agentId: "agent-1", avatarHue: 123 }, false],
+    ["update_profile", { agentId: "x".repeat(INPUT_LIMITS.identifier + 1) }, false],
+    ["update_profile", { agentId: "agent-1", name: "" }, false],
+    ["update_profile", { agentId: "agent-1", unexpected: true }, false],
+    ["ask_user", { questions: [{ question: "Where?", options: [{ label: "Here" }] }] }, true],
+    ["ask_user", { questions: [] }, false],
+    ["ask_user", { questions: [{ question: "Where?", options: [{ label: "Here", unexpected: true }] }] }, false],
+  ])("advertises input constraints for %s: %j", (name, input, accepted) => {
+    const definition = OPENBOT_DYNAMIC_TOOLS.tools.find((tool) => tool.name === name);
+    if (!definition) throw new Error(`Missing tool: ${name}`);
+    expect(z.fromJSONSchema(definition.inputSchema).safeParse(input).success).toBe(accepted);
+  });
+
+  it("keeps profile avatar validation aligned with the shared identity contract", () => {
+    for (const avatarSeed of ["agent:1", "", "INVALID", "../agent", "x".repeat(128), "x".repeat(129), "agent\n"]) {
+      const input = { name: "Agent", description: "", initialMessage: "Start", avatarSeed };
+      expect(createAgentToolSchema.safeParse(input).success).toBe(isAvatarSeed(avatarSeed));
+      expect(updateProfileToolSchema.safeParse({ agentId: "agent-1", avatarSeed }).success).toBe(
+        isAvatarSeed(avatarSeed),
+      );
+    }
+    for (const avatarHue of [...AVATAR_HUES, null]) {
+      expect(updateProfileToolSchema.safeParse({ agentId: "agent-1", avatarHue }).success).toBe(true);
+    }
+  });
+
+  it.each([
+    [{ kind: "hourly", minute: 59 }, true],
+    [{ kind: "daily", time: "23:59" }, true],
+    [{ kind: "weekdays", time: "09:00" }, true],
+    [{ kind: "weekly", weekday: 6, time: "09:00" }, true],
+    [{ kind: "monthly", day: 31, time: "09:00" }, true],
+    [{ kind: "interval", amount: 2, unit: "days", anchorAt: "2026-09-07T09:00:00Z" }, true],
+    [
+      {
+        kind: "advanced",
+        months: [1, 12],
+        days: { kind: "days-of-week", days: [0, 6] },
+        time: { kind: "every", amount: 2, unit: "hours" },
+      },
+      true,
+    ],
+    [{ kind: "custom", expression: "0 9 * * *" }, true],
+    [{ kind: "hourly", minute: 60 }, false],
+    [{ kind: "daily", time: "24:00" }, false],
+    [{ kind: "weekly", weekday: 7, time: "09:00" }, false],
+    [{ kind: "advanced", months: [13], days: { kind: "every-day" }, time: { kind: "at-time", time: "09:00" } }, false],
+    [{ kind: "custom", expression: "" }, false],
+  ])("advertises routine schedule constraints: %j", (schedule, accepted) => {
+    for (const name of ["create_routine", "update_routine"]) {
+      const definition = OPENBOT_DYNAMIC_TOOLS.tools.find((tool) => tool.name === name);
+      if (!definition) throw new Error(`Missing tool: ${name}`);
+      const input =
+        name === "create_routine"
+          ? { name: "Routine", instruction: "Run this", schedule }
+          : { routineId: "routine-1", schedule };
+      expect(z.fromJSONSchema(definition.inputSchema).safeParse(input).success).toBe(accepted);
+    }
   });
 });

--- a/src/backend/openbot-tools.ts
+++ b/src/backend/openbot-tools.ts
@@ -1,377 +1,222 @@
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
-import { AVATAR_HUES } from "@openbot/contracts/ipc";
-import { ROUTINE_SCHEDULE_JSON_SCHEMA } from "./routine-tool-schema";
+import { z } from "zod";
+import { createAgentToolSchema, updateProfileToolSchema } from "./agent/profile-tools";
+import {
+  assignAgentSectionToolSchema,
+  createSectionToolSchema,
+  deleteSectionToolSchema,
+  renameSectionToolSchema,
+} from "./agent/sidebar-tools";
+import { routineScheduleZodSchema } from "./routine-tool-schema";
+
+interface OpenBotToolDefinition {
+  name: string;
+  description: string;
+  shape: z.ZodRawShape;
+}
+
+/** Shared declarations for Codex, Grok, and Claude. Service handlers enforce execution rules. */
+export const OPENBOT_TOOL_DEFINITIONS: readonly OpenBotToolDefinition[] = [
+  {
+    name: "list_sites",
+    description: "List static sites hosted by the signed-in OpenBot user. Use this before retrying a hosting mutation.",
+    shape: {},
+  },
+  {
+    name: "publish_site",
+    description:
+      "Publish a new static site after the user explicitly asks to publish it. The source must be inside this agent's workspace or OpenBot Shared.",
+    shape: {
+      sourcePath: z.string().min(1).max(INPUT_LIMITS.path),
+      title: z.string().min(1).max(120),
+      description: z.string().min(1).max(500),
+      spaFallback: z.boolean().optional(),
+    },
+  },
+  {
+    name: "replace_site",
+    description:
+      "Replace an owned static site after the user explicitly asks to replace it. This keeps the URL and resets expiry to 30 days.",
+    shape: {
+      siteId: z.string().min(1).max(INPUT_LIMITS.identifier),
+      sourcePath: z.string().min(1).max(INPUT_LIMITS.path),
+      title: z.string().min(1).max(120),
+      description: z.string().min(1).max(500),
+      spaFallback: z.boolean().optional(),
+    },
+  },
+  {
+    name: "delete_site",
+    description: "Delete an owned static site after the user explicitly asks to delete it.",
+    shape: { siteId: z.string().min(1).max(INPUT_LIMITS.identifier) },
+  },
+  {
+    name: "attach_files_to_response",
+    description:
+      "Attach existing local files to the current response for the user. Use this after creating screenshots, charts, diagrams, reports, or other files that the user should receive. OpenBot copies each file and shows image previews in the conversation.",
+    shape: { paths: z.array(z.string().min(1).max(INPUT_LIMITS.path)).min(1).max(INPUT_LIMITS.attachments) },
+  },
+  {
+    name: "list_sections",
+    description: "List sidebar sections (folders), their stable ids, and agent assignments before grouping agents.",
+    shape: {},
+  },
+  {
+    name: "create_section",
+    description:
+      "Create a sidebar section (folder) to group existing agents. List sections first and reuse an existing matching section.",
+    shape: createSectionToolSchema.shape,
+  },
+  {
+    name: "rename_section",
+    description: "Rename an existing custom sidebar section.",
+    shape: renameSectionToolSchema.shape,
+  },
+  {
+    name: "delete_section",
+    description: "Delete a custom sidebar section without deleting its agents; its agents become ungrouped.",
+    shape: deleteSectionToolSchema.shape,
+  },
+  {
+    name: "assign_agent_section",
+    description: "Move an existing agent into a sidebar section. Pass null for sectionId to ungroup it.",
+    shape: assignAgentSectionToolSchema.shape,
+  },
+  {
+    name: "list_agents",
+    description: "List local OpenBot agents with their name, title, description, and current status.",
+    shape: {},
+  },
+  {
+    name: "create_agent",
+    description:
+      "Create a persistent local OpenBot agent when the user asks for a new teammate. Choose its profile from the user's request and supply its first task. Use update_profile for an existing agent.",
+    shape: createAgentToolSchema.shape,
+  },
+  {
+    name: "update_profile",
+    description:
+      "Update a local OpenBot agent’s name, title, instructions, or generated avatar from the user’s request.",
+    shape: updateProfileToolSchema.shape,
+  },
+  {
+    name: "list_routines",
+    description:
+      "List routines for this agent, or for another local agent when agentId is provided. Use this before updating or deleting a routine.",
+    shape: { agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional() },
+  },
+  {
+    name: "create_routine",
+    description:
+      "Create a scheduled routine for this agent, or for another local agent when agentId is provided. It is active by default and uses the host timezone by default.",
+    shape: {
+      agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional(),
+      name: z.string().min(1).max(INPUT_LIMITS.routineName),
+      instruction: z.string().min(1).max(INPUT_LIMITS.routineInstruction),
+      schedule: routineScheduleZodSchema,
+      active: z.boolean().optional(),
+      timezone: z.string().min(1).max(128).describe("IANA timezone such as Europe/Warsaw.").optional(),
+    },
+  },
+  {
+    name: "update_routine",
+    description:
+      "Update, pause, or resume an existing routine for this agent, or for another local agent when agentId is provided.",
+    shape: {
+      agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional(),
+      routineId: z.string().min(1).max(INPUT_LIMITS.identifier),
+      name: z.string().min(1).max(INPUT_LIMITS.routineName).optional(),
+      instruction: z.string().min(1).max(INPUT_LIMITS.routineInstruction).optional(),
+      schedule: routineScheduleZodSchema.optional(),
+      active: z.boolean().optional(),
+    },
+  },
+  {
+    name: "delete_routine",
+    description: "Delete an existing routine for this agent, or for another local agent when agentId is provided.",
+    shape: {
+      agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional(),
+      routineId: z.string().min(1).max(INPUT_LIMITS.identifier),
+    },
+  },
+  {
+    name: "test_routine",
+    description:
+      "Queue one manual test run of an existing routine for this agent, or for another local agent when agentId is provided.",
+    shape: {
+      agentId: z.string().min(1).max(INPUT_LIMITS.identifier).optional(),
+      routineId: z.string().min(1).max(INPUT_LIMITS.identifier),
+    },
+  },
+  {
+    name: "remember",
+    description:
+      "Stage one short, durable memory for this agent. Use memoryId to correct or consolidate an existing memory. The change commits only if the current turn completes.",
+    shape: {
+      text: z.string().min(1).max(INPUT_LIMITS.agentMemoryText),
+      memoryId: z.string().optional(),
+    },
+  },
+  {
+    name: "forget_memory",
+    description:
+      "Stage deletion of one saved memory when the user asks you to forget it. The change commits only if the current turn completes.",
+    shape: { memoryId: z.string().min(1) },
+  },
+  {
+    name: "ask_user",
+    description:
+      "Ask the user 1–3 short questions and wait for structured answers. Use this instead of asking questions in a normal assistant message whenever clarification or a choice is needed.",
+    shape: {
+      questions: z
+        .array(
+          z.strictObject({
+            id: z.string().max(INPUT_LIMITS.identifier).optional(),
+            header: z.string().max(INPUT_LIMITS.promptHeader).optional(),
+            question: z.string().min(1).max(INPUT_LIMITS.promptQuestion),
+            isSecret: z.boolean().optional(),
+            options: z
+              .array(
+                z.strictObject({
+                  label: z.string().min(1).max(INPUT_LIMITS.promptOptionLabel),
+                  description: z.string().max(INPUT_LIMITS.promptOptionDescription).optional(),
+                }),
+              )
+              .max(INPUT_LIMITS.promptOptions)
+              .optional(),
+          }),
+        )
+        .min(1)
+        .max(3),
+    },
+  },
+  {
+    name: "react_to_user_message",
+    description:
+      "Add one emoji reaction to the current user message for an obvious positive or negative emotional moment, including wins, affection, gratitude, humor, sadness, disappointment, frustration, empathy, or strong approval. An emoji in the written answer does not count as a reaction. Skip neutral messages and never use the reaction instead of the normal answer.",
+    shape: { emoji: z.string().min(1).max(64).describe("Exactly one complete Unicode emoji.") },
+  },
+  {
+    name: "send_message",
+    description:
+      "Queue an asynchronous message and optional local files for one or more OpenBot agents. When replying, pass the original message id as replyToMessageId.",
+    shape: {
+      recipientAgentIds: z.array(z.string()).min(1).max(32),
+      text: z.string().min(1).max(100_000),
+      paths: z.array(z.string()).max(10).optional(),
+      replyToMessageId: z.string().nullable().optional(),
+    },
+  },
+];
 
 export const OPENBOT_DYNAMIC_TOOLS = {
   type: "namespace",
   name: "openbot",
   description: "Attach files to the current response and work with persistent OpenBot teammates.",
-  tools: [
-    {
-      type: "function",
-      name: "list_sites",
-      description:
-        "List static sites hosted by the signed-in OpenBot user. Use this before retrying a hosting mutation.",
-      inputSchema: { type: "object", properties: {}, additionalProperties: false },
-    },
-    {
-      type: "function",
-      name: "publish_site",
-      description:
-        "Publish a new static site after the user explicitly asks to publish it. The source must be inside this agent's workspace or OpenBot Shared.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          sourcePath: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.path },
-          title: { type: "string", minLength: 1, maxLength: 120 },
-          description: { type: "string", minLength: 1, maxLength: 500 },
-          spaFallback: { type: "boolean" },
-        },
-        required: ["sourcePath", "title", "description"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "replace_site",
-      description:
-        "Replace an owned static site after the user explicitly asks to replace it. This keeps the URL and resets expiry to 30 days.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          siteId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-          sourcePath: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.path },
-          title: { type: "string", minLength: 1, maxLength: 120 },
-          description: { type: "string", minLength: 1, maxLength: 500 },
-          spaFallback: { type: "boolean" },
-        },
-        required: ["siteId", "sourcePath", "title", "description"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "delete_site",
-      description: "Delete an owned static site after the user explicitly asks to delete it.",
-      inputSchema: {
-        type: "object",
-        properties: { siteId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier } },
-        required: ["siteId"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "attach_files_to_response",
-      description:
-        "Attach existing local files to the current response for the user. Use this after creating screenshots, charts, diagrams, reports, or other files that the user should receive. OpenBot copies each file and shows image previews in the conversation.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          paths: {
-            type: "array",
-            items: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.path },
-            minItems: 1,
-            maxItems: INPUT_LIMITS.attachments,
-          },
-        },
-        required: ["paths"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "list_sections",
-      description: "List sidebar sections (folders), their stable ids, and agent assignments before grouping agents.",
-      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
-    },
-    {
-      type: "function",
-      name: "create_section",
-      description:
-        "Create a sidebar section (folder) to group existing agents. List sections first and reuse an existing matching section.",
-      inputSchema: {
-        type: "object",
-        properties: { name: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.sidebarSectionName } },
-        required: ["name"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "rename_section",
-      description: "Rename an existing custom sidebar section.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          sectionId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-          name: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.sidebarSectionName },
-        },
-        required: ["sectionId", "name"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "delete_section",
-      description: "Delete a custom sidebar section without deleting its agents; its agents become ungrouped.",
-      inputSchema: {
-        type: "object",
-        properties: { sectionId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier } },
-        required: ["sectionId"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "assign_agent_section",
-      description: "Move an existing agent into a sidebar section. Pass null for sectionId to ungroup it.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          agentId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-          sectionId: { type: ["string", "null"], minLength: 1, maxLength: INPUT_LIMITS.identifier },
-        },
-        required: ["agentId", "sectionId"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "list_agents",
-      description: "List local OpenBot agents with their name, title, description, and current status.",
-      inputSchema: { type: "object", properties: {}, additionalProperties: false },
-    },
-    {
-      type: "function",
-      name: "create_agent",
-      description:
-        "Create a persistent local OpenBot agent when the user asks for a new teammate. Choose its profile from the user's request and supply its first task. Use update_profile for an existing agent.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          name: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.agentName },
-          title: { type: "string", maxLength: INPUT_LIMITS.agentTitle },
-          description: { type: "string", maxLength: INPUT_LIMITS.agentDescription },
-          initialMessage: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.messageText },
-          avatarSeed: { type: "string", minLength: 1, maxLength: 128, pattern: "^[a-z0-9:-]+$" },
-          avatarHue: { type: ["number", "null"], enum: [...AVATAR_HUES, null] },
-        },
-        required: ["name", "description", "initialMessage"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "update_profile",
-      description:
-        "Update a local OpenBot agent’s name, title, instructions, or generated avatar from the user’s request.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          agentId: { type: "string", minLength: 1 },
-          name: { type: "string", maxLength: 80 },
-          title: { type: "string", maxLength: 120 },
-          description: { type: "string", maxLength: INPUT_LIMITS.agentDescription },
-          avatarSeed: { type: "string", minLength: 1, maxLength: 128, pattern: "^[a-z0-9:-]+$" },
-          avatarHue: { type: ["number", "null"], enum: [...AVATAR_HUES, null] },
-        },
-        required: ["agentId"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "list_routines",
-      description:
-        "List routines for this agent, or for another local agent when agentId is provided. Use this before updating or deleting a routine.",
-      inputSchema: {
-        type: "object",
-        properties: { agentId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier } },
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "create_routine",
-      description:
-        "Create a scheduled routine for this agent, or for another local agent when agentId is provided. It is active by default and uses the host timezone by default.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          agentId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-          name: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.routineName },
-          instruction: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.routineInstruction },
-          schedule: ROUTINE_SCHEDULE_JSON_SCHEMA,
-          active: { type: "boolean" },
-          timezone: {
-            type: "string",
-            minLength: 1,
-            maxLength: 128,
-            description: "IANA timezone such as Europe/Warsaw.",
-          },
-        },
-        required: ["name", "instruction", "schedule"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "update_routine",
-      description:
-        "Update, pause, or resume an existing routine for this agent, or for another local agent when agentId is provided.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          agentId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-          routineId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-          name: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.routineName },
-          instruction: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.routineInstruction },
-          schedule: ROUTINE_SCHEDULE_JSON_SCHEMA,
-          active: { type: "boolean" },
-        },
-        required: ["routineId"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "delete_routine",
-      description: "Delete an existing routine for this agent, or for another local agent when agentId is provided.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          agentId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-          routineId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-        },
-        required: ["routineId"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "test_routine",
-      description:
-        "Queue one manual test run of an existing routine for this agent, or for another local agent when agentId is provided.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          agentId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-          routineId: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.identifier },
-        },
-        required: ["routineId"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "remember",
-      description:
-        "Stage one short, durable memory for this agent. Use memoryId to correct or consolidate an existing memory. The change commits only if the current turn completes.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          text: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.agentMemoryText },
-          memoryId: { type: "string" },
-        },
-        required: ["text"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "forget_memory",
-      description:
-        "Stage deletion of one saved memory when the user asks you to forget it. The change commits only if the current turn completes.",
-      inputSchema: {
-        type: "object",
-        properties: { memoryId: { type: "string", minLength: 1 } },
-        required: ["memoryId"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "ask_user",
-      description:
-        "Ask the user 1–3 short questions and wait for structured answers. Use this instead of asking questions in a normal assistant message whenever clarification or a choice is needed.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          questions: {
-            type: "array",
-            minItems: 1,
-            maxItems: 3,
-            items: {
-              type: "object",
-              properties: {
-                id: { type: "string", maxLength: INPUT_LIMITS.identifier },
-                header: { type: "string", maxLength: INPUT_LIMITS.promptHeader },
-                question: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.promptQuestion },
-                isSecret: { type: "boolean" },
-                options: {
-                  type: "array",
-                  maxItems: INPUT_LIMITS.promptOptions,
-                  items: {
-                    type: "object",
-                    properties: {
-                      label: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.promptOptionLabel },
-                      description: { type: "string", maxLength: INPUT_LIMITS.promptOptionDescription },
-                    },
-                    required: ["label"],
-                    additionalProperties: false,
-                  },
-                },
-              },
-              required: ["question"],
-              additionalProperties: false,
-            },
-          },
-        },
-        required: ["questions"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "react_to_user_message",
-      description:
-        "Add one emoji reaction to the current user message for an obvious positive or negative emotional moment, including wins, affection, gratitude, humor, sadness, disappointment, frustration, empathy, or strong approval. An emoji in the written answer does not count as a reaction. Skip neutral messages and never use the reaction instead of the normal answer.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          emoji: {
-            type: "string",
-            minLength: 1,
-            maxLength: 64,
-            description: "Exactly one complete Unicode emoji.",
-          },
-        },
-        required: ["emoji"],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: "function",
-      name: "send_message",
-      description:
-        "Queue an asynchronous message and optional local files for one or more OpenBot agents. When replying, pass the original message id as replyToMessageId.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          recipientAgentIds: {
-            type: "array",
-            items: { type: "string" },
-            minItems: 1,
-            maxItems: 32,
-          },
-          text: { type: "string", minLength: 1, maxLength: 100_000 },
-          paths: { type: "array", items: { type: "string" }, maxItems: 10 },
-          replyToMessageId: { type: ["string", "null"] },
-        },
-        required: ["recipientAgentIds", "text"],
-        additionalProperties: false,
-      },
-    },
-  ],
+  tools: OPENBOT_TOOL_DEFINITIONS.map((definition) => ({
+    type: "function" as const,
+    name: definition.name,
+    description: definition.description,
+    inputSchema: z.toJSONSchema(z.strictObject(definition.shape), { target: "draft-7" }),
+  })),
 } as const;

--- a/src/backend/routine-tool-schema.ts
+++ b/src/backend/routine-tool-schema.ts
@@ -3,142 +3,7 @@ import { z } from "zod";
 
 const ROUTINE_TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
 
-const ROUTINE_TIME_JSON_SCHEMA = {
-  type: "string",
-  pattern: "^([01]\\d|2[0-3]):[0-5]\\d$",
-  description: "Local time in HH:mm format.",
-} as const;
-
-const ROUTINE_DAY_SELECTION_JSON_SCHEMA = {
-  oneOf: [
-    {
-      type: "object",
-      properties: { kind: { const: "every-day" } },
-      required: ["kind"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        kind: { const: "days-of-week" },
-        days: { type: "array", minItems: 1, items: { type: "integer", minimum: 0, maximum: 6 } },
-      },
-      required: ["kind", "days"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        kind: { const: "days-of-month" },
-        days: { type: "array", minItems: 1, items: { type: "integer", minimum: 1, maximum: 31 } },
-      },
-      required: ["kind", "days"],
-      additionalProperties: false,
-    },
-  ],
-} as const;
-
-const ROUTINE_TIME_SELECTION_JSON_SCHEMA = {
-  oneOf: [
-    {
-      type: "object",
-      properties: { kind: { const: "at-time" }, time: ROUTINE_TIME_JSON_SCHEMA },
-      required: ["kind", "time"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        kind: { const: "every" },
-        amount: { type: "integer", minimum: 1, maximum: 100_000 },
-        unit: { type: "string", enum: ["minutes", "hours"] },
-      },
-      required: ["kind", "amount", "unit"],
-      additionalProperties: false,
-    },
-  ],
-} as const;
-
-export const ROUTINE_SCHEDULE_JSON_SCHEMA = {
-  description: "Routine schedule. Weekdays use 0 for Sunday through 6 for Saturday; clock values use HH:mm local time.",
-  oneOf: [
-    {
-      type: "object",
-      properties: { kind: { const: "hourly" }, minute: { type: "integer", minimum: 0, maximum: 59 } },
-      required: ["kind", "minute"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: { kind: { const: "daily" }, time: ROUTINE_TIME_JSON_SCHEMA },
-      required: ["kind", "time"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: { kind: { const: "weekdays" }, time: ROUTINE_TIME_JSON_SCHEMA },
-      required: ["kind", "time"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        kind: { const: "weekly" },
-        weekday: { type: "integer", minimum: 0, maximum: 6 },
-        time: ROUTINE_TIME_JSON_SCHEMA,
-      },
-      required: ["kind", "weekday", "time"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        kind: { const: "monthly" },
-        day: { type: "integer", minimum: 1, maximum: 31 },
-        time: ROUTINE_TIME_JSON_SCHEMA,
-      },
-      required: ["kind", "day", "time"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        kind: { const: "interval" },
-        amount: { type: "integer", minimum: 1, maximum: 100_000 },
-        unit: { type: "string", enum: ["minutes", "hours", "days"] },
-        anchorAt: { type: "string", description: "An ISO 8601 date-time anchoring the interval." },
-      },
-      required: ["kind", "amount", "unit", "anchorAt"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        kind: { const: "advanced" },
-        months: {
-          type: "array",
-          minItems: 1,
-          items: { type: "integer", minimum: 1, maximum: 12 },
-        },
-        days: ROUTINE_DAY_SELECTION_JSON_SCHEMA,
-        time: ROUTINE_TIME_SELECTION_JSON_SCHEMA,
-      },
-      required: ["kind", "months", "days", "time"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        kind: { const: "custom" },
-        expression: { type: "string", minLength: 1, maxLength: INPUT_LIMITS.routineCron },
-      },
-      required: ["kind", "expression"],
-      additionalProperties: false,
-    },
-  ],
-} as const;
-
-const routineTimeSchema = z.string().regex(ROUTINE_TIME_PATTERN);
+const routineTimeSchema = z.string().regex(ROUTINE_TIME_PATTERN).describe("Local time in HH:mm format.");
 const routineDaySelectionSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("every-day") }).strict(),
   z.object({ kind: z.literal("days-of-week"), days: z.array(z.number().int().min(0).max(6)).min(1) }).strict(),
@@ -155,27 +20,29 @@ const routineTimeSelectionSchema = z.discriminatedUnion("kind", [
     .strict(),
 ]);
 
-export const routineScheduleZodSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("hourly"), minute: z.number().int().min(0).max(59) }).strict(),
-  z.object({ kind: z.literal("daily"), time: routineTimeSchema }).strict(),
-  z.object({ kind: z.literal("weekdays"), time: routineTimeSchema }).strict(),
-  z.object({ kind: z.literal("weekly"), weekday: z.number().int().min(0).max(6), time: routineTimeSchema }).strict(),
-  z.object({ kind: z.literal("monthly"), day: z.number().int().min(1).max(31), time: routineTimeSchema }).strict(),
-  z
-    .object({
-      kind: z.literal("interval"),
-      amount: z.number().int().min(1).max(100_000),
-      unit: z.enum(["minutes", "hours", "days"]),
-      anchorAt: z.string(),
-    })
-    .strict(),
-  z
-    .object({
-      kind: z.literal("advanced"),
-      months: z.array(z.number().int().min(1).max(12)).min(1),
-      days: routineDaySelectionSchema,
-      time: routineTimeSelectionSchema,
-    })
-    .strict(),
-  z.object({ kind: z.literal("custom"), expression: z.string().min(1).max(INPUT_LIMITS.routineCron) }).strict(),
-]);
+export const routineScheduleZodSchema = z
+  .discriminatedUnion("kind", [
+    z.object({ kind: z.literal("hourly"), minute: z.number().int().min(0).max(59) }).strict(),
+    z.object({ kind: z.literal("daily"), time: routineTimeSchema }).strict(),
+    z.object({ kind: z.literal("weekdays"), time: routineTimeSchema }).strict(),
+    z.object({ kind: z.literal("weekly"), weekday: z.number().int().min(0).max(6), time: routineTimeSchema }).strict(),
+    z.object({ kind: z.literal("monthly"), day: z.number().int().min(1).max(31), time: routineTimeSchema }).strict(),
+    z
+      .object({
+        kind: z.literal("interval"),
+        amount: z.number().int().min(1).max(100_000),
+        unit: z.enum(["minutes", "hours", "days"]),
+        anchorAt: z.string().describe("An ISO 8601 date-time anchoring the interval."),
+      })
+      .strict(),
+    z
+      .object({
+        kind: z.literal("advanced"),
+        months: z.array(z.number().int().min(1).max(12)).min(1),
+        days: routineDaySelectionSchema,
+        time: routineTimeSelectionSchema,
+      })
+      .strict(),
+    z.object({ kind: z.literal("custom"), expression: z.string().min(1).max(INPUT_LIMITS.routineCron) }).strict(),
+  ])
+  .describe("Routine schedule. Weekdays use 0 for Sunday through 6 for Saturday; clock values use HH:mm local time.");


### PR DESCRIPTION
OpenBot tool names, descriptions, and argument schemas were repeated in the dynamic tool catalog and Claude MCP registration. Claude missed guidance about workspace restrictions, site expiry, routine defaults, and memory commits. Both declarations now use one Zod catalog, with the existing profile, section, and routine schemas. Claude keeps its native AskUserQuestion flow.

The profile schema now shares the avatar seed pattern with the identity validator. Generated update_profile declarations state the non-empty name and identifier limits already enforced by the handler. Service validation, authorization, and file protections remain in place. Production code: 254 lines added, 707 removed (net -453). Tests: 93 added, 14 removed (net +79).

Surfaces: desktop backend/provider adapters, shared identity contracts, and architecture documentation. No UI or released Team API wire changes. Model and harness: GPT-6, Codex desktop.

Validation:
- `bun run test:desktop -- src/backend/openbot-tools.test.ts` — 32 passed.
- `bun run test:desktop -- src/backend/claude-client.test.ts` — 15 passed.
- `bun run test:desktop -- packages/contracts/src/ipc.test.ts` — 44 passed.
- `bun run test:desktop -- src/backend/agent-service.providers.test.ts` — 17 passed, including outdated tool refresh, history handoff, restart, and unchanged-session reuse.
- `bun run lint` and `bun run typecheck` passed. Lint reports eight existing mobile module-mock warnings outside this change; their native boundaries remain unchanged.
- Mutation checks failed for the intended short-memory, schedule-range, avatar-validation, and Claude-guidance cases. All mutations were restored and the tests passed again. `git diff --check` passed.

Rollout: generated JSON schemas change the tool fingerprint. The existing lifecycle can replace a Codex provider session before the next turn and carry history into it. The durable OpenBot thread, agent identity, workspace, and stored conversation remain in place. The existing provider lifecycle tests cover this path. Live provider model calls and the complete desktop suite remain for CI or a separate smoke test.
