### PR TITLE
fix: keep delete button label visible on hover

### DIFF
--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -1741,8 +1741,11 @@ textarea {
   color: var(--openbot-text-primary);
 }
 
-.agent-delete-actions .agent-delete-confirm:hover {
-  background: var(--openbot-danger);
+@media (hover: hover) and (pointer: fine) {
+  .agent-delete-actions .agent-delete-confirm:hover:not(:disabled):not([data-disabled]) {
+    background: var(--openbot-danger-hover);
+    color: var(--openbot-text-primary);
+  }
 }
 
 @keyframes agent-context-in {


### PR DESCRIPTION
## What changed

<!-- Describe the user-visible outcome and why this is the smallest useful change. -->

## Verification

- [ ] Narrow checks for what changed: `biome check <paths>`, a targeted `tsc`, and the affected test files — CI owns the full suite
- [ ] Surfaces touched are named under "What changed": renderer, mobile, `apps/auth-api`, the three `--openbot-*` palettes, IPC contracts and `mock-openbot.ts`, reverse states, migrations and the latest schema, documentation
- [ ] Relevant manual smoke test completed, or not applicable
- [ ] No credentials, private data, generated output, or real user files are included

## Risk and security impact

<!-- Note changes to permissions, IPC, filesystem access, persistence, browser behavior, or network access. Write "None" when not applicable. -->

## Screenshots

<!-- Include before/after screenshots for visual changes. Remove this section when not applicable. -->

## Approvability

<!-- Remove this section unless the PR adds a `biome-ignore`, `@ts-expect-error`, `@ts-ignore`, a rule-disabling `biome.json` override, or a widening to `any`/`unknown` or a type assertion at a boundary. Otherwise name the reason each one is there. -->
