### PR TITLE
Fix remote connection errors and workspace refresh after reconnect

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -274,6 +274,11 @@ Mobile sign-out keeps the encrypted credential and local session until the accou
 revocation. If the DELETE response fails, mobile validates that same token: a 401 confirms it is no
 longer active and completes sign-out immediately. A successful session check or an inconclusive
 network/service error keeps the credential for retry; a late result cannot clear a newer login.
+The desktop keeps remote connection errors visible in the workspace during retries. A successful
+connection clears the error. A new connection sequence or a return to online reloads the active
+workspace without remounting its providers, so failed refreshes retain cached data. Server switches
+still dispose the old scope; load generations and selection guards reject late responses.
+
 Hosts opt in with the additive Signal hello `multiplex` flag; legacy desktops keep their one-peer
 limit so a second phone cannot replace an existing client's connection. Signal multiplexes
 connections by logical session, and the hidden desktop renderer owns a separate

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -277,7 +277,7 @@ network/service error keeps the credential for retry; a late result cannot clear
 The desktop keeps remote connection errors visible in the workspace during retries. A successful
 connection clears the error. A new connection sequence or a return to online reloads the active
 workspace without remounting its providers, so failed refreshes retain cached data. Server switches
-still dispose the old scope; load generations and selection guards reject late responses.
+still dispose the old scope; load generations and scope guards reject late responses.
 
 Hosts opt in with the additive Signal hello `multiplex` flag; legacy desktops keep their one-peer
 limit so a second phone cannot replace an existing client's connection. Signal multiplexes

--- a/docs/remote-session-deployment.md
+++ b/docs/remote-session-deployment.md
@@ -1,0 +1,101 @@
+# Concurrent remote sessions: issue #325
+
+## Read-only production evidence
+
+Checked on 2026-09-08. No production changes were made for this investigation.
+
+- SSH target: `sui-alexandria`. Compose directory: `/opt/openbot/remote`.
+- Signal container: `openbot-remote-remote-api-1`, created `2026-09-01T10:53:29.873613544Z`.
+- Running image: `sha256:7f94a50aee8b89ccf16803c0b9811f6fe19a5d876d14cfeed51deb97e4eee6dd`.
+- Running `signal-service.ts` SHA-256: `b1514f74e6b2ff708c430154b793261a667b5b107c69ee6bd79e6c0fd2356efc`.
+  Its client admission code rejects every different session when a host already has a connection.
+  Its protocol parser has no `multiplex` field. This confirms that this image lacks multiplex support.
+- Latest Worker version observed: `bf613b5c-8c44-4c73-8226-1c2651bab5c7`, version number 265,
+  created `2026-09-08T09:16:13.382129Z`, deployed at 100% at `2026-09-08T09:16:14.464933Z`.
+  This is version evidence, not an end-to-end compatibility result.
+- D1 records `0018_remote_device_sessions.sql` as applied at `2026-09-04 12:21:44`.
+  The SELECT changed no data. Do not apply this migration again or reverse it.
+- `/opt/openbot` is not a Git checkout. The public Signal health routes do not identify the source version.
+
+To repeat the read-only checks, run from this repository:
+
+```sh
+ssh sui-alexandria 'docker inspect openbot-remote-remote-api-1 --format "{{.Image}} {{.Created}}"'
+ssh sui-alexandria 'docker exec openbot-remote-remote-api-1 sha256sum /app/remote/api/src/signal-service.ts'
+bunx wrangler deployments list --cwd apps/auth-api --json
+bunx wrangler d1 execute openbot-auth --cwd apps/auth-api --remote \
+  --command "SELECT name, applied_at FROM d1_migrations WHERE name = '0018_remote_device_sessions.sql'" --json
+```
+
+## Deployment procedure — requires separate approval
+
+Commit and check the intended source before deployment. Use the approved commit as `HEAD` below.
+Run the required CI checks first. If the target environment lacks the device-session schema or Worker,
+apply the compatible additive D1 migrations before deploying the Worker. Use the existing production
+CI deployment procedure. Do not infer Worker compatibility from its date alone.
+
+Stage the approved source on the host without replacing its configuration or key files:
+
+```sh
+release_dir="/opt/openbot/releases/$(git rev-parse HEAD)"
+ssh sui-alexandria "mkdir -p '$release_dir'"
+git archive HEAD | ssh sui-alexandria "tar --exclude='.env*' --exclude='*/.env*' -x -C '$release_dir'"
+ssh sui-alexandria "ln -s /opt/openbot/remote/.env.production '$release_dir/remote/.env.production'"
+ssh sui-alexandria "ln -s /opt/openbot/runtime '$release_dir/runtime'"
+ssh sui-alexandria "ln -s /opt/openbot/node_modules '$release_dir/node_modules'"
+ssh sui-alexandria "ln -s /opt/openbot/remote/.env.keys '$release_dir/remote/.env.keys'"
+```
+
+The runtime and dependency links let the existing Dotenvx wrapper run. Docker installs Signal
+dependencies from the approved lockfile inside the image.
+
+On `sui-alexandria`, change to that release directory. Retain the running image **before** the build.
+Run only these Signal commands; `remote:update` also updates coturn and is not appropriate here.
+
+```sh
+signal_previous_image=$(docker inspect openbot-remote-remote-api-1 --format '{{.Image}}')
+docker image tag "$signal_previous_image" openbot-remote-api:before-325
+remote/bin/dotenvx run --overload -f remote/.env.production -fk remote/.env.keys -- \
+  docker compose -p openbot-remote -f remote/compose.yaml build remote-api
+remote/bin/dotenvx run --overload -f remote/.env.production -fk remote/.env.keys -- \
+  docker compose -p openbot-remote -f remote/compose.yaml up -d --no-build --no-deps remote-api
+docker inspect openbot-remote-remote-api-1 --format '{{.Image}} {{.State.Health.Status}}'
+curl --fail --silent --show-error https://signal.openbot.run/health/ready
+```
+
+Wait for Docker health to become `healthy`. Check the running source for `multiplex` and record its
+checksum. Keep the previous image until the device checks below pass. Do not print container environment
+variables, resume tokens, tickets, or raw connection logs.
+
+Signal replacement closes signaling WebSockets. Existing WebRTC data channels should continue while
+signaling reconnects. The first resume after a restart checks the durable control plane. Coturn stays
+running, so the update does not deliberately end its relay allocations. Validate this with an active
+connection; health checks alone do not prove it.
+
+If the new Signal fails, restore the retained image from the same release directory:
+
+```sh
+docker image tag openbot-remote-api:before-325 openbot-remote-remote-api
+remote/bin/dotenvx run --overload -f remote/.env.production -fk remote/.env.keys -- \
+  docker compose -p openbot-remote -f remote/compose.yaml up -d --no-build --no-deps --force-recreate remote-api
+```
+
+Rollback restores the old one-session limit. It does not reverse D1 migrations or revoke device sessions.
+
+## Required device validation — pending
+
+Use a current desktop B as host, desktop A as a client, and a mobile client from a compatible source.
+Record their versions, the Worker version, the D1 migration result, and the Signal image.
+
+1. Connect mobile to A, accept B's Member invitation on mobile, then open B on A.
+2. Repeat with A joining B before mobile opens B. Both clients must load B's agents and data.
+3. Stop A. Mobile must remain connected to B. Repeat with a disconnect of one device session.
+4. Reconnect A and verify that its agent list and data refresh. Switch servers during a pending load;
+   the old response must not replace the selected server's data.
+5. With an older host that omits `multiplex`, connect a second client. It must show a connection error
+   and Retry, while the first client remains connected. Retry must retain the error until success.
+6. During the approved Signal replacement, check that active data channels survive and that both
+   clients can resume signaling. Test a relay connection as well as a direct connection.
+
+Do not close issue #325 until these checks pass. PR #324 remains separate; its invitation UI changes
+are not included here. No automatic Signal deployment is added.

