### PR TITLE
fix(mobile): allow offline sign-out with deferred revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Use `bun run dev:seed --dry-run` to inspect the target and fixture counts withou
 | --- | --- |
 | `bun run dev` | Start the local Auth API, Signal service, and Electron client with renderer HMR on its app profile. Ports are allocated through the dev registry, so a sibling worktree never takes one this stack won. It refuses a second stack in the same worktree unless you pass `--force`, and `--isolated` gives the worktree a profile of its own keyed to its path instead of the shared `OpenBot Dev` one. |
 | `bun run preview` | Preview the built Electron client with the green preview icon. |
+| `bun run mobile:go` | Start the mobile app in Expo Go and clear the Metro cache. |
+| `bun run mobile:go:tunnel` | Start the mobile app in Expo Go through a Metro tunnel and clear the cache. The OpenBot API and Signal still need their own reachable addresses. |
 | `bun run dev:api` | Start the TanStack Start API and its local D1 database on `127.0.0.1:3100`. |
 | `bun run api:start` | Build and preview the Cloudflare Worker locally. |
 | `bun run api:migrate:local` | Apply D1 migrations to the local development database. |
@@ -183,6 +185,21 @@ records, and public assets. It does not carry chats, files, commands, or remote 
 The development runner advertises both Mobile Connect and its Signal service on the preferred private
 LAN interface. Restart the runner after changing networks so newly generated QR codes contain the
 current address.
