### PR TITLE
Fix Dynamic Island icons after opening OpenBot

### DIFF
--- a/src/renderer/src/components/ui/dynamic-island.tsx
+++ b/src/renderer/src/components/ui/dynamic-island.tsx
@@ -284,6 +284,18 @@ export function DynamicIsland(props: DynamicIslandProps): JSX.Element {
     state: viewState,
     renderedState: renderedPanelState,
   });
+  onSettled(() => {
+    const resetHover = () => {
+      // Focus can leave the native overlay without a pointer-leave event.
+      // A pending hover must not reopen it after the surface has collapsed.
+      clearHoverTimers();
+      pointerInside = false;
+      hoverOpenedState = null;
+      setIsHovering(false);
+    };
+    window.addEventListener("blur", resetHover);
+    return () => window.removeEventListener("blur", resetHover);
+  });
   onCleanup(() => {
     clearHoverTimers();
     if (panelExitTimer !== undefined) clearTimeout(panelExitTimer);
@@ -552,6 +564,9 @@ function createSmoothSizeResize(options: SmoothSizeResizeOptions): void {
     ({ enabled, target }) => {
       sharedLeadingEnabled = enabled;
       targetSharedLeading = target;
+      // A status can become idle while expanded. Give the transform back to
+      // CSS so the idle icon does not keep the status avatar's panel position.
+      if (!enabled) options.sharedLeading()?.style.removeProperty("transform");
     },
   );
   createEffect(
@@ -562,6 +577,7 @@ function createSmoothSizeResize(options: SmoothSizeResizeOptions): void {
     ({ enabled, target }) => {
       sharedTrailingEnabled = enabled;
       targetSharedTrailing = target;
+      if (!enabled) options.sharedTrailing()?.style.removeProperty("transform");
     },
   );
   function finishAnimation(current?: Animation[]): void {

--- a/src/renderer/src/features/dynamic-island/DynamicIslandSurface.test.tsx
+++ b/src/renderer/src/features/dynamic-island/DynamicIslandSurface.test.tsx
@@ -24,6 +24,36 @@ const SOURCE_OPTIONS = [
 afterEach(() => vi.useRealTimers());
 
 describe("DynamicIslandSurface", () => {
+  it("cancels pending hover expansion when the main window takes focus and allows a new hover", async () => {
+    const mock = createQuestionMock(questionPresentation("focus-question", [sourceQuestion()]));
+    render(() => <DynamicIslandSurface />);
+    const island = await screen.findByRole("region", { name: "OpenBot question from AI" });
+    vi.useFakeTimers();
+
+    await fireEvent.mouseEnter(island);
+    await fireEvent(window, new Event("blur"));
+    await vi.runAllTimersAsync();
+
+    expect(screen.getByRole("button", { name: "Expand OpenBot question from AI" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByRole("button", { name: "Official data. Use the public dataset" })).not.toBeInTheDocument();
+
+    await fireEvent(window, new Event("focus"));
+    await fireEvent.mouseEnter(island);
+    await vi.runAllTimersAsync();
+    expect(screen.getByRole("button", { name: "Official data. Use the public dataset" })).toBeVisible();
+
+    await fireEvent(window, new Event("blur"));
+    await vi.runAllTimersAsync();
+    expect(screen.getByRole("button", { name: "Expand OpenBot question from AI" })).toBeVisible();
+    await fireEvent.mouseEnter(island);
+    await vi.runAllTimersAsync();
+    expect(screen.getByRole("button", { name: "Official data. Use the public dataset" })).toBeVisible();
+    mock.dispose();
+  });
+
   it("hides only the idle island when that preference changes", async () => {
     const mock = createMockOpenBot();
     let updatePreference: ((preference: DynamicIslandPreference) => void) | undefined;

--- a/src/renderer/stories/DynamicIsland.stories.tsx
+++ b/src/renderer/stories/DynamicIsland.stories.tsx
@@ -5,7 +5,7 @@ import type {
   DynamicIslandPromptItem,
 } from "@openbot/contracts/ipc";
 import type { JSX } from "@solidjs/web";
-import { createMemo } from "solid-js";
+import { createMemo, createSignal } from "solid-js";
 import { fn } from "storybook/test";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import type { DynamicIslandViewState } from "../src/components/ui";
@@ -277,3 +277,35 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {};
+
+export const OpenChatReturnsToIdle: Story = {
+  render: () => (
+    <DynamicIslandDisplayComparison
+      defaultState="expanded"
+      renderIsland={(preview) => {
+        const [presentation, setPresentation] = createSignal(presentationFor("chat", "standard", "single"));
+        return (
+          <OpenBotDynamicIsland
+            presentation={presentation()}
+            state={preview.state()}
+            displayMode={preview.displayMode}
+            suppressInitialHover
+            onStateChange={preview.onStateChange}
+            onAction={() => {
+              setPresentation({ serverId: "local", mode: "idle" });
+              preview.onStateChange("compact", "pointer");
+            }}
+          />
+        );
+      }}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Click Open chat on each display. The island must collapse and show its idle icons inside the black surface.",
+      },
+    },
+  },
+};


### PR DESCRIPTION
## What changed

Fix Dynamic Island state after opening OpenBot or moving focus to the main window. Clear pending hover actions on window blur, and remove the old avatar transform when shared motion is disabled.

Before: a pending hover could reopen a collapsed island after focus loss. When a message changed to idle during collapse, the idle icon could keep the avatar's expanded position and fall outside the visible surface.

After: focus loss clears hover state, a new hover can open the island again, and idle icons use their normal positions.

Surfaces touched: desktop renderer, its focus-loss and return states, and Storybook. Add a regression test for repeated blur and hover, plus an `OpenChatReturnsToIdle` story for built-in and external displays.

Fixes #166.

## Verification

- [x] Targeted tests: `DynamicIslandSurface.test.tsx` (7 passed) and `dynamic-island.test.tsx` (3 passed).
- [x] The new regression test failed before the fix because a pending hover reopened the island after blur. It passed after the fix.
- [x] `bun run lint` passed with eight existing mobile test warnings; `bun run typecheck` and `bun run check:ui` passed. The commit hook also passed.
- [x] Surfaces touched are named above.
- [ ] Native macOS open, restore, minimize, and refocus checks: blocked because the local Auth API did not become ready. Storybook started, but its browser preview did not load. Earlier targeted test runs hit time limits under load; the final runs passed.
- [x] No credentials, private data, generated output, or real user files are included.

Model: GPT-6. Harness: Codex desktop; Vitest with jsdom and the OpenBot mock bridge for renderer tests.

## Risk and security impact

No changes to permissions, IPC contracts, persistence, filesystem access, or network access. Native window behavior and the visual result still need manual verification.

## Screenshots

The issue contains the reported image. Before/after screenshots could not be captured because the development app and Storybook preview did not load. The story above provides the repeatable visual check.
