### PR TITLE
Preserve mobile connections across background transitions

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -108,8 +108,10 @@ Mobile Settings can update your account name and photo through the same account 
 disconnect account sessions. The appearance preference is stored only on the phone.
 After a profile change, the account API sends Signal a signed notification identifying the account.
 Signal notifies only that account’s connected devices, without including the profile or credentials.
-Devices refresh the profile on notification, reconnection or foreground entry; there is no periodic
-profile polling. These authenticated requests retrieve
+Devices check the profile and joined-server directory on a cold launch and every 15 minutes while active.
+Returning from the background does not trigger an automatic check. On mobile, Notification Center and
+other iOS `inactive` transitions do not count as leaving the app and do not reset the timer. Profile change notifications
+can trigger an earlier refresh. These authenticated requests retrieve
 account identity (name, email and avatar URL), not conversations or workspace content.
 
 Mobile hidden and pinned chat preferences are stored on the phone, separately per account and server.

--- a/apps/mobile/src/features/auth/context/mobile-session-context.test.tsx
+++ b/apps/mobile/src/features/auth/context/mobile-session-context.test.tsx
@@ -1,0 +1,172 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import type { MobileSession } from "../api/mobile-auth";
+import { MobileSessionProvider, useMobileSession } from "./mobile-session-context";
+
+const native = vi.hoisted(() => ({
+  state: "active",
+  listeners: new Set<(state: string) => void>(),
+  validate:
+    vi.fn<(session: MobileSession, apply?: (session: MobileSession | null) => void) => Promise<MobileSession | null>>(),
+  read: vi.fn<() => Promise<MobileSession | null>>(),
+}));
+vi.mock("react-native", () => ({
+  AppState: {
+    get currentState() {
+      return native.state;
+    },
+    addEventListener: (_event: string, listener: (state: string) => void) => {
+      native.listeners.add(listener);
+      return { remove: () => native.listeners.delete(listener) };
+    },
+  },
+}));
+// This provider owns the lifecycle subscription. Storage and HTTP behavior are covered by mobile-auth.test.ts.
+vi.mock("@/features/auth/api/mobile-auth", () => ({
+  readMobileSession: native.read,
+  validateMobileSession: native.validate,
+  retryMobileSessionRevocations: async () => {},
+  logoutMobileSession: async () => {},
+  updateMobileProfile: async () => {},
+  MobileSessionExpiredError: class extends Error {},
+}));
+
+const session: MobileSession = {
+  apiUrl: "https://api.example.com",
+  sessionToken: "test-credential",
+  host: { hostId: "host", fingerprint: "a".repeat(43) },
+  user: { id: "user", email: "user@example.com", name: "User", avatarUrl: null },
+};
+let current: ReturnType<typeof useMobileSession>;
+function Account() {
+  current = useMobileSession();
+  return null;
+}
+const container = document.createElement("div");
+let root = createRoot(container);
+beforeEach(async () => {
+  vi.useFakeTimers();
+  native.state = "active";
+  native.read.mockResolvedValue(session);
+  native.validate.mockReset().mockImplementation(async (value, apply) => {
+    apply?.(value);
+    return value;
+  });
+  await act(async () =>
+    root.render(
+      <MobileSessionProvider>
+        <Account />
+      </MobileSessionProvider>,
+    ),
+  );
+  native.validate.mockClear();
+});
+afterEach(async () => {
+  await act(() => root.unmount());
+  root = createRoot(container);
+  vi.useRealTimers();
+});
+async function transition(state: string) {
+  await act(async () => {
+    native.state = state;
+    for (const listener of native.listeners) listener(state);
+  });
+}
+
+it("preserves the session without automatic checks on background return or Notification Center", async () => {
+  await vi.advanceTimersByTimeAsync(120_000);
+  await transition("inactive");
+  await transition("active");
+  expect(native.validate).not.toHaveBeenCalled();
+  await transition("background");
+  await transition("active");
+  expect(native.validate).not.toHaveBeenCalled();
+  await transition("background");
+  await vi.advanceTimersByTimeAsync(30_000);
+  await transition("inactive");
+  await transition("active");
+  expect(native.validate).not.toHaveBeenCalled();
+  native.validate.mockClear();
+  await transition("background");
+  await transition("active");
+  expect(native.validate).not.toHaveBeenCalled();
+  expect(current.session).toBe(session);
+});
+
+it("checks every 15 minutes while open, preserves the timer through overlays, and stops in the background", async () => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(14 * 60_000);
+  });
+  await transition("inactive");
+  await transition("active");
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(59_999);
+  });
+  expect(native.validate).not.toHaveBeenCalled();
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1);
+  });
+  expect(native.validate).toHaveBeenCalledTimes(1);
+  await transition("background");
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+  });
+  expect(native.validate).toHaveBeenCalledTimes(1);
+  await transition("inactive");
+  await transition("active");
+  expect(native.validate).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(15 * 60_000);
+  });
+  expect(native.validate).toHaveBeenCalledTimes(2);
+});
+
+it("coalesces pending profile invalidations and applies the latest profile", async () => {
+  const pending = Promise.withResolvers<MobileSession>();
+  native.validate.mockImplementationOnce(async (_value, apply) => {
+    const updated = await pending.promise;
+    apply?.(updated);
+    return updated;
+  });
+  let refreshing: Promise<void>;
+  await act(async () => {
+    refreshing = current.refreshProfile();
+  });
+  await act(async () => {
+    await current.refreshProfile();
+    await current.refreshProfile();
+  });
+  native.validate.mockImplementation(async (_value, apply) => {
+    const updated = { ...session, user: { ...session.user, name: "Latest" } };
+    apply?.(updated);
+    return updated;
+  });
+  await act(async () => {
+    pending.resolve({ ...session, user: { ...session.user, name: "Updated" } });
+    await refreshing;
+  });
+  expect(native.validate).toHaveBeenCalledTimes(2);
+  expect(current.session?.user.name).toBe("Latest");
+});
+
+it("defers profile invalidation in the background and clears a revoked session on return", async () => {
+  await transition("background");
+  await act(async () => current.refreshProfile());
+  expect(native.validate).not.toHaveBeenCalled();
+  native.validate.mockImplementationOnce(async (_value, apply) => {
+    apply?.(null);
+    return null;
+  });
+  await transition("active");
+  expect(current.session).toBeNull();
+});
+
+it("retains the credential after a network failure without retrying on background return", async () => {
+  native.validate.mockRejectedValueOnce(new Error("Offline"));
+  await act(async () => current.refreshProfile());
+  await transition("background");
+  await transition("active");
+  expect(native.validate).toHaveBeenCalledTimes(1);
+  expect(current.session).toBe(session);
+});