--- a/remote/README.md
+++ b/remote/README.md
@@ -75,6 +75,10 @@ into drain and waits for the allocations to finish. A single coturn instance is 
 failure. Forcing a coturn restart ends active relay sessions. The client performs an ICE restart and resumes
 a file transfer from the last acknowledged offset once the service is back.
 
-The first version supports one active logical client session per host. Reconnecting the same session replaces
-the old Signal socket. A second session gets a `host_busy` error and can retry once the first session has
-ended.
+Current hosts advertise `multiplex: true` and support independent device sessions at the same time.
+Reconnecting one session replaces only that session's Signal socket. Disconnecting or revoking one device
+must not end another device's session. Legacy hosts that omit `multiplex` keep the one-client limit:
+a second session receives `host_busy` without interrupting the first.
+
+See [the issue #325 deployment procedure](../docs/remote-session-deployment.md) for the production evidence,
+a Signal-only update, rollback commands, and the required desktop/mobile checks.

--- a/remote/api/test/signal-service.test.ts
+++ b/remote/api/test/signal-service.test.ts
@@ -195,59 +195,67 @@ describe("SignalService", () => {
     expect(service.metrics().activePeerConnections).toBe(1);
   });
 
-  it("keeps phones on the same account isolated across reconnect, revocation and host recovery", async () => {
-    const service = new SignalService(fakeTokens(), 8);
-    const host = socket("host");
-    await hello(service, host, "host-ticket", "host");
-    const first = socket("first-client");
-    await hello(service, first, "client-ticket", "client");
-    const second = socket("second-client");
-    await hello(service, second, "second-client-ticket", "client");
-    expect(first.closed).toBe(false);
-    expect(second.closed).toBe(false);
-    expect(service.metrics().activePeerConnections).toBe(2);
-    const secondId = JSON.parse(second.messages.at(-1) ?? "{}").connectionId;
-    expect(secondId).toEqual(expect.any(String));
-    await service.receive(
-      host,
-      JSON.stringify({ type: "offer", version: 1, channel: "team", connectionId: secondId, sdp: "second-only" }),
-    );
-    expect(second.messages.at(-1)).toContain("second-only");
-    expect(first.messages.some((message) => message.includes("second-only"))).toBe(false);
-    await service.receive(
-      first,
-      JSON.stringify({ type: "offer", version: 1, channel: "team", connectionId: secondId, sdp: "cross-device" }),
-    );
-    expect(first.messages.at(-1)).toContain('"code":"permission_denied"');
+  it.each([false, true])(
+    "keeps devices isolated across reconnect, revocation and host recovery (reverse order: %s)",
+    async (reverse) => {
+      const service = new SignalService(fakeTokens(), 8);
+      const host = socket("host");
+      await hello(service, host, "host-ticket", "host");
+      const first = socket("first-client");
+      const second = socket("second-client");
+      if (reverse) {
+        await hello(service, second, "second-client-ticket", "client");
+        await hello(service, first, "client-ticket", "client");
+      } else {
+        await hello(service, first, "client-ticket", "client");
+        await hello(service, second, "second-client-ticket", "client");
+      }
+      expect(first.closed).toBe(false);
+      expect(second.closed).toBe(false);
+      expect(service.metrics().activePeerConnections).toBe(2);
+      const secondId = JSON.parse(second.messages.at(-1) ?? "{}").connectionId;
+      expect(secondId).toEqual(expect.any(String));
+      await service.receive(
+        host,
+        JSON.stringify({ type: "offer", version: 1, channel: "team", connectionId: secondId, sdp: "second-only" }),
+      );
+      expect(second.messages.at(-1)).toContain("second-only");
+      expect(first.messages.some((message) => message.includes("second-only"))).toBe(false);
+      await service.receive(
+        first,
+        JSON.stringify({ type: "offer", version: 1, channel: "team", connectionId: secondId, sdp: "cross-device" }),
+      );
+      expect(first.messages.at(-1)).toContain('"code":"permission_denied"');
 
-    service.disconnect(first);
-    const resumed = socket("resumed-client");
-    await hello(service, resumed, "resume-client", "client");
-    expect(service.metrics().activePeerConnections).toBe(2);
-    expect(second.closed).toBe(false);
-    service.disconnect(host);
-    const recoveredHost = socket("recovered-host");
-    await hello(service, recoveredHost, "resume-host", "host");
-    expect(service.metrics().activePeerConnections).toBe(2);
-    expect(recoveredHost.messages.filter((message) => message.includes('"type":"peer-ready"'))).toHaveLength(2);
+      service.disconnect(first);
+      const resumed = socket("resumed-client");
+      await hello(service, resumed, "resume-client", "client");
+      expect(service.metrics().activePeerConnections).toBe(2);
+      expect(second.closed).toBe(false);
+      service.disconnect(host);
+      const recoveredHost = socket("recovered-host");
+      await hello(service, recoveredHost, "resume-host", "host");
+      expect(service.metrics().activePeerConnections).toBe(2);
+      expect(recoveredHost.messages.filter((message) => message.includes('"type":"peer-ready"'))).toHaveLength(2);
 
-    service.revokeSession("client-session");
-    expect(resumed.closed).toBe(true);
-    expect(second.closed).toBe(false);
-    expect(service.metrics().activePeerConnections).toBe(1);
-    const remainingId = JSON.parse(second.messages.at(-1) ?? "{}").connectionId;
-    await service.receive(
-      recoveredHost,
-      JSON.stringify({
-        type: "answer",
-        version: 1,
-        channel: "team",
-        connectionId: remainingId,
-        sdp: "still-connected",
-      }),
-    );
-    expect(second.messages.at(-1)).toContain("still-connected");
-  });
+      service.revokeSession("client-session");
+      expect(resumed.closed).toBe(true);
+      expect(second.closed).toBe(false);
+      expect(service.metrics().activePeerConnections).toBe(1);
+      const remainingId = JSON.parse(second.messages.at(-1) ?? "{}").connectionId;
+      await service.receive(
+        recoveredHost,
+        JSON.stringify({
+          type: "answer",
+          version: 1,
+          channel: "team",
+          connectionId: remainingId,
+          sdp: "still-connected",
+        }),
+      );
+      expect(second.messages.at(-1)).toContain("still-connected");
+    },
+  );
 
   it("does not send a second phone to an older desktop without multiplex support", async () => {
     const service = new SignalService(fakeTokens(), 8);

--- a/src/main/remote-server-connections.test.ts
+++ b/src/main/remote-server-connections.test.ts
@@ -15,6 +15,20 @@ function connections() {
 }
 
 describe("RemoteServerConnections", () => {
+  it("retains host-busy through disconnect and retry until connection succeeds", () => {
+    const { tracker } = connections();
+    tracker.reportTransportError("host", "host_busy", "The host already has an active remote session.");
+    for (const state of ["offline", "connecting"] as const) {
+      tracker.setState("host", state);
+      expect(tracker.statusFor("host")).toMatchObject({
+        state,
+        issue: { message: "The host already has an active remote session.", retryable: true },
+      });
+    }
+    tracker.markConnected("host");
+    expect(tracker.statusFor("host")).toMatchObject({ state: "online", issue: null, connectionSequence: 1 });
+  });
+
   it("announces a failure once, however many requests it refuses", () => {
     const { tracker, changes, suspended } = connections();
 

--- a/src/renderer/src/App.read-state.test.tsx
+++ b/src/renderer/src/App.read-state.test.tsx
@@ -100,7 +100,7 @@ describe("OpenBot connected desktop shell", () => {
     },
   );
 
-  it.each(["success", "failure", "late response"])(
+  it.each(["success", "failure", "late response", "received message", "visible message", "sent message"])(
     "refreshes the open direct conversation on reconnect (%s)",
     async (outcome) => {
       const remote = { ...testServer("remote-1", true), connectionSequence: 1 };
@@ -135,9 +135,17 @@ describe("OpenBot connected desktop shell", () => {
         page("Cached direct message", 1),
       );
       let loadedMessage: () => string | undefined = () => undefined;
+      let readState: () => DirectConversationSnapshot["readState"] = () => undefined;
+      let send = async (): Promise<void> => {
+        throw new Error("The provider is not ready.");
+      };
       function Probe() {
         const direct = useDirectMessages();
         loadedMessage = () => direct.directConversations().alice?.messages[0]?.text;
+        readState = () => direct.directConversations().alice?.readState;
+        send = async () => {
+          await direct.sendDirectMessage("Sent during refresh", "sent-3");
+        };
         return null;
       }
       render(() => (
@@ -165,11 +173,50 @@ describe("OpenBot connected desktop shell", () => {
         emitServers?.([{ ...remote, connectionSequence: 3 }]);
         await screen.findByText("Missed direct message");
       }
+      const incoming = outcome === "received message" || outcome === "visible message";
+      if (incoming) {
+        if (outcome === "received message") window.dispatchEvent(new Event("blur"));
+        emitDirectMessage?.({
+          type: "team-direct-message",
+          memberIds: ["self", "alice"],
+          message: {
+            id: "live-3",
+            threadId: "direct-1",
+            senderMemberId: "alice",
+            recipientMemberId: "self",
+            text: "Received during refresh",
+            sequence: 3,
+            createdAt: "2026-09-08T00:00:00Z",
+          },
+        });
+        await screen.findByText("Received during refresh");
+      }
+      if (outcome === "sent message") {
+        vi.mocked(window.openbot.servers.sendDirectMessage).mockResolvedValueOnce({
+          id: "sent-3",
+          threadId: "direct-1",
+          senderMemberId: "self",
+          recipientMemberId: "alice",
+          text: "Sent during refresh",
+          sequence: 3,
+          createdAt: "2026-09-08T00:00:00Z",
+        });
+        await send();
+      }
+      if (outcome === "visible message" || outcome === "sent message") {
+        await waitFor(() => expect(readState()?.throughSequence).toBe(3));
+      }
       if (outcome === "failure") rejectPage?.(new Error("The host is offline."));
       else resolvePage?.(page(outcome === "late response" ? "Stale direct message" : "Missed direct message", 2));
       await pendingPage.catch(() => undefined);
       flush();
       expect(loadedMessage()).toBe(outcome === "failure" ? "Cached direct message" : "Missed direct message");
+      if (incoming) {
+        expect(await screen.findByText("Received during refresh")).toBeInTheDocument();
+        expect(readState()?.unreadCount).toBe(outcome === "received message" ? 1 : 0);
+      }
+      if (outcome === "sent message") expect(await screen.findByText("Sent during refresh")).toBeInTheDocument();
+      if (outcome === "visible message" || outcome === "sent message") expect(readState()?.throughSequence).toBe(3);
       expect(
         await screen.findByText(outcome === "failure" ? "Cached direct message" : "Missed direct message"),
       ).toBeInTheDocument();

--- a/src/renderer/src/App.read-state.test.tsx
+++ b/src/renderer/src/App.read-state.test.tsx
@@ -1,6 +1,7 @@
 import type {
   ConversationPage,
   ConversationReadState,
+  DirectConversationPage,
   DirectConversationSnapshot,
   DirectThreadSummary,
 } from "@openbot/contracts/ipc";
@@ -8,12 +9,14 @@ import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-lib
 import { flush } from "solid-js";
 import { expect, it, vi } from "vitest";
 import { App } from "./App";
+import { AppAccessGate } from "./AppView";
 import { AppProviders } from "./app-providers";
 import {
   emitAgentEvent,
   emitDirectMessage,
   emitDynamicIslandAction,
   emitPresence,
+  emitServers,
   installOpenbotStub,
   presenceMember,
   testConversationPage,
@@ -94,6 +97,82 @@ describe("OpenBot connected desktop shell", () => {
       await pending;
       flush();
       expect(screen.getByLabelText("Direct unread")).toHaveTextContent("2");
+    },
+  );
+
+  it.each(["success", "failure", "late response"])(
+    "refreshes the open direct conversation on reconnect (%s)",
+    async (outcome) => {
+      const remote = { ...testServer("remote-1", true), connectionSequence: 1 };
+      vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([remote]);
+      vi.mocked(window.openbot.servers.getPresence).mockResolvedValue({
+        serverId: remote.id,
+        updatedAt: "2026-09-08T00:00:00Z",
+        members: [
+          presenceMember("self", "person@example.com", "Person"),
+          presenceMember("alice", "alice@example.com", "Alice"),
+        ],
+      });
+      const page = (text: string, revision: number): DirectConversationPage => ({
+        threadId: "direct-1",
+        otherMemberId: "alice",
+        revision,
+        messages: [
+          {
+            id: `message-${revision}`,
+            threadId: "direct-1",
+            senderMemberId: "alice",
+            recipientMemberId: "self",
+            text,
+            sequence: revision,
+            createdAt: "2026-09-08T00:00:00Z",
+          },
+        ],
+        readState: { unreadCount: 0, firstUnreadMessageId: null, throughSequence: revision },
+        pageInfo: { hasOlder: false, olderCursor: null },
+      });
+      vi.mocked(window.openbot.servers.readDirectConversationPage).mockResolvedValueOnce(
+        page("Cached direct message", 1),
+      );
+      let loadedMessage: () => string | undefined = () => undefined;
+      function Probe() {
+        const direct = useDirectMessages();
+        loadedMessage = () => direct.directConversations().alice?.messages[0]?.text;
+        return null;
+      }
+      render(() => (
+        <AppProviders peopleEnabled>
+          <AppAccessGate />
+          <Probe />
+        </AppProviders>
+      ));
+      await fireEvent.click(await screen.findByRole("button", { name: /Alice/ }));
+      await screen.findByText("Cached direct message");
+      let resolvePage: ((value: DirectConversationPage) => void) | undefined;
+      let rejectPage: ((error: Error) => void) | undefined;
+      const pendingPage = new Promise<DirectConversationPage>((resolve, reject) => {
+        resolvePage = resolve;
+        rejectPage = reject;
+      });
+      vi.mocked(window.openbot.servers.readDirectConversationPage).mockReturnValueOnce(pendingPage);
+      emitServers?.([{ ...remote, connectionSequence: 2 }]);
+      await waitFor(() => expect(window.openbot.servers.readDirectConversationPage).toHaveBeenCalledTimes(2));
+      expect(screen.getByText("Cached direct message")).toBeInTheDocument();
+      if (outcome === "late response") {
+        vi.mocked(window.openbot.servers.readDirectConversationPage).mockResolvedValueOnce(
+          page("Missed direct message", 3),
+        );
+        emitServers?.([{ ...remote, connectionSequence: 3 }]);
+        await screen.findByText("Missed direct message");
+      }
+      if (outcome === "failure") rejectPage?.(new Error("The host is offline."));
+      else resolvePage?.(page(outcome === "late response" ? "Stale direct message" : "Missed direct message", 2));
+      await pendingPage.catch(() => undefined);
+      flush();
+      expect(loadedMessage()).toBe(outcome === "failure" ? "Cached direct message" : "Missed direct message");
+      expect(
+        await screen.findByText(outcome === "failure" ? "Cached direct message" : "Missed direct message"),
+      ).toBeInTheDocument();
     },
   );
 

--- a/src/renderer/src/App.read-state.test.tsx
+++ b/src/renderer/src/App.read-state.test.tsx
@@ -1,4 +1,9 @@
-import type { ConversationPage, ConversationReadState, DirectConversationSnapshot } from "@openbot/contracts/ipc";
+import type {
+  ConversationPage,
+  ConversationReadState,
+  DirectConversationSnapshot,
+  DirectThreadSummary,
+} from "@openbot/contracts/ipc";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { flush } from "solid-js";
 import { expect, it, vi } from "vitest";
@@ -15,12 +20,82 @@ import {
   testServer,
 } from "./app-test-harness";
 import { useConversation } from "./features/conversation/conversation-context";
+import { useDirectMessages } from "./features/conversation/direct-messages-context";
 import { useServerScope } from "./features/servers/server-scope";
 
 describe("OpenBot connected desktop shell", () => {
   beforeEach(() => {
     installOpenbotStub();
   });
+
+  it.each(["older response", "older failure", "latest failure"])(
+    "retains current direct-thread unread state after an %s",
+    async (outcome) => {
+      let refresh = async (): Promise<void> => {
+        throw new Error("The provider is not ready.");
+      };
+      function Probe() {
+        const direct = useDirectMessages();
+        const scope = useServerScope();
+        refresh = direct.refreshDirectThreads;
+        return (
+          <output aria-label="Direct unread">
+            {scope.loaded() ? (direct.directThreads()[0]?.unreadCount ?? 0) : "Loading"}
+          </output>
+        );
+      }
+      render(() => (
+        <AppProviders>
+          <Probe />
+        </AppProviders>
+      ));
+      await waitFor(() => expect(screen.getByLabelText("Direct unread")).toHaveTextContent("0"));
+      emitPresence?.({
+        serverId: "local",
+        updatedAt: "2026-09-08T00:00:00Z",
+        members: [presenceMember("self", "person@example.com", "Person")],
+      });
+      const threads: DirectThreadSummary[] = [
+        {
+          threadId: "direct-1",
+          otherMemberId: "alice",
+          unreadCount: 2,
+          updatedAt: "2026-09-08T00:00:00Z",
+          lastMessage: {
+            id: "message-1",
+            threadId: "direct-1",
+            senderMemberId: "alice",
+            recipientMemberId: "self",
+            text: "Hello",
+            sequence: 2,
+            createdAt: "2026-09-08T00:00:00Z",
+          },
+        },
+      ];
+      vi.mocked(window.openbot.servers.listDirectThreads).mockResolvedValueOnce(threads);
+      await refresh();
+      flush();
+      expect(screen.getByLabelText("Direct unread")).toHaveTextContent("2");
+      let resolvePending: ((value: DirectThreadSummary[]) => void) | undefined;
+      let rejectPending: ((error: Error) => void) | undefined;
+      vi.mocked(window.openbot.servers.listDirectThreads).mockReturnValueOnce(
+        new Promise((resolve, reject) => {
+          resolvePending = resolve;
+          rejectPending = reject;
+        }),
+      );
+      const pending = refresh();
+      if (outcome !== "latest failure") {
+        vi.mocked(window.openbot.servers.listDirectThreads).mockResolvedValueOnce(threads);
+        await refresh();
+      }
+      if (outcome === "older response") resolvePending?.([]);
+      else rejectPending?.(new Error("The host is offline."));
+      await pending;
+      flush();
+      expect(screen.getByLabelText("Direct unread")).toHaveTextContent("2");
+    },
+  );
 
   it("clears desktop unread state when the same member reads on another device", async () => {
     vi.mocked(window.openbot.agent.readConversationPage).mockResolvedValue(

--- a/src/renderer/src/App.servers.test.tsx
+++ b/src/renderer/src/App.servers.test.tsx
@@ -1,5 +1,6 @@
 import type { AgentEvent, ConversationMessage, ServerSummary } from "@openbot/contracts/ipc";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import { flush } from "solid-js";
 import { expect, it, vi } from "vitest";
 import { App } from "./App";
 import {
@@ -93,6 +94,83 @@ describe("OpenBot connected desktop shell", () => {
     expect(window.openbot.agent.listAgents).not.toHaveBeenCalled();
     await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     await waitFor(() => expect(window.openbot.servers.retryConnection).toHaveBeenCalledWith("remote-1"));
+  });
+
+  it("keeps a busy-host error visible during retry and loads agents after recovery", async () => {
+    const local = testServer("local", false);
+    const busy: ServerSummary = {
+      ...testServer("remote-1", true),
+      state: "offline",
+      issue: {
+        code: "network_unavailable",
+        message: "The host already has an active remote session.",
+        retryable: true,
+      },
+    };
+    vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([local, busy]);
+    render(() => <App />);
+    expect(await screen.findByRole("alert")).toHaveTextContent(busy.issue?.message ?? "");
+    expect(window.openbot.agent.listAgents).not.toHaveBeenCalled();
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(window.openbot.servers.retryConnection).toHaveBeenCalledWith(busy.id));
+    emitServers?.([local, { ...busy, state: "connecting" }]);
+    expect(screen.getByRole("alert")).toHaveTextContent("The host already has an active remote session.");
+    emitServers?.([local, { ...busy, state: "online", issue: null, connectionSequence: 1 }]);
+    expect(await screen.findByRole("heading", { name: "Chief" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Cannot connect to Studio Mac" })).not.toBeInTheDocument();
+  });
+
+  it.each(["sequence", "online"])("refreshes after %s changes without clearing cached agents", async (change) => {
+    const local = testServer("local", false);
+    const remote: ServerSummary = { ...testServer("remote-1", true), connectionSequence: 1 };
+    vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([local, remote]);
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    let resolveAgents: ((agents: typeof AGENTS) => void) | undefined;
+    vi.mocked(window.openbot.agent.listAgents).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveAgents = resolve;
+      }),
+    );
+    if (change === "online") emitServers?.([local, { ...remote, state: "offline" }]);
+    emitServers?.([local, { ...remote, connectionSequence: change === "sequence" ? 2 : 1 }]);
+    await waitFor(() => expect(window.openbot.agent.listAgents).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole("heading", { name: "Chief" })).toBeInTheDocument();
+    resolveAgents?.([{ ...AGENTS[0], name: "Recovered Chief" }]);
+    expect(await screen.findByRole("heading", { name: "Recovered Chief" })).toBeInTheDocument();
+  });
+
+  it("keeps cached agents after a failed refresh and ignores an older reconnect response", async () => {
+    const local = testServer("local", false);
+    const remote: ServerSummary = { ...testServer("remote-1", true), connectionSequence: 1 };
+    vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([local, remote]);
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    let rejectAgents: ((error: Error) => void) | undefined;
+    vi.mocked(window.openbot.agent.listAgents).mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectAgents = reject;
+      }),
+    );
+    emitServers?.([local, { ...remote, connectionSequence: 2 }]);
+    await waitFor(() => expect(window.openbot.agent.listAgents).toHaveBeenCalledTimes(2));
+    rejectAgents?.(new Error("The host is not reachable."));
+    // A later successful load is the barrier after the failed refresh.
+    let resolveOld: ((agents: typeof AGENTS) => void) | undefined;
+    const oldAgents = new Promise<typeof AGENTS>((resolve) => {
+      resolveOld = resolve;
+    });
+    vi.mocked(window.openbot.agent.listAgents).mockReturnValueOnce(oldAgents);
+    emitServers?.([local, { ...remote, connectionSequence: 3 }]);
+    await waitFor(() => expect(window.openbot.agent.listAgents).toHaveBeenCalledTimes(3));
+    expect(screen.getByRole("heading", { name: "Chief" })).toBeInTheDocument();
+    vi.mocked(window.openbot.agent.listAgents).mockResolvedValueOnce([{ ...AGENTS[0], name: "Current Chief" }]);
+    emitServers?.([local, { ...remote, connectionSequence: 4 }]);
+    await screen.findByRole("heading", { name: "Current Chief" });
+    resolveOld?.([]);
+    await oldAgents;
+    flush();
+    expect(screen.getByRole("heading", { name: "Current Chief" })).toBeInTheDocument();
   });
 
   it("keeps a newer online event when retry returns an older summary", async () => {
@@ -205,7 +283,7 @@ describe("OpenBot connected desktop shell", () => {
     emitServers?.([local, negotiated]);
     await waitFor(() => expect(window.openbot.agent.getSidebarLayout).toHaveBeenCalled());
     expect(window.openbot.browser.listTabs).toHaveBeenCalled();
-    // The server was already active, so the workspace reloads by remounting on
+    // The server was already active, so the workspace reloads on
     // the completed handshake. Nothing asks main to select it a second time.
     expect(window.openbot.servers.select).not.toHaveBeenCalled();
   });

--- a/src/renderer/src/App.servers.test.tsx
+++ b/src/renderer/src/App.servers.test.tsx
@@ -66,6 +66,25 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.getByRole("button", { name: "Studio Mac server" })).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("finishes the pending workspace load when the active server is selected again", async () => {
+    const local = testServer("local", false);
+    const remote = testServer("remote-1", true);
+    vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([local, remote]);
+    vi.mocked(window.openbot.servers.select).mockResolvedValueOnce([local, remote]);
+    let resolveAgents: ((agents: typeof AGENTS) => void) | undefined;
+    vi.mocked(window.openbot.agent.listAgents).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveAgents = resolve;
+      }),
+    );
+    render(() => <App />);
+    await waitFor(() => expect(window.openbot.agent.listAgents).toHaveBeenCalledOnce());
+    await fireEvent.click(screen.getByRole("button", { name: "Studio Mac server" }));
+    await waitFor(() => expect(window.openbot.servers.select).toHaveBeenCalledWith(remote.id));
+    resolveAgents?.(AGENTS);
+    expect(await screen.findByRole("heading", { name: "Chief" })).toBeInTheDocument();
+  });
+
   it("blocks an incompatible remote workspace and offers a manual retry", async () => {
     vi.mocked(window.openbot.servers.list).mockResolvedValueOnce([
       { ...testServer("local", false) },

--- a/src/renderer/src/WorkspaceShell.tsx
+++ b/src/renderer/src/WorkspaceShell.tsx
@@ -45,7 +45,7 @@ export function WorkspaceShell(props: { account: () => CentralAuthUser }) {
   const blockedRemoteServer = createMemo(() => {
     const server = activeServer();
     if (server?.kind !== "remote") return null;
-    return server.state === "incompatible" || server.issue?.code === "protocol_error" ? server : null;
+    return server.state === "incompatible" || server.issue != null ? server : null;
   });
   const activePeopleEnabled = createMemo(
     () => platform.peopleEnabled && activeServerSupportsCapability("direct-messages"),

--- a/src/renderer/src/app-providers.tsx
+++ b/src/renderer/src/app-providers.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "@solidjs/web";
-import { createMemo, type ParentProps, Show } from "solid-js";
+import { type ParentProps, Show } from "solid-js";
 import { AnsweredPromptsProvider } from "./answered-prompts";
 import { AppBootstrap } from "./app-bootstrap";
 import { AuthProvider } from "./features/account/account-context";
@@ -113,28 +113,11 @@ export function AppProviders(props: ParentProps<AppProps>): JSX.Element {
   );
 }
 
-/**
- * The keyed boundary. Its `when` is the active server id, so changing servers
- * disposes every provider below and mounts a fresh set - the unmount *is* the
- * per-server teardown, and the mount *is* the per-server load.
- *
- * The nonce is the second half of the key, and it is what let the
- * `serverLoadRequest` effect in `server-selection.tsx` go away. `servers.tsx`
- * publishes that request for a server that is already active but has not been
- * loaded - a remote that just negotiated a protocol, or one whose compatibility
- * retry succeeded - which the id alone cannot express, because the id did not
- * change. Folding the nonce into the key turns "please load this server" into
- * "please mount this server again", and there is only one mechanism left.
- */
+/** Server switches dispose scoped state; reconnects reload it without clearing cached data. */
 function ServerScopeBoundary(props: ParentProps<ScopedConversationProps>): JSX.Element {
-  const { activeServerId, serverLoadRequest } = useServers();
-  const scopeKey = createMemo(() => {
-    const serverId = activeServerId();
-    const request = serverLoadRequest();
-    return request?.serverId === serverId ? `${serverId}\u0000${request.nonce}` : serverId;
-  });
+  const { activeServerId } = useServers();
   return (
-    <Show keyed when={scopeKey()}>
+    <Show keyed when={activeServerId()}>
       <ScopedProviders stableConversation={props.stableConversation}>{props.children}</ScopedProviders>
     </Show>
   );

--- a/src/renderer/src/features/conversation/direct-messages-context.tsx
+++ b/src/renderer/src/features/conversation/direct-messages-context.tsx
@@ -121,7 +121,18 @@ const DirectMessages = createSimpleContext({
           .catch(() => undefined);
       }
       setActiveDirectMemberId(memberId);
-      setDirectConversationLoading(true);
+      await loadDirectConversation(memberId, false);
+    }
+
+    async function refreshDirectConversation(): Promise<void> {
+      const memberId = activeDirectMemberId();
+      if (!memberId || !scopeIsCurrent() || !activeServerSupportsCapability("direct-messages")) return;
+      await loadDirectConversation(memberId, true);
+    }
+
+    async function loadDirectConversation(memberId: string, retainCached: boolean): Promise<void> {
+      const hasCached = retainCached && Boolean(directConversations()[memberId]);
+      setDirectConversationLoading(!hasCached);
       setDirectConversationError(null);
       const request = ++directConversationRequest;
       try {
@@ -130,7 +141,7 @@ const DirectMessages = createSimpleContext({
           anchor: { type: "latest" },
           limit: 50,
         });
-        if (request !== directConversationRequest) return;
+        if (!scopeIsCurrent() || request !== directConversationRequest) return;
         setDirectConversations((current) => ({
           ...current,
           [memberId]: snapshot,
@@ -140,10 +151,11 @@ const DirectMessages = createSimpleContext({
           void markDirectMessagesRead(memberId, snapshot.messages.at(-1)?.sequence).catch(() => undefined);
         }
       } catch (error) {
-        if (request !== directConversationRequest) return;
-        setDirectConversationError(error instanceof Error ? error.message : "The messages could not load.");
+        if (!scopeIsCurrent() || request !== directConversationRequest) return;
+        if (!hasCached)
+          setDirectConversationError(error instanceof Error ? error.message : "The messages could not load.");
       } finally {
-        if (request === directConversationRequest) setDirectConversationLoading(false);
+        if (scopeIsCurrent() && request === directConversationRequest) setDirectConversationLoading(false);
       }
     }
 
@@ -455,6 +467,7 @@ const DirectMessages = createSimpleContext({
       directOlderErrors,
       directTypingMemberIds,
       refreshDirectThreads,
+      refreshDirectConversation,
       openDirectConversation,
       loadOlderDirectMessages,
       openDirectMessage,

--- a/src/renderer/src/features/conversation/direct-messages-context.tsx
+++ b/src/renderer/src/features/conversation/direct-messages-context.tsx
@@ -73,20 +73,25 @@ const DirectMessages = createSimpleContext({
     const [directTypingMemberIds, setDirectTypingMemberIds] = createSignal<Set<string>>(new Set());
     const directConversationReadOperations = new Map<string, Promise<void>>();
     let directConversationRequest = 0;
+    let directThreadsRequest = 0;
 
     const activeDirectMember = createMemo(() =>
       peopleEnabled ? directPeople().find((member) => member.id === activeDirectMemberId()) : undefined,
     );
 
     async function refreshDirectThreads(): Promise<void> {
+      const request = ++directThreadsRequest;
+      if (!scopeIsCurrent()) return;
       if (!currentTeamMember() || !activeServerSupportsCapability("direct-messages")) {
         setDirectThreads([]);
         return;
       }
       try {
-        setDirectThreads(await window.openbot.servers.listDirectThreads());
+        const threads = await window.openbot.servers.listDirectThreads();
+        if (!scopeIsCurrent() || request !== directThreadsRequest) return;
+        setDirectThreads(threads);
       } catch {
-        setDirectThreads([]);
+        // A failed refresh does not mean the server has no conversations.
       }
     }
 
@@ -419,13 +424,8 @@ const DirectMessages = createSimpleContext({
 
     createEffect(
       () => currentTeamMember()?.id ?? null,
-      (memberId) => {
-        if (!peopleEnabled) return;
-        if (!memberId) {
-          setDirectThreads([]);
-          return;
-        }
-        void refreshDirectThreads();
+      () => {
+        if (peopleEnabled) void refreshDirectThreads();
       },
     );
 

--- a/src/renderer/src/features/conversation/direct-messages-context.tsx
+++ b/src/renderer/src/features/conversation/direct-messages-context.tsx
@@ -15,6 +15,37 @@ import { useServers } from "../servers/servers-context";
 import { usePresence } from "../team/team-context";
 import { preserveKnownDirectUnread } from "./conversation-read-state";
 
+/** Keep live messages and completed reads that arrived after the recovery page was read. */
+function recoveredDirectConversation(
+  page: DirectConversationPage,
+  cached: DirectConversationSnapshot | undefined,
+  currentMemberId: string | undefined,
+): DirectConversationPage {
+  if (!cached || cached.threadId !== page.threadId) return page;
+  const newer = cached.messages.filter((message) => message.sequence > page.revision);
+  const messages = [...page.messages, ...newer];
+  let readState = page.readState;
+  if (cached.readState && (!readState || cached.readState.throughSequence > readState.throughSequence)) {
+    readState = preserveKnownDirectUnread(
+      cached.readState,
+      cached.readState.throughSequence,
+      messages,
+      currentMemberId,
+    );
+  } else if (readState) {
+    const throughSequence = readState.throughSequence;
+    const unread = newer.filter(
+      (message) => message.senderMemberId !== currentMemberId && message.sequence > throughSequence,
+    );
+    readState = {
+      ...readState,
+      unreadCount: readState.unreadCount + unread.length,
+      firstUnreadMessageId: readState.firstUnreadMessageId ?? unread[0]?.id ?? null,
+    };
+  }
+  return { ...page, messages, revision: Math.max(page.revision, cached.revision), readState };
+}
+
 /**
  * Person-to-person conversations on the active team server: the thread list, the
  * page of messages open for each member, and who is typing.
@@ -136,12 +167,15 @@ const DirectMessages = createSimpleContext({
       setDirectConversationError(null);
       const request = ++directConversationRequest;
       try {
-        const snapshot = await window.openbot.servers.readDirectConversationPage({
+        const page = await window.openbot.servers.readDirectConversationPage({
           memberId,
           anchor: { type: "latest" },
           limit: 50,
         });
         if (!scopeIsCurrent() || request !== directConversationRequest) return;
+        const snapshot = retainCached
+          ? recoveredDirectConversation(page, directConversations()[memberId], currentTeamMember()?.id)
+          : page;
         setDirectConversations((current) => ({
           ...current,
           [memberId]: snapshot,

--- a/src/renderer/src/features/remote-desktop/RemoteCompatibilityScreen.tsx
+++ b/src/renderer/src/features/remote-desktop/RemoteCompatibilityScreen.tsx
@@ -1,5 +1,5 @@
 import type { ServerSummary } from "@openbot/contracts/ipc";
-import { For } from "solid-js";
+import { For, Show } from "solid-js";
 import { Alert, AlertContent, AlertDescription, Button } from "../../components/ui";
 
 /**
@@ -13,7 +13,8 @@ export function RemoteCompatibilityScreen(props: { server: ServerSummary; onRetr
   const title = () => {
     if (props.server.issue?.code === "client_update_required") return "Update this OpenBot app";
     if (props.server.issue?.code === "host_update_required") return `Update OpenBot on ${props.server.name}`;
-    return "The host returned unsafe data";
+    if (props.server.issue?.code === "protocol_error") return "The host returned unsafe data";
+    return `Cannot connect to ${props.server.name}`;
   };
   const description = () => {
     if (props.server.issue?.code === "client_update_required") {
@@ -21,6 +22,9 @@ export function RemoteCompatibilityScreen(props: { server: ServerSummary; onRetr
     }
     if (props.server.issue?.code === "host_update_required") {
       return "The host supports only older protocols than this app. Update the host, then try again.";
+    }
+    if (props.server.issue?.code !== "protocol_error") {
+      return props.server.issue?.message ?? "The host is not reachable.";
     }
     return "OpenBot stopped this connection because a known payload was invalid. Your current workspace data was not changed.";
   };
@@ -41,16 +45,18 @@ export function RemoteCompatibilityScreen(props: { server: ServerSummary; onRetr
           <AlertDescription>{description()}</AlertDescription>
         </AlertContent>
       </Alert>
-      <dl class="remote-compatibility-details">
-        <For each={details()}>
-          {([label, value]) => (
-            <div>
-              <dt>{label}</dt>
-              <dd>{value}</dd>
-            </div>
-          )}
-        </For>
-      </dl>
+      <Show when={props.server.state === "incompatible" || props.server.issue?.code === "protocol_error"}>
+        <dl class="remote-compatibility-details">
+          <For each={details()}>
+            {([label, value]) => (
+              <div>
+                <dt>{label}</dt>
+                <dd>{value}</dd>
+              </div>
+            )}
+          </For>
+        </dl>
+      </Show>
       <Button onClick={() => void props.onRetry()}>Retry</Button>
     </main>
   );

--- a/src/renderer/src/features/servers/server-scope.tsx
+++ b/src/renderer/src/features/servers/server-scope.tsx
@@ -43,7 +43,7 @@ const ServerScope = createSimpleContext({
   init: () => {
     const { centralAuth } = useAuth();
     const { setupState } = useSetup();
-    const { servers, activeServerId, initialServersReady, serverLoadRequest, currentServerSelection } = useServers();
+    const { servers, activeServerId, initialServersReady, serverLoadRequest } = useServers();
     const { pendingAgentSelection, setPendingAgentSelection } = useServerSwitch();
     const { setTeamPresence } = usePresence();
     const { activeDirectMemberId, directConversations, refreshDirectThreads, markDirectMessagesRead } =
@@ -69,8 +69,7 @@ const ServerScope = createSimpleContext({
     let loadGeneration = 0;
     function loadWorkspace(): void {
       const generation = ++loadGeneration;
-      const selectionIsCurrent = currentServerSelection();
-      const isCurrent = () => scopeIsCurrent() && selectionIsCurrent() && generation === loadGeneration;
+      const isCurrent = () => scopeIsCurrent() && generation === loadGeneration;
       if (!isCurrent()) return;
       const serverId = activeServerId();
       const server = servers().find((candidate) => candidate.id === serverId);

--- a/src/renderer/src/features/servers/server-scope.tsx
+++ b/src/renderer/src/features/servers/server-scope.tsx
@@ -46,8 +46,13 @@ const ServerScope = createSimpleContext({
     const { servers, activeServerId, initialServersReady, serverLoadRequest } = useServers();
     const { pendingAgentSelection, setPendingAgentSelection } = useServerSwitch();
     const { setTeamPresence } = usePresence();
-    const { activeDirectMemberId, directConversations, refreshDirectThreads, markDirectMessagesRead } =
-      useDirectMessages();
+    const {
+      activeDirectMemberId,
+      directConversations,
+      refreshDirectThreads,
+      refreshDirectConversation,
+      markDirectMessagesRead,
+    } = useDirectMessages();
     const { setModelOptions, activeAgent, setAgentStatus, applyStoredAgents } = useAgents();
     const {
       setBrowserControlState,
@@ -134,6 +139,7 @@ const ServerScope = createSimpleContext({
         })
         .catch(() => undefined);
       void refreshDirectThreads();
+      void refreshDirectConversation();
     }
 
     onSettled(() => {

--- a/src/renderer/src/features/servers/server-scope.tsx
+++ b/src/renderer/src/features/servers/server-scope.tsx
@@ -43,7 +43,7 @@ const ServerScope = createSimpleContext({
   init: () => {
     const { centralAuth } = useAuth();
     const { setupState } = useSetup();
-    const { servers, activeServerId, initialServersReady } = useServers();
+    const { servers, activeServerId, initialServersReady, serverLoadRequest, currentServerSelection } = useServers();
     const { pendingAgentSelection, setPendingAgentSelection } = useServerSwitch();
     const { setTeamPresence } = usePresence();
     const { activeDirectMemberId, directConversations, refreshDirectThreads, markDirectMessagesRead } =
@@ -65,6 +65,77 @@ const ServerScope = createSimpleContext({
     const owner = getOwner();
     /** This scope still owns the screen - the successor to `activeServerId() !== serverId`. */
     const scopeIsCurrent = (): boolean => !(owner && isDisposed(owner));
+
+    let loadGeneration = 0;
+    function loadWorkspace(): void {
+      const generation = ++loadGeneration;
+      const selectionIsCurrent = currentServerSelection();
+      const isCurrent = () => scopeIsCurrent() && selectionIsCurrent() && generation === loadGeneration;
+      if (!isCurrent()) return;
+      const serverId = activeServerId();
+      const server = servers().find((candidate) => candidate.id === serverId);
+      if (server?.kind === "remote" && (server.state === "incompatible" || server.issue != null)) {
+        return;
+      }
+      void Promise.all([
+        window.openbot.agent
+          .getStatus()
+          .then((value) => {
+            if (isCurrent()) setAgentStatus(value);
+          })
+          .catch(() => undefined),
+        window.openbot.agent
+          .listModels()
+          .then((value) => {
+            if (isCurrent()) setModelOptions(value);
+          })
+          .catch(() => undefined),
+        window.openbot.agent
+          .listAgents()
+          .then((storedAgents) => {
+            if (!isCurrent()) return;
+            applyStoredAgents(storedAgents);
+            reconcileActiveServerPins(storedAgents.map((agent) => agent.id));
+          })
+          .catch((error) => {
+            if (!isCurrent()) return;
+            setAgentStatus((current) => ({ ...current, message: String(error) }));
+          }),
+        loadSidebarLayout(server)
+          .then((value) => {
+            if (isCurrent()) setSidebarLayout(value);
+          })
+          .catch(() => undefined),
+        window.openbot.agent
+          .listConversationReads()
+          .then((value) => {
+            if (isCurrent()) applyConversationReads(value);
+          })
+          .catch(() => undefined),
+      ]).finally(() => {
+        if (isCurrent()) setLoaded(true);
+      });
+      if (supportsBrowser(server)) {
+        const applyDisplayState = beginBrowserLoad();
+        void loadBrowserDisplayState(server)
+          .then((value) => {
+            if (isCurrent()) applyDisplayState(value);
+          })
+          .catch(() => undefined);
+        void loadBrowserControlState(server)
+          .then((value) => {
+            if (isCurrent()) setBrowserControlState(value);
+          })
+          .catch(() => undefined);
+      }
+      void window.openbot.servers
+        .getPresence()
+        .then((value) => {
+          if (isCurrent()) setTeamPresence(value);
+        })
+        .catch(() => undefined);
+      void refreshDirectThreads();
+    }
 
     onSettled(() => {
       const handleGlobalSearchShortcut = (event: KeyboardEvent) => {
@@ -100,62 +171,20 @@ const ServerScope = createSimpleContext({
       };
       window.addEventListener("focus", handleWindowFocus);
 
-      void initialServersReady.then(() => {
-        if (!scopeIsCurrent()) return;
-        const serverId = activeServerId();
-        const server = servers().find((candidate) => candidate.id === serverId);
-        if (server?.kind === "remote" && (server.state === "incompatible" || server.issue?.code === "protocol_error")) {
-          return;
-        }
-        void Promise.all([
-          window.openbot.agent
-            .getStatus()
-            .then(setAgentStatus)
-            .catch(() => undefined),
-          window.openbot.agent
-            .listModels()
-            .then(setModelOptions)
-            .catch(() => undefined),
-          window.openbot.agent
-            .listAgents()
-            .then((storedAgents) => {
-              applyStoredAgents(storedAgents);
-              reconcileActiveServerPins(storedAgents.map((agent) => agent.id));
-            })
-            .catch((error) => {
-              setAgentStatus((current) => ({ ...current, message: String(error) }));
-            }),
-          loadSidebarLayout(server)
-            .then(setSidebarLayout)
-            .catch(() => undefined),
-          window.openbot.agent
-            .listConversationReads()
-            .then(applyConversationReads)
-            .catch(() => undefined),
-        ]).finally(() => {
-          if (scopeIsCurrent()) setLoaded(true);
-        });
-        if (supportsBrowser(server)) {
-          const applyDisplayState = beginBrowserLoad();
-          void loadBrowserDisplayState(server)
-            .then(applyDisplayState)
-            .catch(() => undefined);
-          void loadBrowserControlState(server)
-            .then(setBrowserControlState)
-            .catch(() => undefined);
-        }
-        void window.openbot.servers
-          .getPresence()
-          .then(setTeamPresence)
-          .catch(() => undefined);
-        void refreshDirectThreads();
-      });
+      void initialServersReady.then(loadWorkspace);
 
       return () => {
         window.removeEventListener("keydown", handleGlobalSearchShortcut);
         window.removeEventListener("focus", handleWindowFocus);
       };
     });
+
+    createEffect(
+      () => serverLoadRequest(),
+      (request) => {
+        if (request?.serverId === activeServerId()) loadWorkspace();
+      },
+    );
 
     // "Select this agent once you are on its server" - written before the switch
     // by the marketplace and the Dynamic Island, consumed by whichever scope the

--- a/src/renderer/src/features/servers/servers-context.tsx
+++ b/src/renderer/src/features/servers/servers-context.tsx
@@ -22,8 +22,8 @@ import { serverSupportsCapability } from "./server-capabilities";
  * - **`serverLoadRequest` is how this domain asks for that anyway.** A retried
  *   incompatible host, or a remote that only just reported its version, has to
  *   be loaded again the moment the summaries say so. Rather than call downward,
- *   `applyServerSummaries` publishes the request and whoever owns `selectServer`
- *   reacts to it - the same `{ id, nonce }` shape the renderer already uses for
+ *   `applyServerSummaries` publishes the request and the active server scope reloads its data.
+ *   It uses the same `{ id, nonce }` shape the renderer already uses for
  *   `settingsRequest` and `messageFocusRequest`. The nonce is load-bearing: the
  *   same server can need loading twice in a row.
  *
@@ -111,7 +111,17 @@ const Servers = createSimpleContext({
           Boolean(server.compatibility?.hostAppVersion)
         );
       });
-      const loadTarget = retryTarget ?? negotiatedTarget;
+      const reconnectedTarget = value.find((server) => {
+        const old = previous.get(server.id);
+        return (
+          old?.active &&
+          server.active &&
+          server.kind === "remote" &&
+          server.state === "online" &&
+          (old.state !== "online" || (server.connectionSequence ?? 0) > (old.connectionSequence ?? 0))
+        );
+      });
+      const loadTarget = retryTarget ?? negotiatedTarget ?? reconnectedTarget;
       if (loadTarget) {
         pendingCompatibilityRetryServerId = null;
         loadRequestNonce += 1;
@@ -154,7 +164,7 @@ const Servers = createSimpleContext({
         await window.openbot.servers.retryConnection(serverId);
       } catch (error) {
         pendingCompatibilityRetryServerId = null;
-        toast.error("The host is still incompatible", {
+        toast.error("The connection failed", {
           description: error instanceof Error ? error.message : String(error),
         });
       }


### PR DESCRIPTION
## What changed

A remote connection rejected with `host_busy` could leave the desktop showing an empty workspace. The active workspace now shows the connection error and Retry. It retains the error during retry and reloads agents and workspace data after recovery.

Reconnect refreshes run inside the existing server scope, so failed loads retain cached data. Direct-thread refreshes also use request and scope guards and retain unread state on failure. Recovery refreshes the open direct conversation while retaining its cached messages on failure. Messages received or sent during the refresh are merged with the returned page, and newer read state is retained. Load generations and scope guards reject late responses. Selecting the active server again keeps its pending workspace load valid. Server switches still dispose the old scope. Existing IPC fields, released protocols, and legacy-host limits are unchanged.

This PR is separate from #324 and targets `main`. Related to #325; do not close that issue until production device validation passes.

Surfaces: desktop renderer; desktop connection-state and Signal tests; architecture and deployment documentation. Production Signal was inspected and lacks multiplex support. D1 migration 0018 is applied. The document records the Worker version and gives Signal-only update and rollback commands. No production update is included.

## Verification

- [x] Live-message recovery races: background incoming, visible incoming, and successful send cases pass. Replacing the snapshot without merging makes all three fail.

- [x] Open direct-conversation recovery: success, failed refresh, and late-response cases pass. Removing the refresh call, cache retention, or request guard makes the relevant regression tests fail.

- [x] Same-server selection regression: all 32 server UI tests pass. The new pending-load case fails with the old selection guard.

- [x] Direct-thread regression checks: all 46 tests in `App.read-state.test.tsx` pass. The three new cases fail with the original refresh behavior (late success, late failure, and latest failure).

- [x] Approved wider check: `bun run test:desktop -- App.servers remote-server-connections remote-server-manager team-webrtc remote-peer` — 96 tests passed across 9 files.

- [x] 82 targeted tests passed: desktop server UI (31), connection state (5), Signal (15), Worker control plane (10), and shared remote peer (21).
- [x] Full `bun run lint`, `bun run typecheck`, and `bun run check:ui` passed.
- [x] Fault checks failed as expected when error display, reconnect refresh, stale-response protection, error retention, multiplex admission, or cache retention was broken. Each change was restored and the relevant tests passed again.
- [x] Surfaces and reverse actions are identified above. Session isolation, reconnect, and revocation are covered by tests.
- [ ] Live two-desktop/mobile validation remains pending. `bun run dev --isolated` started at port 5174, but onboarding Next did not advance. The connection flow and screenshots could not be verified. Only this worktree's dev stack was stopped.
- [x] No credentials, generated output, or user files are included.

Lint retains eight existing module-mock warnings in mobile auth and theme tests. These mocks cover native boundaries outside this change.

Model: GPT-6. Harness: Codex desktop; Vitest with the repository app/connection fixtures; `dev:automation` for the isolated app.

## Before and after

| Scenario | Before | After |
| --- | --- | --- |
| Signal rejects a second session | Connection error absent from the active workspace | Persistent connection error and Retry |
| Active server reconnects | Agent refresh can be missed | Reload on a new connection sequence or return to online |
| Refresh is pending or fails | Workspace remount can discard cached state | Existing data stays in the server scope |
| An older load completes | Can apply over newer data | Late response is ignored |

## Risk and security impact

The main risk is workspace refresh ordering. Tests cover recovery and stale responses. No IPC, database schema, permission, or released wire protocol changes are made. Current Signal multiplex logic and the one-client protection for older hosts remain intact.

Production Signal still needs a separately approved update. The deployment procedure keeps coturn running and retains the prior Signal image. Worker compatibility and active direct/relay sessions still need end-to-end validation.




