### PR TITLE
Shorten agent instructions and complete the architecture map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,323 +2,172 @@
 
 ## Communication
 
-Always use ASD-STE100 Simplified Technical English when you work in this repository or communicate
-with the user. Apply this rule to questions, progress updates, explanations, and final answers.
-Keep exact text unchanged in quotations, code, commands, file paths, identifiers, and required
-technical terms.
+Use ASD-STE100 Simplified Technical English for questions, updates, explanations, and final answers.
+Keep quotations, code, commands, paths, identifiers, and required technical terms unchanged.
 
-Two tiers. **Non-negotiable** items protect user data, released contracts, or the security boundary;
-trade one away only on the developer's explicit decision. Everything else is a **default** their
-preference overrides — if they ask for something this file discourages, do it and say what you set
-aside. Never argue back by citing this file.
+**Non-negotiable** rules protect user data, released contracts, and security. Change them only on
+an explicit developer decision. All other rules are defaults: follow the developer's preference
+and state which default you set aside. Do not argue by citing this file.
 
 ## Non-negotiable
 
-- **Migrations are irreversible.** Nothing copies `openbot.db` before an upgrade. Preserve all user
-  data, support every shipped source schema, never assume a backup exists.
-- **Released Team API adapters are permanent.** A shipped wire protocol never changes meaning.
-- **The renderer-to-main trust boundary holds** — Electron sandboxing, context isolation, navigation
-  policy, IPC sender validation, and their tests. Agents already run with `danger-full-access`; the
-  process boundary is what is left.
-- **Secrets stay redacted** on every path that logs, exports, or sends, diagnostics and analytics
-  included.
-- **The licence is PolyForm Noncommercial 1.0.0.** No dependency that conflicts with it, no
-  relicensed file.
+- **Migrations are irreversible.** No backup of `openbot.db` is made before an upgrade. Preserve all
+  user data and support every shipped source schema. Never assume a backup exists.
+- **Released Team API adapters are permanent.** Do not change a shipped wire protocol's meaning.
+- **Keep the renderer-to-main trust boundary:** Electron sandboxing, context isolation, navigation
+  policy, IPC sender validation, and their tests. Coding agents already have `danger-full-access`.
+- **Redact secrets** on every log, export, and send path, including diagnostics and analytics.
+- **Keep PolyForm Noncommercial 1.0.0.** Do not add incompatible dependencies or relicense files.
 
