### PR TITLE
Keep agent list avatars static

### DIFF
--- a/apps/mobile/src/features/agents/components/agent-list-row.tsx
+++ b/apps/mobile/src/features/agents/components/agent-list-row.tsx
@@ -109,7 +109,7 @@ export function AgentListRow({
   const isUnpinTarget = transition?.agentId === agent.id && transition.target === "row";
   const avatar = (
     <AgentPinAvatar agentId={agent.id} location={avatarLocation} size={54}>
-      <BloubAvatar agentId={agent.id} hue={agent.avatarHue} seed={agent.avatarSeed} size={54} />
+      <BloubAvatar agentId={agent.id} hue={agent.avatarHue} seed={agent.avatarSeed} size={54} animateIdle={false} />
     </AgentPinAvatar>
   );
 

--- a/apps/mobile/src/features/agents/components/agent-pin-transition-overlay.tsx
+++ b/apps/mobile/src/features/agents/components/agent-pin-transition-overlay.tsx
@@ -39,6 +39,7 @@ export function AgentPinTransitionOverlay({ progress, transition }: AgentPinTran
         hue={transition.avatarHue}
         seed={transition.avatarSeed}
         size={transition.from.width}
+        animateIdle={false}
       />
     </Animated.View>
   );

--- a/apps/mobile/src/features/agents/components/bloub-avatar.tsx
+++ b/apps/mobile/src/features/agents/components/bloub-avatar.tsx
@@ -16,6 +16,7 @@ interface BloubAvatarProps {
   hue: AvatarHue | null;
   seed: string;
   size?: number;
+  animateIdle?: boolean;
 }
 
 const AVATAR_PAPER = "#f9f9f9";
@@ -34,7 +35,7 @@ function AvatarDot({ frame, index, color }: { frame: DerivedValue<BloubActivityF
   return <AnimatedCircle fill={color} animatedProps={props} />;
 }
 
-export function BloubAvatar({ agentId, hue, seed, size = 54 }: BloubAvatarProps) {
+export function BloubAvatar({ agentId, hue, seed, size = 54, animateIdle = true }: BloubAvatarProps) {
   const { agents, servers } = useMobileWorkspace();
   const serverId = agents.find((agent) => agent.id === agentId)?.serverId;
   const disconnected = !servers.some((server) => server.id === serverId && server.state === "online");
@@ -44,6 +45,7 @@ export function BloubAvatar({ agentId, hue, seed, size = 54 }: BloubAvatarProps)
       hue={hue}
       seed={seed}
       size={size}
+      animateIdle={animateIdle}
       disconnected={disconnected}
       working={!disconnected && Boolean(activity && activity.phase !== "waiting")}
     />
@@ -56,11 +58,12 @@ export const BloubAvatarPreview = memo(function BloubAvatarPreview({
   size = 54,
   disconnected = false,
   working = false,
+  animateIdle = true,
 }: Omit<BloubAvatarProps, "agentId"> & { disconnected?: boolean; working?: boolean }) {
   const appearance = useConnectionAppearance(disconnected);
   const colorProps = useAnimatedProps(() => ({ values: [appearance.get().saturation] }));
   const appearanceProps = useAnimatedProps(() => ({ opacity: appearance.get().opacity }));
-  const frame = useBloubActivityFrame(seed, working, !disconnected);
+  const frame = useBloubActivityFrame(seed, working, animateIdle && !disconnected);
   const bodyProps = useAnimatedProps(() => frame.get().body);
   const maskId = `bloub-${useId().replaceAll(":", "")}`;
   const color = getBloubAvatarColor(seed, hue);

--- a/apps/mobile/src/features/agents/components/pinned-agents-strip.tsx
+++ b/apps/mobile/src/features/agents/components/pinned-agents-strip.tsx
@@ -72,7 +72,13 @@ function PinnedAgentItem({ agent }: { agent: MobileAgent }) {
           >
             <Link.AppleZoom>
               <AgentPinAvatar agentId={agent.id} location="pinned" size={76}>
-                <BloubAvatar agentId={agent.id} hue={agent.avatarHue} seed={agent.avatarSeed} size={76} />
+                <BloubAvatar
+                  agentId={agent.id}
+                  hue={agent.avatarHue}
+                  seed={agent.avatarSeed}
+                  size={76}
+                  animateIdle={false}
+                />
                 {isUnread ? (
                   <View
                     className="absolute right-0 top-0 size-3.5 rounded-full border-2 bg-accent"

--- a/apps/mobile/src/features/agents/screens/hidden-chats-screen.tsx
+++ b/apps/mobile/src/features/agents/screens/hidden-chats-screen.tsx
@@ -49,7 +49,13 @@ export function HiddenChatsScreen() {
                   className="min-w-0 flex-1 flex-row items-center gap-3 rounded-2xl px-1 py-1"
                   style={({ pressed }) => ({ opacity: pressed ? 0.58 : 1 })}
                 >
-                  <BloubAvatar agentId={agent.id} hue={agent.avatarHue} seed={agent.avatarSeed} size={46} />
+                  <BloubAvatar
+                    agentId={agent.id}
+                    hue={agent.avatarHue}
+                    seed={agent.avatarSeed}
+                    size={46}
+                    animateIdle={false}
+                  />
                   <Typography.Paragraph className="min-w-0 flex-1" weight="semibold" numberOfLines={1}>
                     {agent.name}
                   </Typography.Paragraph>


### PR DESCRIPTION
## Summary

- Add an `animateIdle` option to `BloubAvatar`.
- Disable idle animation for agent list, pinned agent, hidden chat, and pin transition avatars.
- Preserve idle animation by default for other avatar uses.

## Testing

Not run (not requested)