--- a/apps/mobile/src/features/auth/context/mobile-session-context.tsx
+++ b/apps/mobile/src/features/auth/context/mobile-session-context.tsx
@@ -1,3 +1,4 @@
+import { watchRemoteDirectory } from "@openbot/team-client";
 import {
   createContext,
   type PropsWithChildren,
@@ -95,15 +96,22 @@ export function MobileSessionProvider({ children }: PropsWithChildren) {
     let checking = false;
     let refreshAgain = false;
     let appState: AppStateStatus = AppState.currentState;
+    let stopPeriodicCheck: (() => void) | null = null;
 
     async function checkSession(): Promise<void> {
       const current = sessionRef.current;
-      if (!active || appState !== "active" || !current) return;
+      if (!active || !current) return;
+      if (appState === "background") {
+        refreshAgain = true;
+        return;
+      }
       if (checking) {
         refreshAgain = true;
         return;
       }
       checking = true;
+      refreshAgain = false;
+      startPeriodicCheck();
       try {
         await validateMobileSession(current, (validated) => {
           if (active) {
@@ -122,18 +130,31 @@ export function MobileSessionProvider({ children }: PropsWithChildren) {
       }
     }
 
+    function startPeriodicCheck() {
+      stopPeriodicCheck?.();
+      stopPeriodicCheck = appState === "background" ? null : watchRemoteDirectory(() => checkSession());
+    }
+    startPeriodicCheck();
+
     const appStateSubscription = AppState.addEventListener("change", (nextAppState) => {
-      const resumed = (appState === "background" || appState === "inactive") && nextAppState === "active";
+      if (nextAppState === "inactive") return;
+      const resumed = appState === "background" && nextAppState === "active";
       appState = nextAppState;
+      if (nextAppState === "background") {
+        stopPeriodicCheck?.();
+        stopPeriodicCheck = null;
+      }
       if (resumed) {
         void retryMobileSessionRevocations();
-        void checkSession();
+        startPeriodicCheck();
+        if (refreshAgain) void checkSession();
       }
     });
     refreshProfileRef.current = checkSession;
 
     return () => {
       active = false;
+      stopPeriodicCheck?.();
       appStateSubscription.remove();
     };
   }, [setCurrentSession]);

--- a/apps/mobile/src/features/workspace/components/server-connection.test.tsx
+++ b/apps/mobile/src/features/workspace/components/server-connection.test.tsx
@@ -144,3 +144,43 @@ it("refreshes membership after revocation without waiting for a foreground trans
   );
   expect(refreshMemberships).toHaveBeenCalledTimes(1);
 });
+
+it("retains background failures and defers membership requests and retries until resume", async () => {
+  vi.useFakeTimers();
+  const directory = new RemoteTeamDirectoryClient({ apiUrl: "https://example.com", token: "test", fetch });
+  const memberships = vi.fn(async () => {});
+  const load = vi.fn(async (id: string, key: string, client: RemoteTeamTransportRef) => client.connect(id, key));
+  const register = () => {};
+  const status = vi.fn();
+  const event = () => {};
+  const render = (active: boolean) =>
+    root.render(
+      <ServerConnection
+        hostId="host"
+        publicKey="key"
+        active={active}
+        directory={directory}
+        register={register}
+        load={load}
+        onStatus={status}
+        onTeamEvent={event}
+        onMembershipChanged={memberships}
+      />,
+    );
+  await act(async () => render(true));
+  await act(async () => render(false));
+  await act(async () => render(true));
+  expect(load).toHaveBeenCalledTimes(1);
+  await act(async () => render(false));
+  await act(async () =>
+    endpoints.get("host")?.update({ hostId: "host", state: "offline", code: "session_revoked", message: null }),
+  );
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(60_000);
+  });
+  expect(memberships).not.toHaveBeenCalled();
+  await act(async () => render(true));
+  expect(memberships).toHaveBeenCalledTimes(1);
+  expect(load).toHaveBeenCalledTimes(2);
+  expect(status).toHaveBeenLastCalledWith("host", { phase: "online", attempt: 0, remainingSeconds: 0 }, null);
+});