+
+`mobile:go:tunnel` exposes only the Expo development server. It does not expose the local account
+API, Signal, or TURN. A phone on 5G cannot use the default LAN addresses. For a test across networks,
+use a VPN that connects both devices, or provide HTTPS and WSS endpoints that forward to this dev
+stack's account API and Signal ports. Set `OPENBOT_MOBILE_AUTH_API_URL` to the reachable account API
+origin and `REMOTE_SIGNAL_URL` to the reachable Signal URL, including `/v1/signal`, before starting
+`bun run dev`. Use the ports reported by `bun run dev:status`; they can differ between worktrees.
+If direct WebRTC cannot connect, `TURN_HOST` must name a reachable coturn service and
+`TURN_SHARED_SECRET` must match that service. An HTTP tunnel cannot forward TURN traffic.
+Generate and scan a new Mobile Connect code after changing the account API address; an existing
+mobile session retains its original address.
+
+Mobile sign-out removes the local login even when the account API is unavailable. The app keeps
+only the credential in secure storage for revocation retries at startup, on return to the foreground,
+and on the next connection attempt. Remote revocation completes when the account API is reachable.
 
 For manual team testing, `bun run dev:test-client` starts a complete two-client harness. The second
 client uses the isolated `OpenBot Dev Test Client` profile and renderer port 5174. `dev:reset` also

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -79,6 +79,8 @@
   },
   "scripts": {
     "start": "expo start",
+    "start:go": "bunx expo start --go --clear",
+    "start:go:tunnel": "bunx expo start --go --clear --tunnel",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "lint": "biome check --max-diagnostics=none src",

--- a/apps/mobile/src/features/auth/api/mobile-auth.test.ts
+++ b/apps/mobile/src/features/auth/api/mobile-auth.test.ts
@@ -73,6 +73,36 @@ describe("mobile session revocation", () => {
     },
   );
 
+  it("processes a sign-out queued during a retry without repeating failed credentials", async () => {
+    const started = Promise.withResolvers<void>();
+    const response = Promise.withResolvers<Response>();
+    const replacement = { ...session, apiUrl: "https://other.example.com", sessionToken: "replacement-token" };
+    native.fetch.mockImplementation(async (url, init) => {
+      if (url === `${replacement.apiUrl}/v1/mobile-auth/session`) return new Response(null, { status: 204 });
+      if (init?.method === "DELETE") {
+        started.resolve();
+        return response.promise;
+      }
+      return Response.json(session.user);
+    });
+    await logoutMobileSession(session);
+    await started.promise;
+    const retry = retryMobileSessionRevocations();
+    native.storage.set(key, JSON.stringify(replacement));
+    await logoutMobileSession(replacement);
+    response.resolve(new Response(null, { status: 500 }));
+    await retry;
+    expect(native.fetch.mock.calls.map(([url, init]) => [url, init?.method ?? "GET"])).toEqual([
+      [`${session.apiUrl}/v1/mobile-auth/session`, "DELETE"],
+      [`${session.apiUrl}/v1/mobile-auth/session`, "GET"],
+      [`${replacement.apiUrl}/v1/mobile-auth/session`, "DELETE"],
+    ]);
+    expect(JSON.parse(native.storage.get("openbot.mobile.pending-revocations.v1") ?? "null")).toEqual([
+      { apiUrl: session.apiUrl, sessionToken: session.sessionToken },
+    ]);
+    expect(native.storage.has(key)).toBe(false);
+  });
+
   it("does not restore a login if the app stopped after queuing sign-out", async () => {
     native.storage.set(
       "openbot.mobile.pending-revocations.v1",

--- a/apps/mobile/src/features/auth/api/mobile-auth.test.ts
+++ b/apps/mobile/src/features/auth/api/mobile-auth.test.ts
@@ -8,6 +8,7 @@ import {
   MobileSessionExpiredError,
   readMobileSession,
   redeemMobileConnectUrl,
+  retryMobileSessionRevocations,
   revokeMobileAccountSession,
   updateMobileProfile,
   validateMobileSession,
@@ -44,108 +45,104 @@ beforeEach(() => {
   native.storage.set(key, JSON.stringify(session));
   native.fetch.mockReset();
 });
-afterEach(() => vi.useRealTimers());
+afterEach(async () => {
+  await retryMobileSessionRevocations();
+  vi.useRealTimers();
+});
 
 describe("mobile session revocation", () => {
   it.each(["network", "timeout", 500, 401] as const)(
-    "retains the credential after %s so logout can be retried",
+    "signs out locally after %s and retains only a pending revocation",
     async (failure) => {
       vi.useFakeTimers();
       failNextLogout(failure);
       native.fetch.mockResolvedValueOnce(Response.json(session.user));
-      const result = logoutMobileSession(session).then(
-        () => "signed-out",
-        () => "failed",
-      );
-      await vi.advanceTimersByTimeAsync(10_000);
-      expect(await result).toBe("failed");
-      expect(await readMobileSession()).toEqual(session);
-
-      native.fetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
       await logoutMobileSession(session);
+      expect(native.storage.has(key)).toBe(false);
+      expect(JSON.parse(native.storage.get("openbot.mobile.pending-revocations.v1") ?? "null")).toEqual([
+        { apiUrl: session.apiUrl, sessionToken: session.sessionToken },
+      ]);
+      const retry = retryMobileSessionRevocations();
+      await vi.advanceTimersByTimeAsync(20_000);
+      await retry;
+      expect(native.storage.has("openbot.mobile.pending-revocations.v1")).toBe(true);
+      native.fetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
       expect(await readMobileSession()).toBeNull();
+      await retryMobileSessionRevocations();
+      expect(native.storage.has("openbot.mobile.pending-revocations.v1")).toBe(false);
     },
   );
 
-  it.each(["network", "timeout", 500, 401] as const)(
-    "finishes logout immediately when %s hides a completed server revocation",
-    async (failure) => {
-      vi.useFakeTimers();
-      failNextLogout(failure);
-      native.fetch.mockResolvedValueOnce(Response.json({ error: { code: "unauthorized" } }, { status: 401 }));
-      const result = logoutMobileSession(session).then(
-        () => "signed-out",
-        () => "failed",
-      );
-      await vi.advanceTimersByTimeAsync(10_000);
-      expect(await result).toBe("signed-out");
-      expect(await readMobileSession()).toBeNull();
-      expect(native.fetch).toHaveBeenLastCalledWith(
-        "https://api.openbot.run/v1/mobile-auth/session",
-        expect.objectContaining({
-          headers: { Authorization: "Bearer test-session-token" },
-        }),
-      );
-    },
-  );
-
-  it.each(["network", 500, "malformed"] as const)(
-    "keeps the credential when the follow-up session check fails (%s)",
-    async (failure) => {
-      failNextLogout(500);
-      native.fetch.mockImplementationOnce(async () => {
-        if (failure === "network") throw new TypeError("Network unavailable");
-        return failure === "malformed" ? Response.json({}) : new Response(null, { status: failure });
-      });
-      await expect(logoutMobileSession(session)).rejects.toThrow("Could not confirm sign-out.");
-      expect(await readMobileSession()).toEqual(session);
-    },
-  );
-
-  it("does not clear a newer login when the follow-up check confirms the old token was revoked", async () => {
-    failNextLogout(401);
-    let confirm!: (response: Response) => void;
-    native.fetch.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          confirm = resolve;
-        }),
+  it("does not restore a login if the app stopped after queuing sign-out", async () => {
+    native.storage.set(
+      "openbot.mobile.pending-revocations.v1",
+      JSON.stringify([{ apiUrl: session.apiUrl, sessionToken: session.sessionToken }]),
     );
-    const pending = logoutMobileSession(session).then(
-      () => "signed-out",
-      () => "failed",
-    );
-    await vi.waitFor(() => expect(native.fetch).toHaveBeenCalledTimes(2));
-    const replacement = { ...session, sessionToken: "new-test-session-token" };
-    native.storage.set(key, JSON.stringify(replacement));
-    confirm(Response.json({ error: { code: "unauthorized" } }, { status: 401 }));
-    expect(await pending).toBe("signed-out");
-    expect(await readMobileSession()).toEqual(replacement);
+    native.fetch.mockRejectedValue(new TypeError("Network unavailable"));
+    expect(await readMobileSession()).toBeNull();
+    await retryMobileSessionRevocations();
+    expect(native.storage.has(key)).toBe(false);
+    expect(native.storage.has("openbot.mobile.pending-revocations.v1")).toBe(true);
   });
 
-  it.each([false, true])("waits for confirmed revocation and preserves a newer login (%s)", async (newLogin) => {
-    let confirm!: (response: Response) => void;
-    native.fetch.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          confirm = resolve;
-        }),
-    );
-    const pending = logoutMobileSession(session);
-    await vi.waitFor(() => expect(native.fetch).toHaveBeenCalledOnce());
-    expect(await readMobileSession()).toEqual(session);
-    const replacement = { ...session, sessionToken: "new-test-session-token" };
-    if (newLogin) native.storage.set(key, JSON.stringify(replacement));
-    confirm(new Response(null, { status: 204 }));
-    await pending;
-    expect(await readMobileSession()).toEqual(newLogin ? replacement : null);
-    expect(native.fetch).toHaveBeenCalledWith(
+  it("allows a new QR login while the old account service is unreachable", async () => {
+    native.storage.set("openbot.mobile.device-id.v1", "existing-device");
+    const replacement = { ...session, apiUrl: "https://other.example.com", sessionToken: "replacement-token" };
+    native.fetch.mockImplementation(async (url, init) => {
+      if (url === `${replacement.apiUrl}/v1/mobile-auth/redeem` && init?.method === "POST") {
+        return Response.json(replacement);
+      }
+      throw new TypeError("Old account service is unreachable");
+    });
+    await logoutMobileSession(session);
+    await retryMobileSessionRevocations();
+    const code = createMobileConnectUrl({ apiUrl: replacement.apiUrl, ticket: "t".repeat(32), host: session.host });
+    expect(await redeemMobileConnectUrl(code)).toEqual(replacement);
+    expect(await readMobileSession()).toEqual(replacement);
+    await retryMobileSessionRevocations();
+    expect(JSON.parse(native.storage.get("openbot.mobile.pending-revocations.v1") ?? "null")).toEqual([
+      { apiUrl: session.apiUrl, sessionToken: session.sessionToken },
+    ]);
+  });
+
+  it("removes a pending token when a lost response hides successful revocation", async () => {
+    failNextLogout("network");
+    native.fetch.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    await logoutMobileSession(session);
+    await retryMobileSessionRevocations();
+    expect(native.storage.has(key)).toBe(false);
+    expect(native.storage.has("openbot.mobile.pending-revocations.v1")).toBe(false);
+    expect(native.fetch).toHaveBeenLastCalledWith(
       "https://api.openbot.run/v1/mobile-auth/session",
-      expect.objectContaining({
-        method: "DELETE",
-        headers: { Authorization: "Bearer test-session-token" },
-      }),
+      expect.objectContaining({ headers: { Authorization: "Bearer test-session-token" } }),
     );
+  });
+
+  it("does not wait for the network or clear a replacement login", async () => {
+    const started = Promise.withResolvers<void>();
+    const response = Promise.withResolvers<Response>();
+    native.fetch.mockImplementationOnce(() => {
+      started.resolve();
+      return response.promise;
+    });
+    await logoutMobileSession(session);
+    await started.promise;
+    expect(native.storage.has(key)).toBe(false);
+    const replacement = { ...session, sessionToken: "new-test-session-token" };
+    native.storage.set(key, JSON.stringify(replacement));
+    response.resolve(new Response(null, { status: 204 }));
+    await retryMobileSessionRevocations();
+    expect(await readMobileSession()).toEqual(replacement);
+    expect(native.storage.has("openbot.mobile.pending-revocations.v1")).toBe(false);
+  });
+
+  it("preserves a login at another API with the same token", async () => {
+    const replacement = { ...session, apiUrl: "https://other.example.com" };
+    native.storage.set(key, JSON.stringify(replacement));
+    native.fetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await logoutMobileSession(session);
+    await retryMobileSessionRevocations();
+    expect(await readMobileSession()).toEqual(replacement);
   });
 });
 

--- a/apps/mobile/src/features/auth/api/mobile-auth.ts
+++ b/apps/mobile/src/features/auth/api/mobile-auth.ts
@@ -273,6 +273,7 @@ export async function logoutMobileSession(session: MobileSession): Promise<void>
       await SecureStore.setItemAsync(MOBILE_REVOCATIONS_KEY, JSON.stringify(pending), {
         keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
       });
+      revocationRetryRequested = true;
     }
     const stored = await SecureStore.getItemAsync(MOBILE_SESSION_KEY);
     if (stored && sameCredential(decodeStoredMobileCredential(JSON.parse(stored)), session)) {
@@ -293,39 +294,47 @@ async function readPendingRevocations(): Promise<MobileCredential[]> {
 }
 
 let revocationRetry: Promise<void> | null = null;
+let revocationRetryRequested = false;
 
 // Pending tokens are never restored as logins. Keep them in Keychain until the
 // account service confirms revocation, without blocking local sign-out or login.
 export function retryMobileSessionRevocations(): Promise<void> {
   if (revocationRetry) return revocationRetry;
   revocationRetry = (async () => {
-    const pending = await serializeMobileSessionStorage(readPendingRevocations);
-    await Promise.all(
-      pending.map(async (credential) => {
-        try {
-          await revokeMobileCredential(credential);
-          await serializeMobileSessionStorage(async () => {
-            const remaining = (await readPendingRevocations()).filter((item) => !sameCredential(item, credential));
-            if (remaining.length === 0) {
-              await SecureStore.deleteItemAsync(MOBILE_REVOCATIONS_KEY);
-            } else {
-              await SecureStore.setItemAsync(MOBILE_REVOCATIONS_KEY, JSON.stringify(remaining), {
-                keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    const attempted: MobileCredential[] = [];
+    try {
+      do {
+        revocationRetryRequested = false;
+        const pending = (await serializeMobileSessionStorage(readPendingRevocations)).filter(
+          (credential) => !attempted.some((item) => sameCredential(item, credential)),
+        );
+        attempted.push(...pending);
+        await Promise.all(
+          pending.map(async (credential) => {
+            try {
+              await revokeMobileCredential(credential);
+              await serializeMobileSessionStorage(async () => {
+                const remaining = (await readPendingRevocations()).filter((item) => !sameCredential(item, credential));
+                if (remaining.length === 0) {
+                  await SecureStore.deleteItemAsync(MOBILE_REVOCATIONS_KEY);
+                } else {
+                  await SecureStore.setItemAsync(MOBILE_REVOCATIONS_KEY, JSON.stringify(remaining), {
+                    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+                  });
+                }
               });
+            } catch {
+              // Retry failed credentials only on the next external trigger.
             }
-          });
-        } catch {
-          // Retry on startup, foreground validation, or the next QR scan.
-        }
-      }),
-    );
-  })()
-    .catch(() => {
+          }),
+        );
+      } while (revocationRetryRequested);
+    } catch {
       // A storage failure must not produce an unhandled background rejection.
-    })
-    .finally(() => {
+    } finally {
       revocationRetry = null;
-    });
+    }
+  })();
   return revocationRetry;
 }
 

--- a/apps/mobile/src/features/auth/api/mobile-auth.ts
+++ b/apps/mobile/src/features/auth/api/mobile-auth.ts
@@ -19,6 +19,7 @@ import { z } from "zod";
 import { isAndroid, isIOS } from "@/shared/lib/platform";
 
 const MOBILE_SESSION_KEY = "openbot.mobile.session.v1";
+const MOBILE_REVOCATIONS_KEY = "openbot.mobile.pending-revocations.v1";
 const MOBILE_DEVICE_ID_KEY = "openbot.mobile.device-id.v1";
 const MOBILE_AUTH_REQUEST_TIMEOUT_MS = 10_000;
 
@@ -41,6 +42,7 @@ export interface MobileSession {
 type MobileCredential = Pick<MobileSession, "apiUrl" | "sessionToken">;
 
 export async function redeemMobileConnectUrl(value: string): Promise<MobileSession> {
+  void retryMobileSessionRevocations();
   const payload = parseMobileConnectUrl(value);
   if (!payload) {
     throw new Error("This is not a valid OpenBot Mobile Connect code.");
@@ -89,6 +91,7 @@ export async function redeemMobileConnectUrl(value: string): Promise<MobileSessi
 }
 
 export async function readMobileSession(): Promise<MobileSession | null> {
+  void retryMobileSessionRevocations();
   return serializeMobileSessionStorage(() => readStoredSessionAndRevokeInvalid(false));
 }
 
@@ -103,6 +106,11 @@ async function readStoredSessionAndRevokeInvalid(requireRevocation: boolean): Pr
   try {
     const value = JSON.parse(stored);
     credential = decodeStoredMobileCredential(value);
+    const storedCredential = credential;
+    if ((await readPendingRevocations()).some((pending) => sameCredential(pending, storedCredential))) {
+      await SecureStore.deleteItemAsync(MOBILE_SESSION_KEY);
+      return null;
+    }
     return decodeStoredMobileSession(value);
   } catch {
     if (credential) {
@@ -124,6 +132,7 @@ export function validateMobileSession(
   session: MobileSession,
   onValidated?: (validated: MobileSession | null) => void,
 ): Promise<MobileSession | null> {
+  void retryMobileSessionRevocations();
   return serializeMobileProfile(async () => {
     const validated = await refreshMobileProfile(session);
     onValidated?.(validated);
@@ -257,8 +266,67 @@ async function writeMobileProfile(session: MobileSession, change: MobileProfileC
 }
 
 export async function logoutMobileSession(session: MobileSession): Promise<void> {
-  await revokeMobileCredential(session);
-  await deleteMobileSessionIfCurrent(session.sessionToken);
+  await serializeMobileSessionStorage(async () => {
+    const pending = await readPendingRevocations();
+    if (!pending.some((item) => sameCredential(item, session))) {
+      pending.push({ apiUrl: session.apiUrl, sessionToken: session.sessionToken });
+      await SecureStore.setItemAsync(MOBILE_REVOCATIONS_KEY, JSON.stringify(pending), {
+        keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      });
+    }
+    const stored = await SecureStore.getItemAsync(MOBILE_SESSION_KEY);
+    if (stored && sameCredential(decodeStoredMobileCredential(JSON.parse(stored)), session)) {
+      await SecureStore.deleteItemAsync(MOBILE_SESSION_KEY);
+    }
+  });
+  void retryMobileSessionRevocations();
+}
+
+function sameCredential(left: MobileCredential, right: MobileCredential): boolean {
+  return left.apiUrl === right.apiUrl && left.sessionToken === right.sessionToken;
+}
+
+async function readPendingRevocations(): Promise<MobileCredential[]> {
+  const stored = await SecureStore.getItemAsync(MOBILE_REVOCATIONS_KEY);
+  if (!stored) return [];
+  return z.array(z.unknown()).parse(JSON.parse(stored)).map(decodeStoredMobileCredential);
+}
+
+let revocationRetry: Promise<void> | null = null;
+
+// Pending tokens are never restored as logins. Keep them in Keychain until the
+// account service confirms revocation, without blocking local sign-out or login.
+export function retryMobileSessionRevocations(): Promise<void> {
+  if (revocationRetry) return revocationRetry;
+  revocationRetry = (async () => {
+    const pending = await serializeMobileSessionStorage(readPendingRevocations);
+    await Promise.all(
+      pending.map(async (credential) => {
+        try {
+          await revokeMobileCredential(credential);
+          await serializeMobileSessionStorage(async () => {
+            const remaining = (await readPendingRevocations()).filter((item) => !sameCredential(item, credential));
+            if (remaining.length === 0) {
+              await SecureStore.deleteItemAsync(MOBILE_REVOCATIONS_KEY);
+            } else {
+              await SecureStore.setItemAsync(MOBILE_REVOCATIONS_KEY, JSON.stringify(remaining), {
+                keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+              });
+            }
+          });
+        } catch {
+          // Retry on startup, foreground validation, or the next QR scan.
+        }
+      }),
+    );
+  })()
+    .catch(() => {
+      // A storage failure must not produce an unhandled background rejection.
+    })
+    .finally(() => {
+      revocationRetry = null;
+    });
+  return revocationRetry;
 }
 
 async function revokeMobileCredential(session: MobileCredential): Promise<void> {

--- a/apps/mobile/src/features/auth/context/mobile-session-context.tsx
+++ b/apps/mobile/src/features/auth/context/mobile-session-context.tsx
@@ -16,6 +16,7 @@ import {
   type MobileSession,
   MobileSessionExpiredError,
   readMobileSession,
+  retryMobileSessionRevocations,
   updateMobileProfile,
   validateMobileSession,
 } from "@/features/auth/api/mobile-auth";
@@ -124,7 +125,10 @@ export function MobileSessionProvider({ children }: PropsWithChildren) {
     const appStateSubscription = AppState.addEventListener("change", (nextAppState) => {
       const resumed = (appState === "background" || appState === "inactive") && nextAppState === "active";
       appState = nextAppState;
-      if (resumed) void checkSession();
+      if (resumed) {
+        void retryMobileSessionRevocations();
+        void checkSession();
+      }
     });
     refreshProfileRef.current = checkSession;
 
@@ -138,7 +142,7 @@ export function MobileSessionProvider({ children }: PropsWithChildren) {
     const current = sessionRef.current;
     if (!current) return;
     await logoutMobileSession(current);
-    if (sessionRef.current?.sessionToken === current.sessionToken) {
+    if (sessionRef.current?.sessionToken === current.sessionToken && sessionRef.current?.apiUrl === current.apiUrl) {
       setCurrentSession(null);
     }
   }, [setCurrentSession]);

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "dev:test-client": "bun scripts/dev-services.ts test-client",
     "dev:all": "bun scripts/dev-services.ts all",
     "mobile": "bun run --cwd apps/mobile start",
+    "mobile:go": "bun run --cwd apps/mobile start:go",
+    "mobile:go:tunnel": "bun run --cwd apps/mobile start:go:tunnel",
     "mobile:android": "bun run --cwd apps/mobile android",
     "mobile:ios": "bun run --cwd apps/mobile ios",
     "mobile:lint": "bun run --cwd apps/mobile lint",


### PR DESCRIPTION
## What changed

When the account API was unreachable, mobile sign-out failed and kept the user signed in. Sign-out now removes the local login without waiting for the network. The app stores the credential separately in secure storage until the server confirms revocation, and retries at startup, on return to the foreground, and on a new connection attempt. A new QR login can proceed while an old revocation is pending. Cleanup preserves replacement logins and handles an app restart during sign-out.

Includes the Expo Go command aliases and documents that the Expo tunnel exposes Metro only. Cross-network development still requires reachable account API, Signal, and TURN endpoints or a VPN.

Surfaces: mobile authentication and session persistence, root/mobile development commands, and README. Reverse action: QR login after offline sign-out. No visual layout changes.

## Verification

- Review fix: sign-outs added during an active retry get another pass. Credentials already attempted in that cycle are skipped. The new regression test failed on the original code (missing replacement revocation) and with the attempted-credential filter removed (duplicate failed requests), then passed with the fix.

- `bun run test:desktop -- apps/mobile/src/features/auth/api/mobile-auth.test.ts`: 40 tests passed.
- `bun run lint`: passed with eight existing module-mock warnings. The existing native storage and transport mocks have no injectable seam; they remain unchanged.
- `bun run typecheck`: passed across all projects.
- Temporarily broke offline sign-out, restart recovery, API identity comparison, confirmed cleanup, and QR login during pending revocation. Each selected regression test failed for the intended reason. Restored the code and reran the file successfully.
- Phone testing and a live 5G connection remain unverified.
- Model: GPT-6. Harness: Codex desktop; Vitest with native storage and HTTP mocks.

## Risk and security impact

Pending revocation credentials remain in secure storage and cannot restore a login. Server-side revocation is delayed while the account API is unreachable. The app retains the credential until revocation is confirmed. This change does not expose development services to the internet or change the Team API protocol.

