### PR TITLE
fix: separate Remote Desktop availability from update errors

### DIFF
--- a/src/main/remote-screen-gateway.test.ts
+++ b/src/main/remote-screen-gateway.test.ts
@@ -21,6 +21,34 @@ afterEach(async () => {
 });
 
 describe("RemoteScreenGateway", () => {
+  it.each(["darwin", "win32"] as const)(
+    "allows a %s host with runtime components to create a session",
+    async (platform) => {
+      const gateway = createGateway({ platform });
+      expect(gateway.capabilities().ready).toBe(true);
+      const session = await createSession(gateway, "http://127.0.0.1:9");
+      expect(session.phase).toBe("connecting");
+      await gateway.stop();
+    },
+  );
+
+  it.each(["darwin", "win32", "linux"] as const)(
+    "reports the setup failure for an unavailable %s host",
+    async (platform) => {
+      const gateway = createGateway({ platform, runtimeInstalled: false });
+      expect(gateway.capabilities().ready).toBe(false);
+      await expect(createSession(gateway, "http://127.0.0.1:9")).rejects.toMatchObject({
+        code: "host_unavailable",
+        message:
+          platform === "linux"
+            ? "Remote desktop hosting is not supported on Linux."
+            : "The Sunshine and Moonlight Web runtime is missing or is not supported on this host. Install the full OpenBot release on an Apple silicon Mac or Windows x64 host, then restart OpenBot.",
+      });
+      expect(gateway.list()).toEqual([]);
+      await gateway.stop();
+    },
+  );
+
   it("issues and consumes a one-time 60 second viewer grant", async () => {
     const gateway = createGateway();
     const { origin, close } = await serveGateway(gateway);
@@ -313,6 +341,8 @@ describe("RemoteScreenGateway", () => {
 
 function createGateway(
   options: {
+    platform?: "darwin" | "win32" | "linux";
+    runtimeInstalled?: boolean;
     now?: () => number;
     runtimeBaseUrl?: string;
     selectDisplay?: (displayId: string) => Promise<void>;
@@ -320,9 +350,12 @@ function createGateway(
   } = {},
 ): RemoteScreenGateway {
   return new RemoteScreenGateway({
-    platform: "darwin",
+    platform: options.platform ?? "darwin",
     unattended: true,
-    runtimePaths: { sunshine: "/sunshine", moonlightWebServer: "/web-server", moonlightStreamer: "/streamer" },
+    runtimePaths:
+      options.runtimeInstalled === false
+        ? null
+        : { sunshine: "/sunshine", moonlightWebServer: "/web-server", moonlightStreamer: "/streamer" },
     runtimeStateDirectory: "/tmp/openbot-test-runtime",
     getRuntimeCredentials: async () => ({ username: "openbot", password: "secret" }),
     getDisplays: () => displays,

--- a/src/main/remote-screen-gateway.ts
+++ b/src/main/remote-screen-gateway.ts
@@ -138,8 +138,15 @@ export class RemoteScreenGateway {
     if (this.#sessions.size >= REMOTE_DESKTOP_MAX_SESSIONS) {
       throw new RemoteScreenError(429, "session_capacity_reached", "The host already has four active sessions.");
     }
-    if (!this.#options.runtimePaths || this.#options.platform === "linux") {
-      throw new RemoteScreenError(503, "host_unavailable", "The Sunshine and Moonlight Web runtime is not installed.");
+    if (this.#options.platform === "linux") {
+      throw new RemoteScreenError(503, "host_unavailable", "Remote desktop hosting is not supported on Linux.");
+    }
+    if (!this.#options.runtimePaths) {
+      throw new RemoteScreenError(
+        503,
+        "host_unavailable",
+        "The Sunshine and Moonlight Web runtime is missing or is not supported on this host. Install the full OpenBot release on an Apple silicon Mac or Windows x64 host, then restart OpenBot.",
+      );
     }
     await this.#ensureRuntime();
     // The runtime starts and answers either way, so this is the only place the refusal can become a

--- a/src/renderer/src/App.servers.test.tsx
+++ b/src/renderer/src/App.servers.test.tsx
@@ -724,63 +724,76 @@ describe("OpenBot connected desktop shell", () => {
     );
   });
 
-  it("opens, hides, resumes, and disconnects Remote Control from the header", async () => {
-    vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([
-      {
-        id: "remote-1",
-        name: "Studio Mac",
-        logoUrl: null,
-        kind: "remote",
-        state: "online",
-        apiUrl: "https://studio-mac-k7m4q2pz-host.openbot.run",
-        remoteDesktopAvailable: true,
-        role: "owner",
-        active: true,
-      },
-    ]);
-    vi.mocked(window.openbot.remoteDesktop.connect).mockResolvedValueOnce({
-      id: "desktop-1",
-      serverId: "remote-1",
-      viewerUrl: "https://studio-mac-k7m4q2pz-host.openbot.run/v1/remote-screen/sessions/desktop-1/viewer",
-      viewerGrant: "viewer-grant",
-      displays: [],
-      selectedDisplayId: null,
-      phase: "connecting",
-      transport: "unknown",
-      errorCode: null,
-      message: "Connecting…",
-      createdAt: "2026-08-18T12:00:00.000Z",
-      grantExpiresAt: "2026-08-18T12:01:00.000Z",
-    });
+  it.each([true, false])(
+    "opens, hides, resumes, and disconnects Remote Control with cached availability %s",
+    async (remoteDesktopAvailable) => {
+      vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([
+        {
+          id: "remote-1",
+          name: "Studio Mac",
+          logoUrl: null,
+          kind: "remote",
+          state: "online",
+          apiUrl: "https://studio-mac-k7m4q2pz-host.openbot.run",
+          remoteDesktopAvailable,
+          role: "owner",
+          active: true,
+        },
+      ]);
+      const setupError = "The host has not allowed OpenBot to record its screen.";
+      if (!remoteDesktopAvailable) {
+        vi.mocked(window.openbot.remoteDesktop.connect).mockRejectedValueOnce(new Error(setupError));
+      }
+      vi.mocked(window.openbot.remoteDesktop.connect).mockResolvedValueOnce({
+        id: "desktop-1",
+        serverId: "remote-1",
+        viewerUrl: "https://studio-mac-k7m4q2pz-host.openbot.run/v1/remote-screen/sessions/desktop-1/viewer",
+        viewerGrant: "viewer-grant",
+        displays: [],
+        selectedDisplayId: null,
+        phase: "connecting",
+        transport: "unknown",
+        errorCode: null,
+        message: "Connecting…",
+        createdAt: "2026-08-18T12:00:00.000Z",
+        grantExpiresAt: "2026-08-18T12:01:00.000Z",
+      });
 
-    render(() => <App />);
-    await screen.findByRole("heading", { name: "Chief" });
-    expect(window.openbot.remoteDesktop.connect).not.toHaveBeenCalled();
-    expect(screen.queryByTitle("Sunshine remote desktop")).not.toBeInTheDocument();
-    const openButton = screen.getByRole("button", { name: "Open remote control" });
-    await fireEvent.click(openButton);
+      render(() => <App />);
+      await screen.findByRole("heading", { name: "Chief" });
+      expect(window.openbot.remoteDesktop.connect).not.toHaveBeenCalled();
+      expect(screen.queryByTitle("Sunshine remote desktop")).not.toBeInTheDocument();
+      const openButton = screen.getByRole("button", { name: "Open remote control" });
+      await fireEvent.click(openButton);
 
-    const remoteDesktop = await screen.findByRole("main", { name: "Remote control" });
-    const appFrame = document.querySelector<HTMLElement>(".app-frame");
-    if (!appFrame) throw new Error("App frame is missing.");
-    expect(appFrame.inert).toBe(true);
-    expect(appFrame).toHaveAttribute("aria-hidden", "true");
-    await waitFor(() => expect(window.openbot.remoteDesktop.connect).toHaveBeenCalledWith({ serverId: "remote-1" }));
+      const remoteDesktop = await screen.findByRole("main", { name: "Remote control" });
+      const appFrame = document.querySelector<HTMLElement>(".app-frame");
+      if (!appFrame) throw new Error("App frame is missing.");
+      expect(appFrame.inert).toBe(true);
+      expect(appFrame).toHaveAttribute("aria-hidden", "true");
+      await waitFor(() => expect(window.openbot.remoteDesktop.connect).toHaveBeenCalledWith({ serverId: "remote-1" }));
 
-    await screen.findByTitle("Sunshine remote desktop");
-    await fireEvent.click(within(remoteDesktop).getByRole("button", { name: "Back to OpenBot" }));
-    await waitFor(() => expect(appFrame.inert).toBe(false));
-    // Hiding keeps the session alive, so resuming must not open a second one.
-    expect(window.openbot.remoteDesktop.disconnect).not.toHaveBeenCalled();
+      if (!remoteDesktopAvailable) {
+        expect(await screen.findByRole("alert")).toHaveTextContent(setupError);
+        expect(screen.queryByText("Update required")).not.toBeInTheDocument();
+        await fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+      }
+      await screen.findByTitle("Sunshine remote desktop");
+      expect(screen.queryByText("Update required")).not.toBeInTheDocument();
+      await fireEvent.click(within(remoteDesktop).getByRole("button", { name: "Back to OpenBot" }));
+      await waitFor(() => expect(appFrame.inert).toBe(false));
+      // Hiding keeps the session alive, so resuming must not open a second one.
+      expect(window.openbot.remoteDesktop.disconnect).not.toHaveBeenCalled();
 
-    await fireEvent.click(screen.getByRole("button", { name: "Resume remote control" }));
-    expect(await screen.findByTitle("Sunshine remote desktop")).toBeInTheDocument();
-    expect(window.openbot.remoteDesktop.connect).toHaveBeenCalledTimes(1);
-    await fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
-    await waitFor(() => expect(window.openbot.remoteDesktop.disconnect).toHaveBeenCalledWith("desktop-1"));
-    await waitFor(() => expect(screen.queryByTitle("Sunshine remote desktop")).not.toBeInTheDocument());
-    expect(screen.getByRole("button", { name: "Open remote control" })).toBeInTheDocument();
-  });
+      await fireEvent.click(screen.getByRole("button", { name: "Resume remote control" }));
+      expect(await screen.findByTitle("Sunshine remote desktop")).toBeInTheDocument();
+      expect(window.openbot.remoteDesktop.connect).toHaveBeenCalledTimes(remoteDesktopAvailable ? 1 : 2);
+      await fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+      await waitFor(() => expect(window.openbot.remoteDesktop.disconnect).toHaveBeenCalledWith("desktop-1"));
+      await waitFor(() => expect(screen.queryByTitle("Sunshine remote desktop")).not.toBeInTheDocument());
+      expect(screen.getByRole("button", { name: "Open remote control" })).toBeInTheDocument();
+    },
+  );
 
   it("disconnects a hidden Remote Control session when the server changes", async () => {
     const servers = [

--- a/src/renderer/src/features/conversation/ConversationHeader.tsx
+++ b/src/renderer/src/features/conversation/ConversationHeader.tsx
@@ -70,8 +70,7 @@ export function ConversationHeader() {
         </Show>
         <Show when={props.remoteDesktopEnabled !== false && props.server?.kind === "remote" ? props.server : undefined}>
           {(server) => {
-            const enabled = () =>
-              props.remoteDesktopSessionActive || (server().state === "online" && server().remoteDesktopAvailable);
+            const enabled = () => props.remoteDesktopSessionActive || server().state === "online";
             const label = () => (props.remoteDesktopSessionActive ? "Resume remote control" : "Open remote control");
             return (
               <Button

--- a/src/renderer/src/features/remote-desktop/RemoteDesktopWorkspace.tsx
+++ b/src/renderer/src/features/remote-desktop/RemoteDesktopWorkspace.tsx
@@ -221,9 +221,6 @@ export function RemoteDesktopWorkspace(props: RemoteDesktopWorkspaceProps) {
           <Show when={props.server.state !== "online"}>
             <DesktopEmptyState title="Host is offline" message="Reconnect to the host before you open its desktop." />
           </Show>
-          <Show when={props.server.state === "online" && !props.server.remoteDesktopAvailable}>
-            <DesktopEmptyState title="Update required" message="This host requires Sunshine remote control support." />
-          </Show>
           <Show when={effectiveState() === "connecting"}>
             <div class="remote-desktop-overlay" role="status">
               <AgentAvatar

--- a/src/renderer/src/features/remote-desktop/remote-desktop-context.tsx
+++ b/src/renderer/src/features/remote-desktop/remote-desktop-context.tsx
@@ -145,10 +145,12 @@ const RemoteDesktop = createSimpleContext({
     async function openRemoteDesktopWorkspace(serverId: string, trigger: HTMLElement): Promise<void> {
       const server = servers().find((item) => item.id === serverId);
       const existingSession = latestRemoteDesktopSession(serverId);
+      // Availability is a cached probe. A fresh session request checks the host and returns
+      // the setup error, so a failed probe must not prevent the user from trying again.
       if (
         server?.kind !== "remote" ||
         !serverSupportsCapability(server, "remote-desktop") ||
-        (!existingSession && (server.state !== "online" || !server.remoteDesktopAvailable))
+        (!existingSession && server.state !== "online")
       ) {
         return;
       }

--- a/src/renderer/src/features/servers/ServerSettingsModal.test.tsx
+++ b/src/renderer/src/features/servers/ServerSettingsModal.test.tsx
@@ -110,6 +110,54 @@ function props(overrides: Partial<ServerSettingsModalProps> = {}): ServerSetting
 }
 
 describe("ServerSettingsModal", () => {
+  it.each([true, false])("does not request an update for a compatible host with availability %s", async (ready) => {
+    render(() => (
+      <ServerSettingsModal
+        {...props({
+          server: {
+            ...remoteServer,
+            remoteDesktopAvailable: ready,
+            compatibility: {
+              localAppVersion: "0.5.0",
+              hostAppVersion: "0.5.0",
+              localProtocol: { minimum: 1, maximum: 3 },
+              hostProtocol: { minimum: 1, maximum: 3 },
+              negotiatedProtocol: 3,
+              capabilities: ["remote-desktop"],
+            },
+          },
+        })}
+      />
+    ));
+    await fireEvent.click(screen.getByRole("tab", { name: "Remote desktop" }));
+    expect(await screen.findByText(ready ? "Service available" : "Service not ready")).toBeInTheDocument();
+    expect(screen.queryByText(/update required/iu)).not.toBeInTheDocument();
+  });
+
+  it.each(["client_update_required", "host_update_required"] as const)(
+    "identifies the end that needs an update: %s",
+    async (code) => {
+      const message = code === "client_update_required" ? "Update this OpenBot app." : "Update OpenBot on the host.";
+      render(() => (
+        <ServerSettingsModal
+          {...props({
+            server: {
+              ...remoteServer,
+              state: "incompatible",
+              remoteDesktopAvailable: false,
+              issue: { code, message, retryable: true },
+            },
+          })}
+        />
+      ));
+      await fireEvent.click(screen.getByRole("tab", { name: "Remote desktop" }));
+      expect(
+        await screen.findByText(code === "client_update_required" ? "Client update required" : "Host update required"),
+      ).toBeInTheDocument();
+      expect(screen.getByText(message)).toBeInTheDocument();
+    },
+  );
+
   it("saves the first local identity without publishing it", async () => {
     const onSaveIdentity = vi.fn(async () => undefined);
     const onSetPublished = vi.fn(async () => undefined);

--- a/src/renderer/src/features/servers/ServerSettingsModal.tsx
+++ b/src/renderer/src/features/servers/ServerSettingsModal.tsx
@@ -64,6 +64,7 @@ import {
 import { truncateMiddle } from "../../components/ui/utils";
 import { SettingsDialogShell } from "../settings/SettingsDialogShell";
 import { teamMemberName } from "../team/TeamPersonAvatar";
+import { serverSupportsCapability } from "./server-capabilities";
 
 export interface ServerSettingsModalProps {
   open: boolean;
@@ -1121,6 +1122,33 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
   }
 
   function remoteDesktopConnection() {
+    const status = () => {
+      const server = props.server;
+      if (server.issue) {
+        return {
+          title:
+            server.issue.code === "client_update_required"
+              ? "Client update required"
+              : server.issue.code === "host_update_required"
+                ? "Host update required"
+                : "Connection unavailable",
+          message: server.issue.message,
+        };
+      }
+      if (server.state !== "online") {
+        return { title: "Host is offline", message: "Reconnect to the host before you open its desktop." };
+      }
+      if (!serverSupportsCapability(server, "remote-desktop")) {
+        return { title: "Host update required", message: "Update OpenBot on the host to use remote control." };
+      }
+      return server.remoteDesktopAvailable
+        ? { title: "Service available", message: "WebRTC control is available for all active members." }
+        : {
+            title: "Service not ready",
+            message:
+              "Start Remote Control to check the host components and permissions. The host will report any setup error.",
+          };
+    };
     return (
       <Item size="spacious">
         <ItemMedia class="server-settings-desktop-icon">
@@ -1128,17 +1156,13 @@ export function ServerSettingsModal(props: ServerSettingsModalProps) {
         </ItemMedia>
         <ItemContent>
           <ItemTitle>Remote control</ItemTitle>
-          <ItemDescription class="server-settings-desktop-description">
-            {props.server.remoteDesktopAvailable
-              ? "WebRTC control is available for all active members."
-              : "Update required or remote control is unavailable."}
-          </ItemDescription>
+          <ItemDescription class="server-settings-desktop-description">{status().message}</ItemDescription>
           <Badge
             class="server-settings-desktop-status"
-            tone={props.server.remoteDesktopAvailable ? "success" : "warning"}
+            tone={status().title === "Service available" ? "success" : "warning"}
             shape="pill"
           >
-            {props.server.remoteDesktopAvailable ? "Service available" : "Update required"}
+            {status().title}
           </Badge>
         </ItemContent>
         <ItemActions class="server-settings-desktop-hint">


### PR DESCRIPTION
## What changed

A failed or stale Remote Desktop availability check displayed **Update required** and disabled the monitor button, even for a compatible host. An online host can now receive a fresh session request and report the actual setup error. Settings use the negotiated capabilities and connection issue to separate client updates, host updates, and service availability.

The host now gives separate messages for unsupported Linux hosting and missing or unsupported Sunshine/Moonlight components, with a repair instruction.

Closes #161.

Surfaces changed: desktop renderer and desktop main-process remote screen service. Reverse states covered: retry, hide, resume, and disconnect. Mobile, public web, the self-hosted Signal service, palettes, IPC contracts, preview mocks, migrations, and documentation are unchanged.

### Before and after

| Condition | Before | After |
| --- | --- | --- |
| Compatible online host, cached availability is false | “Update required”; monitor button disabled | “Service not ready”; monitor button sends a fresh connection request |
| Connection requires an update | Generic update label | Identifies the client or host and shows the connection issue |
| Host setup fails | Cached status can prevent the request | Shows the host error and offers “Try again” |
| Host is Linux | Reports that runtime components are not installed | Reports that Linux hosting is unsupported |

## Verification

- [x] Targeted Biome check, `bun run lint`, `bun run typecheck`, and `bun run check:ui` passed. Lint reports eight existing module-mocking warnings in unchanged mobile tests.
- [x] Affected tests: `remote-screen-gateway.test.ts`, `ServerSettingsModal.test.tsx`, `App.servers.test.tsx`, and `RemoteDesktopWorkspace.test.tsx`. All 61 cases passed across the initial runs and targeted retries. Nine existing renderer cases reached their time limits under concurrent machine load; all nine passed on retry without changes to code or time limits.
- [x] Regression tests failed for the expected reasons with the original production code restored, then passed with the fix.
- [x] Surfaces and reverse states are listed above.
- [x] No credentials, private data, generated output, or real user files are included.
- [ ] Live remote streaming/manual smoke test: not performed. No development app was running. Platform tests simulate macOS and Windows host setup and Linux refusal; they do not verify native screen capture or streaming on each operating system.

Model: GPT-6. Harness: Codex desktop, with repository Vitest node and renderer projects.

## Risk and security impact

An online, capability-compatible remote host can receive a session request after an availability probe fails. Host authentication, session limits, screen permissions, IPC validation, and renderer isolation still apply. No new endpoint, permission, persistence change, or released wire-format change is introduced.
