### PR TITLE
fix: keep agent deletion safe to retry

### DIFF
--- a/src/backend/agent-service.restart.test.ts
+++ b/src/backend/agent-service.restart.test.ts
@@ -366,7 +366,7 @@ describe.sequential("AgentService: restart", () => {
     expect(events).toContainEqual({ type: "agents-changed", agents: service.listAgents() });
   });
 
-  it("holds due routines and queued work during deletion, then resumes after failure", async () => {
+  it("holds due routines and rejects messages during deletion, then resumes after failure", async () => {
     const { store, mailbox } = stores(root);
     service = new AgentService(
       store,
@@ -403,9 +403,10 @@ describe.sequential("AgentService: restart", () => {
       await expect(service.testRoutine({ agentId: agent.id, routineId: routine.id })).rejects.toThrow(
         "Wait until the agent operation finishes before running a routine.",
       );
-      await service.sendMessage({ agentId: agent.id, text: "Hold this work until cleanup finishes." });
-      await vi.advanceTimersByTimeAsync(0);
-      expect(service.listQueue(agent.id).deliveries).toMatchObject([{ status: "queued", turnId: null }]);
+      await expect(service.sendMessage({ agentId: agent.id, text: "Wait for cleanup." })).rejects.toThrow(
+        "The recipient is being deleted. Retry after deletion finishes.",
+      );
+      expect(service.listQueue(agent.id).deliveries).toEqual([]);
       expect(store.activeProviderSession(agent.id)).toBeNull();
       await expect(service.deleteAgent(agent.id)).rejects.toThrow("Agent deletion is already in progress.");
 

--- a/src/backend/agent-service.restart.test.ts
+++ b/src/backend/agent-service.restart.test.ts
@@ -320,6 +320,7 @@ describe.sequential("AgentService: restart", () => {
     });
     expect(store.database.pendingHostedSiteTerminalEvents()).toHaveLength(1);
     await service.deleteAgent("sales-outbound");
+    await expect(service.deleteAgent("sales-outbound")).resolves.toBeUndefined();
     expect(service.listAgents().some((agent) => agent.id === "sales-outbound")).toBe(false);
     expect(store.database.pendingHostedSiteTerminalEvents()).toEqual([]);
     expect(
@@ -345,6 +346,24 @@ describe.sequential("AgentService: restart", () => {
       "Stop the agent and cancel its queued messages before deleting it.",
     );
     expect(service.listAgents().some((agent) => agent.id === "chief")).toBe(true);
+  });
+
+  it("keeps an agent available for retry when mailbox deletion fails", async () => {
+    const { store, mailbox } = stores(root);
+    service = new AgentService(store, mailbox, fakeBrowser());
+    await service.initialize();
+    const agent = await store.getOrCreate("delete-retry");
+    const events: AgentEvent[] = [];
+    service.on("event", (event) => events.push(event));
+    vi.spyOn(mailbox, "deleteAgentData").mockRejectedValueOnce(new Error("private/path secret"));
+
+    await expect(service.deleteAgent(agent.id)).rejects.toThrow("The agent data could not be removed completely.");
+    expect(service.listAgents().some((entry) => entry.id === agent.id)).toBe(true);
+    expect(events.filter((event) => event.type === "agents-changed")).toEqual([]);
+
+    await service.deleteAgent(agent.id);
+    expect(service.listAgents().some((entry) => entry.id === agent.id)).toBe(false);
+    expect(events).toContainEqual({ type: "agents-changed", agents: service.listAgents() });
   });
 
   it("queues independent manual routine runs and renders routine metadata", async () => {

--- a/src/backend/agent-service.restart.test.ts
+++ b/src/backend/agent-service.restart.test.ts
@@ -366,6 +366,66 @@ describe.sequential("AgentService: restart", () => {
     expect(events).toContainEqual({ type: "agents-changed", agents: service.listAgents() });
   });
 
+  it("holds due routines and queued work during deletion, then resumes after failure", async () => {
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "codex",
+      (provider) => new FakeAgentClient(provider),
+    );
+    await service.initialize();
+    const agent = await store.getOrCreate("delete-routine");
+    vi.useFakeTimers({ now: new Date("2026-08-25T11:00:00.000Z") });
+    let releaseCleanup: (() => void) | undefined;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    vi.spyOn(mailbox, "deleteAgentData").mockImplementationOnce(async () => {
+      await cleanupGate;
+      throw new Error("Cleanup failed");
+    });
+    const routine = service.createRoutine({
+      agentId: agent.id,
+      name: "Check during deletion",
+      instruction: "Check the queue.",
+      active: true,
+      timezone: "UTC",
+      schedule: { kind: "interval", amount: 15, unit: "minutes", anchorAt: "2026-08-25T11:00:00.000Z" },
+    });
+    const deletion = service.deleteAgent(agent.id);
+    const failedDeletion = expect(deletion).rejects.toThrow("Retry deleting the agent.");
+    try {
+      await vi.advanceTimersByTimeAsync(15 * 60_000);
+      expect(service.listRoutineRuns({ agentId: agent.id, routineId: routine.id })).toEqual([]);
+      await expect(service.testRoutine({ agentId: agent.id, routineId: routine.id })).rejects.toThrow(
+        "Wait until the agent operation finishes before running a routine.",
+      );
+      await service.sendMessage({ agentId: agent.id, text: "Hold this work until cleanup finishes." });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(service.listQueue(agent.id).deliveries).toMatchObject([{ status: "queued", turnId: null }]);
+      expect(store.activeProviderSession(agent.id)).toBeNull();
+      await expect(service.deleteAgent(agent.id)).rejects.toThrow("Agent deletion is already in progress.");
+
+      releaseCleanup?.();
+      await failedDeletion;
+      const changed = nextRoutinesChanged(service, agent.id);
+      await vi.advanceTimersByTimeAsync(0);
+      await changed;
+      expect(service.listRoutineRuns({ agentId: agent.id, routineId: routine.id })).toEqual([
+        expect.objectContaining({ kind: "scheduled" }),
+      ]);
+      vi.useRealTimers();
+      await waitFor(() => service?.listQueue(agent.id).deliveries.some((delivery) => delivery.status === "running"));
+    } finally {
+      releaseCleanup?.();
+      await failedDeletion;
+      vi.useRealTimers();
+    }
+  });
+
   it("queues independent manual routine runs and renders routine metadata", async () => {
     const clients = new Map<AgentProvider, FakeAgentClient>();
     const { store, mailbox } = stores(root);

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -115,6 +115,7 @@ export interface ResolvedSharedFile {
 export class AgentService extends EventEmitter<AgentServiceEvents> {
   readonly #profileSave: ProfileSave;
   readonly #profileClients = new Set<AgentClient>();
+  readonly #deletingAgents = new Set<string>();
   readonly #store: AgentStore;
   readonly #mailbox: MailboxStore;
   readonly #browser: AgentBrowserHost;
@@ -200,7 +201,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
         awaitDrain: (agentId) => this.#drain.taskFor(agentId),
         syncMailboxMessages: (snapshot) => this.#mailboxSync.syncMailboxMessages(snapshot),
         listAgents: () => this.listAgents(),
-        pendingDuplicateAgents: () => this.#duplication.pendingAgents(),
+        excludedAgents: () => new Set([...this.#duplication.pendingAgents(), ...this.#deletingAgents]),
         isRunning: () => this.#initialized && !this.#stopping,
       },
     });
@@ -716,6 +717,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
   }
 
   async deleteAgent(agentId: string): Promise<void> {
+    if (this.#deletingAgents.has(agentId)) throw new Error("Agent deletion is already in progress.");
     const agent = this.#store.list().find((candidate) => candidate.id === agentId);
     const hasPendingWork = this.#mailbox
       .listQueue(agentId)
@@ -725,14 +727,18 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     }
 
     const { wasPending, release } = this.#duplication.releaseForDelete(agentId);
+    this.#deletingAgents.add(agentId);
     try {
+      this.#routines.arm();
       await this.#deleteAgentData(agent ?? { id: agentId, threadId: null });
+      this.#duplication.forget(agentId);
+      if (!wasPending) this.#emit({ type: "agents-changed", agents: this.listAgents() });
     } finally {
       release();
+      this.#deletingAgents.delete(agentId);
+      this.#routines.arm();
+      if (this.#store.list().some((candidate) => candidate.id === agentId)) this.#drain.scheduleDrain(agentId);
     }
-    this.#duplication.forget(agentId);
-    if (!wasPending) this.#emit({ type: "agents-changed", agents: this.listAgents() });
-    this.#routines.arm();
   }
 
   async #deleteAgentData(agent: Pick<AgentSummary, "id" | "threadId">): Promise<void> {

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -728,6 +728,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
 
     const { wasPending, release } = this.#duplication.releaseForDelete(agentId);
     this.#deletingAgents.add(agentId);
+    const releaseDeliveries = this.#mailbox.blockAgentDeliveries(agentId);
     try {
       this.#routines.arm();
       await this.#deleteAgentData(agent ?? { id: agentId, threadId: null });
@@ -735,6 +736,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       if (!wasPending) this.#emit({ type: "agents-changed", agents: this.listAgents() });
     } finally {
       release();
+      releaseDeliveries();
       this.#deletingAgents.delete(agentId);
       this.#routines.arm();
       if (this.#store.list().some((candidate) => candidate.id === agentId)) this.#drain.scheduleDrain(agentId);
@@ -993,9 +995,11 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
   }
 
   async sendMessage(input: SendMessageInput): Promise<QueuedMessageReceipt> {
+    const validateRecipient = this.#mailbox.prepareDelivery([input.agentId]);
     if (this.#duplication.isPending(input.agentId)) throw new Error(`Unknown agent: ${input.agentId}`);
     const agent = await this.#store.getOrCreate(input.agentId);
     await this.ensureProvider(providerForAgent(agent));
+    validateRecipient();
     const receipt = await this.#mailbox.enqueue({
       sender: { kind: "user" },
       recipientAgentIds: [agent.id],

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -717,7 +717,6 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
 
   async deleteAgent(agentId: string): Promise<void> {
     const agent = this.#store.list().find((candidate) => candidate.id === agentId);
-    if (!agent) throw new Error(`Unknown agent: ${agentId}`);
     const hasPendingWork = this.#mailbox
       .listQueue(agentId)
       .deliveries.some((delivery) => ["queued", "starting", "running"].includes(delivery.status));
@@ -727,7 +726,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
 
     const { wasPending, release } = this.#duplication.releaseForDelete(agentId);
     try {
-      await this.#deleteAgentData(agent);
+      await this.#deleteAgentData(agent ?? { id: agentId, threadId: null });
     } finally {
       release();
     }
@@ -736,20 +735,20 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     this.#routines.arm();
   }
 
-  async #deleteAgentData(agent: AgentSummary): Promise<void> {
+  async #deleteAgentData(agent: Pick<AgentSummary, "id" | "threadId">): Promise<void> {
     const providerSessions = agent.threadId ? this.#store.database.listProviderSessions(agent.threadId) : [];
-    // Keep session records available for a retry if removing private transcript files fails.
-    for (const session of providerSessions) await this.#threads.deleteProviderSessionFiles(session.externalSessionId);
-    const errors: unknown[] = [];
+    let stage = "provider-files";
     try {
+      // Keep session records available if private file removal needs a retry.
+      for (const session of providerSessions) await this.#threads.deleteProviderSessionFiles(session.externalSessionId);
+      stage = "mailbox";
       await this.#mailbox.deleteAgentData(agent.id);
-    } catch (error) {
-      errors.push(error);
-    }
-    try {
+      stage = "agent-files-and-record";
       await this.#store.deleteAgent(agent.id);
-    } catch (error) {
-      errors.push(error);
+    } catch {
+      // File-system errors can contain private paths. Log only the failed stage.
+      logger.warn("Agent deletion failed.", { stage });
+      throw new Error("The agent data could not be removed completely. Retry deleting the agent.");
     }
     this.#conversation.forgetAgent(agent.id);
     this.#turn.forgetAgent(agent.id);
@@ -763,7 +762,6 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       }
     }
     this.#compaction.forgetAgent(agent.id);
-    if (errors.length > 0) throw new AggregateError(errors, "The agent data could not be removed completely.");
   }
 
   async initialize(): Promise<void> {

--- a/src/backend/agent-store.test.ts
+++ b/src/backend/agent-store.test.ts
@@ -805,6 +805,48 @@ describe("AgentStore", () => {
     ]);
   });
 
+  it("retains the agent across reload after partial file deletion and permits retry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-store-"));
+    temporaryRoots.push(root);
+    const userData = join(root, "user-data");
+    const home = join(root, "home");
+    const store = new AgentStore(userData, home);
+    await store.initialize();
+    const agent = await store.createAgent(AGENT_PROFILE_INPUT);
+    const marker = join(userData, "agent-duplications", `${agent.id}.pending`);
+    // A directory at the marker path makes unlink fail after workspace removal.
+    await mkdir(marker, { recursive: true });
+    await expect(store.deleteAgent(agent.id)).rejects.toThrow();
+    expect(store.list().map((entry) => entry.id)).toEqual([agent.id]);
+
+    const restored = new AgentStore(userData, home);
+    await restored.initialize();
+    expect(restored.list().map((entry) => entry.id)).toEqual([agent.id]);
+    await rm(marker, { recursive: true });
+    await restored.deleteAgent(agent.id);
+    // Older releases could leave managed files after removing the record.
+    await mkdir(agent.workspacePath, { recursive: true });
+    await writeFile(join(agent.workspacePath, "leftover.txt"), "owned data");
+    await restored.deleteAgent(agent.id);
+    expect(restored.list()).toEqual([]);
+    await expect(readdir(agent.workspacePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("keeps the in-memory roster when the deletion transaction fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-store-"));
+    temporaryRoots.push(root);
+    const store = new AgentStore(join(root, "user-data"), join(root, "home"));
+    await store.initialize();
+    const agent = await store.createAgent(AGENT_PROFILE_INPUT);
+    vi.spyOn(store.database, "hardDeleteAgent").mockImplementationOnce(() => {
+      throw new Error("Database write failed");
+    });
+    await expect(store.deleteAgent(agent.id)).rejects.toThrow("Database write failed");
+    expect(store.list().map((entry) => entry.id)).toEqual([agent.id]);
+    await store.deleteAgent(agent.id);
+    expect(store.list()).toEqual([]);
+  });
+
   it("deletes agents persistently without reseeding examples", async () => {
     const root = await mkdtemp(join(tmpdir(), "openbot-store-"));
     temporaryRoots.push(root);

--- a/src/backend/agent-store.ts
+++ b/src/backend/agent-store.ts
@@ -554,17 +554,18 @@ export class AgentStore {
     };
   }
 
-  async deleteAgent(id: string): Promise<AgentSummary> {
-    const agent = this.#requireAgent(id);
-    this.#state.agents = this.#state.agents.filter((candidate) => candidate.id !== id);
-    this.#database.hardDeleteAgent(`agents:hard-delete:${randomUUID()}`, id, agent.threadId, this.#state.agents);
-    await Promise.all([
-      rm(join(this.#avatarsRoot, id), { recursive: true, force: true }),
-      rm(`${join(this.#avatarsRoot, id)}.openbot-stage`, { recursive: true, force: true }),
-      rm(join(this.#agentsRoot, id), { recursive: true, force: true }),
-      rm(`${join(this.#agentsRoot, id)}.openbot-stage`, { recursive: true, force: true }),
-      rm(this.#duplicationMarkerPath(id), { force: true }),
-    ]);
+  async deleteAgent(id: string): Promise<AgentSummary | null> {
+    validateAgentId(id);
+    const agent = this.#state.agents.find((candidate) => candidate.id === id);
+    for (const path of [
+      join(this.#avatarsRoot, id),
+      `${join(this.#avatarsRoot, id)}.openbot-stage`,
+      join(this.#agentsRoot, id),
+      `${join(this.#agentsRoot, id)}.openbot-stage`,
+    ]) {
+      await rm(path, { recursive: true, force: true });
+    }
+    await rm(this.#duplicationMarkerPath(id), { force: true });
     // A workspace that could not follow the rename legitimately sits under the pre-rename root, and deleting
     // only the derived path would leave that agent's files behind. Every path here is derived rather than
     // read from `workspacePath`, because that column comes out of the user's own database file and a
@@ -579,8 +580,13 @@ export class AgentStore {
     if (legacyId !== null) {
       legacyPaths.push(join(this.#avatarsRoot, legacyId), join(this.#legacyAgentsRoot, legacyId));
     }
-    await Promise.all(legacyPaths.map((path) => rm(path, { recursive: true, force: true })));
-    return { ...agent };
+    for (const path of legacyPaths) await rm(path, { recursive: true, force: true });
+    // Keep the record for retry until every managed path is removed. Publish the new
+    // in-memory list only after the database transaction succeeds.
+    const remaining = this.#state.agents.filter((candidate) => candidate.id !== id);
+    this.#database.hardDeleteAgent(`agents:hard-delete:${randomUUID()}`, id, agent?.threadId ?? null, remaining);
+    this.#state.agents = remaining;
+    return agent ? { ...agent } : null;
   }
 
   async getOrCreate(id: string, name?: string, title?: string): Promise<AgentSummary> {

--- a/src/backend/agent/routine-scheduler.ts
+++ b/src/backend/agent/routine-scheduler.ts
@@ -458,8 +458,10 @@ export class RoutineScheduler {
   }
 
   async #enqueueRun(run: RoutineRun): Promise<void> {
+    const validateRecipient = this.#mailbox.prepareDelivery([run.agentId]);
     const agent = await this.#store.getOrCreate(run.agentId);
     try {
+      validateRecipient();
       const receipt = await this.#mailbox.enqueue({
         sender: {
           kind: "routine",

--- a/src/backend/agent/routine-scheduler.ts
+++ b/src/backend/agent/routine-scheduler.ts
@@ -57,10 +57,9 @@ export interface RoutineHooks {
   syncMailboxMessages(snapshot: ConversationSnapshot): void;
   listAgents(): AgentSummary[];
   /**
-   * Agents mid-duplication, which never fire: a half-copied agent is not yet a running one, and its
-   * routines would otherwise start against a workspace that is still being written.
+   * Agents being copied or deleted cannot run while their workspace is changing.
    */
-  pendingDuplicateAgents(): ReadonlySet<string>;
+  excludedAgents(): ReadonlySet<string>;
   /** The timer only arms while the service is initialized and not stopping. */
   isRunning(): boolean;
 }
@@ -109,7 +108,7 @@ export class RoutineScheduler {
 
   /** The scheduler's clause in the drain mute registry. */
   mayDrain(agentId: string): boolean {
-    return !this.#deletionAgents.has(agentId);
+    return !this.#deletionAgents.has(agentId) && !this.#hooks.excludedAgents().has(agentId);
   }
 
   list(agentId: string): Routine[] {
@@ -231,6 +230,8 @@ export class RoutineScheduler {
   }
 
   async test(input: TestRoutineInput): Promise<RoutineRun> {
+    if (!this.mayDrain(input.agentId))
+      throw new Error("Wait until the agent operation finishes before running a routine.");
     this.#conversation.requireKnownAgent(input.agentId);
     const routine = this.#routines.get(input.agentId, input.routineId);
     if (!routine) throw new Error("This routine no longer exists.");
@@ -412,7 +413,7 @@ export class RoutineScheduler {
     if (this.#timer) clearTimeout(this.#timer);
     this.#timer = null;
     if (!this.#hooks.isRunning()) return;
-    const nextDueAt = this.#routines.nextDueAt(this.#hooks.pendingDuplicateAgents());
+    const nextDueAt = this.#routines.nextDueAt(this.#hooks.excludedAgents());
     if (!nextDueAt) return;
     const delay = Math.max(0, Math.min(new Date(nextDueAt).getTime() - Date.now(), 2_147_000_000));
     this.#timer = setTimeout(() => {
@@ -430,7 +431,9 @@ export class RoutineScheduler {
   async #processDue(now = new Date()): Promise<void> {
     const changedAgents = new Set<string>();
     try {
-      for (const due of this.#routines.due(now, this.#hooks.pendingDuplicateAgents())) {
+      for (const due of this.#routines.due(now, this.#hooks.excludedAgents())) {
+        // A previous enqueue can yield while another agent starts deletion.
+        if (this.#hooks.excludedAgents().has(due.routine.agentId)) continue;
         let scheduledFor = new Date(due.nextRunAt);
         let nextRunAt = nextRoutineOccurrence(due.schedule, due.routine.timezone, scheduledFor);
         while (nextRunAt.getTime() <= now.getTime()) {

--- a/src/backend/mailbox-delivery-gate.ts
+++ b/src/backend/mailbox-delivery-gate.ts
@@ -1,0 +1,24 @@
+/** Prevents delivery insertion across asynchronous agent deletion and attachment preparation. */
+export class MailboxDeliveryGate {
+  readonly #blockedAgents = new Set<string>();
+  readonly #versions = new Map<string, number>();
+
+  block(agentId: string): () => void {
+    this.#blockedAgents.add(agentId);
+    this.#versions.set(agentId, (this.#versions.get(agentId) ?? 0) + 1);
+    return () => this.#blockedAgents.delete(agentId);
+  }
+
+  prepare(agentIds: string[]): () => void {
+    const versions = agentIds.map((id) => this.#versions.get(id) ?? 0);
+    const validate = () => {
+      if (
+        agentIds.some((id, index) => this.#blockedAgents.has(id) || (this.#versions.get(id) ?? 0) !== versions[index])
+      ) {
+        throw new Error("The recipient is being deleted. Retry after deletion finishes.");
+      }
+    };
+    validate();
+    return validate;
+  }
+}

--- a/src/backend/mailbox-store.test.ts
+++ b/src/backend/mailbox-store.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { access, mkdir, mkdtemp, open, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, open, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { serializeAttachmentReference } from "@openbot/contracts/attachment-references";
@@ -551,6 +551,47 @@ describe("MailboxStore", () => {
     await restored.initialize();
 
     await expect(restored.resolveAttachment(draft.id)).resolves.toBeNull();
+  });
+
+  it("rejects deliveries during deletion and permits new work after release", async () => {
+    const release = store.blockAgentDeliveries("chief");
+    await expect(
+      store.enqueue({
+        sender: { kind: "agent", agentId: "sales" },
+        recipientAgentIds: ["chief", "sales"],
+        text: "Work",
+      }),
+    ).rejects.toThrow("The recipient is being deleted.");
+    expect(store.listQueue("chief").deliveries).toEqual([]);
+    expect(store.listQueue("sales").deliveries).toEqual([]);
+    release();
+    await store.enqueue({ sender: { kind: "user" }, recipientAgentIds: ["chief"], text: "Retry" });
+    expect(store.listQueue("chief").deliveries).toMatchObject([{ text: "Retry", status: "queued" }]);
+  });
+
+  it("rejects prepared attachments after deletion finishes without restoring deleted deliveries", async () => {
+    const source = join(root, "overlapping.txt");
+    await writeFile(source, "Keep this draft available for retry.");
+    const [draft] = await store.prepareAttachments([source]);
+    const sending = store.enqueue({
+      sender: { kind: "user" },
+      recipientAgentIds: ["chief"],
+      text: "Overlapping delivery",
+      draftIds: [draft.id],
+    });
+    // Enqueue has reached asynchronous attachment preparation, but cannot insert yet.
+    const release = store.blockAgentDeliveries("chief");
+    const rejected = expect(sending).rejects.toThrow("The recipient is being deleted.");
+    release();
+    await rejected;
+    await store.deleteAgentData("chief");
+    await store.enqueue({ sender: { kind: "user" }, recipientAgentIds: ["sales"], text: "Unrelated write" });
+    expect(store.listQueue("chief").deliveries).toEqual([]);
+    expect(await readdir(join(root, "Shared", "Transfers"))).toEqual([]);
+    await expect(store.resolveAttachment(draft.id)).resolves.toBeTruthy();
+    const restored = new MailboxStore(join(root, "user-data"), join(root, "Shared"));
+    await restored.initialize();
+    expect(restored.listQueue("chief").deliveries).toEqual([]);
   });
 
   it("removes deleted agent deliveries while preserving messages visible to other agents", async () => {

--- a/src/backend/mailbox-store.ts
+++ b/src/backend/mailbox-store.ts
@@ -43,6 +43,7 @@ import {
   isMessageReaction,
 } from "@openbot/contracts/ipc";
 import { type DynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { MailboxDeliveryGate } from "./mailbox-delivery-gate";
 import { OpenBotDatabase } from "./openbot-database";
 import { isRecord } from "./protocol";
 
@@ -177,6 +178,7 @@ export class MailboxStore {
   readonly #draftsRoot: string;
   readonly #transfersRoot: string;
   readonly #database: OpenBotDatabase;
+  readonly #deliveryGate = new MailboxDeliveryGate();
   readonly #stagedGeneratedAttachments = new Map<string, StoredGeneratedAttachment>();
   #state: StoredState = structuredClone(EMPTY_STATE);
 
@@ -320,6 +322,14 @@ export class MailboxStore {
     await rm(dirname(draft.path), { recursive: true, force: true });
   }
 
+  blockAgentDeliveries(agentId: string): () => void {
+    return this.#deliveryGate.block(agentId);
+  }
+
+  prepareDelivery(agentIds: string[]): () => void {
+    return this.#deliveryGate.prepare(agentIds);
+  }
+
   async enqueue(input: EnqueueInput): Promise<QueuedMessageReceipt> {
     if (input.idempotencyKey) {
       const existingMessageId = this.#state.idempotency[input.idempotencyKey];
@@ -327,6 +337,7 @@ export class MailboxStore {
     }
 
     const recipients = [...new Set(input.recipientAgentIds)];
+    const validateRecipients = this.prepareDelivery(recipients);
     if (recipients.length === 0) throw new Error("At least one recipient is required.");
     if (recipients.length > INPUT_LIMITS.messageRecipients) {
       throw new Error(`A message can have at most ${INPUT_LIMITS.messageRecipients} recipients.`);
@@ -365,6 +376,12 @@ export class MailboxStore {
       createdAt,
       sourcePaths,
     );
+    try {
+      validateRecipients();
+    } catch (error) {
+      await rm(join(this.#transfersRoot, messageId), { recursive: true, force: true });
+      throw error;
+    }
     const committedByDraftId = new Map(drafts.map((draft, index) => [draft.id, attachments[index]] as const));
     const message: StoredMessage = {
       id: messageId,


### PR DESCRIPTION
## What changed

Agent deletion removed the database record before file cleanup finished. A cleanup failure left the agent in the UI, but retry returned an unknown-agent error and Force Reload hid it.

Keep the agent record until managed file cleanup succeeds. Update the in-memory list only after the database transaction succeeds, and stop deletion if mailbox cleanup fails. Repeated deletion clears managed files left by older releases. Failures return a retry message and log only the failed cleanup stage, without private paths.

Block routine execution, queue draining, and new deliveries before deletion starts. Recheck deliveries after asynchronous preparation. A per-agent deletion version rejects operations that cross a completed deletion. Remove rejected transfer copies, keep drafts for retry, and release the guards after failure. Reject overlapping deletion requests so one request cannot release another request's guard.

Fixes #156.

Surface touched: the shared backend used by the desktop app and Team API clients, including mobile. No renderer, mobile, public web, Signal service, IPC contract, preview mock, palette, schema, or documentation changes.

## Verification

- [x] `bun run test:desktop -- src/backend/mailbox-store.test.ts src/backend/agent-service.restart.test.ts src/backend/agent/routine-scheduler.test.ts` — 44 passed.
- [x] Agent store tests passed. The additional service routine checks had one provider initialization timeout; that existing test passed when run on its own.
- [x] `bun run lint` — passed with eight existing warnings in mobile test files.
- [x] `bun run typecheck`, `bun run check:ui` (commit hook), and `git diff --check` — passed.
- [x] Regression tests cover reload, retry, partial cleanup, database failure, scheduled runs during deletion, and messages that overlap deletion. Removed the relevant guards and confirmed the tests fail for the intended behavior, then restored them and confirmed they pass.
- [x] Surfaces touched are named above.
- [x] No visual change. No manual Electron smoke test was run.
- [x] No credentials, private data, generated output, or real user files are included.

Model and harness: GPT-6 in Codex desktop; Vitest with temporary test data.

## Risk and security impact

Changes the order of persistent deletion and managed file cleanup. File removal is not a database transaction: a failure can leave some files removed, but the agent record remains available for retry, including after restart. Existing mailbox file cleanup uses its persistent deletion outbox.

Deletion still validates agent IDs and derives paths from managed roots. It does not follow the stored workspace path or remove a legacy directory owned by another agent. No permissions, IPC wire contracts, schema, or network behavior changed.