--- a/apps/mobile/src/features/workspace/components/server-connection.tsx
+++ b/apps/mobile/src/features/workspace/components/server-connection.tsx
@@ -49,6 +49,7 @@ export function ServerConnection({
   activeRef.current = active;
   const generation = useRef(0);
   const wasOnline = useRef(false);
+  const membershipRefreshPending = useRef(false);
   const attach = useCallback((value: RemoteTeamTransportRef | null) => setClient(value), []);
 
   useEffect(() => {
@@ -69,7 +70,7 @@ export function ServerConnection({
         failure = remoteConnectionFailure(context.stage, error);
       },
       (status) => {
-        if (!activeRef.current || disposed) return;
+        if (disposed) return;
         if (status.phase === "online") failure = null;
         onStatus(hostId, status, failure);
       },
@@ -89,7 +90,11 @@ export function ServerConnection({
   useEffect(() => {
     if (!active) generation.current += 1;
     controller.current?.setActive(active);
-  }, [active]);
+    if (active && membershipRefreshPending.current) {
+      membershipRefreshPending.current = false;
+      void onMembershipChanged?.().catch(() => undefined);
+    }
+  }, [active, onMembershipChanged]);
 
   return (
     <RemoteTeamTransport
@@ -98,11 +103,13 @@ export function ServerConnection({
       directory={directory}
       onTeamEvent={onTeamEvent}
       onConnectionUpdate={(update) => {
-        if (!activeRef.current || update.hostId !== hostId) return;
+        if (update.hostId !== hostId) return;
         if (update.state === "online") wasOnline.current = true;
         if (update.state === "offline") {
-          if (update.code === "session_revoked" || wasOnline.current)
-            void onMembershipChanged?.().catch(() => undefined);
+          if (update.code === "session_revoked" || wasOnline.current) {
+            if (activeRef.current) void onMembershipChanged?.().catch(() => undefined);
+            else membershipRefreshPending.current = true;
+          }
           wasOnline.current = false;
           const error = new Error(update.message ?? "The desktop went offline.");
           if (update.code === "protocol_error") controller.current?.suspend(error);

--- a/apps/mobile/src/features/workspace/context/mobile-workspace-context.tsx
+++ b/apps/mobile/src/features/workspace/context/mobile-workspace-context.tsx
@@ -50,7 +50,7 @@ import {
 } from "@/features/workspace/components/server-connection";
 import { type MobileAgentActivities, reduceAgentActivity } from "@/features/workspace/model/agent-activity";
 import { decodeConversation } from "@/features/workspace/model/conversation";
-import { applyServerRecovery, resetServerStatus, serverKind } from "@/features/workspace/model/server-status";
+import { applyServerRecovery, serverKind } from "@/features/workspace/model/server-status";
 import { trustedHostKeys } from "@/features/workspace/model/trusted-host-keys";
 import type {
   MobileAgent,
@@ -113,7 +113,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
   const connections = useRef(new Map<string, ServerConnectionHandle>());
   const loadGeneration = useRef(0);
   const directoryGeneration = useRef(0);
-  const [foreground, setForeground] = useState(AppState.currentState === "active");
+  const [foreground, setForeground] = useState(AppState.currentState !== "background");
   const [servers, setServers] = useState<MobileServer[]>([]);
   const [serverDirectoryState, setServerDirectoryState] = useState<MobileServerDirectoryState>("loading");
   const [serverDirectoryError, setServerDirectoryError] = useState<string | null>(null);
@@ -310,21 +310,24 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
   }, []);
 
   useEffect(() => {
+    let connectionActive = AppState.currentState !== "background";
     const subscription = AppState.addEventListener("change", (state) => {
+      // iOS system overlays report inactive without putting the app in the background.
+      if (state === "inactive") return;
       const active = state === "active";
+      if (active === connectionActive) return;
+      connectionActive = active;
       setForeground(active);
       if (!active) {
         loadGeneration.current += 1;
-        setServers((current) => current.map(resetServerStatus));
       }
-      if (active) void directoryRefresh.refresh(true).catch(() => undefined);
     });
     return () => subscription.remove();
-  }, [directoryRefresh]);
+  }, []);
 
   useEffect(() => {
     if (!foreground) return;
-    return watchRemoteDirectory(() => directoryRefresh.refresh(true));
+    return watchRemoteDirectory(() => directoryRefresh.refresh());
   }, [foreground, directoryRefresh]);
 
   const loadConversation = useCallback(

--- a/apps/mobile/src/features/workspace/model/server-status.test.ts
+++ b/apps/mobile/src/features/workspace/model/server-status.test.ts
@@ -1,12 +1,6 @@
 import { createRemoteConnectionRecovery, REMOTE_RETRY_INTERVAL_MS } from "@openbot/team-client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  applyServerFailure,
-  applyServerRecovery,
-  resetServerStatus,
-  serverKind,
-  serverStatusLabel,
-} from "./server-status";
+import { applyServerFailure, applyServerRecovery, serverKind, serverStatusLabel } from "./server-status";
 import type { MobileServer } from "./workspace-types";
 
 const server: MobileServer = {
@@ -27,7 +21,7 @@ afterEach(() => vi.useRealTimers());
 
 describe("mobile server availability", () => {
   it("keeps the protocol error visible when suspending RTC rejects an in-flight workspace load", async () => {
-    let current = resetServerStatus(server);
+    let current: MobileServer = { ...server, state: "unknown" };
     let connection = Promise.withResolvers<void>();
     const onError = vi.fn(() => {
       current = applyServerFailure(current, "The desktop request failed.");
@@ -61,7 +55,7 @@ describe("mobile server availability", () => {
 
   it("shows retry, protocol error, and recovery states from the live connection controller", async () => {
     vi.useFakeTimers();
-    let current = { ...resetServerStatus(server), initialConnectionPending: true };
+    let current: MobileServer = { ...server, state: "unknown", initialConnectionPending: true };
     let connection = Promise.withResolvers<void>();
     const controller = createRemoteConnectionRecovery(
       () => connection.promise,
@@ -91,17 +85,6 @@ describe("mobile server availability", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(current.state).toBe("online");
     controller.dispose();
-  });
-  it("stops claiming a server is online when its connection is no longer observed", () => {
-    const reset = resetServerStatus({
-      ...server,
-      recoveryStatus: { phase: "online", attempt: 0, remainingSeconds: 0 },
-    });
-    expect(serverStatusLabel(reset)).toBe("Not connected");
-    expect(reset.recoveryStatus).toBeUndefined();
-    expect(reset.initialConnectionPending).toBe(false);
-    expect(reset.publicKey).toBe(server.publicKey);
-    expect(serverStatusLabel({ ...server, state: "error" })).toBe("Connection error");
   });
 });
 

--- a/apps/mobile/src/features/workspace/model/server-status.ts
+++ b/apps/mobile/src/features/workspace/model/server-status.ts
@@ -42,16 +42,6 @@ export function applyServerRecovery(
   };
 }
 
-/** A directory entry is membership, not proof of a usable connection. */
-export function resetServerStatus(server: MobileServer): MobileServer {
-  return {
-    ...server,
-    state: "unknown",
-    connectionMessage: null,
-    recoveryStatus: undefined,
-  };
-}
-
 export function serverKind(hostId: string, pairedHostId: string | undefined): MobileServer["kind"] {
   return hostId === pairedHostId ? "local" : "remote";
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,14 +214,17 @@ passes only serializable, validated commands and events to the native React UI; 
 module or development build is required.
 Mobile server labels in the drawer and connection settings describe the authenticated application
 connection, not membership or Signal presence. Each membership has its own transport and recovery controller while mobile is active.
-Switching servers changes the visible workspace without closing other connections. Backgrounding
-clears observed status to Not connected and pauses recovery. Only the paired desktop is Local;
+Switching servers changes the visible workspace without closing other connections. iOS `inactive`
+transitions leave connections alone. Backgrounding retains the last connection status and pauses
+recovery; transport failures received in the background are retained for resume. Only the paired desktop is Local;
 other servers are Remote regardless of the account role. Connecting becomes Online after compatibility and workspace synchronization succeed;
 transport failures and reconnect attempts show Offline, and protocol failures show Connection error.
 The existing RTC connection updates and recovery controller are the source of truth; the indicator
-adds no polling or health requests. Foreground resume, invite selection and manual refresh reuse
-that controller. A transient RTC disconnected state has a five-second recovery window; failed or closed states
-drive recovery immediately. Backgrounding cancels pending reads so they cannot block resume.
+adds no polling or health requests. Foreground resume reuses a healthy connection without a workspace
+reload. Canceled reads and event resets request data synchronization without showing a reconnect on
+a healthy connection. Invite selection and manual refresh reuse the same controller. A transient RTC
+disconnected state has a five-second recovery window, including on resume; failed or closed states
+drive recovery immediately. Backgrounding pauses the grace timer and cancels pending reads so they cannot block resume.
 Explicit refresh bypasses the retry cooldown without overlapping a pending connection attempt.
 The native/DOM mailbox carries concurrent commands by ID. Switching or disconnecting cancels
 pending callers immediately; peer generations reject late callbacks from a superseded host.
@@ -236,10 +239,11 @@ scanner validates that link and opens the invitation review before acceptance. T
 one server; Mobile Connect codes sign in to the desktop account and select the paired host.
 Both clients read account-wide membership from D1's indexed `remote_memberships` / `remote_hosts`
 join. An offline paired desktop does not remove other memberships, and mobile connects directly
-to each host independently. Desktop window focus refreshes the directory immediately. While its main
-window is focused and the account is signed in, desktop also checks at 30-second intervals for joins
-on other devices. Concurrent reads coalesce; unfocused windows do not poll. Mobile refreshes immediately on
-foreground entry and checks at 30-second intervals while active; background entry stops the timer. Session revocation, explicit refresh,
+to each host independently. A cold launch refreshes the account directory. Both clients check again
+every 15 minutes while active. Concurrent directory reads coalesce; inactive clients do not poll.
+Mobile background entry stops the timer, and foreground entry starts a new 15-minute interval.
+iOS `inactive` transitions, including Notification Center, do not trigger a check or reset the timer.
+Session revocation, explicit refresh,
 and completed invitation acceptance can refresh sooner. A lost healthy connection also requests
 membership reconciliation; a transport failure alone never removes a server. Mobile member controls
 use the same account endpoints: owners and admins can invite, while only owners can change another
@@ -277,9 +281,14 @@ Account profile writes enqueue an `account-profile-changed` invalidation in the 
 account-to-Signal outbox before returning. Worker `waitUntil` delivers notifications outside the
 profile-save response path, with a five-second timeout per request and outbox retries. Signal forwards the optional frame only to authenticated sockets for that
 user; the frame contains no profile or credential. Desktop and mobile fetch the profile through
-the account API on notification, foreground entry, or Signal reconnection, with no periodic polling.
+the account API on notification, cold launch, and every 15 minutes while active.
+Returning from the background or restoring window focus does not trigger an automatic account
+or directory check. iOS `inactive` alone does not trigger a check or reset the periodic timer.
+Explicit profile invalidations trigger an earlier check and are deferred while mobile is in the
+background. Signal readiness does not trigger a profile check; the account timer remains independent
+of transport recovery. Failed automatic checks use the same interval.
 Older Signal clients ignore this optional event. API and Signal both need the event support for push;
-foreground refresh remains the fallback when Signal is unavailable. Unchanged responses do not
+the periodic check remains the fallback when Signal is unavailable. Unchanged responses do not
 publish a new identity. Desktop ignores reads overtaken by a local edit, sign-out or shutdown;
 its central-auth change event updates the renderer and host identity. The mobile drawer and Settings
 both display the session's name and resolve avatar paths against its account API.

--- a/packages/team-client/src/remote-directory.test.ts
+++ b/packages/team-client/src/remote-directory.test.ts
@@ -477,9 +477,9 @@ describe("directory refresh", () => {
     });
     const refresh = createRemoteDirectoryRefresh(load, () => now);
     await Promise.allSettled([refresh.refresh(), refresh.refresh(), refresh.refresh(true)]);
-    now = 29_999;
+    now = 15 * 60_000 - 1;
     await refresh.refresh().catch(() => undefined);
-    now = 30_000;
+    now = 15 * 60_000;
     await refresh.refresh().catch(() => undefined);
     await refresh.refresh(true).catch(() => undefined);
     expect(load).toHaveBeenCalledTimes(3);
@@ -511,11 +511,13 @@ it("finds memberships accepted on another device and stops polling on cleanup", 
         role: "member",
       },
     ];
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(15 * 60_000 - 1);
+    expect(visible).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
     expect(visible).toEqual([HOST_ID]);
     stop();
     hosts = [];
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(15 * 60_000);
     expect(visible).toEqual([HOST_ID]);
   } finally {
     stop();

--- a/packages/team-client/src/remote-directory.ts
+++ b/packages/team-client/src/remote-directory.ts
@@ -399,9 +399,11 @@ function decodeInvite(value: unknown): RemoteTeamInvite {
   };
 }
 
+export const REMOTE_ACCOUNT_CHECK_INTERVAL_MS = 15 * 60_000;
+
 /** The caller starts this watcher in the foreground and stops it on background entry. */
 export function watchRemoteDirectory(refresh: () => Promise<void>): () => void {
-  const timer = setInterval(() => void refresh().catch(() => undefined), 30_000);
+  const timer = setInterval(() => void refresh().catch(() => undefined), REMOTE_ACCOUNT_CHECK_INTERVAL_MS);
   return () => clearInterval(timer);
 }
 
@@ -412,7 +414,7 @@ export function createRemoteDirectoryRefresh(load: () => Promise<void>, now = Da
   return {
     refresh(force = false): Promise<void> {
       if (pending) return pending;
-      if (!force && now() - lastAttempt < 30_000) return Promise.resolve();
+      if (!force && now() - lastAttempt < REMOTE_ACCOUNT_CHECK_INTERVAL_MS) return Promise.resolve();
       lastAttempt = now();
       const operation = load();
       pending = operation;

--- a/packages/team-client/src/remote-peer.test.ts
+++ b/packages/team-client/src/remote-peer.test.ts
@@ -38,7 +38,7 @@ describe("browser remote peer recovery", () => {
     await network.connect();
     try {
       network.socket().receive({ type: "account-profile-changed", version: 1 });
-      await vi.waitFor(() => expect(refreshProfile).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(refreshProfile).toHaveBeenCalledTimes(1));
       const result = await network.runtime.execute({
         id: "after-profile",
         type: "request",
@@ -141,7 +141,7 @@ describe("browser remote peer recovery", () => {
       } else await initial;
       const closed =
         mode === "disconnect" ? network.runtime.execute({ id: "disconnect", type: "disconnect" }) : Promise.resolve();
-      if (mode === "reconnect") network.connection().drop("disconnected");
+      if (mode === "reconnect") network.connection().drop("failed");
       const reconnecting = network.connect();
       await vi.advanceTimersByTimeAsync(0);
       cleanup.resolve();
@@ -298,12 +298,63 @@ describe("browser remote peer recovery", () => {
     await network.runtime.dispose();
   });
 
-  it("does not reuse an authenticated peer whose browser missed the disconnect event", async () => {
+  it("waits for RTC recovery on resume even if the browser missed the disconnect event", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const endSession = vi.fn(async () => {});
+    const network = await setupNetwork({ endSession });
+    await network.connect();
+    network.runtime.setActive(false);
+    network.connection().connectionState = "disconnected";
+    network.runtime.setActive(true);
+    const reconnect = network.connect();
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(endSession).not.toHaveBeenCalled();
+    network.connection().drop("connected");
+    await expect(reconnect).resolves.toMatchObject({ ok: true });
+    expect(network.bootstraps()).toBe(1);
+    await network.runtime.dispose();
+  });
+
+  it("ends an unrecoverable RTC session after the resume grace period", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const endSession = vi.fn(async () => {});
+    const network = await setupNetwork({ endSession });
+    await network.connect();
+    network.runtime.setActive(false);
+    network.connection().drop("disconnected");
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(endSession).not.toHaveBeenCalled();
+    network.runtime.setActive(true);
+    const reconnect = network.connect();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(reconnect).resolves.toMatchObject({ ok: false });
+    expect(endSession).toHaveBeenCalledTimes(1);
+    await expect(network.connect()).resolves.toMatchObject({ ok: true });
+    expect(network.bootstraps()).toBe(2);
+    await network.runtime.dispose();
+  });
+
+  it("reports canceled reads for data synchronization without replacing the healthy peer", async () => {
     const network = await setupNetwork();
     await network.connect();
-    network.connection().connectionState = "disconnected";
-    await expect(network.connect()).resolves.toMatchObject({ ok: true });
-    expect(network.connections).toHaveLength(2);
+    network.updates.length = 0;
+    network.runtime.setActive(false);
+    network.runtime.setActive(true);
+    expect(network.updates).toEqual([]);
+    const read = network.runtime.execute({
+      id: "canceled",
+      type: "request",
+      method: "GET",
+      path: "/v1/agents/slow/conversation",
+      body: {},
+    });
+    await network.slowRequest.promise;
+    network.updates.length = 0;
+    network.runtime.setActive(false);
+    await read;
+    network.runtime.setActive(true);
+    expect(network.updates).toEqual([{ hostId: "host", state: "online", message: null, resync: true }]);
+    expect(network.bootstraps()).toBe(1);
     await network.runtime.dispose();
   });
 

--- a/packages/team-client/src/remote-peer.ts
+++ b/packages/team-client/src/remote-peer.ts
@@ -141,7 +141,9 @@ interface PeerState {
   turnRefreshTimer: ReturnType<typeof setTimeout> | null;
   iceServers: RTCIceServer[];
   lastEventSequence: number;
+  needsResync: boolean;
   connectedResolve: (() => void) | null;
+  connectedPromise: Promise<void> | null;
   connectedReject: ((error: Error) => void) | null;
   connectedTimer: ReturnType<typeof setTimeout> | null;
   disconnectedTimer: ReturnType<typeof setTimeout> | null;
@@ -171,18 +173,27 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
       if (!active) {
         if (state.reconnectTimer !== null) clearTimeout(state.reconnectTimer);
         if (state.turnRefreshTimer !== null) clearTimeout(state.turnRefreshTimer);
+        if (state.disconnectedTimer !== null) clearTimeout(state.disconnectedTimer);
+        state.disconnectedTimer = null;
         state.reconnectTimer = null;
         state.turnRefreshTimer = null;
         // The host can commit a sent write while the app is inactive. Keep its
         // response registered so the caller does not offer to send it again.
+        state.needsResync ||= [...pendingRequests.values()].some(
+          (request) => request.method === "GET" || request.method === "HEAD",
+        );
         rejectRequests(new Error("The app is in the background."), true);
         if (!state.authenticated) failPeer(state, new Error("The app is in the background."), actions);
       } else {
-        if (!isPeerOnline(state)) {
+        if (canRecoverPeer(state)) {
+          scheduleDisconnectedCheck(state, actions);
+          if (!state.socket) openSignal(state, actions);
+        } else if (!isPeerOnline(state)) {
           failPeer(state, new Error("The desktop connection needs to be restored."), actions);
         } else {
           scheduleTurnRefresh(state);
           if (!state.socket) openSignal(state, actions);
+          resyncIfNeeded(state, actions);
         }
       }
     },
@@ -194,11 +205,46 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
       CHANNELS.every((kind) => state.channels[kind]?.readyState === "open")
     );
   }
+  function canRecoverPeer(state: PeerState): boolean {
+    return (
+      state.authenticated &&
+      state.connection?.connectionState === "disconnected" &&
+      CHANNELS.every((kind) => state.channels[kind]?.readyState === "open")
+    );
+  }
+
+  function scheduleDisconnectedCheck(state: PeerState, actions: ActionsRef): void {
+    if (!active || state.disconnectedTimer !== null) return;
+    state.disconnectedTimer = setTimeout(() => {
+      state.disconnectedTimer = null;
+      if (!isPeerOnline(state)) failPeer(state, new Error("The desktop went offline."), actions);
+    }, DISCONNECT_GRACE_MS);
+  }
+
+  function resyncIfNeeded(state: PeerState, actions: ActionsRef): void {
+    if (!active || !isPeerOnline(state) || !state.needsResync) return;
+    state.needsResync = false;
+    void actions.current.onConnectionUpdate({ hostId: state.hostId, state: "online", message: null, resync: true });
+  }
   async function executeCommand(command: RemoteTeamCommand, actions: ActionsRef): Promise<RemoteTeamCommandResult> {
     let commandGeneration = generation;
     try {
       if (command.type === "connect") {
         if (!active) throw new Error("The app is in the background.");
+        if (peer && peer.hostId === command.hostId && peer.hostPublicKey === command.hostPublicKey) {
+          if (canRecoverPeer(peer)) {
+            const recovering = peer;
+            scheduleDisconnectedCheck(recovering, actions);
+            recovering.connectedPromise ??= new Promise<void>((resolve, reject) => {
+              recovering.connectedResolve = resolve;
+              recovering.connectedReject = reject;
+            });
+          }
+          if (peer.connectedPromise) {
+            await peer.connectedPromise;
+            return { commandId: command.id, ok: true };
+          }
+        }
         if (
           peer &&
           isPeerOnline(peer) &&
@@ -276,7 +322,9 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
       turnRefreshTimer: null,
       iceServers: [],
       lastEventSequence: 0,
+      needsResync: false,
       connectedResolve: null,
+      connectedPromise: null,
       connectedReject: null,
       connectedTimer: null,
       disconnectedTimer: null,
@@ -290,6 +338,7 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
         30_000,
       );
     });
+    state.connectedPromise = connected;
     try {
       openSignal(state, actions);
     } catch (error) {
@@ -301,7 +350,6 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
   function openSignal(state: PeerState, actions: ActionsRef): void {
     if (!active || state.closed || peer !== state || state.socket) return;
     const socket = new WebSocket(state.signalUrl);
-    let accountRefreshed = false;
     state.socket = socket;
     socket.onopen = () => {
       if (state.closed || peer !== state || state.socket !== socket) return;
@@ -331,10 +379,6 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
             return failPeer(state, error, actions, "protocol_error");
           }
           // A frame type this build does not know is a newer Signal service, not a broken connection.
-          if (message?.type === "ready" && !accountRefreshed) {
-            accountRefreshed = true;
-            void actions.current.onAccountProfileChanged?.().catch(() => undefined);
-          }
           if (message) await handleSignal(state, message, actions);
         })
         // Only what handling a frame this peer did read can throw -- an ICE or SDP operation the
@@ -443,16 +487,17 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
       if (state.connection !== connection || state.closed || peer !== state) return;
       if (connection.connectionState === "disconnected") {
         // ICE can recover a short network interruption without replacing the authenticated session.
-        state.disconnectedTimer ??= setTimeout(() => {
-          state.disconnectedTimer = null;
-          if (connection.connectionState !== "connected")
-            failPeer(state, new Error("The desktop went offline."), actions);
-        }, DISCONNECT_GRACE_MS);
+        scheduleDisconnectedCheck(state, actions);
         return;
       }
       if (connection.connectionState === "connected" && state.disconnectedTimer !== null) {
         clearTimeout(state.disconnectedTimer);
         state.disconnectedTimer = null;
+      }
+      if (isPeerOnline(state)) {
+        if (active && state.turnRefreshTimer === null) scheduleTurnRefresh(state);
+        settleConnected(state);
+        resyncIfNeeded(state, actions);
       }
       if (connection.connectionState === "failed" || connection.connectionState === "closed") {
         failPeer(state, new Error("The desktop went offline."), actions);
@@ -638,7 +683,10 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
 
   async function request(method: string, path: string, body: TeamProtocolV2Json) {
     const state = peer;
-    if (!state || !isPeerOnline(state)) throw new Error("The selected server is offline.");
+    if (!state || !isPeerOnline(state)) {
+      if (state && (method === "GET" || method === "HEAD")) state.needsResync = true;
+      throw new Error("The selected server is offline.");
+    }
     const requestId = createTeamRequestId((size) => crypto.getRandomValues(new Uint8Array(size)));
     const result = new Promise<{ status: number; body: TeamProtocolV2Json }>((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -824,6 +872,7 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
     state.connectedResolve?.();
     state.connectedResolve = null;
     state.connectedReject = null;
+    state.connectedPromise = null;
   }
 
   function rejectConnection(state: PeerState, error: Error): void {
@@ -832,6 +881,7 @@ export function createRemoteTeamPeer(actions: ActionsRef) {
     state.connectedReject?.(error);
     state.connectedResolve = null;
     state.connectedReject = null;
+    state.connectedPromise = null;
   }
 
   function channelLabel(kind: ChannelKind): string {

--- a/packages/team-client/src/remote-recovery.test.ts
+++ b/packages/team-client/src/remote-recovery.test.ts
@@ -12,6 +12,60 @@ import {
 afterEach(() => vi.useRealTimers());
 
 describe("remote connection recovery", () => {
+  it("keeps a healthy connection online across background transitions and data refreshes", async () => {
+    vi.useFakeTimers();
+    const load = vi.fn(async () => {});
+    const status = vi.fn();
+    const recovery = createRemoteConnectionRecovery(load, () => {}, status);
+    recovery.setActive(true);
+    await vi.advanceTimersByTimeAsync(0);
+    status.mockClear();
+    recovery.setActive(false);
+    recovery.setActive(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+    recovery.refresh();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(status.mock.calls.map(([value]) => value.phase)).toEqual(["online"]);
+    recovery.dispose();
+  });
+
+  it("retains a data invalidation received in the background until resume", async () => {
+    vi.useFakeTimers();
+    const load = vi.fn(async () => {});
+    const recovery = createRemoteConnectionRecovery(load, () => {});
+    recovery.setActive(true);
+    await vi.advanceTimersByTimeAsync(0);
+    recovery.setActive(false);
+    recovery.refresh();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(load).toHaveBeenCalledTimes(1);
+    recovery.setActive(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(2);
+    recovery.dispose();
+  });
+
+  it("replaces interrupted reads once after resume without overlapping them", async () => {
+    vi.useFakeTimers();
+    let finish = () => {};
+    const pending = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const load = vi.fn().mockReturnValueOnce(pending).mockResolvedValue(undefined);
+    const recovery = createRemoteConnectionRecovery(load, () => {});
+    recovery.setActive(true);
+    recovery.setActive(false);
+    recovery.setActive(true);
+    expect(load).toHaveBeenCalledTimes(1);
+    finish();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(2);
+    recovery.dispose();
+  });
+
   it.each([
     "The host already has an active remote session.",
     "Too many active remote connections.",

--- a/packages/team-client/src/remote-recovery.ts
+++ b/packages/team-client/src/remote-recovery.ts
@@ -97,6 +97,7 @@ export function createRemoteConnectionRecovery(
   let active = false;
   let disposed = false;
   let running = false;
+  let online = false;
   let suspended = false;
   let retryRequested = false;
   let refreshRequested = false;
@@ -145,11 +146,15 @@ export function createRemoteConnectionRecovery(
     retryRequested = false;
     refreshRequested = false;
     attempt += 1;
-    onStatus({ phase: "connecting", attempt, remainingSeconds: 0 });
+    // Refreshing data on a usable connection must not look like a reconnect.
+    if (!online) onStatus({ phase: "connecting", attempt, remainingSeconds: 0 });
     try {
       await connect();
     } catch (error) {
-      if (!disposed) onError(error);
+      if (active) {
+        online = false;
+        if (!disposed) onError(error);
+      }
       retryRequested = true;
     } finally {
       running = false;
@@ -159,6 +164,7 @@ export function createRemoteConnectionRecovery(
           void run();
         } else if (retryRequested) scheduleRetry();
         else {
+          online = true;
           attempt = 0;
           retryAt = null;
           onStatus({ phase: "online", attempt: 0, remainingSeconds: 0 });
@@ -172,19 +178,24 @@ export function createRemoteConnectionRecovery(
       if (active === value || disposed) return;
       active = value;
       cancelTimer();
+      if (!active && running) {
+        // Background entry invalidates the consumer's pending workspace reads.
+        refreshRequested = true;
+      }
       if (active) {
         // Coming back to the app is this phone's version of the explicit refresh the desktop asks
         // for after a protocol error, and it is the exit a user reaches without knowing there is
         // one: the desktop they left to update is the reason the frame was unreadable. One attempt
         // per return, not a loop.
         suspended = false;
-        if (running) refreshRequested = true;
+        if (running) return;
         else if (retryAt !== null) scheduleRetry();
-        else void run();
+        else if (!online || refreshRequested) void run();
       }
     },
     offline(error?: unknown) {
       if (disposed) return;
+      online = false;
       if (error !== undefined) onError(error);
       retryRequested = true;
       scheduleRetry();
@@ -197,6 +208,7 @@ export function createRemoteConnectionRecovery(
      */
     suspend(error?: unknown) {
       if (disposed) return;
+      online = false;
       suspended = true;
       retryRequested = false;
       retryAt = null;
@@ -210,7 +222,7 @@ export function createRemoteConnectionRecovery(
       retryAt = null;
       attempt = 0;
       cancelTimer();
-      if (running) refreshRequested = true;
+      if (running || !active) refreshRequested = true;
       else void run();
     },
     dispose() {

--- a/src/main/application-services.ts
+++ b/src/main/application-services.ts
@@ -32,6 +32,7 @@ import type {
 } from "@openbot/contracts/ipc";
 import { IPC_CHANNELS } from "@openbot/contracts/ipc";
 import { createOpenBotLogger, toLogValue } from "@openbot/logging";
+import { REMOTE_ACCOUNT_CHECK_INTERVAL_MS } from "@openbot/team-client";
 import { app, type BrowserWindow, safeStorage, screen, shell } from "electron";
 import electronUpdater from "electron-updater";
 import { AgentService } from "../backend/agent-service";
@@ -267,10 +268,24 @@ export async function createApplicationServices({
       profileRefreshing = false;
     }
   };
-  mainWindow.on("focus", refreshAccountProfile);
+  let profileTimer: ReturnType<typeof setInterval> | null = null;
+  const stopProfileTimer = () => {
+    if (profileTimer !== null) clearInterval(profileTimer);
+    profileTimer = null;
+  };
+  const startProfileTimer = () => {
+    stopProfileTimer();
+    profileTimer = setInterval(() => void refreshAccountProfile(), REMOTE_ACCOUNT_CHECK_INTERVAL_MS);
+    profileTimer.unref();
+  };
+  if (mainWindow.isFocused()) startProfileTimer();
+  mainWindow.on("focus", startProfileTimer);
+  mainWindow.on("blur", stopProfileTimer);
   teardown.push(TEARDOWN_ORDER.updater, "account profile refresh", () => {
     profileRefreshActive = false;
-    mainWindow.removeListener("focus", refreshAccountProfile);
+    stopProfileTimer();
+    mainWindow.removeListener("focus", startProfileTimer);
+    mainWindow.removeListener("blur", stopProfileTimer);
     centralAuth.stopProfileRefresh();
   });
   const store = new AgentStore(app.getPath("userData"), homedir());

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -568,15 +568,22 @@ if (!hasSingleInstanceLock) {
         return remoteAccountSync;
       });
       app.on("browser-window-focus", (_event, window) => {
-        if (window === windowHolder.current) void directoryRefresh.refresh(true);
+        if (window === windowHolder.current) {
+          startDirectoryWatch();
+        }
       });
       const refreshMemberships = () => void directoryRefresh.refresh(true);
       remoteServers.on("directoryInvalidated", refreshMemberships);
-      const stopDirectoryWatch = watchRemoteHostDirectory({
-        isActive: () =>
-          Boolean(windowHolder.current?.isFocused()) && built.centralAuth.getState().status === "signed_in",
-        refresh: () => directoryRefresh.refresh(true),
-      });
+      let stopDirectoryWatch = () => {};
+      const startDirectoryWatch = () => {
+        stopDirectoryWatch();
+        stopDirectoryWatch = watchRemoteHostDirectory({
+          isActive: () =>
+            Boolean(windowHolder.current?.isFocused()) && built.centralAuth.getState().status === "signed_in",
+          refresh: () => directoryRefresh.refresh(),
+        });
+      };
+      startDirectoryWatch();
       teardown.push(0, "joined-server directory refresh", () => {
         stopDirectoryWatch();
         remoteServers.off("directoryInvalidated", refreshMemberships);

--- a/src/main/remote-server-host-directory.test.ts
+++ b/src/main/remote-server-host-directory.test.ts
@@ -184,15 +184,17 @@ it("refreshes cross-device memberships only while active and stops on shutdown",
   const refresh = vi.fn(async () => undefined);
   const stop = watchRemoteHostDirectory({ isActive: () => active, refresh });
   try {
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(15 * 60_000);
     expect(refresh).not.toHaveBeenCalled();
     active = true;
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(15 * 60_000 - 1);
+    expect(refresh).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
     expect(refresh).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(29_999);
+    await vi.advanceTimersByTimeAsync(15 * 60_000 - 1);
     expect(refresh).toHaveBeenCalledTimes(1);
     stop();
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(15 * 60_000);
     expect(refresh).toHaveBeenCalledTimes(1);
   } finally {
     stop();

--- a/src/main/remote-server-host-directory.ts
+++ b/src/main/remote-server-host-directory.ts
@@ -21,6 +21,7 @@
 // Order is preserved deliberately: surviving stored servers keep their positions, and hosts the
 // user has not seen before are appended in directory order. The user drags this list.
 
+import { REMOTE_ACCOUNT_CHECK_INTERVAL_MS } from "@openbot/team-client";
 import type { RemoteHostSummary } from "./central-auth-manager";
 import type { PreservedHostIdentity, StoredRemoteServerView } from "./remote-server-store";
 import type { StoredRemoteServer } from "./remote-server-stored-shape";
@@ -30,7 +31,7 @@ import { fingerprint } from "./team-store";
 export function watchRemoteHostDirectory(options: { isActive(): boolean; refresh(): Promise<void> }): () => void {
   const timer = setInterval(() => {
     if (options.isActive()) void options.refresh().catch(() => undefined);
-  }, 30_000);
+  }, REMOTE_ACCOUNT_CHECK_INTERVAL_MS);
   timer.unref();
   return () => clearInterval(timer);
 }

--- a/src/renderer/src/features/team/team-webrtc.test.ts
+++ b/src/renderer/src/features/team/team-webrtc.test.ts
@@ -134,9 +134,7 @@ it("routes two phones independently and disconnects or resumes only the addresse
   signal.message({ type: "ready", version: 1, connectionId: null, resumeToken: "resume", iceServers: [] });
   signal.message({ type: "account-profile-changed", version: 1 });
   await vi.waitFor(() =>
-    expect(posted("account-profile-changed")).toEqual(
-      Array(2).fill({ type: "account-profile-changed", peerId: "host-1" }),
-    ),
+    expect(posted("account-profile-changed")).toEqual([{ type: "account-profile-changed", peerId: "host-1" }]),
   );
   for (const index of [1, 2])
     signal.message({

--- a/src/renderer/src/features/team/team-webrtc.ts
+++ b/src/renderer/src/features/team/team-webrtc.ts
@@ -148,7 +148,6 @@ async function handleCommand(command: BridgeCommand): Promise<void> {
 function connectSignal(state: PeerState): void {
   if (state.closed || state.socket) return;
   const socket = new WebSocket(state.signalUrl);
-  let accountRefreshed = false;
   state.socket = socket;
   socket.addEventListener("open", () => {
     state.reconnectAttempt = 0;
@@ -173,10 +172,6 @@ function connectSignal(state: PeerState): void {
           return failSignalProtocol(state, error);
         }
         // A frame type this build does not know is a newer Signal service, not a broken connection.
-        if (message?.type === "ready" && !accountRefreshed) {
-          accountRefreshed = true;
-          post({ type: "account-profile-changed", peerId: state.id });
-        }
         if (message) await handleSignal(state, message);
       })
       // Only what handling a frame this peer did read can throw -- an ICE or SDP operation the


### PR DESCRIPTION
## Summary

- Preserve healthy mobile connections across background and iOS inactive transitions.
- Defer background membership and profile refreshes until resume.
- Change automatic account and directory checks to a 15-minute active interval.
- Retain canceled-read resynchronization and add RTC recovery coverage.

## Testing

- Added and updated mobile and team-client tests for background recovery, deferred refreshes, resynchronization, and periodic checks.
- Not run (not requested)