-The first three are spelled out where they are enforced — `src/backend/AGENTS.md`,
-`packages/contracts/AGENTS.md` and `src/main/AGENTS.md`. `CONTRIBUTING.md` "Security-sensitive
-changes" lists the boundaries in full; `docs/ARCHITECTURE.md` "Change rules" says where a change
-belongs.
+See [CONTRIBUTING.md](CONTRIBUTING.md#security-sensitive-changes) for the security boundaries and
+[architecture change rules](docs/ARCHITECTURE.md#change-rules) for code ownership.
 
-## CI owns the minutes-long suites. Run the fast checks yourself.
+## Product constraints
 
-A fresh worktree has no `node_modules`, and every command below dies with `biome: command not found`
-or `Cannot find module '@openbot/logging'` until it does. Run `bun install --frozen-lockfile` first,
-or `bun scripts/prepare-dev-environment.ts`, which adds the local D1 migration, asserts the Bun
-version, and generates `apps/auth-api/.env.dev` if the checkout has none. That file is per-machine
-and untracked; only `.env.production` is still encrypted, so a missing `.env.keys` no longer stops
-local development.
+- Workspaces, conversations, attachments, browser data, and team data stay on the computer that
+  runs OpenBot. Providers, visited pages, and plugins can use the network.
+- **No cloud dependency for core function.** The app works without an account.
+  Cloudflare holds accounts, avatars, host configuration,
+  memberships, invitations, and logical sessions; it does not hold chats, files, or commands.
+- The user's SQLite database is the source of truth, not a remote cache.
+- Agents keep their workspace, thread, and identity across provider switches and restarts.
+  Do not reset an agent to simplify state.
 
-Before you call a task done, run the narrowest test for what you touched, then `bun run lint` and
-`bun run typecheck` — plus `bun run check:ui` if you touched `src/renderer`, which scans the whole
-renderer, and `src` and `apps` for the markup that can name a class, in under 200 ms. All three
-read more than you changed on purpose and none is expensive: `lint` is
-`biome check --max-diagnostics=none .` across every file in about six seconds, `typecheck` is eleven
-`tsc` projects in about four. The wide typecheck is the more useful one — a change in
-`packages/contracts` surfaces as an error in `src/renderer` or `src/main`, which a single `tsc -p`
-on the project you edited never sees. The `lint` flag is load-bearing: Biome caps a report at 20
-diagnostics by default, and it prints the honest total but not the findings past the cap, so a
-cleanup pass without it costs one full-repo run per 20.
+## Checks
 
-`bun run typecheck` is `typecheck:*`, and `typecheck:mobile` is in that glob, so `apps/mobile` is
-checked with everything else — it depends on `@openbot/brand`, `@openbot/contracts` and
-`@openbot/team-client`, and an export change in any of them breaks the app. It used to be named
-`mobile:typecheck`, which the glob missed, and this file used to carry a paragraph asking you to
-remember that. `mobile:typecheck` survives as an alias because CI's Surfaces job calls it by that
-name. It runs `expo customize` and a `uniwind` codegen before `tsc`, but everything it writes is
-gitignored, so the aggregate still leaves your diff alone.
+1. In a fresh worktree, run `bun install --frozen-lockfile` first. Alternatively, run
+   `bun scripts/prepare-dev-environment.ts` to also check Bun, migrate local D1, and create the
+   untracked `apps/auth-api/.env.dev`. Only `.env.production` needs the encrypted setup.
+2. Before completion, run the narrowest relevant test, then `bun run lint` and `bun run typecheck`.
+   Also run `bun run check:ui` for changes in `src/renderer`. Keep the full lint and typecheck scope;
+   `typecheck:*` includes mobile, Signal, and `remote/scripts`.
+3. Run one desktop test file with `bun run test:desktop -- <path>`. Ask for a specific command
+   before a wider test, build, or packaged-app check. Approval covers only that command.
+4. Leave `bun run check`, `bun run check:desktop`, `bun run test`, and `bun run build-storybook`
+   to CI unless authorized. These suites take minutes and desktop tests can fail under load.
+5. Do not run `bun run format`: it rewrites the whole repository. Use
+   `biome check --write <paths>` for changed files, or the pre-commit `bun run check:staged` hook.
+   Keep `--max-diagnostics=none` for full Biome reports.
 
-`remote/api` is in the glob for the same reason, as `typecheck:remote`. Its tests cover ticket
-verification, session revocation and TURN credentials — the Signal service's whole auth boundary —
-and when the workspace arrived nothing ran them, because its only entry point was `remote:check`,
-which also validates both Compose files. The workspace's own `check` needs nothing but Bun and
-finishes in three seconds, so the halves are split — `typecheck:remote` and `test:remote` run in
-Surfaces and Tests beside the other non-desktop surfaces, and `remote:check:compose` is the rest.
-`docker compose config` interpolates client-side and never opens a socket, so the Compose half needs
-the docker CLI but no daemon and runs in Surfaces too; `remote:check` remains the local superset.
-Nothing in CI builds the image, though, and its Dockerfile installs from a pruned checkout —
-one `COPY` per workspace — so a `workspace:*` dependency added to the root manifest breaks
-`remote:up` while every job stays green. `scripts/dependency-catalog.test.ts` is what notices now:
-it walks the workspace dependency graph and asserts a manifest is copied for each one it reaches.
+[Check design notes](docs/development-checks.md#check-coverage) explain CI coverage, command aliases,
+and the separate Node and Bun type environments. Read them when changing checks or dependencies.
 
-`remote/scripts` rides along in that same project. `check.ts` and `update.ts` are Bun scripts
-using `Bun.spawn` and `import.meta.dir`, and no `tsconfig` reached them: `tsconfig.node.json` stops
-at the root `scripts/**` and pins `"types": ["node"]`, which is why no root script uses the `Bun`
-global at all. Adding `@types/bun` at the root would have made Bun globals resolvable repo-wide,
-including in `src/main`, which runs under Node. Instead `remote/api` already had the Bun-typed
-project the scripts needed, so its `include` carries `../scripts/*.ts` and
-`typecheck:remote` covers both. `update.ts` drains and force-recreates the live coturn container, so
-it is worth a checker.
+## Surfaces to check
 
-Do not run `bun run check`, `check:desktop`, `test`, or `build-storybook`: each takes minutes, and
-the desktop suite flakes under load, so a red result tells you nothing about your change. That is
-where the line falls — how long a command takes and whether you can trust its result, not how many
-files it reads. CI owns all of it on every push:
+State which surfaces a change touches. Check all affected consumers and reverse actions.
 
-| CI job | Runner | Command |
-| --- | --- | --- |
-| Check | `macos-14` | `bun run check:desktop` |
-| Tests | `ubuntu-latest` | `bun run test:desktop`, `bun run test:sites`, `bun run test:remote` |
-| Surfaces | `ubuntu-latest` | `bun run mobile:typecheck`, `bun run typecheck:sites`, `bun run typecheck:team-client`, `bun run typecheck:remote`, `bun run remote:check:compose` |
-| API | `ubuntu-latest` | `bun run check:api` |
-| Storybook build | `ubuntu-latest` | `bun run build-storybook` |
+- Desktop renderer (`src/renderer`), mobile (`apps/mobile`), public web (`apps/auth-api`; no separate
+  landing app), hosted-site routing (`apps/site-router`), and Signal (`remote/api`).
+- IPC contracts (`packages/contracts`) and their preview implementation
+  (`src/renderer/src/preview/mock-openbot.ts`).
+- Reverse actions: snooze/unsnooze, pause/resume, revoke/reconnect, mute/unmute.
+- Migrations and the separate latest schema for new databases.
+- Documentation: `README.md` commands, `docs/ARCHITECTURE.md`, and `PRIVACY.md` when outbound data
+  changes.
 
-All five gate the Cloudflare production deploy on a push to `main`. Surfaces did not until recently,
-so a red mobile, site-router, team-client or remote typecheck let the deploy through.
+## Development data and processes
 
-`bun run test:desktop -- <path>` runs one desktop file. Need something wider? Ask for it. Permission
-covers the one command named — not another one, not a build, not a packaged app.
+- Never run `bun run dev:seed` or `bun run dev:reset` unless asked. Seed replaces the whole
+  `OpenBot Dev` profile and deletes its staging copy on success. Reset deletes app, test-client,
+  and legacy host profiles. `bun run dev:seed --dry-run` is read-only.
+- Reuse a running dev instance, or use `bun run dev --isolated` for a profile tied to this worktree.
+  Dev and Storybook allocate ports through a shared registry; use the ports they report. A second
+  dev stack in the same worktree requires `--force`.
+- Use `bun run dev:automation` for smoke checks instead of starting Electron directly.
+  `instances` lists worktrees, profiles, and ports. `snapshot` and `screenshot` are read-only.
+  `click` and `type` require `--allow-mutations` and a named instance: this worktree's record,
+  `--instance=<id>`, or `--port=`. Never click another worktree's app.
+- `pages` lists all window targets. Use `--page=<target-id|url-substring>` for any target, including
+  Dynamic Island or embedded browser views; the default is the app window. Use
+  `--wait-for=<role>,<name>` to wait for an accessible target before capture and after mutation.
+- Never kill by process pattern, such as `pkill -f electron` or `pkill -f bun`.
+  `bun run dev:status` lists all stacks. `bun run dev:stop` stops only this worktree's stack.
+  Use `--pid=<supervisor pid>` to name another stack or `--all` to name all stacks explicitly.
+- Stop checks each PID's start time. If identity cannot be confirmed, it keeps the record and
+  exits non-zero. Resolve the process first, then use `bun run dev:forget` to remove its record.
+  Dead records do not reserve ports; readers must not delete them. For a process outside the
+  registry, target a PID you started or ask.
 
-`bun run format` is the one fast command to leave alone: it is
-`biome check --write --max-diagnostics=none .`, so it rewrites files your task never touched and
-puts them in your diff. Fix what you changed with `biome check --write <paths>`, or let the
-pre-commit hook's `bun run check:staged` do it over the staged set.
+## Terms
 
-## Hit every surface
+- **agent**: the product object (`AgentStore`, `AgentSummary`, `agent-${uuid}`,
+  `~/OpenBot/Agents/<id>`, `projection_agents`), a coding agent, or a marketplace agent
+  (`ipc-marketplace-agents.ts`). **teammate** is prompt and marketing text, never a type.
+  Human members use `TeamMemberSummary`.
+- **bot**: do not use for new product code. Keep released names: Team API v1-v3
+  `bot`/`botId`/`bots-changed` (`current-agent-keys.ts` translates), `bots.json`, `mailbox.json`,
+  `legacy-import:bots:v1`, and readable `~/OpenBot/Bots` path prefixes. Accept `bot-<uuid>` IDs from
+  databases that did not run migration v13. `"first-bot"` is an avatar seed; `BloubBot` and the
+  lucide `Bot` icon are library names.
+- **server**: a joined team server (`ServerSummary`, `servers:*`), the local Team API host
+  (`HostStatus`, `host:*`, `src/main/team-api-server.ts`), the account API (`apps/auth-api`,
+  `auth:*`), or an MCP server (`createSdkMcpServer`).
+- **thread**: durable `projection_threads` record. **conversation**: its read projection, with no
+  separate table. **provider session**: private CLI resume state (`projection_provider_sessions`).
+  **team session**: authenticated remote connection. **turn**: one exchange in a thread.
+- **routine**: a scheduled instruction for one agent (`projection_agent_routines`), not Claude
+  Code `/schedule`.
 
-A change that works on the path you happened to open is the most common half-change here. **Say
-which of these your change touched.**
+## Task-specific instructions
 
-- **Desktop renderer** (`src/renderer`), **mobile** (`apps/mobile`), **public web**
-  (`apps/auth-api` — there is no separate landing app), **self-hosted Signal service**
-  (`remote/api`, which the desktop app and the phone both connect through).
-- **IPC contracts** in `packages/contracts`, and their second implementation
-  `src/renderer/src/preview/mock-openbot.ts`, which Storybook and the preview run against.
-- **Reverse states.** Snooze needs unsnooze, pause resume, revoke reconnect, mute unmute. A state a
-  user can enter and not leave is a bug.
-- **Migrations**, plus the separate latest schema used for new databases.
-- **Documentation**: the `README.md` command table, `docs/ARCHITECTURE.md`, and `PRIVACY.md` when
-  what leaves the machine changes.
+Read the instruction file for each directory you change. Use the
+[workspace map](docs/ARCHITECTURE.md#workspace-map) to find its owner.
 
-## The three ways to hurt yourself
-
-1. **The user's development database.** `bun run dev:seed` destroys and replaces the whole
-   `OpenBot Dev` profile — real conversations, agents, transfers — and its staging copy is deleted
-   on success, so it is not a safety net. `bun run dev:reset` deletes the app, test-client and legacy
-   host profiles. Never run either unless asked; `dev:seed --dry-run` inspects without touching
-   anything.
-2. **The shared dev stack.** Several agents work in worktrees on this machine at once, sharing one
-   profile and one set of default ports. `bun run dev` now allocates every port under one
-   machine-wide lock and publishes it, so a sibling worktree walks past it instead of claiming it
-   as well, and a second stack in *this* worktree is refused unless you pass `--force`. Reuse the
-   running instance anyway, or get a profile of your own with `bun run dev --isolated`, which keys
-   the instance id to the worktree path (`developmentInstanceIdForWorktree` in
-   `src/main/development-profile.ts`). `bun run storybook` allocates through the same registry, so
-   its port is the one it announces. Drive the
-   running instance for e2e smoke checks with `bun run dev:automation` instead of launching Electron
-   yourself. Each dev instance publishes its worktree, profile and ports, so
-   `bun run dev:automation instances` lists what is live and a command run inside a worktree drives
-   that worktree's app. `snapshot`/`screenshot` are read-only; `click`/`type` need
-   `--allow-mutations` and an instance that was named rather than inferred — the record of this
-   worktree counts, `--instance=<id>` and `--port=` name one outright, and another worktree's app is
-   readable but never clickable. Nothing about a dev window is off limits: `pages` lists every
-   target and `--page=<target-id|url-substring>` drives any of them, including a Dynamic Island surface
-   or an embedded browser view. The app window is only what you get when you aim at nothing. `--wait-for=<role>,<name>` settles on an
-  accessible target before a capture and after a mutation, so a flow needs no snapshot loop.
-3. **Killing processes by pattern.** `pkill -f electron` or `pkill -f bun` kills other sessions' work
-   mid-write. `bun run dev:status` lists every stack live on this machine with its ports, pids and
-   worktree, and `bun run dev:stop` stops this worktree's stack and the children it left behind from
-   the registry - a lookup, not a pattern. `dev:status` reports every stack, because the one holding
-   the port this worktree wanted is a sibling's; `dev:stop` acts on this worktree only. Another
-   worktree's stack takes `--pid=<supervisor pid>`, and every stack takes `--all`, so stopping
-   someone else's work is a thing you say rather than a side effect. A pid is signalled only while
-   its start time still matches the record, so a recycled pid is left alone: `dev:stop` reports what
-   it could not confirm, keeps the record and exits non-zero, and `bun run dev:forget` drops such a
-   record once you have dealt with the process yourself. Nothing else deletes a record - a dead one
-   is filtered out of every read, so its ports are free again, but the file waits for `dev:forget`. Anything not in the registry: target a PID
-   you started, or ask.
-
-## Words we use
-
-- **agent** — three unrelated senses: the OpenBot product concept (`AgentStore`, `AgentSummary`,
-  `agent-${uuid}`, `~/OpenBot/Agents/<id>`, table `projection_agents`); a *coding* agent working on
-  this repository; a *marketplace* agent (`ipc-marketplace-agents.ts`). **teammate** is prompt and
-  marketing copy, never a type. Human team members are `TeamMemberSummary`.
-- **bot** — never the product concept in new code. Where it survives it is frozen, and each place can
-  say why: the Team API v1-v3 wire spells the agent `bot`/`botId`/`bots-changed` and always will
-  (`current-agent-keys.ts` is the only translator); `bots.json`, `mailbox.json` and
-  `legacy-import:bots:v1` are names a shipped release already wrote to disk; the `~/OpenBot/Bots`
-  path prefixes stay readable forever; `"first-bot"` is an avatar seed, not a word; and `BloubBot`
-  and lucide's `Bot` icon belong to their libraries. A `bot-<uuid>` id value is still valid — a
-  database restored from the user's own file copy never ran migration v13.
-- **server** — four senses: a remote team server you join (`ServerSummary`, `servers:*` IPC); your
-  own Team API host (`HostStatus`, `host:*` IPC, `src/main/team-api-server.ts`); the cloud account
-  API (`apps/auth-api`, `auth:*` IPC); an MCP server (`createSdkMcpServer`).
-- **thread** is the durable record (`projection_threads`); **conversation** its read projection (no
-  table — an IPC and renderer word); **provider session** the deliberately private CLI-side resume
-  state (`projection_provider_sessions`); **team session** an authenticated remote connection;
-  **turn** the unit of exchange inside a thread.
-- **routine** — a scheduled standing instruction attached to one agent (`projection_agent_routines`).
-  Not the Claude Code `/schedule` sense.
-
-## What OpenBot is
-
-Four invariants you cannot derive from the code. Check a change against them before optimizing
-something else.
-
-- **Local-first, not offline-only.** Workspaces, conversations, attachments, browser data and team
-  data stay on the computer that runs OpenBot. Codex still connects to OpenAI, Claude to Anthropic,
-  Grok to xAI, and visited pages and plugins use the network. Both halves are true.
-- **No cloud dependency for core function.** Cloudflare holds accounts, avatars, host configuration,
-  memberships, invitations and logical sessions — never chats, files or commands. The app works
-  without an account.
-- **The user's SQLite is the source of truth**, not a cache of something remote. This is why
-  migrations are irreversible and a backup cannot be assumed.
-- **Teammates persist.** An agent keeps its workspace, thread and identity across provider switches
-  and restarts. Resetting an agent to get a cleaner state changes the product.
-
-## Where the rest of this lives
-
-Seven directories carry rules this file used to hold. Each is loaded when you open a file under it,
-and each says what its own boundary costs and how to wait in its tests.
-
-| File | What it owns |
+| File | Scope |
 | --- | --- |
-| `src/renderer/AGENTS.md` | the prerelease SolidJS stack, one store per concern, component reuse, the palette |
-| `src/main/AGENTS.md` | the renderer-to-main trust boundary, and where an IPC endpoint is registered |
-| `src/main/ipc/AGENTS.md` | the four ways to bind a handler, and the steps to add an endpoint |
-| `src/backend/AGENTS.md` | the user's SQLite: irreversible migrations, and the two database build paths |
-| `packages/contracts/AGENTS.md` | the Team API wire protocol, and the one channel list with its manifest and two mirrors |
-| `apps/auth-api/AGENTS.md` | the account Worker, and why its D1 migrations must survive a deploy race |
-| `apps/mobile/AGENTS.md` | the Expo app, and the build and simulator commands that need explicit permission |
+| [src/renderer/AGENTS.md](src/renderer/AGENTS.md) | SolidJS, stores, components, palette |
+| [src/main/AGENTS.md](src/main/AGENTS.md) | Renderer-to-main boundary and main-process ownership |
+| [src/main/ipc/AGENTS.md](src/main/ipc/AGENTS.md) | Handler binding and endpoint registration |
+| [src/backend/AGENTS.md](src/backend/AGENTS.md) | SQLite migrations and database creation |
+| [packages/contracts/AGENTS.md](packages/contracts/AGENTS.md) | Frozen Team API protocols and IPC mirrors |
+| [apps/auth-api/AGENTS.md](apps/auth-api/AGENTS.md) | Account Worker and D1 deployment races |
+| [apps/mobile/AGENTS.md](apps/mobile/AGENTS.md) | Expo and build/simulator permissions |
 
-Read the one for the directory you are changing before you change it. `docs/ARCHITECTURE.md`
-"Change rules" says where a change belongs when it is not obvious.
-
-One file is scoped to a task rather than a directory: `.agents/skills/release-upgrade-safety/` audits
-the diff since the last released tag for the upgrade and data-loss hazards an installed user cannot
-undo, and nothing opens it for you — reach for it when a version is about to be bumped or tagged.
+Before a version bump or tag, use
+[release-upgrade-safety](.agents/skills/release-upgrade-safety/SKILL.md) to audit upgrade and data-loss
+risks since the last release.
 
 ## Tests
 
-1. **The default answer is no test.** Prefer changing an existing test to adding one. A new test
-   names the consequence it protects; a new test *file* needs a boundary that does not exist yet.
-2. **Watch it fail.** Break what it covers — change the value, delete the guard, return early — and
-   confirm it goes red *for the reason you meant*. Still green means it tests nothing; "expected 3
-   children, got 2" means it tests the tree, so fix the assertion before restoring the code. No
-   linter can run this check, and it is what separates a test from a costume. Say in the PR that you
-   did it.
-3. **Check whether something already enforces it.** `tsc`, Biome with its GritQL rules, and
-   `bun run check:ui` cover a large class mechanically. If one of them does, skip the test.
-4. **A test that needs a timeout to pass is wrong.** Wait on an observable condition — a state
-   change, an emitted event, a resolved promise — never the clock. A sleep long enough to pass on
-   your machine is short enough to flake on a loaded runner. A spy call is such a condition:
-   `await waitFor(() => expect(send).toHaveBeenCalled())` is the sanctioned way to satisfy this
-   rule, and is not the mock-shaped assertion the module-mock warning is about. The barrier
-   synchronizes; the assertions after it carry the consequence. Counting `toHaveBeenCalled*` across
-   the suite cannot tell the two apart, so do not "fix" a barrier by grep.
-5. **Test behaviour, data, and accessible roles and names** — not markup, classes, layout or
-   animation timing. Where focus lands *is* behaviour: assert it with `toHaveFocus()`. Assert exact
-   text only for a product contract, an error or security message, serialized output, or a
-   localization key. Visual detail belongs in a Storybook story.
-6. **The file name picks the vitest project.** `*.test.ts` runs in `node` with no DOM, `*.test.tsx`
-   renders JSX in jsdom, `*.dom.test.ts` is the narrow case of a DOM without a component. Needing
-   either of the last two for logic means the logic is not separable yet.
-7. **A test is mandatory** at the renderer-to-main trust boundary, the IPC contract, database schema
-   and migrations, persisted state, secrets, the provider process boundary, the Team API wire
-   protocol, and the updater — at the lowest stable boundary, once, not at both the component and the
-   application level.
+- Prefer an existing test. Add a test only for a user or caller consequence; add a file only for a
+  new boundary. Skip assertions already enforced by TypeScript, Biome, or `check:ui`.
+- Tests are mandatory for changes to the renderer-to-main boundary, IPC contracts, database schema
+  and migrations, persisted state, secrets, provider processes, Team API wire protocols, and the
+  updater. Test once at the lowest stable boundary.
+- For each added assertion, break the behavior and confirm the test fails for the intended reason.
+  Restore the code and report this check in the PR.
+- Wait for state, an event, or a promise, not elapsed time. A spy can provide the wait condition,
+  such as `await waitFor(() => expect(send).toHaveBeenCalled())`; assert the user consequence after
+  that wait. Do not remove synchronization because it uses a spy.
+- Assert behavior and data. Query accessible roles and names; use `toHaveFocus()` for focus.
+  Do not assert markup, classes, layout, animation timing, or snapshots. Use exact text only for
+  product contracts, error/security messages, serialized output, or localization keys.
+- Use Storybook for visual details. Do not add test IDs to avoid missing accessibility.
+  Story play functions can use them; renderer `data-testid` use must stay within the existing
+  `check:ui` budget of five. A new hook must replace an existing one.
+- `*.test.ts` uses Node; `*.test.tsx` uses JSX and jsdom; `*.dom.test.ts` uses DOM without a
+  component. Keep pure logic in Node tests.
 
-Before adding an assertion, ask what a user or a caller would see differently if it failed. "A class
-name changed", "the colour changed", "the element moved", "the tree grew a node" — drop it; colour
-and layout belong in a story, the tree nowhere. How you reach the element counts too: a `data-testid`
-is a hook the product does not otherwise need and a CSS class is a styling detail, so both pin the
-test to markup that is free to change. Query by accessible role and name; nothing accessible to query
-is an accessibility gap in the component, not a reason for a test id. A snapshot is the same failure
-in bulk — it names no consequence, so it gets updated, not read.
+### Check rules
 
-Biome enforces the mechanical half and only that. In test files it rejects `toHaveClass`,
-`toHaveStyle`, `getComputedStyle`, `toContainElement`, `toHaveAttribute("title", …)`,
-`expect(x.innerHTML)`, DOM-tree walks, `querySelector("svg" | "img")`, `document.activeElement`,
-snapshots, the `*ByTestId` queries, an assertion reached through a CSS class, an awaited bare
-`setTimeout`, and `it.only`. It does not see a `data-testid` attribute itself — a GritQL rule cannot
-read the product tree from a test file — so `check:ui` carries that half instead, as a budget frozen
-at the five the renderer has today. It is a budget rather than a ban because three of the five are
-read by play functions in `src/renderer/stories`, which is sanctioned: a sixth hook has to replace
-one of those, and an accessible role and name is the only other way in. All of it stays available in
-`src/renderer/stories`, where it belongs.
+- Fix errors. Assess warnings; do not make correct code worse to silence one. Do not add
+  `biome-ignore`. Explain retained warnings in the PR.
+- GritQL rules must match syntax, not infer domain decisions, and must not duplicate a built-in
+  Biome rule. Consider traversal cost before adding a rule.
+- Each rule in `tools/biome/anti-slop/rules` needs positive and negative fixtures in `../fixtures`.
+  Mark rejected lines with `// flag`; verify with `scripts/anti-slop-rules.test.ts`.
+- Each UI check needs both `renderer` and `renderer-clean` fixtures in `tools/ui-foundation/fixtures`.
+  Verify with `scripts/ui-foundation-check.test.ts`.
 
-`check:ui` also owns the one renderer surface no compiler reads at all. A CSS rule whose class no
-component, story or HTML entry point names is dead and silent about it, which is how 1,400 lines of
-styling for markup that no longer exists accumulated; the scan reports each such class by name. A
-class a `prefix-${value}` template builds still counts as named, but only where that template sits
-inside a `class={…}` — an `id` built the same way has the same shape, and honouring it there would
-spare every rule sharing that prefix. Around
-focus only `document.activeElement` is rejected: it asserts against the document instead of the
-element the test already holds, and fails with "expected null" rather than naming the control.
-`toHaveFocus()` is encouraged.
-
-Two severities. **Error** is for patterns with no honest counter-example: a snapshot, a test id, a
-sleep. **Warning** is for a judgement a pattern cannot make — an `object` parameter, a module mock.
-A warning is a prompt to think, never a demand to rewrite; `biome-ignore` is not available to you, so
-making correct code worse to silence one is the one wrong answer. Leave it and say why in the PR.
-
-Every rule in `tools/biome/anti-slop/rules` owns a fixture in `../fixtures` marking each rejected
-line with `// flag` beside correct code it must leave alone; `scripts/anti-slop-rules.test.ts` checks
-both halves. A pattern that matches nothing is green and enforces nothing — that is how one rule
-stayed blind to `querySelector<HTMLElement>` for months. A new rule without a fixture is not a rule.
-
-A rule here bans a spelling, not a decision, and it does not repeat one Biome already ships.
-`no-runtime-typeof` was deleted for failing the first test: GritQL sees no types, so it could not
-separate `typeof` narrowing an `unknown` at a trust boundary from `typeof` on a value the compiler
-already knows, and all sixteen of its standing warnings turned out to be the correct use — which
-taught readers to skim the warning class that `no-module-mocking` lives in.
-`no-chained-type-assertions` was deleted for failing the second: `noUnsafeTypeAssertion` is already
-an error and reported every chain it caught, while the rule was blind to the unparenthesised
-`value as unknown as T` spelling. `noExplicitAny` owns `any` for the same reason. Cost is the
-tiebreaker when a rule is merely thin: each plugin is a separate traversal of every file, priced by
-how common its head pattern is, so a rule keyed on `const $name = $value` costs more than the rest of
-the linter put together — that is what `no-shape-in-symbol-names` cost to enforce a naming
-preference that review already covers.
-
-`bun run check:ui` is held to the same contract by `tools/ui-foundation/fixtures` and
-`scripts/ui-foundation-check.test.ts`. Two of its checks had gone blind before this existed. The
-`renderer` tree breaks every check once, beside the correct neighbour each must leave alone;
-`renderer-clean` breaks none of them, and carries the negative half for the checks that report
-once per file rather than once per occurrence — in the first tree the violation accounts for the
-failure whether or not the check has also started rejecting the correct code beside it. Adding a
-check means adding to both.
+Read [check design notes](docs/development-checks.md#lint-and-ui-rules) when changing these checks.
+They describe the enforced syntax, fixture behavior, and reasons for removed rules.
 
 ## Pull requests
 
-- **Never open a PR unless you were asked to.**
-- Show before and after for a UI change, and state the model and harness in the body.
-- Wider checks belong before the PR, not during it — ask for the specific command you need.
-
-### Approvability
-
-A PR is not auto-approvable, and needs a named reason in the body, when it adds a `biome-ignore`,
-`@ts-expect-error` or `@ts-ignore`; adds a rule-disabling `overrides` entry to `biome.json` or
-unregisters a GritQL plugin; or widens a type to `any` or `unknown` at a boundary or asserts past a
-checker. These are the exact escape hatches the anti-slop rules exist to close: fix the finding at
-the domain boundary, or say the rule is wrong for this case and let the developer decide.
+- Open a PR only when asked.
+- For UI changes, show before and after. State the model and harness in the PR body.
+- Get approval for a specific wider check and run it before opening the PR.
+- A PR needs a named reason and is not auto-approvable if it adds `biome-ignore`, `@ts-expect-error`,
+  or `@ts-ignore`; disables rules through `biome.json` overrides or removes a GritQL plugin; widens
+  a boundary to `any` or `unknown`; or uses an assertion to bypass a checker. Fix the domain issue,
+  or explain why the rule is wrong and let the developer decide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Type-only imports (`import type`) are erased by the compiler and stay allowed in
 
 1. Create a branch from `main`.
 2. Add or update tests for behavior changes and reproduced bugs.
-3. Run `bun run check`. Coding agents do not: see `AGENTS.md` "CI owns the minutes-long suites".
+3. Run `bun run check`. Coding agents do not: see [AGENTS.md, Checks](AGENTS.md#checks).
 4. Describe user-visible changes, risks, and manual verification in the pull request.
 
 Do not commit generated `out`, `dist`, coverage, local browser profiles, Electron `userData`, CLI

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -77,7 +77,7 @@ bun run doctor               # diagnose dependency and config issues
 bunx expo install --fix      # fix incompatible package versions
 ```
 
-Both are scoped to this app: `lint` is `biome check --max-diagnostics=none src` and `typecheck` runs `codegen` before `tsc`. See "Execution and verification limits" above for when to run them, and `AGENTS.md` "CI owns the minutes-long suites" for the repository-wide commands worth avoiding and why.
+Both are scoped to this app: `lint` is `biome check --max-diagnostics=none src` and `typecheck` runs `codegen` before `tsc`. See "Execution and verification limits" above for when to run them, and [repository checks](../../AGENTS.md#checks) for the repository-wide commands worth avoiding and why.
 
 ## Navigation & Routing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,16 +1,23 @@
 # OpenBot architecture
 
-OpenBot is a Bun workspace with one packaged desktop application, one cloud application, and small
-packages for code that has more than one consumer.
+OpenBot is a Bun workspace with a desktop application, a mobile application, two Cloudflare Workers,
+a self-hosted Signal service, and shared packages.
 
 ## Workspace map
 
 ```text
 apps/
-  auth-api/          Cloudflare Worker, account login, remote membership, and connection tickets
+  auth-api/          Cloudflare Worker for public web, accounts, memberships, and connection tickets
+  mobile/            Expo React Native client for remote team hosts
+  site-router/       Cloudflare Worker that serves published sites from private R2 storage
 packages/
+  brand/             Shared logos, avatars, and design tokens
   contracts/         Process and network boundary types, limits, and pure validation
   logging/           ts-log Logger interface plus the redacting console/file implementation
+  team-client/       Shared team connection, recovery, and WebRTC framing code
+remote/
+  api/               Bun Signal service for SDP, ICE, ticket checks, and TURN credentials
+  scripts/           Bun checks and update commands for Signal and coturn
 src/
   backend/           Agent runtime, provider adapters, event storage, queues, and browser host
   main/              Electron lifecycle, trusted IPC, host server, and operating-system adapters
@@ -297,7 +304,7 @@ Protocol support has no fixed time or release limit. Removal is an exceptional a
 ## Required verification
 
 Run the narrowest relevant test, then `bun run lint` and `bun run typecheck`; both are cheap enough
-to run whole, and CI owns the minutes-long suites. See `AGENTS.md` "CI owns the minutes-long suites"
+to run whole, and CI owns the minutes-long suites. See [AGENTS.md, Checks](../AGENTS.md#checks)
 for the division of labour and what each CI job covers.
 Changes to packaging, native modules, or Electron security also require the applicable macOS and
 Windows package verification commands. Live provider and team smoke tests use isolated temporary

--- a/docs/development-checks.md
+++ b/docs/development-checks.md
@@ -1,0 +1,94 @@
+# Development check design notes
+
+These notes explain the checks referenced by [repository instructions](../AGENTS.md#checks).
+Read the relevant section when changing CI, dependencies, or lint rules. Routine tasks use the
+short command list in `AGENTS.md`.
+
+## Check coverage
+
+Full lint and typecheck read more than the changed files. A shared export can break desktop,
+mobile, or a service outside the edited project. Lint uses
+`biome check --max-diagnostics=none .`: the default diagnostic limit hides findings after the first
+20 even though the reported total includes them. `bun run format` adds `--write` to the full scan;
+this is why routine fixes target paths or use the staged-file hook.
+
+The aggregate typecheck selects `typecheck:*`. Mobile was previously named only `mobile:typecheck`
+and was omitted. It now has `typecheck:mobile`; the old name remains an alias for CI. Mobile uses
+`@openbot/brand`, `@openbot/contracts`, and `@openbot/team-client`. Its Expo and Uniwind generation
+writes ignored files before TypeScript runs.
+
+Signal had a similar gap: `remote:check` was its only entry point and also required Compose
+validation. `typecheck:remote` and `test:remote` now run in CI. `remote:check:compose` validates both
+Compose files with the Docker CLI; it does not need a daemon. `remote:check` remains the combined
+local command.
+
+`remote/api/tsconfig.json` also covers `remote/scripts/*.ts`. These scripts use Bun, while root
+`scripts/**` and Electron main use Node types. Keep Bun types within the remote project rather than
+adding Bun globals at the root. `remote/scripts/update.ts` drains and recreates the live coturn
+container, so its type coverage matters.
+
+The Signal Dockerfile installs from a pruned checkout with one manifest copy per workspace.
+CI does not build that image. `scripts/dependency-catalog.test.ts` checks that the copied manifests
+cover the workspace dependency graph; keep that check when changing workspace dependencies.
+
+The source of truth for CI is [.github/workflows/ci.yml](../.github/workflows/ci.yml).
+Its main jobs are:
+
+| Job | Runner | Commands |
+| --- | --- | --- |
+| Check | `macos-14` | `bun run check:desktop` |
+| Tests | `ubuntu-latest` | `bun run test:desktop`, `bun run test:sites`, `bun run test:remote` |
+| Surfaces | `ubuntu-latest` | `bun run mobile:typecheck`, `bun run typecheck:sites`, `bun run typecheck:team-client`, `bun run typecheck:remote`, `bun run remote:check:compose` |
+| API | `ubuntu-latest` | `bun run check:api` |
+| Storybook build | `ubuntu-latest` | `bun run build-storybook` |
+
+All five gate Cloudflare production deployment on `main`. Surfaces was previously missing from
+that dependency list, which allowed deployment despite a failed mobile or remote check.
+These long suites belong in CI; local desktop runs can reach their time limits under load.
+
+The development setup script checks Bun, migrates local D1, and creates a missing
+`apps/auth-api/.env.dev`. This file is per-machine and untracked. Only `.env.production` remains
+encrypted; a missing `.env.keys` does not block ordinary local setup.
+
+## Lint and UI rules
+
+Biome rejects these patterns in tests: `toHaveClass`, `toHaveStyle`, `getComputedStyle`,
+`toContainElement`, `toHaveAttribute("title", …)`, `expect(x.innerHTML)`, DOM-tree walks,
+`querySelector("svg" | "img")`, `document.activeElement`, snapshots, `*ByTestId` queries,
+assertions reached through CSS classes, an awaited bare `setTimeout`, and `it.only`.
+Use `toHaveFocus()` to name the element whose focus matters. Storybook stories are the place for
+visual checks and play functions.
+
+GritQL cannot connect a test query to the product's `data-testid` attribute. `check:ui` checks the
+renderer attribute budget separately. The budget is five because existing story play functions
+use three of those hooks. It permits replacement, not growth.
+
+`check:ui` also detects CSS classes that no component, story, or HTML entry point names. This found
+about 1,400 lines of unused CSS. A dynamic `prefix-${value}` counts as a use only inside a class
+attribute; the same template in an ID must not keep unrelated CSS alive.
+
+Errors cover prohibited syntax. Warnings ask for judgment, such as an `object` parameter or a
+module mock. Making correct boundary code worse to remove a warning defeats the check. A spy call
+can synchronize an async test; the assertions after that wait must prove behavior.
+
+Every GritQL rule has rejected examples marked `// flag` beside accepted examples. This matters
+because a rule that matches nothing passes without enforcing anything. One rule failed to detect
+`querySelector<HTMLElement>` until its fixture covered that spelling.
+
+The UI fixtures have two trees. `renderer` breaks every check beside valid examples.
+`renderer-clean` breaks none. Both are needed: a check that reports once per file can falsely reject
+a valid example without changing the failure count in the first tree.
+
+### Removed rules and their limits
+
+- `no-runtime-typeof` could not distinguish valid narrowing of `unknown` at a trust boundary from
+  redundant checks of known values. All sixteen warnings were valid uses. The false positives
+  made other warnings easier to overlook.
+- `no-chained-type-assertions` repeated Biome's `noUnsafeTypeAssertion` and missed the
+  unparenthesized `value as unknown as T` spelling. `noExplicitAny` already covers `any`.
+- `no-shape-in-symbol-names` enforced a naming preference with a `const $name = $value` pattern.
+  Each plugin traverses the files separately, and that common pattern cost more than the rest of
+  the linter. Review can handle a naming decision without that cost.
+
+A new rule must reject a specific syntax, leave valid neighboring code alone, and add coverage
+that the existing checks do not provide.

--- a/docs/main-process-design-notes.md
+++ b/docs/main-process-design-notes.md
@@ -1,0 +1,113 @@
+# Main-process design notes
+
+[The main-process instructions](../src/main/AGENTS.md) contain the active rules and file ownership
+map. This document explains the decisions and the failures that led to them.
+
+## IPC coverage and privileged imports
+
+The main process runs with the user's full privileges. Agents already use `danger-full-access`;
+Electron sandboxing, context isolation, navigation policy and sender validation protect the process
+boundary that remains. A renderer feature must be assessed as a capability available to a
+compromised renderer.
+
+IPC domain modules return typed handler groups. Missing endpoints produce `TS2741`; extra endpoint
+names produce `TS2353`. Missing groups in `registerIpcGroups` also produce `TS2741`. This replaced a
+source scan that found modules which the dispatcher did not call. Removing both a registrar import
+and its spread now fails compilation.
+
+The payload binding types make `(input: unknown) => Result` incompatible with the no-payload
+`() => Result` form. This requires an explicit decoder. Decoding follows sender validation so an
+untrusted frame cannot reach a parser.
+
+`ipc-channel-coverage.test.ts` restricts the name `ipcMain` to `ipc/define-ipc-group.ts`. An aliased
+import elsewhere could otherwise register a handler without a sender check. The test restricts the
+trusted wrapper names to that file too: the wrappers accept string channels, so direct use could
+create an endpoint outside the declared groups. Direct `IPC_CHANNELS.x` references keep renderer
+sends visible to the same coverage checks.
+
+`index.ts` calls `app.setPath`, `app.enableSandbox` and
+`protocol.registerSchemesAsPrivileged` at module scope. Tests that import it need an Electron mock.
+Source coverage tests read the file instead. A service without an Electron dependency can use
+ordinary unit tests; an unnecessary import would force it into the Electron mock setup.
+
+## Test harnesses
+
+The remote-server suite once had eight separate socket fakes. Five declared `readonly readyState`,
+so closing the fake left it OPEN. The event stream's two `readyState !== WebSocket.OPEN` guards
+could not run in the tests that appeared to cover them. `FakeEventSocket` in
+`remote-server-test-harness.ts` now models that transition in one place. The harness is a plain
+`.ts` module with no test cases, like `src/backend/agent-service-test-harness.ts`.
+
+Remote-server modules each have a matching test file. The backend's `agent-service.*.test.ts`
+pattern splits tests of one large class and is not the model for this module family.
+
+`TeamApiServer` is different: its cases call routes through real HTTP listeners. Route domains are
+the useful test boundary, so `team-api-server.*.test.ts` follows that split. Its shared harness
+requires explicit choices where defaults would change what a case tests. `host-service.test.ts`
+was separated because those cases test another class.
+
+Service events, returned promises, listener callbacks and harness barriers identify the state a
+test needs. `waitForServer` reports differences against the complete server summary.
+`deferredRoute` separates request arrival from its response. Fixed elapsed time cannot provide
+those guarantees under runner load. Use fake timers for behavior whose input is elapsed time.
+
+## Construction and shutdown
+
+Service construction, windows, saved bounds, shutdown, development remote setup, session
+configuration, renderer event forwarding and IPC handlers moved out of `index.ts`. The file keeps
+lifecycle and dispatch work.
+
+`createApplicationServices` remains one function because control-flow narrowing makes construction
+order explicit: a service assigned to a `const` can satisfy later non-null constructor parameters.
+Splitting it into stages would pass a roughly 15-field object between stages and restore ordering
+hazards. It only constructs. Adding event wiring would require more inputs than outputs and invert
+the dependency direction.
+
+Shutdown is largely in construction order, rather than reverse order. The browser host closes
+before its picture-in-picture window. Provider runtimes stop before the agent service that owns
+them. Teardown ordinals state this order beside construction instead of repeating it elsewhere.
+
+Dependencies wired before `app.whenReady()` need getters because the services do not yet exist.
+Capturing `null` there never recovers. The renderer forwarders and window module now read one
+service handle each instead of eleven separate handles. Code wired during construction can receive
+values directly. Both a getter and a nullable value can type-check, so the compiler cannot select
+the correct lifetime.
+
+A similar lifetime issue applies to windows: a constructor needs the current window, but a callback
+that runs later must obtain it again. macOS can close and rebuild the main window without ending
+the application.
+
+## Remote services and released protocols
+
+`remote-server-manager.ts` was 2,828 lines before its concerns moved to the flat `remote-server-*`
+and `remote-*-decoding` family. The manager connects those modules through callbacks. The request
+path does not need to know about the event stream, and the event stream does not need to know about
+the error path. The callback connection preserves those dependency boundaries.
+
+Team API routes use the same narrow dependency style as IPC handlers. Four behavior rules explain
+the dispatch order:
+
+- Compatibility runs first so an old client can read how to update instead of receiving 426 on
+  every request.
+- Remote-screen delegation precedes the protocol gate because a browser that loads the viewer
+  sends no protocol header or token.
+- Authentication precedes route selection so an unknown path without a token returns 401.
+- The dispatcher handles unmatched paths and methods. Released clients receive 404 for a wrong
+  method on a known path.
+
+One dispatcher catch keeps unexpected errors visible to the logger and returns 500. A local catch
+could incorrectly convert them to 400. There is one `HttpError` class because `instanceof` would
+not recognize a second definition and would turn an intended 400 into 500.
+
+The explicit `Promise<RouteOutcome>` return annotation produces `TS2366` when a route falls off the
+end. This project has no `noImplicitReturns` guard. Without the annotation, inference can accept
+`undefined`, which becomes a silent 404.
+
+Host and preload decoders remain separate because they validate different trust boundaries. HTTPS
+V1/V3 and WebRTC V2 remain separate because their encodings are released contracts. Control-plane
+methods remain on `RemoteTeamDirectory` because they contact a different server from the host.
+
+`ipc-channel-coverage.test.ts` checks a name bijection between `decode*FromHost` under `src/main`
+and `decode*FromMain` in the preload. This prevents deleting one side and redirecting its callers
+to the other, which could apply trusted-main validation to a remote server. The test only checks
+names: review must still detect two names that refer to one decoder.

--- a/src/main/AGENTS.md
+++ b/src/main/AGENTS.md
@@ -1,220 +1,136 @@
 # `src/main`
 
-The Electron main process: the trust boundary, the windows, the lifecycle, and the services the
-renderer is not allowed to reach directly. Everything here runs with the user's full privileges, so
-the question for any change is not "does the renderer need this" but "what can a compromised
-renderer do with it".
+The Electron main process owns the trust boundary, windows, lifecycle and privileged services.
+Check each change for what a compromised renderer could do with it.
 
-## Where an IPC endpoint goes
+For rationale and module history, see
+[main-process design notes](../../docs/main-process-design-notes.md).
 
-A renderer-to-main endpoint is **declared in `packages/contracts`** — a wire value in
-`ipc-channels.ts` and an entry in a group in `ipc-endpoints.ts` — and **implemented in
-`src/main/ipc/`, one file per domain**, never inline in `index.ts`. A module there exports one
-`*IpcHandlers` function that *returns* its handlers keyed by endpoint name rather than registering
-them; `registerIpcHandlers` in `index.ts` wires dependencies, spreads them all into
-`registerIpcGroups`, and does nothing else. `team-handlers.ts` is the shape to copy — a
-`*IpcDependencies` interface, object destructuring in the signature, a
-`Pick<IpcGroupHandlers, …>` return type, no imports from `index.ts`.
+## IPC endpoints
 
-That return type is what makes the main side exhaustive without a test. Miss an endpoint and it is
-`TS2741` naming the endpoint; add one the group never declared and it is `TS2353`; leave a whole
-group with no registrar behind it and `registerIpcGroups` in `index.ts` is `TS2741` naming the
-group. `ipc/AGENTS.md` has the four ways to bind a handler.
+- Declare endpoints in `packages/contracts/src/ipc-channels.ts` and `ipc-endpoints.ts`. Implement them
+  in `src/main/ipc/`, one file per domain. Do not put handlers in `index.ts`.
+- Follow `ipc/team-handlers.ts`: a `*IpcDependencies` interface, destructured dependencies, a
+  `*IpcHandlers` function that returns handlers keyed by endpoint name, and a
+  `Pick<IpcGroupHandlers, …>` return type. Do not import from `index.ts`.
+- `registerIpcHandlers` in `index.ts` only supplies dependencies and passes all groups to
+  `registerIpcGroups`. The declared types check endpoint and group coverage; do not add a test for
+  this type check. Read [IPC binding rules](ipc/AGENTS.md) for the four handler forms.
+- `handleTrusted` and `handleTrustedWithEvent` from `trusted-ipc.ts` are the only registration
+  primitives. Only `ipc/define-ipc-group.ts` may call them or use `ipcMain`.
+- Parse every argument with `payloadHandler(decode, handler)`. Use `ipc/validation.ts` primitives
+  (`requireString`, `stringPayload`, `optionalPayload`, `nullishPayload`, `isObject`) and domain
+  `*-inputs.ts` parsers. The sender check must run before decoding. Do not bind raw `unknown` as a
+  no-payload handler.
+- Use `sendToRenderer` from `renderer-ipc.ts` to send messages. It drops messages for destroyed or
+  loading windows. Its channel argument must be a direct `IPC_CHANNELS.x` reference; do not use a
+  string literal or an intermediate variable. Handlers do not name channels; groups do.
+- Add a channel in one change across `ipc-channels.ts`, `ipc-endpoints.ts`, `src/main/ipc/`,
+  `src/preload/index.ts` and `src/renderer/src/preview/mock-openbot.ts`. See
+  [contract rules](../../packages/contracts/AGENTS.md) for coverage, including the untyped preload.
 
-Three things run at module scope in `index.ts` — `app.setPath`, `app.enableSandbox`,
-`protocol.registerSchemesAsPrivileged` — which is why nothing in the main process can be imported
-by a test that has not mocked `electron`, and why the coverage test below reads sources instead.
+## Trust boundary
 
-- `handleTrusted` / `handleTrustedWithEvent` from `./trusted-ipc` are the only registration
-  primitives, and `./ipc/define-ipc-group.ts` is the only caller of them.
-  `ipc-channel-coverage.test.ts` fails on the *name* `ipcMain` anywhere else in `src/main`, because
-  an aliased import would register an endpoint with no sender check that no scan can see, and on
-  either wrapper's name anywhere else, because both take a `string` channel — a direct call is a
-  privileged handler on a channel no group declares.
-- Parse every argument, and the type checker holds you to it. A handler with a payload is bound with
-  `payloadHandler(decode, handler)`, and there is no constructor that pairs a payload with a raw
-  `unknown`, because `(input: unknown) => Result` is not assignable to the no-payload `() => Result`
-  that `handler()` takes. `./ipc/validation.ts`
-  has the primitives (`requireString`, `stringPayload`, `optionalPayload`, `nullishPayload`,
-  `isObject`) and the `*-inputs.ts` files hold the per-domain parsers. Decoding runs *after* the
-  sender check, so an untrusted frame never reaches a parser.
-- Never write a channel name as a string literal. A handler never names a channel at all — the group
-  does — and the remaining references, all `sendToRenderer` calls, go through `IPC_CHANNELS`. The
-  coverage test rejects a channel argument that is not a direct `IPC_CHANNELS.x` reference: a literal
-  or a variable would hide the endpoint from every assertion in that file.
-- Sending to the renderer goes through `sendToRenderer` in `./renderer-ipc.ts`, which drops the
-  message on a destroyed or still-loading window rather than throwing into the emitter.
+Sandboxing, context isolation, navigation policy, IPC sender validation and their tests are
+non-negotiable. Changes to `trusted-renderer.ts` (origins), `renderer-permissions.ts` (permissions)
+or `content-security-policy.ts` (loaded content) need tests. Treat changes to
+`isTrustedRendererUrl`, including development use, as security boundary changes.
 
-A domain module the dispatcher never calls used to be invisible, and a test scanned for it. It is
-now the return type's job: the module's groups are missing from the `registerIpcGroups` argument, so
-deleting the spread and its import together is `TS2741` rather than a clean compile.
+Do not import across the renderer/main boundary. Biome checks `src/main`, `src/backend` and
+`src/preload` against renderer imports, and checks the reverse direction. Main may import backend.
+Put shared types in `packages/contracts`.
 
-Adding a channel touches five files in one change: `ipc-channels.ts`, `ipc-endpoints.ts`,
-`src/main/ipc/`, `src/preload/index.ts`, and `src/renderer/src/preview/mock-openbot.ts`. Only the
-preload has no type behind it. See `packages/contracts/AGENTS.md` for what enforces which pair.
+Keep these implementations separate:
 
-## The boundary is a Non-negotiable
+- `FromHost` decoders and preload `FromMain` decoders: they protect different trust boundaries.
+  Add each decoder to both sides. `ipc-channel-coverage.test.ts` checks matching names; review must
+  also check that the two names do not share one decoder.
+- HTTPS V1/V3 and WebRTC V2 encodings: these are released wire protocols.
+- `RemoteTeamDirectory` control-plane methods: these contact a different server from the host.
 
-Sandboxing, context isolation, navigation policy and sender validation are the whole reason the
-process split exists — agents already run with `danger-full-access`, so nothing behind the boundary
-is defence in depth. `trusted-renderer.ts` decides what an origin is, `renderer-permissions.ts` what
-it may ask for, `content-security-policy.ts` what it may load. Each has a test, and a change to any
-of them needs one. Widening `isTrustedRendererUrl` to accept a development convenience is the
-single most expensive edit available in this directory.
+## Tests
 
-The split is also enforced by path. `biome.json` gives `src/main`, `src/backend` and `src/preload` a
-`noRestrictedImports` group rejecting `**/renderer/**`, and the renderer the mirror of it, so the
-first import across the boundary fails `bun run lint` with the reason rather than passing review as
-a convenience. `src/main` importing `src/backend` is the one direction left open, and the handler
-registrations and the Team API server use it. Share a type through `packages/contracts` instead of
-reaching for the module.
+Wait on observable conditions, not fixed delays. A fixed delay is valid only as test input, such as
+configured latency. Use these existing barriers:
 
-## Waiting in a main-process test
-
-A test that needs a timeout to pass is wrong (root AGENTS.md, Tests rule 4). These are the barriers
-this directory already has, in the order to reach for them:
-
-| Situation | Wait on |
+| Situation | Barrier |
 | --- | --- |
-| A service emits a status event | its own emitter — `provider-runtime-manager.test.ts` has the four-line `waitFor(manager, predicate)` that resolves on the first matching snapshot |
-| A handler returns a promise | the promise. `handleTrusted` returns whatever the handler returns, so the registration captured by a mocked `ipcMain` is awaitable |
-| A spy will be called, with no event to hold | `await vi.waitFor(() => expect(spy).toHaveBeenCalledOnce())` |
-| A socket or server must be listening | `await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))` — the callback, never a delay |
-| A debounce, retry backoff or poll interval | `vi.useFakeTimers()` and advance it. A real 300 ms wait is a flake on a loaded runner |
-| A remote server reaches a state the renderer would see | `waitForServer(fixture, { state: "online" })` from `remote-server-test-harness.ts`, which fails with the diff against the whole summary rather than "expected undefined" |
-| A remote host receives a request | `deferredRoute()` from the same harness — `await route.arrived` holds until the route is actually called, and `route.resolve(...)` releases it |
+| Service status | Its emitter; see `waitFor(manager, predicate)` in `provider-runtime-manager.test.ts` |
+| Handler completion | Its returned promise, including listeners captured from `handleTrusted` |
+| Spy call without an event | `await vi.waitFor(() => expect(spy).toHaveBeenCalledOnce())` |
+| Server ready | `await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))` |
+| Debounce, backoff or polling | `vi.useFakeTimers()` and advance the timers |
+| Remote server state | `waitForServer(fixture, { state: "online" })` from `remote-server-test-harness.ts` |
+| Remote request arrival | `deferredRoute()` from that harness; await `route.arrived`, then use `route.resolve(...)` |
 
-A fixed delay is only ever right as *input* — the interval a test configures a service with, an
-artificial provider latency — never as the thing a test waits on.
+Use `remote-server-test-harness.ts` before writing WebSocket or `fetch` fakes for `remote-server-*`.
+Pair `foo.ts` with `foo.test.ts`. Keep `team-api-server.*.test.ts` split by route domain: these tests
+use real HTTP listeners. Use `team-api-server-test-harness.ts` and read its header for required
+explicit fixture choices. Tests for `HostService` belong in `host-service.test.ts`.
 
-Before writing a WebSocket or `fetch` fake for anything under `remote-server-*`, use
-`remote-server-test-harness.ts`. It is a plain `.ts` contributing no `it`, in the shape of
-`src/backend/agent-service-test-harness.ts`, and it exists because the suite had grown eight
-hand-rolled socket fakes of which five declared `readonly readyState` — so closing one left it
-reading OPEN and both `readyState !== WebSocket.OPEN` guards in the event stream were unreachable
-from the tests that appeared to cover them. `FakeEventSocket` gets that right once. Its files split
-`foo.ts` / `foo.test.ts`; the `agent-service.*.test.ts` pattern in `src/backend` is not the model
-here, because that one divides the tests of a class that refused to divide.
+Tests that import Electron code must mock `electron`. Follow `trusted-ipc.test.ts`: use
+`vi.hoisted` for a registrations `Map`, capture listeners with `vi.mock("electron")`, and invoke them
+with a fabricated sender frame. Services that can be tested without Electron should not import it.
+`index.ts` has module-scope Electron calls; source coverage tests read it instead of importing it.
 
-`team-api-server.*.test.ts` is the one place that pattern *is* right, and for the same reason it is
-wrong above: `TeamApiServer` is a class that will not divide. Every case drives real HTTP against a
-real listener on a real port, so the only seam between two cases is the route they call - which is
-why the suite is cut by domain, alongside the route modules, rather than by unit. Its fixtures are
-`team-api-server-test-harness.ts`, and its header says what the harness will not default for you and
-why each of those defaults would quietly change what a case tests. `host-service.test.ts` came out of
-the same file: it was the block testing a different class.
+## Ownership and lifecycle
 
-`electron` cannot be imported outside an Electron process, so a test for anything in here mocks it.
-`trusted-ipc.test.ts` shows the pattern: `vi.hoisted` a registrations `Map`, `vi.mock("electron")`
-to capture into it, then invoke the captured listener with a fabricated sender frame. Mocking is
-what the file under test forces, not a preference — a service that can be tested without it should
-not import `electron` in the first place.
+Keep `index.ts` as the dispatcher and lifecycle module. Do not move these responsibilities into it:
 
-## Size
-
-`index.ts` is the dispatcher plus lifecycle code and should not grow service construction again.
-Eight things that used to live in it now have their own file, and none of them should come back:
-
-| File | What it owns |
+| File | Owner of |
 | --- | --- |
-| `application-services.ts` | building every service in dependency order, and nothing else |
-| `main-window.ts` | every `BrowserWindow`, the renderer URLs, the application menu, the bounds recorder |
-| `main-window-state.ts` | reading, resolving and debounce-writing the window's saved position |
-| `teardown-registry.ts` | the shutdown sequence, declared at construction rather than restated |
-| `development-remote-bootstrap.ts` | the dev-only `OPENBOT_DEV_REMOTE_ROLE` account and connection |
-| `session-configuration.ts` | the renderer CSP and bundle protocol, the permission handlers, the attachment/avatar/logo protocols |
-| `renderer-forwarders.ts` | the eleven service events relayed to the renderer |
-| `ipc/*-handlers.ts` | every IPC endpoint, one file per domain |
+| `application-services.ts` | Service construction in dependency order |
+| `main-window.ts` | Every `BrowserWindow`, renderer URLs, menu, bounds recorder |
+| `main-window-state.ts` | Reading, resolving and debounce-writing saved window position |
+| `teardown-registry.ts` | Shutdown sequence |
+| `development-remote-bootstrap.ts` | Dev-only `OPENBOT_DEV_REMOTE_ROLE` account and connection |
+| `session-configuration.ts` | Renderer CSP, bundle protocol, permissions, attachment/avatar/logo protocols |
+| `renderer-forwarders.ts` | Service events sent to the renderer |
+| `ipc/*-handlers.ts` | IPC endpoints by domain |
 
-`createApplicationServices` is **one function on purpose**, not a sequence of stages. A service
-assigned to a `const` and passed to a non-null parameter type-checks only through control-flow
-narrowing inside a single function body; cutting it into sub-stages would put a 15-field parameter
-object between every pair and bring back the ordering hazard below. It also *only constructs* — the
-event wiring, `registerIpcHandlers`, `loadRenderer` and `app.on("activate")` stay in `index.ts`,
-because a composition root that also wires ends up with a parameter list larger than its return
-value, which is a service locator with the dependency direction inverted.
+Keep `createApplicationServices` as one function that only constructs services. Event wiring,
+`registerIpcHandlers`, `loadRenderer` and `app.on("activate")` stay in `index.ts`. Register each
+service teardown beside its construction, with an explicit ordinal. Do not infer shutdown order
+from construction order or reverse it.
 
-Each service registers its own teardown step next to its construction, with an explicit ordinal.
-The order is declared rather than inferred because shutdown here is largely *construction* order,
-not its reverse: the browser host closes before the picture-in-picture window that holds it, and the
-provider runtimes stop before the agent service that owns them.
+Dependencies wired at module scope before `app.whenReady()` must be getters, such as
+`getAgentService: () => AgentService | null`, read on each call. This applies to
+`renderer-forwarders.ts` and `main-window.ts`. Dependencies wired inside `application-services.ts`
+take values, including protocol services and IPC stores. Constructor arguments take the current
+window; callbacks that run later must read `getMainWindow()` again.
 
-A dependency wired at module scope, before `app.whenReady()`, is passed as a **function** -
-`getAgentService: () => AgentService | null` - and read on every call, because nothing is
-constructed yet and a captured `null` never recovers. `renderer-forwarders.ts` and `main-window.ts`
-are the two that qualify, and they now read one handle each rather than eleven. Anything wired from
-*inside* `application-services.ts` takes the value: `configureAttachmentProtocol` and
-`configureServerLogoProtocols` both take `remoteServers: RemoteServerManager`, and the IPC
-registrars take their stores directly. Which of the two a dependency needs is the one thing here
-`tsc` cannot decide for you - `() => X | null` and `X | null` both type-check at every call site.
-The same trap has a second form inside the composition root: a constructor argument wants the
-window that exists now, while a callback that fires later must re-read `getMainWindow()`, or it goes
-stale the first time macOS closes and rebuilds the window.
+`remote-server-manager.ts` owns the IPC surface and connects its modules through callbacks. Keep
+new concerns in the matching module below, or a new sibling. Do not connect the request, event or
+error paths by importing each other.
 
-`remote-server-manager.ts` used to be the outlier at 2828 lines. It is now the composition root of a
-flat `remote-server-*` / `remote-*-decoding` family, and each of those files has exactly one reason
-to change:
-
-| Concern | File |
+| Concern | Files |
 | --- | --- |
-| the list of servers on disk, and its schema | `remote-server-store.ts`, `remote-server-stored-shape.ts` |
-| one Team API call: negotiation, framing, decoding | `remote-server-client.ts`, `remote-server-http.ts`, `remote-server-errors.ts` |
-| what a failure means to the user | `remote-server-connection-status.ts`, `remote-server-connections.ts` |
-| the live event channel and its reconnect policy | `remote-server-event-stream.ts`, `remote-server-event-refresh.ts` |
-| members, invitations, presence, host reconciliation | `remote-team-directory.ts`, `remote-server-presence.ts`, `remote-server-host-directory.ts` |
-| what a host is allowed to send | `remote-host-decoding.ts` and its four wire-area siblings |
+| Stored server list and schema | `remote-server-store.ts`, `remote-server-stored-shape.ts` |
+| Team API requests | `remote-server-client.ts`, `remote-server-http.ts`, `remote-server-errors.ts` |
+| User-visible connection failures | `remote-server-connection-status.ts`, `remote-server-connections.ts` |
+| Events and reconnects | `remote-server-event-stream.ts`, `remote-server-event-refresh.ts` |
+| Team directory, presence, host reconciliation | `remote-team-directory.ts`, `remote-server-presence.ts`, `remote-server-host-directory.ts` |
+| Host payload decoding | `remote-host-decoding.ts` and its four wire-area siblings |
 
-A new remote concern goes in the file whose one reason it shares, or in a new sibling next to them --
-not in the manager, whose job is to own the IPC surface and wire these together. The manager is where
-they *meet*: the request path never names the event stream and the event stream never names the error
-path, so a callback passed in its constructor is how the two are connected. That indirection is the
-design, not an accident to tidy up.
+## Team API routes
 
-`team-api-server.ts` went the same way, one level down. The class, the WebSocket side and the
-lifecycle stay in it; the routes live in `src/main/team-api/`, one file per domain, each exporting a
-`route*(context, deps)` that answers `"handled"` or `"unmatched"` and declaring its own narrow
-`*RouteDependencies` in the shape `src/main/ipc/` uses:
+`team-api-server.ts` keeps the class, WebSocket handling and lifecycle. Routes live in `team-api/`,
+one file per domain. Each exports `route*(context, deps)` with narrow `*RouteDependencies` and an
+explicit `Promise<RouteOutcome>` return type. Finish each route with `return "unmatched"`; the
+return type enforces this without a test.
 
-| Concern | File |
+| Concern | Files in `team-api/` |
 | --- | --- |
-| the shared vocabulary: the class every route throws, the service types, the parsers, the context | `http-error.ts`, `dependencies.ts`, `request-helpers.ts`, `request-context.ts` |
-| members, invitations, sessions, presence, the account routes behind auth | `route-team.ts` |
-| one domain each | `route-remote-screen.ts`, `route-direct.ts`, `route-browser.ts`, `route-files.ts` |
-| the agent collection and the sole `/v1/agents/:agentId` regex, which owns the four below | `route-agents.ts` |
-| one agent sub-resource each | `route-agent-memories.ts`, `route-agent-routines.ts`, `route-agent-conversation.ts`, `route-agent-queue.ts` |
+| Shared error, dependencies, parsing, context | `http-error.ts`, `dependencies.ts`, `request-helpers.ts`, `request-context.ts` |
+| Members, invitations, sessions, presence, authenticated account routes | `route-team.ts` |
+| Screen, direct requests, browser, files | `route-remote-screen.ts`, `route-direct.ts`, `route-browser.ts`, `route-files.ts` |
+| Agent collection and the only `/v1/agents/:agentId` regex | `route-agents.ts` |
+| Agent sub-resources, owned by `route-agents.ts` | `route-agent-memories.ts`, `route-agent-routines.ts`, `route-agent-conversation.ts`, `route-agent-queue.ts` |
 
-A new endpoint goes in the module for its domain, and nothing else has to be read. Four invariants
-hold the split together, and the wire protocol is frozen (root AGENTS.md, Non-negotiable), so none of
-them is a preference:
+Preserve these released wire rules:
 
-- **The gates run in order**: `compatibility`, then the remote-screen delegation, then the protocol
-  gate, then a path-independent 401. `compatibility` first is what stops an out-of-date client
-  looping on 426 with no way to read the endpoint telling it to update; the delegation above the
-  protocol gate is because a browser fetching the viewer sends no protocol header and no token; the
-  401 above the routes is why an unknown path without a token is 401 and not 404.
-- **The dispatcher owns the only 404.** A module that does not serve a path *or its method* returns
-  `"unmatched"` and never answers on its own. This is what keeps a wrong method on a known path
-  answering 404 rather than 405, which is what the released clients were built against.
-- **The dispatcher owns the only `catch`.** A local one would cut an unexpected error off from the
-  logger and answer 400 where the truth was a 500.
-- **`HttpError` has one definition**, in `http-error.ts`. The catch classifies by `instanceof`, so a
-  second copy silently turns every 400 into a 500 and no round-trip test sees it.
-
-The last statement of every route module is `return "unmatched"`, and what enforces that is the
-declared `Promise<RouteOutcome>` rather than the convention: falling out of the end is TS2366,
-"function lacks ending return statement". There is no `noImplicitReturns` here, so the annotation is
-the whole guard - a module that drops it gets `undefined` inferred, and `undefined` reads as a silent
-404. `tsc` covers this, so it does not want a test.
-
-Three things are deliberately not unified, and each says so in its own file header: the `FromHost`
-decoders and their `FromMain` twins in `src/preload/index.ts` (different trust boundaries), the HTTPS
-V1/V3 and WebRTC V2 wire encodings (released protocols), and the control-plane methods on
-`RemoteTeamDirectory` (a different server from the host).
-
-Only the first of those three is also *checked*. `ipc-channel-coverage.test.ts` compares the set of
-`decode*FromHost` names under `src/main` against the set of `decode*FromMain` names in the preload
-and fails unless they match exactly, so neither half can lose its twin - which is how the pair gets
-merged in practice: one is deleted, its callers point at the other, and trusted-sender validation
-ends up applied to a remote team server. Adding a decoder to one side means adding it to the other.
-The check enforces the naming bijection and nothing more; two names bound to one decoder still needs
-a reviewer, and the test says so where it is defined.
+- Run gates in order: `compatibility`, remote-screen delegation, protocol gate, path-independent 401.
+- Only the dispatcher returns 404. An unsupported path **or method** returns `"unmatched"` from the
+  route; a wrong method stays 404, not 405.
+- Only the dispatcher catches errors. Unexpected errors must reach the logger and return 500.
+- Define `HttpError` only in `http-error.ts`; classification uses `instanceof`.


### PR DESCRIPTION
Root and main-process instructions mixed active rules with long accounts of earlier failures. A coding agent had to read about 40 KB before the architecture guide, whose workspace map also omitted several current applications and packages.

Keep safety rules, commands, ownership, terminology, and task-specific links in the instruction files. Move check and main-process rationale into two linked reference documents. Keep the current TypeScript cache guidance from main. Complete the workspace map with mobile, site-router, Signal, remote scripts, brand, and team-client, and repair references to the renamed Checks section.

- Root and main instructions: 6,255 to 2,630 words (58% less); 40,601 to 20,050 bytes (51% less).
- Production code: 0 lines changed. Tests: 0 lines changed. This reduces required instruction reading, not runtime code.
- Scope: repository documentation, main-process guidance, and one mobile guidance link. No runtime, UI, wire protocol, or storage changes.
- Rule review compared both instruction files with the base. It preserved safety and released-contract requirements and restored the explicit no-cloud-dependency rule after review.

Validation: all 26 local Markdown links and anchors resolve; all eight workspace package directories appear in the map; CI command descriptions match the workflow; bun run lint, bun run typecheck, and git diff --check pass. Lint retains eight existing mobile module-mock warnings because this change does not alter those tests. No behavior test or mutation check was added for documentation-only changes.

Model: GPT-6 (Codex). Harness: Codex desktop, with two bounded coding agents for main guidance and the architecture map.
