### PR TITLE
Show every integrated model and let a user CLI update itself

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -459,10 +459,12 @@ failure keeps the reason the CLI gave, in one error that goes to the provider ro
 OpenBot downloads nothing on this path, so the pinned artifact checksums are untouched. The managed
 copy refuses this command, because the runtime manager replaces that installation whole.
 
-The update replaces the binary under a running client. A provider that has an agent in a turn
-therefore refuses the command and tells the user to wait, and no turn may start on that provider
-until the new client is ready: the drain scheduler skips an agent whose provider reports
-`isReplacingCli`, and the delivery waits in the mailbox until the new client schedules it again.
+The update replaces the binary under a running client. A provider that has an agent in a turn -
+or a delivery on its way to one, which holds no turn id yet - therefore refuses the command and
+tells the user to wait. No turn may start on that provider until the new client is ready: the drain
+scheduler skips an agent whose provider reports `isReplacingCli`, before it can reschedule the
+delivery, and `onProviderResumed` schedules the held deliveries when the replacement ends, after a
+failure as well as after a success.
 
 That updater decides for itself what the newest version is, and its release channel can name an
 older one than the lock: `grok update` can report success and leave the CLI where it was. The IPC

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -462,7 +462,15 @@ copy refuses this command, because the runtime manager replaces that installatio
 Every runtime the store reaches is on this computer: `window.openbot.providerRuntimes` addresses no
 other one, while the agent status beside it describes whichever server is open. The store therefore
 takes `isLocalServer`, and a workspace on another computer announces no offer and starts no update -
-the same rule the provider row and the picker already follow.
+the same rule the provider row and the picker already follow. A server switch rebuilds that store,
+so the version a user closed the notification on is kept by the notification module, which outlives
+the switch: the offer is raised again on the way back only if the user never closed it.
+
+Replacing the CLI is not a start. `#activateProviderClient` skips `onProvidersReady` for it, because
+that hook is restart recovery: it settles every unresolved delivery, and the other providers keep
+running through the replacement, so a live turn would be recorded as `interrupted` - which
+`MailboxStore.markTerminal` then refuses to correct. `onProviderResumed` schedules the deliveries
+the replacement held back.
 
 The update replaces the binary under a running client. A provider that has an agent in a turn -
 a delivery on its way to one, which holds no turn id yet, or a context compaction, whose

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -466,11 +466,14 @@ the same rule the provider row and the picker already follow. A server switch re
 so the version a user closed the notification on is kept by the notification module, which outlives
 the switch: the offer is raised again on the way back only if the user never closed it.
 
-Replacing the CLI is not a start. `#activateProviderClient` skips `onProvidersReady` for it, because
+Replacing the CLI is not a start, on either path: `#activateProviderClient` swaps the client of a
+provider that has one, `#connect` connects one whose client is gone, and both skip
+`onProvidersReady` for the replacement, because
 that hook is restart recovery: it settles every unresolved delivery, and the other providers keep
 running through the replacement, so a live turn would be recorded as `interrupted` - which
 `MailboxStore.markTerminal` then refuses to correct. `onProviderResumed` schedules the deliveries
-the replacement held back.
+the replacement held back. The refusal record is written through one queue, because two providers
+can finish an update at once and the older snapshot must not be renamed over the newer one.
 
 The update replaces the binary under a running client. A provider that has an agent in a turn -
 a delivery on its way to one, which holds no turn id yet, or a context compaction, whose

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -455,8 +455,14 @@ one Update button, and one entry point in the runtime store, `startProviderUpdat
 behind it differs: a `system` install goes to `updateProviderCli`, which runs that CLI's own updater
 (`codex update`) and then restarts the provider on the binary now on disk. That updater reports no
 progress, so the notification holds its indeterminate step until the provider comes back, and a
-failure keeps the reason the CLI gave. OpenBot downloads nothing on this path, so the pinned artifact checksums are untouched. The
-managed copy refuses this command, because the runtime manager replaces that installation whole.
+failure keeps the reason the CLI gave, in one error that goes to the provider row and to the caller.
+OpenBot downloads nothing on this path, so the pinned artifact checksums are untouched. The managed
+copy refuses this command, because the runtime manager replaces that installation whole.
+
+The update replaces the binary under a running client. A provider that has an agent in a turn
+therefore refuses the command and tells the user to wait, and no turn may start on that provider
+until the new client is ready: the drain scheduler skips an agent whose provider reports
+`isReplacingCli`, and the delivery waits in the mailbox until the new client schedules it again.
 
 That updater decides for itself what the newest version is, and its release channel can name an
 older one than the lock: `grok update` can report success and leave the CLI where it was. The IPC

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -438,10 +438,36 @@ installation is display metadata until the pinned runtime passes the existing do
 checks. Runtime snapshots carry the previous version and an optional `availableVersion` through the
 preload decoder. Cancellation and failure preserve the previous installation and its update offer.
 
-Settings starts the shared renderer runtime store. An explicit update opens one notification;
-revisioned snapshots move it through progress, failure, retry, and completion. Closing the
-notification does not cancel the download, and later reports do not reopen it. Fresh provider
-downloads retain their existing flow. These actions apply only to the local desktop host.
+Settings starts the shared renderer runtime store. The store announces each provider that gains an
+offer as one notification, from an effect over both the runtime snapshot and the agent status,
+because the two arrive separately and either one can complete an offer. An explicit update opens
+the same notification; revisioned snapshots move it through progress, failure, retry, and
+completion. Only the crossing into "update available" is announced, so a dismissed notification
+stays dismissed until the offer changes. Closing the notification does not cancel the download,
+and later reports do not reopen it. Fresh provider downloads retain their existing flow. These
+actions apply only to the local desktop host.
+
+A CLI the user installed themselves is not managed, but it is still compared against the lock.
+Each provider status row reports `cliSource`, and main passes the version of a `system` row to
+`ProviderRuntimeManager.setSystemVersion`, which compares it against the pinned version exactly as
+it compares a managed installation. The row and the notification therefore use the one update offer, the
+one Update button, and one entry point in the runtime store, `startProviderUpdate`. Only the work
+behind it differs: a `system` install goes to `updateProviderCli`, which runs that CLI's own updater
+(`codex update`) and then restarts the provider on the binary now on disk. That updater reports no
+progress, so the notification holds its indeterminate step until the provider comes back, and a
+failure keeps the reason the CLI gave. OpenBot downloads nothing on this path, so the pinned artifact checksums are untouched. The
+managed copy refuses this command, because the runtime manager replaces that installation whole.
+
+That updater decides for itself what the newest version is, and its release channel can name an
+older one than the lock: `grok update` can report success and leave the CLI where it was. The IPC
+handler therefore reports the version before and after the run to
+`ProviderRuntimeManager.noteSystemCliUpdate`. An update that finishes on the version it started on
+is the updater's answer: the manager records that pair of versions in `cli-update-refusals.json`
+beside the managed runtimes, and drops the offer from `availableVersion`, so the row and the
+notification stop offering an update that cannot happen. The record is kept against both the
+installed and the pinned version, so a new pinned version is a new offer, and so is a CLI the user
+moves by other means. The runtime store keeps the same answer in memory for the run that produced
+it, only to settle the notification before the next snapshot arrives.
 
 ## Agent usage analytics
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -459,9 +459,15 @@ failure keeps the reason the CLI gave, in one error that goes to the provider ro
 OpenBot downloads nothing on this path, so the pinned artifact checksums are untouched. The managed
 copy refuses this command, because the runtime manager replaces that installation whole.
 
+Every runtime the store reaches is on this computer: `window.openbot.providerRuntimes` addresses no
+other one, while the agent status beside it describes whichever server is open. The store therefore
+takes `isLocalServer`, and a workspace on another computer announces no offer and starts no update -
+the same rule the provider row and the picker already follow.
+
 The update replaces the binary under a running client. A provider that has an agent in a turn -
-or a delivery on its way to one, which holds no turn id yet - therefore refuses the command and
-tells the user to wait. No turn may start on that provider until the new client is ready: the drain
+a delivery on its way to one, which holds no turn id yet, or a context compaction, whose
+`turn/started` `ContextCompaction.claimTurn` takes away from the agent - therefore refuses the
+command and tells the user to wait. No turn may start on that provider until the new client is ready: the drain
 scheduler skips an agent whose provider reports `isReplacingCli`, before it can reschedule the
 delivery, and `onProviderResumed` schedules the held deliveries when the replacement ends, after a
 failure as well as after a success.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -455,7 +455,10 @@ one Update button, and one entry point in the runtime store, `startProviderUpdat
 behind it differs: a `system` install goes to `updateProviderCli`, which runs that CLI's own updater
 (`codex update`) and then restarts the provider on the binary now on disk. That updater reports no
 progress, so the notification holds its indeterminate step until the provider comes back, and a
-failure keeps the reason the CLI gave, in one error that goes to the provider row and to the caller.
+failure keeps the reason the CLI gave, redacted, in one error that goes to the provider row and to
+the caller - and on, through the Team API, to the team's connected clients.
+The owner comes from the last resolution of the binary, not from the client that runs it, so a
+provider that is signed out still reports its own install rather than reading as the managed copy.
 OpenBot downloads nothing on this path, so the pinned artifact checksums are untouched. The managed
 copy refuses this command, because the runtime manager replaces that installation whole.
 

--- a/packages/contracts/src/ipc-agent-identity.ts
+++ b/packages/contracts/src/ipc-agent-identity.ts
@@ -26,6 +26,18 @@ export function isAgentModel(value: unknown): value is AgentModelId {
   return isString(value) && value.length > 0 && value.length <= 160 && /^[A-Za-z0-9][A-Za-z0-9._:/[\]-]*$/.test(value);
 }
 
+/**
+ * The model each provider starts on, and the one the model picker marks as the default.
+ *
+ * A provider lists its own models, so an id here can be missing from a given CLI: every caller
+ * falls back to the first model that provider does list, and the picker simply marks nothing.
+ */
+export const DEFAULT_PROVIDER_MODELS: Record<AgentProviderId, AgentModelId> = {
+  codex: "gpt-5.6-luna",
+  claude: "claude-sonnet-5",
+  grok: "grok-4.6",
+};
+
 export function isClaudeModel(model: AgentModelId): boolean {
   return model.startsWith("claude-");
 }

--- a/packages/contracts/src/ipc-agent-status.ts
+++ b/packages/contracts/src/ipc-agent-status.ts
@@ -40,6 +40,13 @@ export interface AgentProviderStatus {
   email?: string | null;
   connectionState?: "connecting";
   checkError?: string | null;
+  /**
+   * Who owns the CLI binary in use. `system` is an install the user made and can update themselves,
+   * with the CLI's own updater; `managed` is the pinned copy OpenBot downloaded, which only an
+   * OpenBot release moves. The two have different update stories, so the picker has to tell them
+   * apart, and only the provider that resolved a CLI reports one at all.
+   */
+  cliSource?: "system" | "managed";
 }
 
 function isAgentProviderStatus(value: unknown): value is AgentProviderStatus {
@@ -51,7 +58,8 @@ function isAgentProviderStatus(value: unknown): value is AgentProviderStatus {
     isNullableBoundedString(value.message, INPUT_LIMITS.messageText) &&
     (value.email === undefined || isNullableBoundedString(value.email, INPUT_LIMITS.email)) &&
     (value.connectionState === undefined || isBoundedString(value.connectionState, INPUT_LIMITS.identifier)) &&
-    (value.checkError === undefined || isNullableBoundedString(value.checkError, INPUT_LIMITS.messageText))
+    (value.checkError === undefined || isNullableBoundedString(value.checkError, INPUT_LIMITS.messageText)) &&
+    (value.cliSource === undefined || isBoundedString(value.cliSource, INPUT_LIMITS.identifier))
   );
 }
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -23,6 +23,7 @@ export const IPC_CHANNELS = {
   openExternal: "app:open-external",
   connectProvider: "app:connect-provider",
   refreshAgentProviders: "app:refresh-agent-providers",
+  updateProviderCli: "app:update-provider-cli",
   providerRuntimesGetStatus: "provider-runtimes:get-status",
   providerRuntimesDownload: "provider-runtimes:download",
   providerRuntimesCancel: "provider-runtimes:cancel",

--- a/packages/contracts/src/ipc-desktop-apis.ts
+++ b/packages/contracts/src/ipc-desktop-apis.ts
@@ -380,6 +380,12 @@ export interface OpenBotDesktopApi {
   openExternal: (destination: ExternalDestination) => Promise<void>;
   connectProvider: (provider: AgentProviderId) => Promise<AgentStatus>;
   refreshAgentProviders: () => Promise<AgentStatus>;
+  /**
+   * Runs the provider CLI's own updater, for a CLI the user installed themselves. It is their copy,
+   * so the version they end on is whatever that updater fetches, which owes nothing to the version
+   * OpenBot pins for the runtime it manages.
+   */
+  updateProviderCli: (provider: AgentProviderId) => Promise<AgentStatus>;
   providerRuntimes: ProviderRuntimesDesktopApi;
   openUrl: (url: string) => Promise<void>;
   voice: VoiceDesktopApi;

--- a/packages/contracts/src/ipc-endpoints.ts
+++ b/packages/contracts/src/ipc-endpoints.ts
@@ -48,6 +48,7 @@ export const IPC_ENDPOINTS = {
   providers: {
     connectProvider: request(IPC_CHANNELS.connectProvider),
     refreshAgentProviders: request(IPC_CHANNELS.refreshAgentProviders),
+    updateProviderCli: request(IPC_CHANNELS.updateProviderCli),
   },
   providerRuntimes: {
     getStatus: request(IPC_CHANNELS.providerRuntimesGetStatus),

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -665,6 +665,10 @@ describe("renderer-to-main boundary guards", () => {
     // Open about values, not about shape: the renderer reads `id` and `state` off every entry.
     expect(isAgentStatus({ ...status, providers: [null] })).toBe(false);
     expect(isAgentStatus({ ...status, providers: [{ id: "codex" }] })).toBe(false);
+    // `cliSource` decides whether the picker offers the CLI's own updater. It stays open like the
+    // fields above - an owner we do not know simply matches nothing - but it has to be a string.
+    expect(isAgentStatus({ ...status, providers: [{ ...providers[0], cliSource: "system" }] })).toBe(true);
+    expect(isAgentStatus({ ...status, providers: [{ ...providers[0], cliSource: 1 }] })).toBe(false);
   });
 
   it("requires an agent provider and a well-formed avatar on every agent summary", () => {

--- a/scripts/provider-storage-smoke.ts
+++ b/scripts/provider-storage-smoke.ts
@@ -57,7 +57,7 @@ async function runOptionalGrok(database: OpenBotDatabase): Promise<boolean> {
   try {
     await client.request("initialize", {}, decodeRecordResponse);
     const account = await client.request("account/read", {}, decodeAccountReadResult);
-    const models = await client.request("model/list", { limit: 100, includeHidden: false }, decodeModelListResponse);
+    const models = await client.request("model/list", { limit: 100, includeHidden: true }, decodeModelListResponse);
     model = account.account ? (models.data.find((candidate) => candidate.model)?.model ?? null) : null;
   } catch {
     // This is an optional smoke and an unauthenticated local Grok installation is a valid skip.

--- a/src/backend/agent-service-test-harness.ts
+++ b/src/backend/agent-service-test-harness.ts
@@ -149,6 +149,7 @@ export class FakeAgentClient extends EventEmitter implements AgentClient {
         data:
           this.provider === "codex"
             ? [
+                "gpt-reserve",
                 "gpt-5.6-luna",
                 "gpt-5.6-terra",
                 "gpt-5.6-sol",
@@ -156,6 +157,7 @@ export class FakeAgentClient extends EventEmitter implements AgentClient {
                 "gpt-5.4",
                 "gpt-5.4-mini",
                 "gpt-5.3-codex-spark",
+                "codex-auto-review",
               ].map((model) => ({ model }))
             : this.provider === "grok"
               ? ["grok-4.5", "grok-fast"].map((model) => ({ model }))
@@ -541,6 +543,43 @@ fi
   );
   await chmod(executable, 0o755);
   return executable;
+}
+
+/**
+ * A Claude CLI that can update itself: `claude update` writes the marker, and every later
+ * `--version` reports `updatedVersion`, the way a real self-update changes the binary underfoot.
+ * The marker path is also what a test reads to see whether the updater ran at all.
+ */
+export async function createUpdatableFakeClaude(
+  directory: string,
+  updatedVersion: string,
+  updateError?: string,
+): Promise<{ executable: string; marker: string }> {
+  const executable = join(directory, "claude-updatable");
+  const marker = join(directory, "claude-update-marker");
+  await writeFile(
+    executable,
+    `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  if [ -f '${marker}' ]; then
+    printf '%s\\n' '${updatedVersion} (Claude Code)'
+  else
+    printf '%s\\n' '2.1.246 (Claude Code)'
+  fi
+elif [ "$1" = "auth" ]; then
+  printf '%s' '{"loggedIn":true,"email":"claude@example.com","subscriptionType":"max"}'
+elif [ "$1" = "update" ]; then
+${
+  updateError
+    ? `  printf '%s\\n' '${updateError}' >&2
+  exit 1`
+    : `  printf '%s\\n' 'updated' > '${marker}'`
+}
+fi
+`,
+  );
+  await chmod(executable, 0o755);
+  return { executable, marker };
 }
 
 export async function createPendingFakeClaude(directory: string): Promise<string> {

--- a/src/backend/agent-service-test-harness.ts
+++ b/src/backend/agent-service-test-harness.ts
@@ -550,13 +550,19 @@ fi
  * `--version` reports `updatedVersion`, the way a real self-update changes the binary underfoot.
  * The marker path is also what a test reads to see whether the updater ran at all.
  */
+/**
+ * A fake Claude CLI that can update itself. With `gate`, the updater waits for that file to
+ * appear, which is how a test holds the CLI in mid-replacement and acts while it is there.
+ */
 export async function createUpdatableFakeClaude(
   directory: string,
   updatedVersion: string,
   updateError?: string,
-): Promise<{ executable: string; marker: string }> {
+  gate?: string,
+): Promise<{ executable: string; marker: string; started: string }> {
   const executable = join(directory, "claude-updatable");
   const marker = join(directory, "claude-update-marker");
+  const started = join(directory, "claude-update-started");
   await writeFile(
     executable,
     `#!/bin/sh
@@ -569,6 +575,8 @@ if [ "$1" = "--version" ]; then
 elif [ "$1" = "auth" ]; then
   printf '%s' '{"loggedIn":true,"email":"claude@example.com","subscriptionType":"max"}'
 elif [ "$1" = "update" ]; then
+  printf '%s\\n' 'started' > '${started}'
+${gate ? `  while [ ! -f '${gate}' ]; do sleep 0.02; done` : ""}
 ${
   updateError
     ? `  printf '%s\\n' '${updateError}' >&2
@@ -579,7 +587,7 @@ fi
 `,
   );
   await chmod(executable, 0o755);
-  return { executable, marker };
+  return { executable, marker, started };
 }
 
 export async function createPendingFakeClaude(directory: string): Promise<string> {

--- a/src/backend/agent-service.queue.test.ts
+++ b/src/backend/agent-service.queue.test.ts
@@ -73,7 +73,7 @@ describe.sequential("AgentService: queue", () => {
         avatarSeed: "setup:claude-planning",
       }),
     ).resolves.toMatchObject({
-      model: "claude-opus-5",
+      model: "claude-sonnet-5",
       reasoningEffort: "high",
     });
     await service.setPreferredProvider("codex");

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -52,7 +52,7 @@ import type {
   UpdateQueuedMessageInput,
   UpdateRoutineInput,
 } from "@openbot/contracts/ipc";
-import { AGENT_RUNTIME_TEXT_LIMIT, isMessageReaction } from "@openbot/contracts/ipc";
+import { AGENT_RUNTIME_TEXT_LIMIT, DEFAULT_PROVIDER_MODELS, isMessageReaction } from "@openbot/contracts/ipc";
 import { isString } from "@openbot/contracts/runtime-values";
 import { createOpenBotLogger } from "@openbot/logging";
 import { AgentMemories } from "./agent/agent-memories";
@@ -516,7 +516,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
     const provider = agent?.provider ?? this.#providers.preferredProvider();
     await this.ensureProvider(provider);
     const models = this.#providers.listModels();
-    const defaultModel = provider === "codex" ? "gpt-5.6-luna" : provider === "claude" ? "claude-opus-5" : null;
+    const defaultModel = DEFAULT_PROVIDER_MODELS[provider];
     const model = agent
       ? models.find((candidate) => candidate.id === agent.model && candidate.provider === provider)
       : (models.find((candidate) => candidate.provider === provider && candidate.id === defaultModel) ??
@@ -554,8 +554,7 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
       const preferredProvider = this.#providers.preferredProvider();
       if (preferredProvider !== agent.provider) {
         const models = this.#providers.listModels();
-        const preferredDefault =
-          preferredProvider === "codex" ? "gpt-5.6-luna" : preferredProvider === "claude" ? "claude-opus-5" : null;
+        const preferredDefault = DEFAULT_PROVIDER_MODELS[preferredProvider];
         const preferredModel =
           models.find((model) => model.provider === preferredProvider && model.id === preferredDefault) ??
           models.find((model) => model.provider === preferredProvider);
@@ -818,6 +817,10 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
 
   connectProvider(provider: AgentProvider, openExternal: (url: string) => Promise<void>): Promise<AgentStatus> {
     return this.#providers.connectProvider(provider, openExternal);
+  }
+
+  updateProviderCli(provider: AgentProvider): Promise<AgentStatus> {
+    return this.#providers.updateProviderCli(provider);
   }
 
   async stop(): Promise<void> {

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -236,12 +236,14 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
         isStopping: () => this.#stopping,
         isProviderBusy: (provider) =>
           this.#drain.hasStartingDeliveries(provider) ||
-          this.#store
-            .list()
-            .some(
-              (agent) =>
-                providerForAgent(agent) === provider && this.#conversation.snapshot(agent.id)?.activeTurnId != null,
-            ),
+          this.#store.list().some(
+            (agent) =>
+              providerForAgent(agent) === provider &&
+              // A compaction is a provider turn as well, and it holds no active turn id: its
+              // `turn/started` belongs to the compaction, not to the agent, so `claimTurn` takes
+              // it away. Only its own guard reports the turn the CLI is running.
+              (this.#conversation.snapshot(agent.id)?.activeTurnId != null || !this.#compaction.mayDrain(agent.id)),
+          ),
         onProviderResumed: (provider) => {
           for (const agent of this.#store.list()) {
             if (providerForAgent(agent) === provider) this.#drain.scheduleDrain(agent.id);

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -234,6 +234,13 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
           this.#browser.clearControls();
         },
         isStopping: () => this.#stopping,
+        hasActiveTurns: (provider) =>
+          this.#store
+            .list()
+            .some(
+              (agent) =>
+                providerForAgent(agent) === provider && this.#conversation.snapshot(agent.id)?.activeTurnId != null,
+            ),
       },
       emit: (event) => this.#emit(event),
       emitError: (code, error, agentId) => this.#emitError(code, error, agentId),

--- a/src/backend/agent-service.ts
+++ b/src/backend/agent-service.ts
@@ -234,13 +234,19 @@ export class AgentService extends EventEmitter<AgentServiceEvents> {
           this.#browser.clearControls();
         },
         isStopping: () => this.#stopping,
-        hasActiveTurns: (provider) =>
+        isProviderBusy: (provider) =>
+          this.#drain.hasStartingDeliveries(provider) ||
           this.#store
             .list()
             .some(
               (agent) =>
                 providerForAgent(agent) === provider && this.#conversation.snapshot(agent.id)?.activeTurnId != null,
             ),
+        onProviderResumed: (provider) => {
+          for (const agent of this.#store.list()) {
+            if (providerForAgent(agent) === provider) this.#drain.scheduleDrain(agent.id);
+          }
+        },
       },
       emit: (event) => this.#emit(event),
       emitError: (code, error, agentId) => this.#emitError(code, error, agentId),

--- a/src/backend/agent/drain-scheduler.ts
+++ b/src/backend/agent/drain-scheduler.ts
@@ -1,3 +1,5 @@
+import { AGENT_PROVIDERS } from "@openbot/contracts/ipc";
+import type { AgentProvider } from "../agent-client";
 import type { AgentStore } from "../agent-store";
 import type { DeliveryContext, MailboxStore } from "../mailbox-store";
 import { decodeTurnResponse } from "../protocol";
@@ -54,6 +56,14 @@ export class DrainScheduler {
   readonly #threads: ThreadLifecycle;
   readonly #hooks: DrainHooks;
   readonly #drainingAgents = new Set<string>();
+  /**
+   * How many deliveries are on their way to a turn, per provider.
+   *
+   * A delivery is claimed before its first await and released when it has an active turn or has
+   * failed. Between the two it holds no turn id, and only this count stops a CLI update from
+   * replacing the client it is about to prompt.
+   */
+  readonly #startingDeliveries = new Map<AgentProvider, number>();
   readonly #scheduledDrains = new Set<string>();
   readonly #drainTasks = new Map<string, Promise<void>>();
 
@@ -124,7 +134,10 @@ export class DrainScheduler {
       this.#hooks.isStopping() ||
       this.#drainingAgents.has(agentId) ||
       !this.mayDrain(agentId) ||
-      !this.#providers.isReady()
+      !this.#providers.isReady() ||
+      // Before the try, so the delivery is not rescheduled in a loop while the CLI is replaced.
+      // ProviderRuntime schedules this agent again once the new client is ready.
+      this.#deliveryProviders(agentId).some((provider) => this.#providers.isReplacingCli(provider))
     )
       return;
     this.#drainingAgents.add(agentId);
@@ -134,9 +147,6 @@ export class DrainScheduler {
       const context = this.#mailbox.nextQueued(agentId);
       if (!context) return;
       const agent = this.#store.list().find((candidate) => candidate.id === agentId);
-      // The provider's CLI is being replaced. The delivery stays queued, and the new client
-      // schedules this drain again once it is ready.
-      if (agent && this.#providers.isReplacingCli(providerForAgent(agent))) return;
       const session = agent ? this.#store.activeProviderSession(agentId) : null;
       if (session && this.#compaction.reserve(agentId, session.externalSessionId)) {
         await this.#compaction.request(agentId, session.externalSessionId);
@@ -152,6 +162,8 @@ export class DrainScheduler {
   async startDelivery(context: DeliveryContext): Promise<void> {
     const { delivery, managedAttachments } = context;
     let confirmedTurnId: string | null = null;
+    const claimed = this.#deliveryProviders(delivery.recipientAgentId);
+    for (const provider of claimed) this.#startingDeliveries.set(provider, this.#starting(provider) + 1);
     try {
       await this.#mailbox.markStarting(delivery.id);
       this.#mailboxSync.emitQueue(delivery.recipientAgentId);
@@ -332,6 +344,26 @@ export class DrainScheduler {
       this.#mailboxSync.emitQueue(delivery.recipientAgentId);
       this.#hooks.emitError("delivery_start_failed", error, delivery.recipientAgentId);
       this.scheduleDrain(delivery.recipientAgentId);
+    } finally {
+      for (const provider of claimed) this.#startingDeliveries.set(provider, this.#starting(provider) - 1);
     }
+  }
+
+  /** True while a delivery for this provider is between its first await and its turn. */
+  hasStartingDeliveries(provider: AgentProvider): boolean {
+    return this.#starting(provider) > 0;
+  }
+
+  #starting(provider: AgentProvider): number {
+    return this.#startingDeliveries.get(provider) ?? 0;
+  }
+
+  /**
+   * The providers a delivery to this agent can reach. One for an agent that exists; an agent
+   * startDelivery has still to create can land on any of them, so all of them are claimed.
+   */
+  #deliveryProviders(agentId: string): AgentProvider[] {
+    const agent = this.#store.list().find((candidate) => candidate.id === agentId);
+    return agent ? [providerForAgent(agent)] : [...AGENT_PROVIDERS];
   }
 }

--- a/src/backend/agent/drain-scheduler.ts
+++ b/src/backend/agent/drain-scheduler.ts
@@ -134,6 +134,9 @@ export class DrainScheduler {
       const context = this.#mailbox.nextQueued(agentId);
       if (!context) return;
       const agent = this.#store.list().find((candidate) => candidate.id === agentId);
+      // The provider's CLI is being replaced. The delivery stays queued, and the new client
+      // schedules this drain again once it is ready.
+      if (agent && this.#providers.isReplacingCli(providerForAgent(agent))) return;
       const session = agent ? this.#store.activeProviderSession(agentId) : null;
       if (session && this.#compaction.reserve(agentId, session.externalSessionId)) {
         await this.#compaction.request(agentId, session.externalSessionId);

--- a/src/backend/agent/provider-runtime.test.ts
+++ b/src/backend/agent/provider-runtime.test.ts
@@ -605,6 +605,46 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
     releaseTurnStart?.();
   });
 
+  it("refuses to replace a CLI that is compacting a thread", async () => {
+    let releaseCompaction: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      releaseCompaction = resolve;
+    });
+    let compactionReached = false;
+    let client: FakeAgentClient | undefined;
+    const { store, mailbox } = stores(root);
+    service = new AgentService(store, mailbox, fakeBrowser(), 30_000, "codex", (provider) => {
+      const created = new FakeAgentClient(provider, "", true, true, {}, async (method, target) => {
+        if (method !== "thread/compact/start" || target !== "codex") return;
+        compactionReached = true;
+        await blocked;
+      });
+      if (provider === "codex") client = created;
+      return created;
+    });
+    const events: AgentEvent[] = [];
+    service.on("event", (event) => events.push(event));
+    await service.initialize();
+    await service.sendMessage({ agentId: "chief", text: "First large task" });
+    await waitFor(() => events.some((event) => event.type === "turn-completed"));
+
+    // A pressured thread compacts before its next message, and that compaction is a provider turn
+    // the agent never owns: it holds no active turn id, so only its own guard reports it.
+    client?.emit("notification", {
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "codex-session-1",
+        tokenUsage: { last: { totalTokens: 82_000 }, modelContextWindow: 100_000 },
+      },
+    });
+    void service.sendMessage({ agentId: "chief", text: "Run after compaction" });
+    await waitFor(() => compactionReached);
+
+    await expect(service.updateProviderCli("codex")).rejects.toThrow(/working on a turn/u);
+
+    releaseCompaction?.();
+  });
+
   it("delivers a message queued while a failed update held the CLI", async () => {
     const gate = join(root, "claude-update-gate");
     const claude = await createUpdatableFakeClaude(root, "2.1.250", "Installed by Homebrew.", gate);

--- a/src/backend/agent/provider-runtime.test.ts
+++ b/src/backend/agent/provider-runtime.test.ts
@@ -684,6 +684,34 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
     await waitFor(() => started.filter((agentId) => agentId === agent.id).length > turnsBefore);
   });
 
+  it("leaves another provider's running turn alone while a CLI is replaced", async () => {
+    const claude = await createUpdatableFakeClaude(root, "2.1.250");
+    process.env.OPENBOT_CLAUDE_PATH = claude.executable;
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "codex",
+      (provider) => new FakeAgentClient(provider, "", false),
+    );
+    const running = service;
+    const events: AgentEvent[] = [];
+    service.on("event", (event) => events.push(event));
+    await service.initialize();
+    await service.sendMessage({ agentId: "chief", text: "Keep working." });
+    await waitFor(() => events.some((event) => event.type === "turn-started"));
+    const turnId = (await running.readConversation("chief")).activeTurnId;
+
+    // Claude is idle, so its CLI is replaced. Restart recovery would settle every unresolved
+    // delivery, and this one belongs to a turn Codex is still running.
+    await service.updateProviderCli("claude");
+
+    expect(running.listQueue("chief").deliveries[0]?.status).toBe("running");
+    expect((await running.readConversation("chief")).activeTurnId).toBe(turnId);
+  });
+
   it("keeps the CLI's own reason when its updater refuses", async () => {
     const claude = await createUpdatableFakeClaude(root, "2.1.250", "Installed by Homebrew. Run brew upgrade.");
     process.env.OPENBOT_CLAUDE_PATH = claude.executable;

--- a/src/backend/agent/provider-runtime.test.ts
+++ b/src/backend/agent/provider-runtime.test.ts
@@ -684,33 +684,40 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
     await waitFor(() => started.filter((agentId) => agentId === agent.id).length > turnsBefore);
   });
 
-  it("leaves another provider's running turn alone while a CLI is replaced", async () => {
-    const claude = await createUpdatableFakeClaude(root, "2.1.250");
-    process.env.OPENBOT_CLAUDE_PATH = claude.executable;
-    const { store, mailbox } = stores(root);
-    service = new AgentService(
-      store,
-      mailbox,
-      fakeBrowser(),
-      30_000,
-      "codex",
-      (provider) => new FakeAgentClient(provider, "", false),
-    );
-    const running = service;
-    const events: AgentEvent[] = [];
-    service.on("event", (event) => events.push(event));
-    await service.initialize();
-    await service.sendMessage({ agentId: "chief", text: "Keep working." });
-    await waitFor(() => events.some((event) => event.type === "turn-started"));
-    const turnId = (await running.readConversation("chief")).activeTurnId;
+  // The replacement puts the provider back on the binary now on disk in one of two ways: it swaps
+  // the client of a provider that has one, and it connects one whose client is gone. Neither is a
+  // start, so neither may run restart recovery over the other providers' live deliveries.
+  for (const claudeSignedIn of [true, false]) {
+    it(`leaves another provider's running turn alone while a CLI ${
+      claudeSignedIn ? "is replaced" : "with no client is connected again"
+    }`, async () => {
+      const claude = await createUpdatableFakeClaude(root, "2.1.250");
+      process.env.OPENBOT_CLAUDE_PATH = claude.executable;
+      const { store, mailbox } = stores(root);
+      service = new AgentService(
+        store,
+        mailbox,
+        fakeBrowser(),
+        30_000,
+        "codex",
+        (provider) => new FakeAgentClient(provider, "", false, claudeSignedIn || provider !== "claude"),
+      );
+      const running = service;
+      const events: AgentEvent[] = [];
+      service.on("event", (event) => events.push(event));
+      await service.initialize();
+      await service.sendMessage({ agentId: "chief", text: "Keep working." });
+      await waitFor(() => events.some((event) => event.type === "turn-started"));
+      const turnId = (await running.readConversation("chief")).activeTurnId;
 
-    // Claude is idle, so its CLI is replaced. Restart recovery would settle every unresolved
-    // delivery, and this one belongs to a turn Codex is still running.
-    await service.updateProviderCli("claude");
+      // Claude is idle, so its CLI is replaced. Restart recovery would settle every unresolved
+      // delivery, and this one belongs to a turn Codex is still running.
+      await service.updateProviderCli("claude");
 
-    expect(running.listQueue("chief").deliveries[0]?.status).toBe("running");
-    expect((await running.readConversation("chief")).activeTurnId).toBe(turnId);
-  });
+      expect(running.listQueue("chief").deliveries[0]?.status).toBe("running");
+      expect((await running.readConversation("chief")).activeTurnId).toBe(turnId);
+    });
+  }
 
   it("keeps the CLI's own reason when its updater refuses", async () => {
     const claude = await createUpdatableFakeClaude(root, "2.1.250", "Installed by Homebrew. Run brew upgrade.");

--- a/src/backend/agent/provider-runtime.test.ts
+++ b/src/backend/agent/provider-runtime.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { join } from "node:path";
+import type { AgentEvent } from "@openbot/contracts/ipc";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentProvider } from "../agent-client";
 import { AgentService } from "../agent-service";
@@ -547,6 +548,30 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
       expect.objectContaining({ id: "claude", state: "available", version: "2.1.246" }),
     );
   });
+  it("refuses to replace a CLI that is running a turn", async () => {
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "codex",
+      (provider) => new FakeAgentClient(provider, "", false),
+    );
+    const events: AgentEvent[] = [];
+    service.on("event", (event) => events.push(event));
+    await service.initialize();
+    await service.sendMessage({ agentId: "chief", text: "Keep working." });
+    await waitFor(() => events.some((event) => event.type === "turn-started"));
+
+    // The updater would replace the binary under the running turn, so it is not started at all.
+    await expect(service.updateProviderCli("codex")).rejects.toThrow(/working on a turn/u);
+
+    expect(service.getStatus().providers).toContainEqual(
+      expect.objectContaining({ id: "codex", state: "available", version: "0.144.1" }),
+    );
+  });
+
   it("keeps the CLI's own reason when its updater refuses", async () => {
     const claude = await createUpdatableFakeClaude(root, "2.1.250", "Installed by Homebrew. Run brew upgrade.");
     process.env.OPENBOT_CLAUDE_PATH = claude.executable;
@@ -561,7 +586,8 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
     );
     await service.initialize();
 
-    await expect(service.updateProviderCli("claude")).rejects.toThrow();
+    // The caller and the provider row get the same reason: the CLI's own words.
+    await expect(service.updateProviderCli("claude")).rejects.toThrow(/Installed by Homebrew\. Run brew upgrade\./u);
 
     expect(service.getStatus().providers).toContainEqual(
       expect.objectContaining({

--- a/src/backend/agent/provider-runtime.test.ts
+++ b/src/backend/agent/provider-runtime.test.ts
@@ -1,10 +1,13 @@
 // @vitest-environment node
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { AgentEvent } from "@openbot/contracts/ipc";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentProvider } from "../agent-client";
 import { AgentService } from "../agent-service";
 import {
+  CREATE_AGENT_INPUT,
   createFakeClaude,
   createFakeGrok,
   createPendingFakeClaude,
@@ -570,6 +573,75 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
     expect(service.getStatus().providers).toContainEqual(
       expect.objectContaining({ id: "codex", state: "available", version: "0.144.1" }),
     );
+  });
+
+  it("refuses to replace a CLI while a delivery is on its way to a turn", async () => {
+    let releaseTurnStart: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      releaseTurnStart = resolve;
+    });
+    let turnStartReached = false;
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "codex",
+      (provider) =>
+        new FakeAgentClient(provider, "", false, true, {}, async (method, target) => {
+          if (method !== "turn/start" || target !== "codex") return;
+          turnStartReached = true;
+          await blocked;
+        }),
+    );
+    await service.initialize();
+    void service.sendMessage({ agentId: "chief", text: "Keep working." });
+    // The delivery has no turn id yet, and the client it is about to prompt must not be replaced.
+    await waitFor(() => turnStartReached);
+
+    await expect(service.updateProviderCli("codex")).rejects.toThrow(/working on a turn/u);
+
+    releaseTurnStart?.();
+  });
+
+  it("delivers a message queued while a failed update held the CLI", async () => {
+    const gate = join(root, "claude-update-gate");
+    const claude = await createUpdatableFakeClaude(root, "2.1.250", "Installed by Homebrew.", gate);
+    process.env.OPENBOT_CLAUDE_PATH = claude.executable;
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "claude",
+      (provider) => new FakeAgentClient(provider),
+    );
+    const running = service;
+    const started: string[] = [];
+    service.on("event", (event) => {
+      if (event.type === "turn-started") started.push(event.agentId);
+    });
+    await service.initialize();
+    const agent = await service.createAgent(CREATE_AGENT_INPUT);
+    // The agent's own first message has to be delivered and finished, or it is the turn the
+    // assertion below sees.
+    await waitFor(() => started.includes(agent.id));
+    await waitFor(async () => (await running.readConversation(agent.id)).activeTurnId === null);
+    const turnsBefore = started.filter((agentId) => agentId === agent.id).length;
+
+    const update = service.updateProviderCli("claude");
+    await waitFor(() => existsSync(claude.started));
+    await service.sendMessage({ agentId: agent.id, text: "Take this when you are back." });
+    // The CLI under the client is being replaced, so the delivery waits in the mailbox.
+    expect(started.filter((agentId) => agentId === agent.id)).toHaveLength(turnsBefore);
+
+    await writeFile(gate, "go");
+    // A refused update replaces no client, so nothing else would deliver what it held back.
+    await expect(update).rejects.toThrow(/Installed by Homebrew\./u);
+
+    await waitFor(() => started.filter((agentId) => agentId === agent.id).length > turnsBefore);
   });
 
   it("keeps the CLI's own reason when its updater refuses", async () => {

--- a/src/backend/agent/provider-runtime.test.ts
+++ b/src/backend/agent/provider-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   createFakeClaude,
   createFakeGrok,
   createPendingFakeClaude,
+  createUpdatableFakeClaude,
   FakeAgentClient,
   fakeBrowser,
   readTextOrEmpty,
@@ -83,20 +84,14 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
 
     expect(availableOrder).toEqual(["claude", "grok", "codex"]);
 
+    // The CLI also reports gpt-reserve, gpt-5.5, gpt-5.4-mini and codex-auto-review, the models
+    // this product does not offer.
     expect(
       service
         .listModels()
         .filter((model) => model.provider === "codex")
         .map((model) => model.id),
-    ).toEqual([
-      "gpt-5.6-luna",
-      "gpt-5.6-terra",
-      "gpt-5.6-sol",
-      "gpt-5.5",
-      "gpt-5.4",
-      "gpt-5.4-mini",
-      "gpt-5.3-codex-spark",
-    ]);
+    ).toEqual(["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.4", "gpt-5.3-codex-spark"]);
   });
   it("uses startup fallbacks when provider discovery is unavailable", async () => {
     process.env.OPENBOT_CLAUDE_PATH = await createFakeClaude(root);
@@ -129,7 +124,7 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
             defaultReasoningEffort: "high",
             supportedReasoningEfforts: [{ reasoningEffort: "high" }],
           },
-          { model: "hidden-model", hidden: true },
+          { model: "hidden-model", hidden: true, displayName: "Hidden model" },
         ],
       };
       let failure = false;
@@ -144,6 +139,7 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
       );
       await service.initialize();
       const catalog = () => service?.listModels().filter((model) => model.provider === provider);
+      // A model the CLI marks hidden is still offered: the CLI runs it, so the picker lists it.
       expect(catalog()).toEqual([
         {
           provider,
@@ -152,6 +148,14 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
           description: expect.any(String),
           defaultReasoningEffort: "high",
           supportedReasoningEfforts: ["high"],
+        },
+        {
+          provider,
+          id: "hidden-model",
+          name: "Hidden model",
+          description: expect.any(String),
+          defaultReasoningEffort: "medium",
+          supportedReasoningEfforts: ["medium"],
         },
       ]);
 
@@ -172,7 +176,7 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
       };
       failure = true;
       await refresh();
-      expect(catalog()?.map((model) => model.id)).toEqual([id]);
+      expect(catalog()?.map((model) => model.id)).toEqual([id, "hidden-model"]);
       failure = false;
       response = { data: [{ model: id }, { model: "newly-available" }] };
       await refresh();
@@ -185,6 +189,47 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
       expect(catalog()).toEqual([]);
     },
   );
+
+  it("keeps the whole display name the provider CLI reports", async () => {
+    const { store, mailbox } = stores(root);
+    const client = new FakeAgentClient("codex");
+    client.modelList = () => ({
+      data: [
+        { model: "gpt-5.6-sol", displayName: "GPT-5.6 Sol" },
+        { model: "gpt-6-astra", displayName: "GPT-6 Astra" },
+      ],
+    });
+    service = new AgentService(store, mailbox, fakeBrowser(), 30_000, "codex", () => client);
+    await service.initialize();
+    expect(
+      service
+        .listModels()
+        .filter((model) => model.provider === "codex")
+        .map((model) => model.name),
+    ).toEqual(["GPT-5.6 Sol", "GPT-6 Astra"]);
+  });
+
+  it("names a Claude model by the model, not by the pick Claude Code calls it", async () => {
+    process.env.OPENBOT_CLAUDE_PATH = await createFakeClaude(root);
+    const { store, mailbox } = stores(root);
+    const client = new FakeAgentClient("claude");
+    client.modelList = () => ({
+      data: [
+        { model: "claude-sonnet-5", displayName: "Default (recommended)" },
+        { model: "claude-haiku-4-5-20251001", displayName: "Haiku" },
+        { model: "claude-fable-5-1[1m]", displayName: "Fable" },
+        { model: "claude-next", displayName: "Next" },
+      ],
+    });
+    service = new AgentService(store, mailbox, fakeBrowser(), 30_000, "claude", () => client);
+    await service.initialize();
+    expect(
+      service
+        .listModels()
+        .filter((model) => model.provider === "claude")
+        .map((model) => model.name),
+    ).toEqual(["Claude Sonnet 5", "Claude Haiku 4.5", "Claude Fable 5.1 (1M context)", "Next"]);
+  });
 
   it("collects all ChatGPT pages and keeps the previous catalog when pagination fails", async () => {
     const { store, mailbox } = stores(root);
@@ -206,7 +251,7 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
     ).toEqual(["gpt-5.6-sol", "gpt-6-astra"]);
     expect(client.requests).toContainEqual({
       method: "model/list",
-      params: { limit: 100, includeHidden: false, cursor: "page-2" },
+      params: { limit: 100, includeHidden: true, cursor: "page-2" },
     });
     const previous = service.listModels();
     repeat = true;
@@ -450,5 +495,81 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
     );
     expect(activeClient?.running).toBe(false);
     expect(codexClients[2]?.running).toBe(true);
+  });
+
+  it("runs the user's own CLI updater and reports the version the provider now runs", async () => {
+    const claude = await createUpdatableFakeClaude(root, "2.1.250");
+    process.env.OPENBOT_CLAUDE_PATH = claude.executable;
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "claude",
+      (provider) => new FakeAgentClient(provider),
+    );
+    await service.initialize();
+    expect(service.getStatus().providers).toContainEqual(
+      expect.objectContaining({ id: "claude", version: "2.1.246", cliSource: "system" }),
+    );
+
+    const status = await service.updateProviderCli("claude");
+
+    expect(await readTextOrEmpty(claude.marker)).toContain("updated");
+    expect(status.providers).toContainEqual(
+      expect.objectContaining({ id: "claude", state: "available", version: "2.1.250" }),
+    );
+  });
+
+  it("refuses to run a self-updater against the CLI copy OpenBot manages", async () => {
+    const claude = await createUpdatableFakeClaude(root, "2.1.250");
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "claude",
+      (provider) => new FakeAgentClient(provider),
+      undefined,
+      claude.executable,
+    );
+    await service.initialize();
+    expect(service.getStatus().providers).toContainEqual(
+      expect.objectContaining({ id: "claude", version: "2.1.246", cliSource: "managed" }),
+    );
+
+    await expect(service.updateProviderCli("claude")).rejects.toThrow(/manages/u);
+
+    expect(await readTextOrEmpty(claude.marker)).toBe("");
+    expect(service.getStatus().providers).toContainEqual(
+      expect.objectContaining({ id: "claude", state: "available", version: "2.1.246" }),
+    );
+  });
+  it("keeps the CLI's own reason when its updater refuses", async () => {
+    const claude = await createUpdatableFakeClaude(root, "2.1.250", "Installed by Homebrew. Run brew upgrade.");
+    process.env.OPENBOT_CLAUDE_PATH = claude.executable;
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "claude",
+      (provider) => new FakeAgentClient(provider),
+    );
+    await service.initialize();
+
+    await expect(service.updateProviderCli("claude")).rejects.toThrow();
+
+    expect(service.getStatus().providers).toContainEqual(
+      expect.objectContaining({
+        id: "claude",
+        state: "available",
+        version: "2.1.246",
+        message: expect.stringContaining("Installed by Homebrew. Run brew upgrade."),
+      }),
+    );
   });
 });

--- a/src/backend/agent/provider-runtime.test.ts
+++ b/src/backend/agent/provider-runtime.test.ts
@@ -719,6 +719,52 @@ describe.sequential("ProviderRuntime: account checks and login", () => {
     });
   }
 
+  it("keeps the owner of a CLI whose provider is signed out", async () => {
+    process.env.OPENBOT_CLAUDE_PATH = await createFakeClaude(root);
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "codex",
+      (provider) => new FakeAgentClient(provider, undefined, true, provider !== "claude"),
+    );
+    await service.initialize();
+
+    // Signed out, the provider keeps no client, so the row would name no owner - and an unowned CLI
+    // is read as the managed copy, which sends the user's own install to a download.
+    expect(service.getStatus().providers).toContainEqual(
+      expect.objectContaining({ id: "claude", state: "sign-in-required", cliSource: "system" }),
+    );
+  });
+
+  it("redacts a secret in the reason the updater printed", async () => {
+    const claude = await createUpdatableFakeClaude(
+      root,
+      "2.1.250",
+      "registry refused Authorization: Bearer abcdef123456",
+    );
+    process.env.OPENBOT_CLAUDE_PATH = claude.executable;
+    const { store, mailbox } = stores(root);
+    service = new AgentService(
+      store,
+      mailbox,
+      fakeBrowser(),
+      30_000,
+      "claude",
+      (provider) => new FakeAgentClient(provider),
+    );
+    await service.initialize();
+
+    // The row goes to the caller and to every client the Team API broadcasts to.
+    await expect(service.updateProviderCli("claude")).rejects.toThrow(/\[redacted\]/u);
+
+    const message = service.getStatus().providers?.find((provider) => provider.id === "claude")?.message;
+    expect(message).toContain("[redacted]");
+    expect(message).not.toContain("abcdef123456");
+  });
+
   it("keeps the CLI's own reason when its updater refuses", async () => {
     const claude = await createUpdatableFakeClaude(root, "2.1.250", "Installed by Homebrew. Run brew upgrade.");
     process.env.OPENBOT_CLAUDE_PATH = claude.executable;

--- a/src/backend/agent/provider-runtime.ts
+++ b/src/backend/agent/provider-runtime.ts
@@ -24,16 +24,17 @@ import {
   isRecord,
   type ModelListResponse,
 } from "./../protocol";
-import { BUILT_IN_PROVIDER_DRIVERS, type CliLoginCommand, requireProviderDriver } from "./../provider-drivers";
+import { BUILT_IN_PROVIDER_DRIVERS, type ProviderCliCommand, requireProviderDriver } from "./../provider-drivers";
 import { normalizeAccountUsage } from "./account-usage";
 import type { ConversationRuntime } from "./conversation-runtime";
 import {
   providerFailureStatus,
+  readProcessReason,
   setProviderStatus,
   updateProviderStatus,
   waitForSuccessfulProcess,
 } from "./provider-status";
-import { cleanModelName, providerForAgent, providerLabel } from "./thread-items";
+import { providerForAgent, providerLabel } from "./thread-items";
 
 const CODEX_LOGIN_TIMEOUT_MS = 10 * 60_000;
 
@@ -99,11 +100,47 @@ const INITIAL_STATUS: AgentStatus = {
   fullAccess: true,
 };
 
+/**
+ * Models a provider CLI lists that an OpenBot agent is not meant to run. `codex-auto-review` and
+ * `gpt-reserve` are Codex picks for its own use -- a review pass and spare capacity -- and
+ * `gpt-5.5` and `gpt-5.4-mini` are older models this product does not offer. Everything else the
+ * CLI reports reaches the picker, the models it marks hidden included, so this list is the only
+ * thing that keeps a model out and adding to it is a product decision, not a guess about a flag.
+ */
+const SUPPRESSED_MODEL_IDS: ReadonlyMap<AgentProvider, ReadonlySet<string>> = new Map([
+  ["codex", new Set(["gpt-reserve", "gpt-5.5", "gpt-5.4-mini", "codex-auto-review"])],
+]);
+
+/**
+ * The product name of a Claude model, from its id, or `null` for an id that does not read as one.
+ *
+ * Claude Code lists a model by the part it plays in that CLI - "Default (recommended)", "Opus" -
+ * so its display name says which pick it is there, not which model an agent runs here. The picker
+ * puts all three providers side by side, and the other two name a model in full, so the same
+ * sentence has to be true of this one: the id carries it, with a release stamp the picker has no
+ * use for. `claude-haiku-4-5-20251001` is Claude Haiku 4.5, and `claude-fable-5-1[1m]` is the 1M
+ * context window of Claude Fable 5.1.
+ */
+function claudeModelName(id: string): string | null {
+  const parsed = /^([a-z0-9-]+?)(?:\[([a-z0-9]+)\])?$/u.exec(id.trim().toLowerCase());
+  if (!parsed) return null;
+  const [, base = "", variant] = parsed;
+  const parts = base.split("-");
+  if (parts.shift() !== "claude") return null;
+  const family = parts.shift();
+  if (!family || !/^[a-z]+$/u.test(family)) return null;
+  // Eight digits are the build date, which names a release of the model rather than the model.
+  const version = parts.filter((part) => !/^\d{8}$/u.test(part));
+  if (!version.length || version.some((part) => !/^\d+$/u.test(part))) return null;
+  const name = `Claude ${family[0]?.toUpperCase()}${family.slice(1)} ${version.join(".")}`;
+  return variant ? `${name} (${variant.toUpperCase()} context)` : name;
+}
+
 const FALLBACK_MODELS: AgentModelOption[] = [
   {
     provider: "codex",
     id: "gpt-5.6-luna",
-    name: "Luna",
+    name: "GPT-5.6 Luna",
     description: "Fast and efficient for everyday agent work.",
     defaultReasoningEffort: "medium",
     supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
@@ -111,7 +148,7 @@ const FALLBACK_MODELS: AgentModelOption[] = [
   {
     provider: "codex",
     id: "gpt-5.6-terra",
-    name: "Terra",
+    name: "GPT-5.6 Terra",
     description: "Balanced speed and capability for involved tasks.",
     defaultReasoningEffort: "medium",
     supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
@@ -119,7 +156,7 @@ const FALLBACK_MODELS: AgentModelOption[] = [
   {
     provider: "codex",
     id: "gpt-5.6-sol",
-    name: "Sol",
+    name: "GPT-5.6 Sol",
     description: "Most capable for complex, long-running work.",
     defaultReasoningEffort: "medium",
     supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
@@ -206,8 +243,22 @@ export class ProviderRuntime implements ProviderPort {
     ]);
   }
 
+  /**
+   * Every read of the status names who owns each CLI, from the resolved binary rather than from a
+   * stored field, so a provider that switches between the user's install and the managed copy
+   * cannot leave a stale owner behind. It is added here, not in `#setStatus`, because both the
+   * getter and the events `#setStatus` emits go through it.
+   */
   status(): AgentStatus {
-    return structuredClone(this.#status);
+    const status = structuredClone(this.#status);
+    if (!status.providers) return status;
+    return {
+      ...status,
+      providers: status.providers.map((row) => {
+        const source = this.#cli.get(row.id)?.source;
+        return source ? { ...row, cliSource: source } : row;
+      }),
+    };
   }
 
   isReady(): boolean {
@@ -331,6 +382,56 @@ export class ProviderRuntime implements ProviderPort {
       }
       await this.#cancelCliLogin(provider, null);
       return this.#startCliLogin(provider, cliLogin);
+    });
+  }
+
+  /**
+   * Runs the provider CLI's own updater. This is for an install the user made: it answers to them,
+   * and this is how they move it to a version newer than the one OpenBot pins, without waiting for
+   * an OpenBot release. The managed copy is refused, because the runtime manager replaces that one
+   * whole and a self-updater inside it would leave two owners for one directory.
+   */
+  async updateProviderCli(provider: AgentProvider): Promise<AgentStatus> {
+    const driver = requireProviderDriver(provider);
+    const command = driver.cliUpdate;
+    if (!command) throw new Error(`OpenBot cannot update the ${providerLabel(provider)} CLI.`);
+    return this.#runProviderConnectionCommand(provider, async () => {
+      const cli = await driver.resolveCli({ bundledExecutable: this.#bundledExecutables.get(provider) });
+      if (cli.source === "managed") {
+        throw new Error(`OpenBot manages this ${providerLabel(provider)} CLI and updates it with the app.`);
+      }
+      this.#setProviderConnectionState(provider, "connecting");
+      let reason: () => string | null = () => null;
+      try {
+        const child = spawn(cli.executable, [...command.argv], {
+          cwd: process.cwd(),
+          env: { ...process.env, ...command.env(cli) },
+          // Only the error stream is read. An updater that refuses - a CLI installed by a package
+          // manager that wants to own the upgrade, most often - says why there, and its own reason
+          // is worth more to the user than an exit code.
+          stdio: ["ignore", "ignore", "pipe"],
+          shell: false,
+          windowsHide: process.platform === "win32",
+        });
+        reason = readProcessReason(child);
+        await waitForSuccessfulProcess(child, command.timeoutMs, "Provider update");
+      } catch (error) {
+        this.#setProviderConnectionFailure(
+          provider,
+          new Error(`OpenBot could not update the ${providerLabel(provider)} CLI. ${reason() ?? "Try again."}`),
+          cli.version,
+        );
+        throw error;
+      }
+      // The running client still executes the binary the updater replaced, so it is restarted here.
+      // Its version is what the row shows, and the new one is the whole point of the command.
+      try {
+        await this.#reloadProviderCli(provider);
+      } catch (error) {
+        this.#setProviderConnectionFailure(provider, error, cli.version);
+        throw error;
+      }
+      return this.status();
     });
   }
 
@@ -677,7 +778,22 @@ export class ProviderRuntime implements ProviderPort {
     });
   }
 
-  async #startCliLogin(provider: AgentProvider, command: CliLoginCommand): Promise<AgentStatus> {
+  /** Puts a provider back on the binary that is on disk now, after its CLI replaced itself. */
+  async #reloadProviderCli(provider: AgentProvider): Promise<void> {
+    if (!this.#clients.has(provider)) {
+      this.#clearProviderConnectionState(provider);
+      this.#cli.delete(provider);
+      await this.#connect("starting", [provider], { preserveCheckErrors: true });
+      return;
+    }
+    const cli = await requireProviderDriver(provider).resolveCli({
+      bundledExecutable: this.#bundledExecutables.get(provider),
+    });
+    const candidate = await this.#createAuthenticatedProviderClient(provider, cli);
+    await this.#activateProviderClient(provider, candidate.client, cli, candidate.account);
+  }
+
+  async #startCliLogin(provider: AgentProvider, command: ProviderCliCommand): Promise<AgentStatus> {
     let cli: AgentCliInfo | null = null;
     this.#setProviderConnectionState(provider, "connecting");
 
@@ -1090,6 +1206,7 @@ export class ProviderRuntime implements ProviderPort {
           const previous = this.#models.filter((model) => model.provider === provider);
           const client = this.#clients.get(provider);
           if (!client) return previous;
+          const suppressed = SUPPRESSED_MODEL_IDS.get(provider) ?? new Set<string>();
           try {
             const serverModels = new Map<string, ModelListResponse["data"][number]>();
             const cursors = new Set<string>();
@@ -1097,12 +1214,22 @@ export class ProviderRuntime implements ProviderPort {
             do {
               const response = await client.request(
                 "model/list",
-                { limit: 100, includeHidden: false, ...(cursor ? { cursor } : {}) },
+                { limit: 100, includeHidden: true, ...(cursor ? { cursor } : {}) },
                 decodeModelListResponse,
                 5_000,
               );
+              // Every model the CLI reports is offered apart from SUPPRESSED_MODEL_IDS, the ones it
+              // marks hidden included. A CLI hides a model it still accepts -- a new release such
+              // as `gpt-6-astra` is hidden until its own launch -- and this app has no way to tell
+              // that apart from a model the account cannot use, so a hidden flag was the only
+              // reason a working model was missing from the picker while the same CLI ran it
+              // happily from a terminal.
               for (const item of response.data) {
-                if (!item.hidden && item.model?.trim()) serverModels.set(item.model, item);
+                // The trimmed id is what is kept: `isAgentModel` allows no whitespace, so a padded
+                // id would fail the contract guard downstream and take the whole list with it.
+                const id = item.model?.trim();
+                if (!id || suppressed.has(id.toLowerCase())) continue;
+                serverModels.set(id, { ...item, model: id });
               }
               cursor = client.provider === "codex" ? response.nextCursor : undefined;
               if (cursor && cursors.has(cursor)) throw new Error("Model discovery repeated a pagination cursor.");
@@ -1120,7 +1247,14 @@ export class ProviderRuntime implements ProviderPort {
               models.push({
                 provider: client.provider,
                 id: server.model,
-                name: cleanModelName(server.displayName, fallback?.name ?? server.model),
+                // The name the provider CLI gives, whole: a model is easier to recognise as
+                // `GPT-5.6 Sol` than as `Sol`, and its own CLI names it that way.
+                // Claude Code is the exception, and `claudeModelName` says why.
+                name:
+                  (client.provider === "claude" ? claudeModelName(server.model) : null) ||
+                  server.displayName?.trim() ||
+                  fallback?.name ||
+                  server.model,
                 description:
                   fallback?.description ?? `${providerLabel(client.provider)} model discovered from the local CLI.`,
                 defaultReasoningEffort: isReasoningEffort(server?.defaultReasoningEffort)

--- a/src/backend/agent/provider-runtime.ts
+++ b/src/backend/agent/provider-runtime.ts
@@ -680,8 +680,9 @@ export class ProviderRuntime implements ProviderPort {
     client: AgentClient,
     cli: AgentCliInfo,
     account: NonNullable<AccountReadResult["account"]>,
-    isCurrent?: () => boolean,
+    options: { isCurrent?: () => boolean; notifyReady?: boolean } = {},
   ): Promise<void> {
+    const { isCurrent, notifyReady = true } = options;
     const activation = this.#providerActivation
       .catch(() => undefined)
       .then(async () => {
@@ -742,7 +743,7 @@ export class ProviderRuntime implements ProviderPort {
 
         if (previousClient && previousClient !== client) await previousClient.stop().catch(() => undefined);
         if (provider === "codex") void this.#refreshUsage(client).catch(() => undefined);
-        await this.#hooks.onProvidersReady();
+        if (notifyReady) await this.#hooks.onProvidersReady();
       });
     this.#providerActivation = activation.catch(() => undefined);
     await activation;
@@ -815,7 +816,13 @@ export class ProviderRuntime implements ProviderPort {
       bundledExecutable: this.#bundledExecutables.get(provider),
     });
     const candidate = await this.#createAuthenticatedProviderClient(provider, cli);
-    await this.#activateProviderClient(provider, candidate.client, cli, candidate.account);
+    // Not a start: `onProvidersReady` is restart recovery, and it settles every unresolved delivery,
+    // including the live ones of the other providers - a turn still running would be recorded as
+    // interrupted, which `markTerminal` then refuses to correct. `onProviderResumed` schedules the
+    // deliveries this replacement held back instead.
+    await this.#activateProviderClient(provider, candidate.client, cli, candidate.account, {
+      notifyReady: false,
+    });
   }
 
   async #startCliLogin(provider: AgentProvider, command: ProviderCliCommand): Promise<AgentStatus> {
@@ -853,13 +860,9 @@ export class ProviderRuntime implements ProviderPort {
         await candidate.client.stop().catch(() => undefined);
         return;
       }
-      await this.#activateProviderClient(
-        provider,
-        candidate.client,
-        pending.cli,
-        candidate.account,
-        () => this.#cliLogins.get(provider) === pending,
-      );
+      await this.#activateProviderClient(provider, candidate.client, pending.cli, candidate.account, {
+        isCurrent: () => this.#cliLogins.get(provider) === pending,
+      });
       if (this.#cliLogins.get(provider) === pending) this.#cliLogins.delete(provider);
     } catch (error) {
       await this.#failCliLogin(provider, pending, error);
@@ -973,13 +976,9 @@ export class ProviderRuntime implements ProviderPort {
         throw new Error("ChatGPT did not return an authenticated account.");
       }
       if (this.#codexLogin !== pending) return;
-      await this.#activateProviderClient(
-        "codex",
-        pending.client,
-        pending.cli,
-        account.account,
-        () => this.#codexLogin === pending,
-      );
+      await this.#activateProviderClient("codex", pending.client, pending.cli, account.account, {
+        isCurrent: () => this.#codexLogin === pending,
+      });
       if (this.#codexLogin === pending) this.#codexLogin = null;
     } catch {
       await this.#failCodexLogin(pending, "OpenBot could not verify the ChatGPT connection. Try again.");

--- a/src/backend/agent/provider-runtime.ts
+++ b/src/backend/agent/provider-runtime.ts
@@ -68,6 +68,8 @@ export interface ProviderHooks {
   onProviderLost(client: AgentClient): void;
   /** True once stop() has begun, so a client exiting during shutdown does not trigger a restart. */
   isStopping(): boolean;
+  /** True while an agent on this provider runs a turn, which replacing its CLI would cut short. */
+  hasActiveTurns(provider: AgentProvider): boolean;
 }
 
 /**
@@ -207,6 +209,7 @@ export class ProviderRuntime implements ProviderPort {
   readonly #accounts = new Map<AgentProvider, AccountReadResult["account"]>();
   readonly #providerStarts = new Map<AgentProvider, Promise<void>>();
   readonly #providerConnectionCommands = new Map<AgentProvider, Promise<void>>();
+  readonly #replacingCli = new Set<AgentProvider>();
   #status: AgentStatus = structuredClone(INITIAL_STATUS);
   #providerRefresh: Promise<AgentStatus> | null = null;
   #codexLogin: PendingCodexLogin | null = null;
@@ -400,36 +403,49 @@ export class ProviderRuntime implements ProviderPort {
       if (cli.source === "managed") {
         throw new Error(`OpenBot manages this ${providerLabel(provider)} CLI and updates it with the app.`);
       }
-      this.#setProviderConnectionState(provider, "connecting");
-      let reason: () => string | null = () => null;
-      try {
-        const child = spawn(cli.executable, [...command.argv], {
-          cwd: process.cwd(),
-          env: { ...process.env, ...command.env(cli) },
-          // Only the error stream is read. An updater that refuses - a CLI installed by a package
-          // manager that wants to own the upgrade, most often - says why there, and its own reason
-          // is worth more to the user than an exit code.
-          stdio: ["ignore", "ignore", "pipe"],
-          shell: false,
-          windowsHide: process.platform === "win32",
-        });
-        reason = readProcessReason(child);
-        await waitForSuccessfulProcess(child, command.timeoutMs, "Provider update");
-      } catch (error) {
-        this.#setProviderConnectionFailure(
-          provider,
-          new Error(`OpenBot could not update the ${providerLabel(provider)} CLI. ${reason() ?? "Try again."}`),
-          cli.version,
-        );
-        throw error;
+      // The update replaces the binary under a running client, and the client is restarted after
+      // it. A turn in flight would lose its process, so the user is asked to wait instead.
+      if (this.#hooks.hasActiveTurns(provider)) {
+        throw new Error(`The ${providerLabel(provider)} CLI is working on a turn. Wait for it to finish, then update.`);
       }
-      // The running client still executes the binary the updater replaced, so it is restarted here.
-      // Its version is what the row shows, and the new one is the whole point of the command.
+      this.#setProviderConnectionState(provider, "connecting");
+      // No turn may start on this provider until the new client is ready. Deliveries wait in the
+      // mailbox and #activateProviderClient schedules them again.
+      this.#replacingCli.add(provider);
       try {
-        await this.#reloadProviderCli(provider);
-      } catch (error) {
-        this.#setProviderConnectionFailure(provider, error, cli.version);
-        throw error;
+        let reason: () => string | null = () => null;
+        try {
+          const child = spawn(cli.executable, [...command.argv], {
+            cwd: process.cwd(),
+            env: { ...process.env, ...command.env(cli) },
+            // Only the error stream is read. An updater that refuses - a CLI installed by a package
+            // manager that wants to own the upgrade, most often - says why there, and its own reason
+            // is worth more to the user than an exit code.
+            stdio: ["ignore", "ignore", "pipe"],
+            shell: false,
+            windowsHide: process.platform === "win32",
+          });
+          reason = readProcessReason(child);
+          await waitForSuccessfulProcess(child, command.timeoutMs, "Provider update");
+        } catch (error) {
+          // One error for both readers: the row and the caller each get the updater's own reason.
+          const failure = new Error(
+            `OpenBot could not update the ${providerLabel(provider)} CLI. ${reason() ?? "Try again."}`,
+            { cause: error },
+          );
+          this.#setProviderConnectionFailure(provider, failure, cli.version);
+          throw failure;
+        }
+        // The running client still executes the binary the updater replaced, so it is restarted
+        // here. Its version is what the row shows, and the new one is the point of the command.
+        try {
+          await this.#reloadProviderCli(provider);
+        } catch (error) {
+          this.#setProviderConnectionFailure(provider, error, cli.version);
+          throw error;
+        }
+      } finally {
+        this.#replacingCli.delete(provider);
       }
       return this.status();
     });
@@ -437,6 +453,11 @@ export class ProviderRuntime implements ProviderPort {
 
   clientForAgent(agent: AgentSummary): AgentClient | null {
     return this.#clients.get(providerForAgent(agent)) ?? null;
+  }
+
+  /** True while the CLI's own updater runs and the client that used the old binary is replaced. */
+  isReplacingCli(provider: AgentProvider): boolean {
+    return this.#replacingCli.has(provider);
   }
 
   requireReadyClient(provider: AgentProvider): AgentClient {

--- a/src/backend/agent/provider-runtime.ts
+++ b/src/backend/agent/provider-runtime.ts
@@ -208,6 +208,15 @@ export class ProviderRuntime implements ProviderPort {
   readonly #bundledExecutables: ReadonlyMap<AgentProvider, string | null | undefined>;
   readonly #clients = new Map<AgentProvider, AgentClient>();
   readonly #cli = new Map<AgentProvider, AgentCliInfo>();
+  /**
+   * Who owns each provider's binary, as the last resolution found it.
+   *
+   * `#cli` holds only the CLI a client runs on, and a provider that is signed out has no client
+   * although its binary is resolved and its version is on the row. Without this record that row
+   * names no owner, and an unowned CLI is read as the managed copy: the user's own install would be
+   * offered a download instead of its own updater.
+   */
+  readonly #cliSources = new Map<AgentProvider, AgentCliInfo["source"]>();
   readonly #accounts = new Map<AgentProvider, AccountReadResult["account"]>();
   readonly #providerStarts = new Map<AgentProvider, Promise<void>>();
   readonly #providerConnectionCommands = new Map<AgentProvider, Promise<void>>();
@@ -260,10 +269,25 @@ export class ProviderRuntime implements ProviderPort {
     return {
       ...status,
       providers: status.providers.map((row) => {
-        const source = this.#cli.get(row.id)?.source;
+        const source = this.#cli.get(row.id)?.source ?? this.#cliSources.get(row.id);
         return source ? { ...row, cliSource: source } : row;
       }),
     };
+  }
+
+  /** Resolve a provider's binary and keep who owns it, whether or not the provider is signed in. */
+  async #resolveProviderCli(provider: AgentProvider): Promise<AgentCliInfo> {
+    try {
+      const cli = await requireProviderDriver(provider).resolveCli({
+        bundledExecutable: this.#bundledExecutables.get(provider),
+      });
+      this.#cliSources.set(provider, cli.source);
+      return cli;
+    } catch (error) {
+      // Nothing resolved, so there is no owner to name: a kept one would outlive its binary.
+      this.#cliSources.delete(provider);
+      throw error;
+    }
   }
 
   isReady(): boolean {
@@ -401,7 +425,7 @@ export class ProviderRuntime implements ProviderPort {
     const command = driver.cliUpdate;
     if (!command) throw new Error(`OpenBot cannot update the ${providerLabel(provider)} CLI.`);
     return this.#runProviderConnectionCommand(provider, async () => {
-      const cli = await driver.resolveCli({ bundledExecutable: this.#bundledExecutables.get(provider) });
+      const cli = await this.#resolveProviderCli(provider);
       if (cli.source === "managed") {
         throw new Error(`OpenBot manages this ${providerLabel(provider)} CLI and updates it with the app.`);
       }
@@ -814,9 +838,7 @@ export class ProviderRuntime implements ProviderPort {
       await this.#connect("starting", [provider], { preserveCheckErrors: true, notifyReady: false });
       return;
     }
-    const cli = await requireProviderDriver(provider).resolveCli({
-      bundledExecutable: this.#bundledExecutables.get(provider),
-    });
+    const cli = await this.#resolveProviderCli(provider);
     const candidate = await this.#createAuthenticatedProviderClient(provider, cli);
     // Not a start: `onProvidersReady` is restart recovery, and it settles every unresolved delivery,
     // including the live ones of the other providers - a turn still running would be recorded as
@@ -832,9 +854,7 @@ export class ProviderRuntime implements ProviderPort {
     this.#setProviderConnectionState(provider, "connecting");
 
     try {
-      cli = await requireProviderDriver(provider).resolveCli({
-        bundledExecutable: this.#bundledExecutables.get(provider),
-      });
+      cli = await this.#resolveProviderCli(provider);
       const child = spawn(cli.executable, [...command.argv], {
         cwd: process.cwd(),
         env: { ...process.env, ...command.env(cli) },
@@ -1046,7 +1066,7 @@ export class ProviderRuntime implements ProviderPort {
         let client: AgentClient | null = null;
         let cli: AgentCliInfo | null = null;
         try {
-          cli = await driver.resolveCli({ bundledExecutable: this.#bundledExecutables.get(provider) });
+          cli = await this.#resolveProviderCli(provider);
           client = this.#clientFactory
             ? this.#clientFactory(provider, cli)
             : driver.createClient(cli, this.#requestTimeoutMs);

--- a/src/backend/agent/provider-runtime.ts
+++ b/src/backend/agent/provider-runtime.ts
@@ -809,7 +809,9 @@ export class ProviderRuntime implements ProviderPort {
     if (!this.#clients.has(provider)) {
       this.#clearProviderConnectionState(provider);
       this.#cli.delete(provider);
-      await this.#connect("starting", [provider], { preserveCheckErrors: true });
+      // Connecting the replaced CLI is not a start either: the other providers are running through
+      // it, and `onProvidersReady` would settle their live deliveries. See below.
+      await this.#connect("starting", [provider], { preserveCheckErrors: true, notifyReady: false });
       return;
     }
     const cli = await requireProviderDriver(provider).resolveCli({
@@ -1009,7 +1011,7 @@ export class ProviderRuntime implements ProviderPort {
   async #connect(
     phase: "starting" | "restarting",
     requestedProviders: readonly AgentProvider[],
-    options: { preserveCheckErrors?: boolean; refreshRuntimeInBackground?: boolean } = {},
+    options: { preserveCheckErrors?: boolean; refreshRuntimeInBackground?: boolean; notifyReady?: boolean } = {},
   ): Promise<void> {
     const hadClients = this.#clients.size > 0;
     const providerStatuses: AgentProviderStatus[] = structuredClone(
@@ -1148,7 +1150,7 @@ export class ProviderRuntime implements ProviderPort {
         });
       }
       if (codexClient) void this.#refreshUsage(codexClient).catch(() => undefined);
-      await this.#hooks.onProvidersReady();
+      if (options.notifyReady !== false) await this.#hooks.onProvidersReady();
     };
     if (options.refreshRuntimeInBackground) {
       void refreshRuntime().catch((error) => this.#emitError("provider_metadata_refresh_failed", error));

--- a/src/backend/agent/provider-runtime.ts
+++ b/src/backend/agent/provider-runtime.ts
@@ -68,8 +68,10 @@ export interface ProviderHooks {
   onProviderLost(client: AgentClient): void;
   /** True once stop() has begun, so a client exiting during shutdown does not trigger a restart. */
   isStopping(): boolean;
-  /** True while an agent on this provider runs a turn, which replacing its CLI would cut short. */
-  hasActiveTurns(provider: AgentProvider): boolean;
+  /** True while a turn on this provider runs or starts, which replacing its CLI would cut short. */
+  isProviderBusy(provider: AgentProvider): boolean;
+  /** Runs after a CLI replacement, so deliveries held back during it are delivered. */
+  onProviderResumed(provider: AgentProvider): void;
 }
 
 /**
@@ -405,7 +407,7 @@ export class ProviderRuntime implements ProviderPort {
       }
       // The update replaces the binary under a running client, and the client is restarted after
       // it. A turn in flight would lose its process, so the user is asked to wait instead.
-      if (this.#hooks.hasActiveTurns(provider)) {
+      if (this.#hooks.isProviderBusy(provider)) {
         throw new Error(`The ${providerLabel(provider)} CLI is working on a turn. Wait for it to finish, then update.`);
       }
       this.#setProviderConnectionState(provider, "connecting");
@@ -446,6 +448,8 @@ export class ProviderRuntime implements ProviderPort {
         }
       } finally {
         this.#replacingCli.delete(provider);
+        // Also after a failure: nothing else schedules the deliveries this update held back.
+        this.#hooks.onProviderResumed(provider);
       }
       return this.status();
     });

--- a/src/backend/agent/provider-status.ts
+++ b/src/backend/agent/provider-status.ts
@@ -49,11 +49,38 @@ export function providerFailureStatus(
   return { state: "error", version: version ?? null, message };
 }
 
-export function waitForSuccessfulProcess(child: ChildProcess, timeoutMs: number): Promise<void> {
+/**
+ * Collects a failing process's own explanation from its error stream: the last line it wrote,
+ * bounded, for a message the user reads. Returns null when the process said nothing usable, so the
+ * caller keeps its own wording rather than showing an empty sentence.
+ */
+export function readProcessReason(child: ChildProcess): () => string | null {
+  let text = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    if (text.length < 4_000) text += chunk;
+  });
+  child.stderr?.on("error", () => undefined);
+  return () => {
+    const line = text
+      .split(/\r?\n/u)
+      .map((candidate) => candidate.trim())
+      .filter(Boolean)
+      .at(-1);
+    if (!line) return null;
+    return line.length > 200 ? `${line.slice(0, 199)}…` : line;
+  };
+}
+
+export function waitForSuccessfulProcess(
+  child: ChildProcess,
+  timeoutMs: number,
+  description = "Provider login",
+): Promise<void> {
   return new Promise((resolveProcess, reject) => {
     const timer = setTimeout(() => {
       child.kill("SIGTERM");
-      reject(new Error("Provider login timed out."));
+      reject(new Error(`${description} timed out.`));
     }, timeoutMs);
     timer.unref?.();
     child.once("error", (error) => {
@@ -63,7 +90,7 @@ export function waitForSuccessfulProcess(child: ChildProcess, timeoutMs: number)
     child.once("exit", (code, signal) => {
       clearTimeout(timer);
       if (code === 0 && signal === null) resolveProcess();
-      else reject(new Error(`Provider login stopped with ${signal ?? `code ${String(code)}`}.`));
+      else reject(new Error(`${description} stopped with ${signal ?? `code ${String(code)}`}.`));
     });
   });
 }

--- a/src/backend/agent/provider-status.ts
+++ b/src/backend/agent/provider-status.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import type { AgentProviderStatus } from "@openbot/contracts/ipc";
+import { redactText } from "@openbot/logging";
 import type { AgentProvider } from "../agent-client";
 import { CodexCliError } from "../cli";
 
@@ -53,6 +54,9 @@ export function providerFailureStatus(
  * Collects a failing process's own explanation from its error stream: the last line it wrote,
  * bounded, for a message the user reads. Returns null when the process said nothing usable, so the
  * caller keeps its own wording rather than showing an empty sentence.
+ *
+ * The line is redacted first. It goes into the provider row, which the Team API broadcasts to the
+ * team's connected clients, and a CLI that fails on authentication prints the header or key it sent.
  */
 export function readProcessReason(child: ChildProcess): () => string | null {
   let text = "";
@@ -68,7 +72,8 @@ export function readProcessReason(child: ChildProcess): () => string | null {
       .filter(Boolean)
       .at(-1);
     if (!line) return null;
-    return line.length > 200 ? `${line.slice(0, 199)}…` : line;
+    const safe = redactText(line);
+    return safe.length > 200 ? `${safe.slice(0, 199)}…` : safe;
   };
 }
 

--- a/src/backend/agent/thread-items.ts
+++ b/src/backend/agent/thread-items.ts
@@ -78,11 +78,6 @@ export function toolProgressText(item: ThreadItem, completed: boolean): string |
   return completed ? "Reviewing the latest tool result…" : "Working through the next tool-assisted step…";
 }
 
-export function cleanModelName(value: string | undefined, fallback: string): string {
-  if (!value) return fallback;
-  return value.replace(/^GPT-5\.6[\s:–—-]*/i, "").trim() || fallback;
-}
-
 export function providerForAgent(agent: { provider: AgentProvider }): AgentProvider {
   return agent.provider;
 }

--- a/src/backend/claude-client.ts
+++ b/src/backend/claude-client.ts
@@ -13,6 +13,7 @@ import {
   tool,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { DEFAULT_PROVIDER_MODELS } from "@openbot/contracts/ipc";
 import { type DynamicRecord, isDynamicRecord, isNumber, isOneOf, isString } from "@openbot/contracts/runtime-values";
 import type { AgentProvider } from "./agent-client";
 import { BROWSER_TOOL_DEFINITIONS, OPENBOT_BROWSER_NAMESPACE } from "./browser-tools";
@@ -1011,7 +1012,7 @@ function dynamicContent(value: unknown): CallToolResult["content"] {
 }
 
 function normalizeClaudeModel(model: string): string {
-  return model.startsWith("claude-") ? model : "claude-opus-5";
+  return model.startsWith("claude-") ? model : DEFAULT_PROVIDER_MODELS.claude;
 }
 
 function normalizeClaudeEffort(effort: string): ClaudeEffort {

--- a/src/backend/provider-drivers.ts
+++ b/src/backend/provider-drivers.ts
@@ -7,23 +7,39 @@ import { GrokAgentClient } from "./grok-client";
 import type { AccountReadResult } from "./protocol";
 
 /**
- * Signing in by running the provider's own CLI and waiting for the process to exit. Codex
- * has no entry here: it signs in over the app-server protocol against a URL the user opens
+ * One command OpenBot runs against a provider's own CLI, waiting for the process to exit. Codex
+ * has no `cliLogin` entry: it signs in over the app-server protocol against a URL the user opens
  * in a browser, and shares no step with spawning a command.
  */
-export interface CliLoginCommand {
+export interface ProviderCliCommand {
   readonly argv: readonly string[];
   readonly env: (cli: AgentCliInfo) => Record<string, string>;
   readonly timeoutMs: number;
 }
 
 const CLI_LOGIN_TIMEOUT_MS = 10 * 60_000;
+const CLI_UPDATE_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * The CLI's own updater, for an install the user made. Each of the three ships one, and each one
+ * decides for itself what "latest" means, which is the point: a user is not held to the version
+ * OpenBot pins for the runtime it manages. OpenBot never runs these against its managed copy --
+ * that install is replaced wholesale by the runtime manager, and a self-updater loose inside it
+ * would leave two owners for one directory.
+ */
+const CLI_UPDATE_COMMAND: ProviderCliCommand = {
+  argv: ["update"],
+  env: () => ({}),
+  timeoutMs: CLI_UPDATE_TIMEOUT_MS,
+};
 
 export interface BuiltInProviderDriver {
   id: AgentProviderId;
   label: string;
   signInMessage: string;
-  cliLogin?: CliLoginCommand;
+  cliLogin?: ProviderCliCommand;
+  /** Absent for a provider whose CLI cannot update itself, which offers the user no update. */
+  cliUpdate?: ProviderCliCommand;
   resolveCli(options?: { bundledExecutable?: string | null }): Promise<AgentCliInfo>;
   createClient(cli: AgentCliInfo, requestTimeoutMs: number): AgentClient;
   authState(account: AccountReadResult["account"]): AgentAuthState;
@@ -35,6 +51,7 @@ export const BUILT_IN_PROVIDER_DRIVERS: readonly BuiltInProviderDriver[] = [
     id: "codex",
     label: "Codex",
     signInMessage: "Run `codex login` to use Codex.",
+    cliUpdate: CLI_UPDATE_COMMAND,
     resolveCli: resolveCodexCli,
     createClient: (cli, requestTimeoutMs) => new CodexAppServerClient(cli.executable, requestTimeoutMs),
     authState: (account) => ({ kind: "chatgpt", email: account?.email ?? null }),
@@ -53,6 +70,7 @@ export const BUILT_IN_PROVIDER_DRIVERS: readonly BuiltInProviderDriver[] = [
       env: (cli): Record<string, string> => (cli.source === "managed" ? { DISABLE_AUTOUPDATER: "1" } : {}),
       timeoutMs: CLI_LOGIN_TIMEOUT_MS,
     },
+    cliUpdate: CLI_UPDATE_COMMAND,
     resolveCli: resolveClaudeCli,
     createClient: (cli, requestTimeoutMs) => new ClaudeAgentClient(cli, undefined, undefined, requestTimeoutMs),
     authState: (account) => ({ kind: "claude", email: account?.email ?? null }),
@@ -67,6 +85,7 @@ export const BUILT_IN_PROVIDER_DRIVERS: readonly BuiltInProviderDriver[] = [
       env: () => ({ GROK_OAUTH2_REFERRER: "openbot" }),
       timeoutMs: CLI_LOGIN_TIMEOUT_MS,
     },
+    cliUpdate: CLI_UPDATE_COMMAND,
     resolveCli: resolveGrokCli,
     createClient: (cli, requestTimeoutMs) => new GrokAgentClient(cli, requestTimeoutMs),
     authState: (account) => ({ kind: "grok", email: account?.email ?? null }),

--- a/src/main/application-services.ts
+++ b/src/main/application-services.ts
@@ -24,6 +24,7 @@ import { rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type {
+  AgentStatus,
   AppVariant,
   BrowserDisplayState,
   CentralAuthState,
@@ -357,6 +358,22 @@ export async function createApplicationServices({
     sidebarLayout,
   );
   teardown.push(TEARDOWN_ORDER.service, "the agent service", () => service.stop());
+  /*
+   * The runtime manager decides which provider has an update waiting, by comparing against the
+   * pinned lock. It knows the copies it downloaded itself; a CLI the user installed is only ever
+   * reported in the agent status, so it is passed on from here. Nothing is downloaded for such an
+   * install - the offer only leads to the CLI's own updater.
+   */
+  const trackSystemCliVersions = (status: AgentStatus): void => {
+    for (const provider of status.providers ?? []) {
+      const version = provider.cliSource === "system" ? (provider.version ?? null) : null;
+      providerRuntimes.setSystemVersion(provider.id, version);
+    }
+  };
+  trackSystemCliVersions(service.getStatus());
+  service.on("event", (event) => {
+    if (event.type === "status") trackSystemCliVersions(event.status);
+  });
   providerRuntimes.on("status", forwardProviderRuntimeStatus);
   providerRuntimes.on("ready", (provider) => {
     void service.refreshProvider(provider).catch((error) => {

--- a/src/main/ipc/provider-handlers.ts
+++ b/src/main/ipc/provider-handlers.ts
@@ -1,5 +1,6 @@
 // Signing in to Codex, Claude and Grok, and downloading the CLI runtimes they need.
 
+import type { AgentProviderId, AgentStatus } from "@openbot/contracts/ipc";
 import { shell } from "electron";
 import type { AgentService } from "../../backend/agent-service";
 import type { ProviderRuntimeManager } from "../provider-runtime-manager";
@@ -24,6 +25,17 @@ export function providerIpcHandlers({
           await shell.openExternal(url.toString());
         }),
       ),
+      /*
+       * The CLI's own updater decides what it installs, and it can finish on the version it started
+       * on. The runtime manager owns the offer, so it is told the outcome and can stop repeating one
+       * the updater has already turned down.
+       */
+      updateProviderCli: payloadHandler(parseProviderId, async (provider) => {
+        const before = systemCliVersion(service.getStatus(), provider);
+        const status = await service.updateProviderCli(provider);
+        await providerRuntimes.noteSystemCliUpdate(provider, before, systemCliVersion(status, provider));
+        return status;
+      }),
       refreshAgentProviders: handler(() => service.refreshProviders()),
     },
     providerRuntimes: {
@@ -32,4 +44,10 @@ export function providerIpcHandlers({
       cancel: payloadHandler(parseProviderId, (parsed) => providerRuntimes.cancel(parsed)),
     },
   };
+}
+
+/** The version of a provider CLI the user installed themselves, or `null` for a managed copy. */
+function systemCliVersion(status: AgentStatus, provider: AgentProviderId): string | null {
+  const entry = status.providers?.find((candidate) => candidate.id === provider);
+  return entry?.cliSource === "system" ? (entry.version ?? null) : null;
 }

--- a/src/main/provider-runtime-manager.test.ts
+++ b/src/main/provider-runtime-manager.test.ts
@@ -88,6 +88,59 @@ describe("ProviderRuntimeManager", () => {
     },
   );
 
+  it("offers the pinned version to an older CLI the user installed", async () => {
+    const root = await temporaryRoot();
+    const manager = new ProviderRuntimeManager({ root, platform: "darwin", architecture: "arm64" });
+    await manager.initialize();
+    const pinned = parseAgentRuntimeLock(structuredClone(lockValue)).grok.version;
+    const snapshots: ProviderRuntimeSnapshot[] = [];
+    manager.on("status", (snapshot) => snapshots.push(snapshot));
+
+    manager.setSystemVersion("grok", "0.0.1");
+    expect(snapshots.at(-1)?.providers.grok).toMatchObject({ version: null, availableVersion: pinned });
+
+    manager.setSystemVersion("grok", pinned);
+    expect(manager.getStatus().providers.grok.availableVersion).toBeNull();
+
+    manager.setSystemVersion("grok", pinned);
+    expect(snapshots).toHaveLength(2);
+  });
+
+  it("stops offering a version the user's own updater leaves uninstalled, across restarts", async () => {
+    const root = await temporaryRoot();
+    const pinned = parseAgentRuntimeLock(structuredClone(lockValue)).grok.version;
+    const manager = new ProviderRuntimeManager({ root, platform: "darwin", architecture: "arm64" });
+    await manager.initialize();
+    manager.setSystemVersion("grok", "0.0.1");
+    expect(manager.getStatus().providers.grok.availableVersion).toBe(pinned);
+
+    // The CLI ran its updater and stayed where it was: its own channel has nothing newer for it.
+    await manager.noteSystemCliUpdate("grok", "0.0.1", "0.0.1");
+    expect(manager.getStatus().providers.grok.availableVersion).toBeNull();
+
+    const restarted = new ProviderRuntimeManager({ root, platform: "darwin", architecture: "arm64" });
+    await restarted.initialize();
+    restarted.setSystemVersion("grok", "0.0.1");
+    expect(restarted.getStatus().providers.grok.availableVersion).toBeNull();
+
+    // A CLI that moved on its own is a different install, so the pinned version is offered again.
+    restarted.setSystemVersion("grok", "0.0.2");
+    expect(restarted.getStatus().providers.grok.availableVersion).toBe(pinned);
+  });
+
+  it("offers again once the updater installs something", async () => {
+    const root = await temporaryRoot();
+    const pinned = parseAgentRuntimeLock(structuredClone(lockValue)).grok.version;
+    const manager = new ProviderRuntimeManager({ root, platform: "darwin", architecture: "arm64" });
+    await manager.initialize();
+    manager.setSystemVersion("grok", "0.0.1");
+    await manager.noteSystemCliUpdate("grok", "0.0.1", "0.0.1");
+    manager.setSystemVersion("grok", "0.0.2");
+    await manager.noteSystemCliUpdate("grok", "0.0.1", "0.0.2");
+    expect(manager.getStatus().providers.grok.availableVersion).toBe(pinned);
+    expect(JSON.parse(await readFile(join(root, "cli-update-refusals.json"), "utf8"))).toEqual({});
+  });
+
   it("allows three transfers and cancels only the selected provider", async () => {
     const root = await temporaryRoot();
     const oldClaude = join(root, "claude", "darwin-arm64", "2.1.246", "bin", "claude");

--- a/src/main/provider-runtime-manager.ts
+++ b/src/main/provider-runtime-manager.ts
@@ -77,6 +77,8 @@ export class ProviderRuntimeManager extends EventEmitter<ProviderRuntimeManagerE
    * because an offer that returns on the next start is the same dead end again.
    */
   readonly #refusedUpdates = new Map<AgentProviderId, { version: string; pinnedVersion: string }>();
+  /** The queue that keeps the record's writes in the order the refusals were recorded. */
+  #refusedUpdatesWrite: Promise<void> = Promise.resolve();
   #revision = 0;
   #stopping = false;
 
@@ -185,16 +187,28 @@ export class ProviderRuntimeManager extends EventEmitter<ProviderRuntimeManagerE
     }
   }
 
+  /**
+   * Writes the record, one write at a time.
+   *
+   * Two providers can finish an update at once. Each write serializes the record as it stands when
+   * its turn comes and renames its own temporary file into place, so without the queue the older
+   * snapshot could be renamed last and drop the newer provider's refusal - which the user would meet
+   * as an offer that provider has already turned down.
+   */
   async #writeRefusedUpdates(): Promise<void> {
-    const path = this.#refusedUpdatesPath();
-    const temporaryPath = `${path}.${randomUUID()}.tmp`;
-    try {
-      await mkdir(this.#root, { recursive: true });
-      await writeFile(temporaryPath, `${JSON.stringify(Object.fromEntries(this.#refusedUpdates))}\n`, "utf8");
-      await rename(temporaryPath, path);
-    } catch {
-      await rm(temporaryPath, { force: true }).catch(() => undefined);
-    }
+    const write = this.#refusedUpdatesWrite.then(async () => {
+      const path = this.#refusedUpdatesPath();
+      const temporaryPath = `${path}.${randomUUID()}.tmp`;
+      try {
+        await mkdir(this.#root, { recursive: true });
+        await writeFile(temporaryPath, `${JSON.stringify(Object.fromEntries(this.#refusedUpdates))}\n`, "utf8");
+        await rename(temporaryPath, path);
+      } catch {
+        await rm(temporaryPath, { force: true }).catch(() => undefined);
+      }
+    });
+    this.#refusedUpdatesWrite = write;
+    await write;
   }
 
   #refusedUpdatesPath(): string {

--- a/src/main/provider-runtime-manager.ts
+++ b/src/main/provider-runtime-manager.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { createReadStream, createWriteStream } from "node:fs";
 import {
@@ -67,6 +67,16 @@ export class ProviderRuntimeManager extends EventEmitter<ProviderRuntimeManagerE
   readonly #controllers = new Map<AgentProviderId, AbortController>();
   readonly #tasks = new Map<AgentProviderId, Promise<void>>();
   readonly #cancelled = new Set<AgentProviderId>();
+  /** Versions of provider CLIs the user installed, kept only to compare against the lock. */
+  readonly #systemVersions = new Map<AgentProviderId, string>();
+  /**
+   * The offers the user's own CLI updater has already turned down, one per provider.
+   *
+   * A CLI decides for itself what its newest version is, and its release channel can name an older
+   * one than the lock: `grok update` reports success and leaves the CLI where it was. Kept on disk,
+   * because an offer that returns on the next start is the same dead end again.
+   */
+  readonly #refusedUpdates = new Map<AgentProviderId, { version: string; pinnedVersion: string }>();
   #revision = 0;
   #stopping = false;
 
@@ -93,6 +103,7 @@ export class ProviderRuntimeManager extends EventEmitter<ProviderRuntimeManagerE
   async initialize(): Promise<ProviderRuntimeSnapshot> {
     await mkdir(this.#root, { recursive: true });
     await this.#removeAbandonedStaging();
+    await this.#readRefusedUpdates();
     await Promise.all(PROVIDERS.map((provider) => this.#inspect(provider)));
     const target = this.#target;
     if (target) {
@@ -108,11 +119,86 @@ export class ProviderRuntimeManager extends EventEmitter<ProviderRuntimeManagerE
     if (this.#target) {
       for (const provider of PROVIDERS) {
         const version = runtimeSpec(provider, this.#target, this.#lock).version;
-        const installed = providers[provider].version;
-        providers[provider].availableVersion = installed && olderVersion(installed, version) ? version : null;
+        // The install in use, which is the user's own copy whenever there is one: the resolver
+        // prefers it, so the managed version on disk is not what the provider runs.
+        const installed = this.#systemVersions.get(provider) ?? providers[provider].version;
+        const refused = this.#refusedUpdates.get(provider);
+        const offer = installed !== null && installed !== undefined && olderVersion(installed, version);
+        providers[provider].availableVersion =
+          offer && !(refused?.version === installed && refused.pinnedVersion === version) ? version : null;
       }
     }
     return { revision: this.#revision, providers };
+  }
+
+  /**
+   * Records the version of a provider CLI the user installed, as the agent service resolved it.
+   *
+   * The manager does not own that install and never downloads for it. It owns the lock, though, and
+   * the lock is what says which version is current, so the comparison belongs here with the managed
+   * one rather than in the renderer, which must not compare versions at all. Pass `null` when the
+   * provider went back to the managed copy or resolved nothing.
+   */
+  setSystemVersion(provider: AgentProviderId, version: string | null): void {
+    if ((this.#systemVersions.get(provider) ?? null) === version) return;
+    if (version) this.#systemVersions.set(provider, version);
+    else this.#systemVersions.delete(provider);
+    this.#revision += 1;
+    this.emit("status", this.getStatus());
+  }
+
+  /**
+   * The result of a run of the provider CLI's own updater: the version the CLI was on before it, and
+   * the version it reports now.
+   *
+   * A CLI that finishes on the version it started on has answered: the version the lock pins is not
+   * one its own channel will install, so OpenBot stops offering it. The record is kept against both
+   * versions, so a new pinned version is a new offer, and so is a CLI the user moves by other means.
+   */
+  async noteSystemCliUpdate(provider: AgentProviderId, before: string | null, after: string | null): Promise<void> {
+    if (!this.#target) return;
+    const pinnedVersion = runtimeSpec(provider, this.#target, this.#lock).version;
+    const refused = after !== null && after === before && olderVersion(after, pinnedVersion);
+    const current = this.#refusedUpdates.get(provider);
+    if (refused && current?.version === after && current.pinnedVersion === pinnedVersion) return;
+    if (!refused && !current) return;
+    if (refused && after) this.#refusedUpdates.set(provider, { version: after, pinnedVersion });
+    else this.#refusedUpdates.delete(provider);
+    await this.#writeRefusedUpdates();
+    this.#revision += 1;
+    this.emit("status", this.getStatus());
+  }
+
+  async #readRefusedUpdates(): Promise<void> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readFile(this.#refusedUpdatesPath(), "utf8"));
+    } catch {
+      // A record that is missing or unreadable only costs the user one more refused offer.
+      return;
+    }
+    if (!isDynamicRecord(parsed)) return;
+    for (const provider of PROVIDERS) {
+      const entry = parsed[provider];
+      if (!isDynamicRecord(entry) || !isString(entry.version) || !isString(entry.pinnedVersion)) continue;
+      this.#refusedUpdates.set(provider, { version: entry.version, pinnedVersion: entry.pinnedVersion });
+    }
+  }
+
+  async #writeRefusedUpdates(): Promise<void> {
+    const path = this.#refusedUpdatesPath();
+    const temporaryPath = `${path}.${randomUUID()}.tmp`;
+    try {
+      await mkdir(this.#root, { recursive: true });
+      await writeFile(temporaryPath, `${JSON.stringify(Object.fromEntries(this.#refusedUpdates))}\n`, "utf8");
+      await rename(temporaryPath, path);
+    } catch {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+    }
+  }
+
+  #refusedUpdatesPath(): string {
+    return join(this.#root, "cli-update-refusals.json");
   }
 
   executablePath(provider: AgentProviderId): string | null {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -738,6 +738,10 @@ const openbotApi: OpenBotDesktopApi = {
     ipcRenderer.invoke(IPC_CHANNELS.computerUseCloseMacPermissionSetup).then(decodeVoid),
   openExternal: (destination) => ipcRenderer.invoke(IPC_CHANNELS.openExternal, destination),
   connectProvider: (provider) => ipcRenderer.invoke(IPC_CHANNELS.connectProvider, provider),
+  // Decoded, unlike its two neighbours: this reply is read straight after the user's own CLI was
+  // replaced under the app, so the version and state in it are the point of the call.
+  updateProviderCli: (provider) =>
+    ipcRenderer.invoke(IPC_CHANNELS.updateProviderCli, provider).then(decodeAgentStatusFromMain),
   refreshAgentProviders: () => ipcRenderer.invoke(IPC_CHANNELS.refreshAgentProviders),
   providerRuntimes: {
     getStatus: () => ipcRenderer.invoke(IPC_CHANNELS.providerRuntimesGetStatus).then(decodeProviderRuntimeSnapshot),

--- a/src/renderer/src/App.settings.test.tsx
+++ b/src/renderer/src/App.settings.test.tsx
@@ -207,7 +207,7 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await waitFor(() => expect(window.openbot.agent.getUsage).toHaveBeenCalledWith("chief"));
 
-    await fireEvent.click(await screen.findByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(await screen.findByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
     await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
@@ -442,11 +442,14 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
-    const trigger = screen.getByRole("button", { name: "Agent model: Luna" });
+    const trigger = screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" });
     await fireEvent.click(trigger);
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     expect(within(picker).getByText("0.144.1 (Codex CLI)")).toBeInTheDocument();
-    expect(within(picker).getByRole("option", { name: "Luna, default" })).toHaveAttribute("aria-selected", "true");
+    expect(within(picker).getByRole("option", { name: "GPT-5.6 Luna, default" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
 
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
     expect(window.openbot.agent.updateAgent).not.toHaveBeenCalled();
@@ -488,7 +491,7 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
     await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
@@ -550,7 +553,7 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
     await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
@@ -587,9 +590,9 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
-    await fireEvent.click(within(picker).getByRole("option", { name: "Sol" }));
+    await fireEvent.click(within(picker).getByRole("option", { name: "GPT-5.6 Sol" }));
     const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
     await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
     await fireEvent.click(screen.getByRole("option", { name: "Extra high" }));
@@ -599,9 +602,9 @@ describe("OpenBot connected desktop shell", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Could not change effort. Try again.");
     expect(window.openbot.agent.updateAgent).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole("button", { name: "Agent model: Luna" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" })).toBeEnabled();
     expect(effort).toHaveTextContent("Medium");
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
   });
 
   it("reconciles a concurrent model update after an effort save succeeds", async () => {
@@ -615,7 +618,7 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
     await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
@@ -628,13 +631,13 @@ describe("OpenBot connected desktop shell", () => {
       type: "agents-changed",
       agents: AGENTS.map((agent) => (agent.id === "chief" ? concurrentAgent : agent)),
     });
-    expect(screen.getByRole("button", { name: "Agent model: Luna" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" })).toBeEnabled();
 
     resolveEffortUpdate(concurrentAgent);
 
-    expect(await screen.findByRole("button", { name: "Agent model: Sol" })).toBeEnabled();
+    expect(await screen.findByRole("button", { name: "Agent model: GPT-5.6 Sol" })).toBeEnabled();
     expect(effort).toHaveTextContent("High");
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Sol" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Sol" }));
   });
 
   it("does not roll back a newer effort when an older save fails", async () => {
@@ -648,7 +651,7 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
     await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
@@ -679,7 +682,7 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
     await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
@@ -690,20 +693,20 @@ describe("OpenBot connected desktop shell", () => {
     rejectUpdate(new Error("Chief effort failed"));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Agent model: Luna" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" })).toBeEnabled();
   });
 
   it("rolls back a failed header model change and reports the error", async () => {
     vi.mocked(window.openbot.agent.updateAgent).mockRejectedValueOnce(new Error("Provider failed"));
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
-    await screen.findByRole("button", { name: "Agent model: Luna" });
+    await screen.findByRole("button", { name: "Agent model: GPT-5.6 Luna" });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
-    await fireEvent.click(screen.getByRole("option", { name: "Sol" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
+    await fireEvent.click(screen.getByRole("option", { name: "GPT-5.6 Sol" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Could not change model. Try again.");
-    expect(screen.getByRole("button", { name: "Agent model: Luna" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" })).toBeEnabled();
     expect(
       screen.queryByRole("radiogroup", { name: "What do you want me helping with most?" }),
     ).not.toBeInTheDocument();
@@ -715,7 +718,7 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
     await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
@@ -729,7 +732,7 @@ describe("OpenBot connected desktop shell", () => {
   it("locks the header model picker during active work", async () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
-    const trigger = screen.getByRole("button", { name: "Agent model: Luna" });
+    const trigger = screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" });
     await waitFor(() => expect(trigger).toBeEnabled());
 
     emitAgentEvent?.({
@@ -816,7 +819,7 @@ describe("OpenBot connected desktop shell", () => {
     await screen.findByRole("heading", { name: "Chief" });
     await fireEvent.click(screen.getByRole("button", { name: "View agent settings" }));
     let settings = await screen.findByRole("complementary", { name: "Agent settings" });
-    await fireEvent.click(within(settings).getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(within(settings).getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     let picker = within(settings).getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
     await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
@@ -824,9 +827,9 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(screen.getByRole("button", { name: /Sales Outbound/ }));
     await fireEvent.click(screen.getByRole("button", { name: "View agent settings" }));
     settings = await screen.findByRole("complementary", { name: "Agent settings" });
-    expect(within(settings).getByRole("button", { name: "Agent model: Luna" })).toBeEnabled();
+    expect(within(settings).getByRole("button", { name: "Agent model: GPT-5.6 Luna" })).toBeEnabled();
 
-    await fireEvent.click(within(settings).getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(within(settings).getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     picker = within(settings).getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
     await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));

--- a/src/renderer/src/App.settings.test.tsx
+++ b/src/renderer/src/App.settings.test.tsx
@@ -210,7 +210,7 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(await screen.findByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
-    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
+    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5" }));
 
     await waitFor(() => expect(window.openbot.agent.getUsage).toHaveBeenCalledTimes(2));
     expect(await screen.findByRole("button", { name: "Weekly usage, 18% left" })).toBeInTheDocument();
@@ -454,7 +454,7 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
     expect(window.openbot.agent.updateAgent).not.toHaveBeenCalled();
     expect(within(picker).getByText("2.1.231 (Claude Code)")).toBeInTheDocument();
-    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
+    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5" }));
 
     await waitFor(() =>
       expect(window.openbot.agent.updateAgent).toHaveBeenCalledWith({
@@ -494,7 +494,7 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
-    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
+    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5" }));
     const effort = within(picker).getByRole("button", { name: /Agent reasoning effort/ });
     await fireEvent.pointerDown(effort, { pointerType: "mouse", button: 0 });
     await fireEvent.click(screen.getByRole("option", { name: "High" }));
@@ -556,8 +556,8 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const picker = screen.getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
-    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
-    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Sonnet 5" }));
+    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5" }));
+    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Sonnet 5, default" }));
     expect(window.openbot.agent.updateAgent).toHaveBeenCalledOnce();
 
     await fireEvent.keyDown(picker, { key: "Escape" });
@@ -822,7 +822,7 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(within(settings).getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     let picker = within(settings).getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
-    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
+    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5" }));
 
     await fireEvent.click(screen.getByRole("button", { name: /Sales Outbound/ }));
     await fireEvent.click(screen.getByRole("button", { name: "View agent settings" }));
@@ -832,7 +832,7 @@ describe("OpenBot connected desktop shell", () => {
     await fireEvent.click(within(settings).getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     picker = within(settings).getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(picker).getByRole("tab", { name: /^Claude:/ }));
-    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5, default" }));
+    await fireEvent.click(within(picker).getByRole("option", { name: "Claude Opus 5" }));
     await waitFor(() =>
       expect(window.openbot.agent.updateAgent).toHaveBeenCalledWith({
         agentId: "sales-outbound",

--- a/src/renderer/src/WorkspaceOverlays.tsx
+++ b/src/renderer/src/WorkspaceOverlays.tsx
@@ -203,6 +203,7 @@ function AppSettings(props: AccountProps) {
     providerAvailableVersions,
     providerRuntimeDownloadsAvailable,
     downloadProviderRuntime,
+    startProviderUpdate,
     cancelProviderRuntimeDownload,
     connectProvider,
   } = useProviders();
@@ -232,7 +233,7 @@ function AppSettings(props: AccountProps) {
         agentStatus={agentStatus()}
         providerRuntimeStatuses={localProviderDownloads() ? providerRuntimeStatuses() : undefined}
         providerAvailableVersions={localProviderDownloads() ? providerAvailableVersions() : undefined}
-        onUpdateProvider={localProviderDownloads() ? downloadProviderRuntime : undefined}
+        onUpdateProvider={localProviderDownloads() ? startProviderUpdate : undefined}
         onDownloadProvider={localProviderDownloads() ? downloadProviderRuntime : undefined}
         onCancelProviderDownload={localProviderDownloads() ? cancelProviderRuntimeDownload : undefined}
         onConnectProvider={localProviderDownloads() ? connectProvider : undefined}

--- a/src/renderer/src/analytics.ts
+++ b/src/renderer/src/analytics.ts
@@ -136,7 +136,9 @@ export interface DesktopAnalyticsEvents {
       | "refresh"
       | "download_started"
       | "download_completed"
-      | "download_cancelled";
+      | "download_cancelled"
+      | "cli_update_started"
+      | "cli_update_completed";
     result: AnalyticsResult;
     failure_code?: string;
   };
@@ -322,6 +324,8 @@ const EVENT_ACTIONS: Partial<Record<AnalyticsEventName, readonly string[]>> = {
     "download_started",
     "download_completed",
     "download_cancelled",
+    "cli_update_started",
+    "cli_update_completed",
   ],
   reaction_action: ["add", "remove"],
   maintenance_action: ["export_data", "export_diagnostics"],

--- a/src/renderer/src/app-test-harness.ts
+++ b/src/renderer/src/app-test-harness.ts
@@ -284,7 +284,7 @@ export function testConversationPage(
 }
 
 export async function confirmOnboardingModel(): Promise<void> {
-  await screen.findByRole("button", { name: "Agent model: Luna" });
+  await screen.findByRole("button", { name: "Agent model: GPT-5.6 Luna" });
 }
 
 export function queuedDelivery(
@@ -533,7 +533,7 @@ export function installOpenbotStub(): void {
           {
             provider: "codex",
             id: "gpt-5.6-luna",
-            name: "Luna",
+            name: "GPT-5.6 Luna",
             description: "Fast and efficient for everyday agent work.",
             defaultReasoningEffort: "medium",
             supportedReasoningEfforts: ["low", "medium", "high"],
@@ -541,7 +541,7 @@ export function installOpenbotStub(): void {
           {
             provider: "codex",
             id: "gpt-5.6-terra",
-            name: "Terra",
+            name: "GPT-5.6 Terra",
             description: "Balanced speed and capability for involved tasks.",
             defaultReasoningEffort: "medium",
             supportedReasoningEfforts: ["medium", "high"],
@@ -549,7 +549,7 @@ export function installOpenbotStub(): void {
           {
             provider: "codex",
             id: "gpt-5.6-sol",
-            name: "Sol",
+            name: "GPT-5.6 Sol",
             description: "Most capable for complex, long-running work.",
             defaultReasoningEffort: "high",
             supportedReasoningEfforts: ["medium", "high", "xhigh"],

--- a/src/renderer/src/components/ProviderModelPicker.test.tsx
+++ b/src/renderer/src/components/ProviderModelPicker.test.tsx
@@ -61,9 +61,9 @@ describe("ProviderModelPicker", () => {
       />
     ));
 
-    await fireEvent.click(view.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(view.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const dialog = view.getByRole("dialog", { name: "Choose agent model" });
-    await fireEvent.click(within(dialog).getByRole("option", { name: "Sol" }));
+    await fireEvent.click(within(dialog).getByRole("option", { name: "GPT-5.6 Sol" }));
 
     expect(onChange).toHaveBeenCalledWith("gpt-5.6-sol", "codex");
     expect(dialog).toBeInTheDocument();
@@ -92,7 +92,7 @@ describe("ProviderModelPicker", () => {
       />
     ));
 
-    await fireEvent.click(view.getByRole("button", { name: "Agent model: Luna" }));
+    await fireEvent.click(view.getByRole("button", { name: "Agent model: GPT-5.6 Luna" }));
     const dialog = view.getByRole("dialog", { name: "Choose agent model" });
     expect(within(dialog).getByRole("tab", { name: /ChatGPT:/ })).toBeInTheDocument();
     const grok = within(dialog).getByRole("tab", { name: /Grok:/ });
@@ -104,7 +104,7 @@ describe("ProviderModelPicker", () => {
     );
 
     await fireEvent.click(within(dialog).getByRole("tab", { name: /Claude:/ }));
-    expect(within(dialog).getByRole("option", { name: "Claude Opus 5, default" })).toBeDisabled();
+    expect(within(dialog).getByRole("option", { name: "Claude Sonnet 5, default" })).toBeDisabled();
     expect(onChange).not.toHaveBeenCalled();
   });
 
@@ -118,7 +118,7 @@ describe("ProviderModelPicker", () => {
         onChange={vi.fn()}
       />
     ));
-    const trigger = view.getByRole("button", { name: "Agent model: Luna" });
+    const trigger = view.getByRole("button", { name: "Agent model: GPT-5.6 Luna" });
 
     await fireEvent.click(trigger);
     const dialog = view.getByRole("dialog", { name: "Choose agent model" });

--- a/src/renderer/src/components/ProviderModelPicker.tsx
+++ b/src/renderer/src/components/ProviderModelPicker.tsx
@@ -8,6 +8,7 @@ import type {
   AgentStatus,
   ProviderRuntimeStatus,
 } from "@openbot/contracts/ipc";
+import { DEFAULT_PROVIDER_MODELS } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, For, onSettled, Show, untrack } from "solid-js";
 import {
   Button,
@@ -42,11 +43,6 @@ interface ProviderModelPickerProps {
 }
 
 const PROVIDERS: AgentProviderId[] = ["claude", "codex", "grok"];
-const DEFAULT_MODELS: Partial<Record<AgentProviderId, AgentModelId>> = {
-  claude: "claude-opus-5",
-  codex: "gpt-5.6-luna",
-};
-
 export function ProviderModelPicker(props: ProviderModelPickerProps) {
   const [open, setOpen] = createSignal(false);
   const [railProvider, setRailProvider] = createSignal<AgentProviderId>(untrack(() => props.provider));
@@ -295,14 +291,14 @@ export function ProviderModelPicker(props: ProviderModelPickerProps) {
                               type="button"
                               class={["provider-model-option", { "provider-model-option-selected": selected() }]}
                               aria-label={`${displayModelName(model.name, model.id)}${
-                                model.id === DEFAULT_MODELS[provider] ? ", default" : ""
+                                model.id === DEFAULT_PROVIDER_MODELS[provider] ? ", default" : ""
                               }`}
                               disabled={!available()}
                               onClick={() => selectModel(model.id, provider)}
                             >
                               <span class="provider-model-option-name">
                                 <span>{displayModelName(model.name, model.id)}</span>
-                                <Show when={model.id === DEFAULT_MODELS[provider]}>
+                                <Show when={model.id === DEFAULT_PROVIDER_MODELS[provider]}>
                                   <small>default</small>
                                 </Show>
                               </span>

--- a/src/renderer/src/components/ProviderPicker.tsx
+++ b/src/renderer/src/components/ProviderPicker.tsx
@@ -37,6 +37,10 @@ export interface ProviderPickerProps {
   onConnectProvider?: (provider: AgentProviderId) => void | Promise<void>;
   onDownloadProvider?: (provider: AgentProviderId) => void | Promise<void>;
   onCancelProviderDownload?: (provider: AgentProviderId) => void | Promise<void>;
+  /**
+   * Starts the update the row offers. Whether that re-downloads the managed runtime or runs the
+   * CLI's own updater is decided by the caller, which knows who owns the install.
+   */
   onUpdateProvider?: (provider: AgentProviderId) => void | Promise<void>;
   onInstallProvider?: (provider: AgentProviderId) => void | Promise<void>;
   onSignInProvider?: (provider: AgentProviderId) => void | Promise<void>;
@@ -207,7 +211,7 @@ export function ProviderPicker(props: ProviderPickerProps) {
                       size="xs"
                       class="provider-picker-install"
                       aria-label={`Update ${option().name} to ${option().availableVersion}`}
-                      disabled={props.disabled || props.refreshingProviders}
+                      disabled={props.disabled || props.refreshingProviders || connecting()}
                       onClick={() => void props.onUpdateProvider?.(option().id)}
                     >
                       Update

--- a/src/renderer/src/features/conversation/AgentSettingsPanel.test.tsx
+++ b/src/renderer/src/features/conversation/AgentSettingsPanel.test.tsx
@@ -44,7 +44,7 @@ describe("AgentSettingsPanel", () => {
     await fireEvent.click(await screen.findByRole("button", { name: "Agent model: GPT-5.6 Sol" }));
     const dialog = screen.getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(dialog).getByRole("tab", { name: /^Claude:/ }));
-    await fireEvent.click(within(dialog).getByRole("option", { name: "Claude Sonnet 5" }));
+    await fireEvent.click(within(dialog).getByRole("option", { name: "Claude Sonnet 5, default" }));
 
     await waitFor(() =>
       expect(onUpdateRuntimeSettings).toHaveBeenCalledWith(

--- a/src/renderer/src/features/conversation/AgentSettingsPanel.test.tsx
+++ b/src/renderer/src/features/conversation/AgentSettingsPanel.test.tsx
@@ -60,6 +60,6 @@ describe("AgentSettingsPanel", () => {
     expect(screen.getByRole("button", { name: /Agent reasoning level/ })).toHaveTextContent("Extra high");
     await fireEvent.click(screen.getByRole("button", { name: "Usage" }));
     expect(onOpenUsage).toHaveBeenCalledWith(screen.getByRole("button", { name: "Usage" }));
-    expect(screen.getByRole("button", { name: "Agent model: Sol" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Agent model: GPT-5.6 Sol" })).toBeInTheDocument();
   });
 });

--- a/src/renderer/src/features/conversation/AgentSettingsPanel.test.tsx
+++ b/src/renderer/src/features/conversation/AgentSettingsPanel.test.tsx
@@ -41,7 +41,7 @@ describe("AgentSettingsPanel", () => {
       />
     ));
 
-    await fireEvent.click(await screen.findByRole("button", { name: "Agent model: Sol" }));
+    await fireEvent.click(await screen.findByRole("button", { name: "Agent model: GPT-5.6 Sol" }));
     const dialog = screen.getByRole("dialog", { name: "Choose agent model" });
     await fireEvent.click(within(dialog).getByRole("tab", { name: /^Claude:/ }));
     await fireEvent.click(within(dialog).getByRole("option", { name: "Claude Sonnet 5" }));
@@ -56,7 +56,7 @@ describe("AgentSettingsPanel", () => {
     await fireEvent.keyDown(dialog, { key: "Escape" });
 
     expect(await screen.findByText("Could not save agent settings.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Agent model: Sol" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Agent model: GPT-5.6 Sol" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Agent reasoning level/ })).toHaveTextContent("Extra high");
     await fireEvent.click(screen.getByRole("button", { name: "Usage" }));
     expect(onOpenUsage).toHaveBeenCalledWith(screen.getByRole("button", { name: "Usage" }));

--- a/src/renderer/src/features/provider-updates/provider-runtime-store.ts
+++ b/src/renderer/src/features/provider-updates/provider-runtime-store.ts
@@ -34,7 +34,8 @@ export function createProviderRuntimeStore(
     createSignal<ProviderRuntimeSnapshot>(FALLBACK_PROVIDER_RUNTIMES);
   const updating = new Set<AgentProviderId>();
   /**
-   * A version the user's own CLI updater will not install, per provider.
+   * A version the user's own CLI updater will not install, per provider, with the version it stayed
+   * on. Both are needed: a CLI that moves later is a different install, and the offer is live again.
    *
    * The updater can report success and leave the CLI exactly where it was: its release channel
    * decides what "latest" means for it, and that answer can be older than the version OpenBot pins.
@@ -42,7 +43,9 @@ export function createProviderRuntimeStore(
    * lasting record - it survives a restart, and it owns every version comparison - so this is only
    * the immediate echo, which settles the notification without waiting for the next snapshot.
    */
-  const [refusedVersions, setRefusedVersions] = createSignal<Partial<Record<AgentProviderId, string>>>({});
+  const [refusedVersions, setRefusedVersions] = createSignal<
+    Partial<Record<AgentProviderId, { installed: string; offered: string }>>
+  >({});
   /** What the user was last told about, so one offer is not announced twice. */
   let announced: ProviderUpdate[] = [];
   let disposed = false;
@@ -50,16 +53,15 @@ export function createProviderRuntimeStore(
     const runtime = snapshot.providers[provider];
     const systemVersion = owners.systemCliVersion?.(provider) ?? null;
     const availableVersion = runtime.availableVersion ?? null;
+    const refused = refusedVersions()[provider];
     return {
       provider,
       name: provider === "codex" ? "ChatGPT" : provider === "claude" ? "Claude" : "Grok",
-      // A CLI the user installed has no managed download, so its runtime stays "not-downloaded"
-      // while the provider runs perfectly well. It is installed, on the version it reports.
-      runtime:
-        systemVersion && runtime.phase === "not-downloaded"
-          ? { ...runtime, phase: "ready", version: systemVersion }
-          : runtime,
-      availableVersion: refusedVersions()[provider] === availableVersion ? null : availableVersion,
+      // A CLI the user installed is the one the provider runs, whatever the managed runtime holds.
+      // It is installed, on the version it reports.
+      runtime: systemVersion ? { ...runtime, phase: "ready", version: systemVersion } : runtime,
+      availableVersion:
+        refused?.offered === availableVersion && refused.installed === systemVersion ? null : availableVersion,
     };
   }
 
@@ -100,8 +102,9 @@ export function createProviderRuntimeStore(
     // An updater that finished on the version it started on has given its answer: the version
     // OpenBot pins is not one it will install, and repeating the offer would only repeat this.
     const offered = update.availableVersion;
-    const refused = offered !== null && owners.systemCliVersion?.(provider) === update.runtime.version;
-    if (refused) setRefusedVersions((current) => ({ ...current, [provider]: offered }));
+    const installed = owners.systemCliVersion?.(provider) ?? null;
+    const refused = offered !== null && installed !== null && installed === update.runtime.version;
+    if (refused && installed) setRefusedVersions((current) => ({ ...current, [provider]: { installed, offered } }));
     const settled = providerUpdate(provider);
     // Read locally rather than through the signal just written: the write lands on the next flush.
     reportProviderUpdateToast(

--- a/src/renderer/src/features/provider-updates/provider-runtime-store.ts
+++ b/src/renderer/src/features/provider-updates/provider-runtime-store.ts
@@ -23,6 +23,15 @@ export interface ProviderCliOwners {
   systemCliVersion?: (provider: AgentProviderId) => string | null;
   /** Runs that CLI's own updater. OpenBot downloads nothing on this path. */
   updateSystemCli?: (provider: AgentProviderId) => Promise<void>;
+  /**
+   * Whether the workspace on screen is this computer. Left out, it is.
+   *
+   * Every runtime this store reaches is local - `window.openbot.providerRuntimes` addresses no other
+   * computer - while the agent status beside it describes whichever server is open. A remote
+   * workspace therefore has no offer to make here, and an Update button it raised would change a
+   * runtime the user is not looking at.
+   */
+  isLocalServer?: () => boolean;
 }
 
 /** The real download flow, shared by Settings and the other local provider controls. */
@@ -49,6 +58,7 @@ export function createProviderRuntimeStore(
   /** What the user was last told about, so one offer is not announced twice. */
   let announced: ProviderUpdate[] = [];
   let disposed = false;
+  const isLocalServer = owners.isLocalServer ?? (() => true);
   function providerUpdate(provider: AgentProviderId, snapshot = providerRuntimeSnapshot()): ProviderUpdate {
     const runtime = snapshot.providers[provider];
     const systemVersion = owners.systemCliVersion?.(provider) ?? null;
@@ -70,6 +80,7 @@ export function createProviderRuntimeStore(
    * Retry the notification offers after a failure. Who does the work depends on who owns the CLI.
    */
   function startProviderUpdate(provider: AgentProviderId): Promise<void> {
+    if (!isLocalServer()) return Promise.reject(new Error("Provider CLI updates run on the computer that hosts them."));
     return owners.systemCliVersion?.(provider) ? updateSystemCli(provider) : downloadProviderRuntime(provider);
   }
 
@@ -213,8 +224,11 @@ export function createProviderRuntimeStore(
    * provider - and every progress tick is one - leaves a dismissed notification dismissed.
    */
   createEffect(
-    () => PROVIDERS.map((provider) => providerUpdate(provider)),
+    () => (isLocalServer() ? PROVIDERS.map((provider) => providerUpdate(provider)) : null),
     (next) => {
+      // A remote workspace announces nothing, and leaves the record of what was announced alone:
+      // it says what the user was told about this computer, which the open server does not change.
+      if (!next) return;
       for (const update of providerUpdatesToAnnounce(announced, next)) {
         showProviderUpdateToast(update, () => void startProviderUpdate(update.provider));
       }

--- a/src/renderer/src/features/provider-updates/provider-runtime-store.ts
+++ b/src/renderer/src/features/provider-updates/provider-runtime-store.ts
@@ -1,28 +1,113 @@
 import type { AgentProviderId, ProviderRuntimeSnapshot, ProviderRuntimesDesktopApi } from "@openbot/contracts/ipc";
-import { createSignal, flush, onSettled } from "solid-js";
+import { createEffect, createSignal, flush, onSettled } from "solid-js";
 import { desktopAnalytics } from "../../analytics";
 import { FALLBACK_PROVIDER_RUNTIMES } from "../../app-defaults";
-import type { ProviderUpdate } from "./provider-update";
+import { type ProviderUpdate, providerUpdatesToAnnounce } from "./provider-update";
 import {
   dismissProviderUpdateToast,
   reportProviderUpdateToast,
   showProviderUpdateToast,
 } from "./provider-update-toast";
 
+const PROVIDERS = ["codex", "claude", "grok"] as const;
+
+/**
+ * The provider CLIs OpenBot does not own: the ones the user installed themselves.
+ *
+ * They take the same update offer as a managed runtime - main compares both against the pinned
+ * version - and only the work behind the offer differs, so this store routes it and the rest of the
+ * app sees one update flow. Left out, everything here keeps working for managed runtimes alone.
+ */
+export interface ProviderCliOwners {
+  /** The version of the CLI the user installed for this provider, or `null` for a managed one. */
+  systemCliVersion?: (provider: AgentProviderId) => string | null;
+  /** Runs that CLI's own updater. OpenBot downloads nothing on this path. */
+  updateSystemCli?: (provider: AgentProviderId) => Promise<void>;
+}
+
 /** The real download flow, shared by Settings and the other local provider controls. */
-export function createProviderRuntimeStore(api: ProviderRuntimesDesktopApi | undefined) {
+export function createProviderRuntimeStore(
+  api: ProviderRuntimesDesktopApi | undefined,
+  owners: ProviderCliOwners = {},
+) {
   const [providerRuntimeSnapshot, setProviderRuntimeSnapshot] =
     createSignal<ProviderRuntimeSnapshot>(FALLBACK_PROVIDER_RUNTIMES);
   const updating = new Set<AgentProviderId>();
+  /**
+   * A version the user's own CLI updater will not install, per provider.
+   *
+   * The updater can report success and leave the CLI exactly where it was: its release channel
+   * decides what "latest" means for it, and that answer can be older than the version OpenBot pins.
+   * Offering it again would walk the user through an update that cannot happen. Main keeps the
+   * lasting record - it survives a restart, and it owns every version comparison - so this is only
+   * the immediate echo, which settles the notification without waiting for the next snapshot.
+   */
+  const [refusedVersions, setRefusedVersions] = createSignal<Partial<Record<AgentProviderId, string>>>({});
+  /** What the user was last told about, so one offer is not announced twice. */
+  let announced: ProviderUpdate[] = [];
   let disposed = false;
   function providerUpdate(provider: AgentProviderId, snapshot = providerRuntimeSnapshot()): ProviderUpdate {
     const runtime = snapshot.providers[provider];
+    const systemVersion = owners.systemCliVersion?.(provider) ?? null;
+    const availableVersion = runtime.availableVersion ?? null;
     return {
       provider,
       name: provider === "codex" ? "ChatGPT" : provider === "claude" ? "Claude" : "Grok",
-      runtime,
-      availableVersion: runtime.availableVersion ?? null,
+      // A CLI the user installed has no managed download, so its runtime stays "not-downloaded"
+      // while the provider runs perfectly well. It is installed, on the version it reports.
+      runtime:
+        systemVersion && runtime.phase === "not-downloaded"
+          ? { ...runtime, phase: "ready", version: systemVersion }
+          : runtime,
+      availableVersion: refusedVersions()[provider] === availableVersion ? null : availableVersion,
     };
+  }
+
+  /**
+   * The one thing an Update button does, wherever it is: the provider row, the notification, and the
+   * Retry the notification offers after a failure. Who does the work depends on who owns the CLI.
+   */
+  function startProviderUpdate(provider: AgentProviderId): Promise<void> {
+    return owners.systemCliVersion?.(provider) ? updateSystemCli(provider) : downloadProviderRuntime(provider);
+  }
+
+  /**
+   * Hands the update to the CLI's own updater and reports it in the same notification a managed
+   * download uses. There is no progress to report - the CLI does not tell us any - so the
+   * notification stays on the indeterminate step until the provider comes back on the new binary.
+   */
+  async function updateSystemCli(provider: AgentProviderId): Promise<void> {
+    const run = owners.updateSystemCli;
+    if (!run) throw new Error("Provider CLI updates are unavailable.");
+    const update = providerUpdate(provider);
+    showProviderUpdateToast(
+      { ...update, runtime: { ...update.runtime, phase: "finishing", progress: null } },
+      () => void startProviderUpdate(provider),
+    );
+    try {
+      await run(provider);
+    } catch (error) {
+      if (disposed) return;
+      const message = error instanceof Error ? error.message : "The update could not start. Try again.";
+      reportProviderUpdateToast(
+        { ...update, runtime: { ...update.runtime, phase: "download-error", message } },
+        () => void startProviderUpdate(provider),
+      );
+      return;
+    }
+    if (disposed) return;
+    // The provider reports its new version through the agent status, which has been applied by now.
+    // An updater that finished on the version it started on has given its answer: the version
+    // OpenBot pins is not one it will install, and repeating the offer would only repeat this.
+    const offered = update.availableVersion;
+    const refused = offered !== null && owners.systemCliVersion?.(provider) === update.runtime.version;
+    if (refused) setRefusedVersions((current) => ({ ...current, [provider]: offered }));
+    const settled = providerUpdate(provider);
+    // Read locally rather than through the signal just written: the write lands on the next flush.
+    reportProviderUpdateToast(
+      refused ? { ...settled, availableVersion: null } : settled,
+      () => void startProviderUpdate(provider),
+    );
   }
   /** Revisioned, because the pushed event and the awaited call can land out of order. */
   function applyProviderRuntimeSnapshot(snapshot: ProviderRuntimeSnapshot): void {
@@ -113,6 +198,27 @@ export function createProviderRuntimeStore(api: ProviderRuntimesDesktopApi | und
     });
   }
 
+  /**
+   * Raises one notification for each provider that has just gained an update offer.
+   *
+   * An effect, not a call at the end of each update: an offer is a fact about two pieces of state
+   * that arrive separately and in no fixed order - the runtime snapshot from main, and the agent
+   * status that names the version of a CLI the user installed. Announcing from whichever one landed
+   * last missed the offer whenever the other was still on its way.
+   *
+   * Only the crossing into "update available" is announced, so a snapshot pushed for an unrelated
+   * provider - and every progress tick is one - leaves a dismissed notification dismissed.
+   */
+  createEffect(
+    () => PROVIDERS.map((provider) => providerUpdate(provider)),
+    (next) => {
+      for (const update of providerUpdatesToAnnounce(announced, next)) {
+        showProviderUpdateToast(update, () => void startProviderUpdate(update.provider));
+      }
+      announced = next;
+    },
+  );
+
   onSettled(() => {
     const unsubscribe = api?.onEvent((snapshot) => flush(() => applyProviderRuntimeSnapshot(snapshot)));
     void api
@@ -135,6 +241,7 @@ export function createProviderRuntimeStore(api: ProviderRuntimesDesktopApi | und
     }),
     providerRuntimeDownloadsAvailable: () => Boolean(api),
     applyProviderRuntimeSnapshot,
+    startProviderUpdate,
     downloadProviderRuntime,
     cancelProviderRuntimeDownload,
   };

--- a/src/renderer/src/features/provider-updates/provider-runtime-store.ts
+++ b/src/renderer/src/features/provider-updates/provider-runtime-store.ts
@@ -5,6 +5,8 @@ import { FALLBACK_PROVIDER_RUNTIMES } from "../../app-defaults";
 import { type ProviderUpdate, providerUpdatesToAnnounce } from "./provider-update";
 import {
   dismissProviderUpdateToast,
+  hideProviderUpdateToast,
+  providerUpdateOfferClosed,
   reportProviderUpdateToast,
   showProviderUpdateToast,
 } from "./provider-update-toast";
@@ -230,6 +232,9 @@ export function createProviderRuntimeStore(
       // it says what the user was told about this computer, which the open server does not change.
       if (!next) return;
       for (const update of providerUpdatesToAnnounce(announced, next)) {
+        // A closed notification stays closed, including across the server switch that rebuilds this
+        // store: the record of it is kept by the notification module, which outlives the switch.
+        if (providerUpdateOfferClosed(update.provider, update.availableVersion)) continue;
         showProviderUpdateToast(update, () => void startProviderUpdate(update.provider));
       }
       announced = next;
@@ -246,7 +251,8 @@ export function createProviderRuntimeStore(
       disposed = true;
       unsubscribe?.();
       updating.clear();
-      for (const provider of ["codex", "claude", "grok"] as const) dismissProviderUpdateToast(provider);
+      // Hidden, not dismissed: the offer outlives the workspace this store was built for.
+      for (const provider of ["codex", "claude", "grok"] as const) hideProviderUpdateToast(provider);
     };
   });
   return {

--- a/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
+++ b/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
@@ -256,7 +256,7 @@ it("keeps the CLI's own reason on the notification and retries from it", async (
 it("stops offering a version the CLI's own updater leaves uninstalled", async () => {
   const updateSystemCli = vi.fn(async () => {});
   // The CLI reports the same version it started on: its channel has nothing newer for it.
-  const { store } = systemCliHarness(updateSystemCli, true, "0.146.0");
+  const { store, setInstalled } = systemCliHarness(updateSystemCli, true, "0.146.0");
 
   fireEvent.click(await screen.findByRole("button", { name: "Update" }));
   await waitFor(() => expect(updateSystemCli).toHaveBeenCalledWith("codex"));
@@ -264,6 +264,11 @@ it("stops offering a version the CLI's own updater leaves uninstalled", async ()
   expect(screen.getByText("v0.146.0")).toBeInTheDocument();
   await waitFor(() => expect(store.providerAvailableVersions().codex).toBeNull());
   expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
+
+  // The CLI moved on its own, so it is a different install and the pinned version is offered again.
+  setInstalled("0.150.0");
+  flush();
+  expect(store.providerAvailableVersions().codex).toBe("0.153.4");
 });
 
 it("announces an offer that only becomes one once the agent status lands", async () => {

--- a/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
+++ b/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
@@ -1,10 +1,11 @@
 import type {
+  AgentProviderId,
   ProviderRuntimeSnapshot,
   ProviderRuntimeStatus,
   ProviderRuntimesDesktopApi,
 } from "@openbot/contracts/ipc";
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
-import { flush } from "solid-js";
+import { createSignal, flush } from "solid-js";
 import { afterEach, expect, it, vi } from "vitest";
 import { FALLBACK_UPDATE_STATUS } from "../../app-defaults";
 import { TOAST_DURATION, Toaster } from "../../components/ui";
@@ -30,6 +31,7 @@ const update = () => {};
 
 afterEach(() => {
   dismissProviderUpdateToast("claude");
+  dismissProviderUpdateToast("codex");
   vi.useRealTimers();
 });
 
@@ -126,10 +128,10 @@ function runtimeHarness() {
   return { store, api, emit, onOpenChange };
 }
 
-it("opens a notification from Settings and follows only current snapshots", async () => {
+it("announces an offer and follows only current snapshots", async () => {
   const { store, emit } = runtimeHarness();
   await waitFor(() => expect(store.providerAvailableVersions().claude).toBe("2.1.250"));
-  expect(screen.queryByText("Claude update available")).not.toBeInTheDocument();
+  expect(await screen.findByText("Claude update available")).toBeInTheDocument();
   fireEvent.click(await screen.findByRole("button", { name: "Update Claude to 2.1.250" }));
   expect(await screen.findByText("Updating Claude")).toBeInTheDocument();
   const stale = emit({ phase: "downloading", progress: 42 });
@@ -178,4 +180,98 @@ it("keeps Settings open when the update notification is closed", async () => {
   fireEvent.click(close);
   expect(onOpenChange).not.toHaveBeenCalled();
   expect(screen.getByRole("button", { name: "Close settings" })).toBeInTheDocument();
+});
+
+/** A provider whose CLI the user installed: nothing managed on disk, and a newer version pinned. */
+function systemCliHarness(
+  updateSystemCli: (provider: AgentProviderId) => Promise<void>,
+  startInstalled = true,
+  installedAfterUpdate = "0.153.4",
+) {
+  const status: ProviderRuntimeStatus = { phase: "not-downloaded", progress: null, message: null, version: null };
+  const snapshot: ProviderRuntimeSnapshot = {
+    revision: 1,
+    providers: {
+      codex: { ...status, availableVersion: "0.153.4" },
+      claude: { ...status, availableVersion: null },
+      grok: { ...status, availableVersion: null },
+    },
+  };
+  const api: ProviderRuntimesDesktopApi = {
+    getStatus: async () => snapshot,
+    download: vi.fn(async () => snapshot),
+    cancel: async () => snapshot,
+    onEvent: () => () => {},
+  };
+  // A signal, because this is what the agent status is: it lands on its own, after the snapshot as
+  // often as before it.
+  const [installed, setInstalled] = createSignal<string | null>(startInstalled ? "0.146.0" : null);
+  let store: ReturnType<typeof createProviderRuntimeStore> | undefined;
+  render(() => {
+    store = createProviderRuntimeStore(api, {
+      systemCliVersion: (provider) => (provider === "codex" ? installed() : null),
+      updateSystemCli: async (provider) => {
+        await updateSystemCli(provider);
+        setInstalled(installedAfterUpdate);
+      },
+    });
+    return <Toaster />;
+  });
+  if (!store) throw new Error("The provider runtime store did not mount.");
+  return { store, api, setInstalled };
+}
+
+it("updates a CLI the user installed from the notification, without downloading anything", async () => {
+  const updateSystemCli = vi.fn(async () => {});
+  const { api } = systemCliHarness(updateSystemCli);
+
+  expect(await screen.findByText("ChatGPT update available")).toBeInTheDocument();
+  expect(screen.getByText("v0.146.0 → v0.153.4")).toBeInTheDocument();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+
+  expect(await screen.findByText("Updating ChatGPT")).toBeInTheDocument();
+  await waitFor(() => expect(updateSystemCli).toHaveBeenCalledWith("codex"));
+  expect(await screen.findByText("ChatGPT is up to date")).toBeInTheDocument();
+  expect(screen.getByText("v0.153.4")).toBeInTheDocument();
+  expect(api.download).not.toHaveBeenCalled();
+});
+
+it("keeps the CLI's own reason on the notification and retries from it", async () => {
+  const updateSystemCli = vi
+    .fn<(provider: AgentProviderId) => Promise<void>>()
+    .mockRejectedValueOnce(new Error("OpenBot could not update the ChatGPT CLI. Installed by Homebrew."))
+    .mockResolvedValue(undefined);
+  systemCliHarness(updateSystemCli);
+
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  expect(
+    await screen.findByText("OpenBot could not update the ChatGPT CLI. Installed by Homebrew."),
+  ).toBeInTheDocument();
+
+  fireEvent.click(await screen.findByRole("button", { name: "Retry" }));
+  expect(await screen.findByText("ChatGPT is up to date")).toBeInTheDocument();
+  expect(updateSystemCli).toHaveBeenCalledTimes(2);
+});
+
+it("stops offering a version the CLI's own updater leaves uninstalled", async () => {
+  const updateSystemCli = vi.fn(async () => {});
+  // The CLI reports the same version it started on: its channel has nothing newer for it.
+  const { store } = systemCliHarness(updateSystemCli, true, "0.146.0");
+
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  await waitFor(() => expect(updateSystemCli).toHaveBeenCalledWith("codex"));
+  expect(await screen.findByText("ChatGPT is up to date")).toBeInTheDocument();
+  expect(screen.getByText("v0.146.0")).toBeInTheDocument();
+  await waitFor(() => expect(store.providerAvailableVersions().codex).toBeNull());
+  expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
+});
+
+it("announces an offer that only becomes one once the agent status lands", async () => {
+  const { setInstalled } = systemCliHarness(async () => {}, false);
+
+  await waitFor(() => expect(screen.queryByRole("button", { name: "Close notification" })).not.toBeInTheDocument());
+
+  setInstalled("0.146.0");
+  flush();
+  expect(await screen.findByText("ChatGPT update available")).toBeInTheDocument();
 });

--- a/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
+++ b/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
@@ -206,6 +206,9 @@ function systemCliHarness(
   // A signal, because this is what the agent status is: it lands on its own, after the snapshot as
   // often as before it.
   const [installed, setInstalled] = createSignal<string | null>(startInstalled ? "0.146.0" : null);
+  // The workspace on screen, which decides whether the CLIs this store reaches are the ones the user
+  // is looking at. Every one of them is on this computer.
+  const [local, setLocal] = createSignal(true);
   let store: ReturnType<typeof createProviderRuntimeStore> | undefined;
   render(() => {
     store = createProviderRuntimeStore(api, {
@@ -214,11 +217,12 @@ function systemCliHarness(
         await updateSystemCli(provider);
         setInstalled(installedAfterUpdate);
       },
+      isLocalServer: local,
     });
     return <Toaster />;
   });
   if (!store) throw new Error("The provider runtime store did not mount.");
-  return { store, api, setInstalled };
+  return { store, api, setInstalled, setLocal };
 }
 
 it("updates a CLI the user installed from the notification, without downloading anything", async () => {
@@ -277,6 +281,25 @@ it("announces an offer that only becomes one once the agent status lands", async
   await waitFor(() => expect(screen.queryByRole("button", { name: "Close notification" })).not.toBeInTheDocument());
 
   setInstalled("0.146.0");
+  flush();
+  expect(await screen.findByText("ChatGPT update available")).toBeInTheDocument();
+});
+
+it("offers no CLI update while a workspace on another computer is open", async () => {
+  const updateSystemCli = vi.fn(async () => {});
+  const { store, setLocal } = systemCliHarness(updateSystemCli);
+  setLocal(false);
+  flush();
+
+  // The runtimes this store reaches are on this computer, and the open workspace is not, so there is
+  // nothing to offer and nothing an Update button here could put right. The offer itself is what the
+  // notification would be raised from, so waiting for it is waiting for the moment it is not raised.
+  await waitFor(() => expect(store.providerAvailableVersions().codex).toBe("0.153.4"));
+  expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
+  await expect(store.startProviderUpdate("codex")).rejects.toThrow(/computer that hosts them/u);
+  expect(updateSystemCli).not.toHaveBeenCalled();
+
+  setLocal(true);
   flush();
   expect(await screen.findByText("ChatGPT update available")).toBeInTheDocument();
 });

--- a/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
+++ b/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
@@ -4,7 +4,7 @@ import type {
   ProviderRuntimeStatus,
   ProviderRuntimesDesktopApi,
 } from "@openbot/contracts/ipc";
-import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { createSignal, flush } from "solid-js";
 import { afterEach, expect, it, vi } from "vitest";
 import { FALLBACK_UPDATE_STATUS } from "../../app-defaults";
@@ -302,4 +302,17 @@ it("offers no CLI update while a workspace on another computer is open", async (
   setLocal(true);
   flush();
   expect(await screen.findByText("ChatGPT update available")).toBeInTheDocument();
+});
+
+it("keeps an offer the user closed closed when the workspace is opened again", async () => {
+  const updateSystemCli = vi.fn(async () => {});
+  systemCliHarness(updateSystemCli);
+  fireEvent.click(await screen.findByRole("button", { name: "Close notification" }));
+  await waitFor(() => expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument());
+  // A server switch disposes the store that raised the notification and builds a new one.
+  cleanup();
+
+  const { store } = systemCliHarness(updateSystemCli);
+  await waitFor(() => expect(store.providerAvailableVersions().codex).toBe("0.153.4"));
+  expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
 });

--- a/src/renderer/src/features/provider-updates/provider-update-toast.tsx
+++ b/src/renderer/src/features/provider-updates/provider-update-toast.tsx
@@ -135,15 +135,24 @@ function ProviderUpdateActionLabel(props: { presentation: ProviderUpdatePresenta
   );
 }
 
-/** The notification open for one provider, and the two things about it that still move. */
+/** The notification open for one provider, and the three things about it that still move. */
 interface LiveProviderUpdateToast {
   present: (presentation: ProviderUpdatePresentation) => void;
   setAct: (act: () => void) => void;
+  setOffer: (version: string | null) => void;
 }
 
 const liveToasts = new Map<AgentProviderId, LiveProviderUpdateToast>();
 const dismissTimers = new Map<AgentProviderId, number>();
 const disposers = new Map<AgentProviderId, () => void>();
+/**
+ * The version each provider's notification was closed on by the user.
+ *
+ * It lives here because this module outlives the runtime store, which is rebuilt for every server
+ * the user opens: without it, opening a team workspace and coming back raises an offer the user has
+ * already closed. It is keyed by version, so the next version is a new offer and is announced.
+ */
+const closedOffers = new Map<AgentProviderId, string>();
 
 /**
  * Forget the notification, whether it was dismissed from here or closed by the user.
@@ -183,11 +192,15 @@ function liveToast(provider: AgentProviderId, presentation: ProviderUpdatePresen
     const [current, setCurrent] = createSignal(presentation);
     // Read at click time, so the button that offered the update is the button that retries it.
     let act = (): void => {};
+    let offered: string | null = null;
 
     const live: LiveProviderUpdateToast = {
       present: (next) => setCurrent(next),
       setAct: (next) => {
         act = next;
+      },
+      setOffer: (version) => {
+        offered = version;
       },
     };
     liveToasts.set(provider, live);
@@ -195,6 +208,7 @@ function liveToast(provider: AgentProviderId, presentation: ProviderUpdatePresen
 
     return {
       live,
+      offeredVersion: () => offered,
       // The title is the one thing given as a function. Sonner re-measures the toast whenever the
       // title or the description changes, and the other two are elements that keep their identity
       // for the whole flow, so this read of the signal is what keeps the recorded height honest.
@@ -219,7 +233,12 @@ function liveToast(provider: AgentProviderId, presentation: ProviderUpdatePresen
     action: { label: parts.label, onClick: parts.onClick },
     duration: PERSISTENT,
     onDismiss: () => {
-      if (liveToasts.get(provider) === parts.live) releaseProviderUpdateToast(provider);
+      // Only the user reaches this notification while it is still the live one: every close made
+      // from this module releases it first, so a late callback for one of those finds nothing.
+      if (liveToasts.get(provider) !== parts.live) return;
+      const closed = parts.offeredVersion();
+      if (closed) closedOffers.set(provider, closed);
+      releaseProviderUpdateToast(provider);
     },
   });
 
@@ -235,6 +254,23 @@ export function showProviderUpdateToast(update: ProviderUpdate, onUpdate: () => 
   const live = liveToast(update.provider, presentation);
   live.present(presentation);
   live.setAct(onUpdate);
+  live.setOffer(presentation.updatable ? update.availableVersion : null);
+}
+
+/** The offer this provider's notification was closed on, and so must not be raised again. */
+export function providerUpdateOfferClosed(provider: AgentProviderId, availableVersion: string | null): boolean {
+  return availableVersion !== null && closedOffers.get(provider) === availableVersion;
+}
+
+/**
+ * Take the notification off the screen without ending the offer behind it.
+ *
+ * A server switch rebuilds the runtime store, and what the user was told about this computer is not
+ * the switch's to forget: the offer is raised again on the way back, unless the user closed it.
+ */
+export function hideProviderUpdateToast(provider: AgentProviderId): void {
+  toast.dismiss(toastId(provider));
+  releaseProviderUpdateToast(provider);
 }
 
 /**
@@ -249,6 +285,7 @@ export function reportProviderUpdateToast(update: ProviderUpdate, onRetry: () =>
   const presentation = presentProviderUpdate(update);
   live.present(presentation);
   live.setAct(onRetry);
+  live.setOffer(presentation.updatable ? update.availableVersion : null);
 
   const timer = dismissTimers.get(update.provider);
   if (timer !== undefined) window.clearTimeout(timer);
@@ -261,7 +298,8 @@ export function reportProviderUpdateToast(update: ProviderUpdate, onRetry: () =>
   );
 }
 
+/** End the offer as well as the notification: it has been acted on, cancelled or settled. */
 export function dismissProviderUpdateToast(provider: AgentProviderId): void {
-  toast.dismiss(toastId(provider));
-  releaseProviderUpdateToast(provider);
+  closedOffers.delete(provider);
+  hideProviderUpdateToast(provider);
 }

--- a/src/renderer/src/features/settings/SettingsModal.test.tsx
+++ b/src/renderer/src/features/settings/SettingsModal.test.tsx
@@ -1,5 +1,6 @@
 import type {
   AccountSession,
+  AgentStatus,
   AvatarImageInput,
   CentralAuthUser,
   HostedSitesDesktopApi,
@@ -140,6 +141,48 @@ describe("SettingsModal", () => {
     await fireEvent.click(await screen.findByRole("tab", { name: "Updates" }));
 
     expect(await screen.findByRole("switch", { name: "Automatically download updates" })).not.toBeChecked();
+  });
+
+  it("offers an update for a CLI the user installed, which has no managed download", async () => {
+    const onUpdateProvider = vi.fn(async () => undefined);
+    const agentStatus: AgentStatus = {
+      phase: "ready",
+      cliVersion: "0.146.0",
+      auth: { kind: "chatgpt", email: "norbert@example.com" },
+      providers: [
+        { id: "codex", state: "available", version: "0.146.0", message: null, cliSource: "system" },
+        { id: "claude", state: "available", version: "2.1.246", message: null, cliSource: "managed" },
+        { id: "grok", state: "not-installed", version: null, message: null },
+      ],
+      capabilities: { chat: "ready", browser: "ready", computerUse: "unavailable" },
+      message: null,
+      fullAccess: true,
+    };
+
+    render(() => (
+      <SettingsModal
+        open
+        onOpenChange={() => undefined}
+        value={DEFAULT_GENERAL_SETTINGS}
+        onValueChange={() => undefined}
+        appInfo={{ name: "OpenBot", version: "0.2.1", platform: "darwin", variant: "dev" }}
+        updateStatus={idleUpdateStatus}
+        onUpdateAction={vi.fn(async () => undefined)}
+        account={account}
+        onUpdateAccountName={vi.fn(async () => undefined)}
+        onUpdateAccountAvatar={vi.fn(async () => undefined)}
+        agentStatus={agentStatus}
+        providerRuntimeStatuses={{
+          codex: { phase: "not-downloaded", progress: null, message: null, version: null, availableVersion: "0.153.4" },
+          claude: { phase: "ready", progress: null, message: null, version: "2.1.246", availableVersion: "2.1.263" },
+        }}
+        providerAvailableVersions={{ codex: "0.153.4", claude: "2.1.263" }}
+        onUpdateProvider={onUpdateProvider}
+      />
+    ));
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Update ChatGPT to 0.153.4" }));
+    await waitFor(() => expect(onUpdateProvider).toHaveBeenCalledWith("codex"));
   });
 
   it("runs the updater and reflects its live status", async () => {

--- a/src/renderer/src/features/settings/stores/general-store.ts
+++ b/src/renderer/src/features/settings/stores/general-store.ts
@@ -30,9 +30,15 @@ export function createSettingsGeneralStore(props: GeneralStoreProps) {
         connectionState: agent?.connectionState,
         checkError: agent?.checkError,
         availableVersion: props.providerAvailableVersions?.[provider] ?? null,
+        /*
+         * A CLI the user installed themselves has no managed download, so its runtime stays
+         * "not-downloaded" while the provider works perfectly well. The row reads that as ready, on
+         * the version the provider reports - including when an update is offered for it, which is
+         * the user's own install being newer-able, not a runtime waiting to be downloaded.
+         */
         runtimeStatus:
           runtime?.phase === "not-downloaded" &&
-          !runtime.availableVersion &&
+          (agent?.cliSource === "system" || !runtime.availableVersion) &&
           (agent?.state === "available" || agent?.state === "sign-in-required")
             ? { ...runtime, phase: "ready", version: agent.version ?? null }
             : runtime,

--- a/src/renderer/src/features/settings/stores/general-store.ts
+++ b/src/renderer/src/features/settings/stores/general-store.ts
@@ -31,15 +31,14 @@ export function createSettingsGeneralStore(props: GeneralStoreProps) {
         checkError: agent?.checkError,
         availableVersion: props.providerAvailableVersions?.[provider] ?? null,
         /*
-         * A CLI the user installed themselves has no managed download, so its runtime stays
-         * "not-downloaded" while the provider works perfectly well. The row reads that as ready, on
-         * the version the provider reports - including when an update is offered for it, which is
-         * the user's own install being newer-able, not a runtime waiting to be downloaded.
+         * A CLI the user installed themselves is the one the provider runs, whatever the managed
+         * runtime holds, so the row reads it as ready on the version the provider reports. An
+         * update offered for it is the user's own install being newer-able, not a download.
          */
         runtimeStatus:
-          runtime?.phase === "not-downloaded" &&
-          (agent?.cliSource === "system" || !runtime.availableVersion) &&
-          (agent?.state === "available" || agent?.state === "sign-in-required")
+          runtime &&
+          (agent?.state === "available" || agent?.state === "sign-in-required") &&
+          (agent.cliSource === "system" || (runtime.phase === "not-downloaded" && !runtime.availableVersion))
             ? { ...runtime, phase: "ready", version: agent.version ?? null }
             : runtime,
       };

--- a/src/renderer/src/features/usage/usage.css
+++ b/src/renderer/src/features/usage/usage.css
@@ -1,5 +1,14 @@
+/*
+ * The workspace keeps its place in the app frame grid while Usage is open, so the wrapper draws no
+ * box of its own. Its children are still grid items of the frame, but they are no longer its DOM
+ * children, so `.app-frame > *` no longer reaches them: without this, a conversation panel grows to
+ * its content height and pushes the composer under the window edge.
+ */
 .usage-workspace-content {
   display: contents;
+}
+.usage-workspace-content > * {
+  min-height: 0;
 }
 .app-frame-usage-open .usage-workspace-content {
   visibility: hidden;

--- a/src/renderer/src/preview/fixtures.ts
+++ b/src/renderer/src/preview/fixtures.ts
@@ -109,7 +109,7 @@ export const STORY_MODELS: AgentModelOption[] = [
   {
     provider: "codex",
     id: "gpt-5.6-luna",
-    name: "Luna",
+    name: "GPT-5.6 Luna",
     description: "Fast and efficient for everyday agent work.",
     defaultReasoningEffort: "medium",
     supportedReasoningEfforts: ["low", "medium", "high"],
@@ -117,7 +117,7 @@ export const STORY_MODELS: AgentModelOption[] = [
   {
     provider: "codex",
     id: "gpt-5.6-terra",
-    name: "Terra",
+    name: "GPT-5.6 Terra",
     description: "Balanced speed and capability for involved tasks.",
     defaultReasoningEffort: "medium",
     supportedReasoningEfforts: ["medium", "high"],
@@ -125,7 +125,7 @@ export const STORY_MODELS: AgentModelOption[] = [
   {
     provider: "codex",
     id: "gpt-5.6-sol",
-    name: "Sol",
+    name: "GPT-5.6 Sol",
     description: "Most capable for complex, long-running work.",
     defaultReasoningEffort: "high",
     supportedReasoningEfforts: ["medium", "high", "xhigh"],
@@ -144,6 +144,14 @@ export const STORY_MODELS: AgentModelOption[] = [
     name: "Claude Sonnet 5",
     description: "Balanced Claude model for general agent work.",
     defaultReasoningEffort: "high",
+    supportedReasoningEfforts: ["low", "medium", "high"],
+  },
+  {
+    provider: "grok",
+    id: "grok-4.6",
+    name: "Grok 4.6",
+    description: "Discovered from Grok CLI over ACP.",
+    defaultReasoningEffort: "medium",
     supportedReasoningEfforts: ["low", "medium", "high"],
   },
   {

--- a/src/renderer/src/preview/mock-openbot.ts
+++ b/src/renderer/src/preview/mock-openbot.ts
@@ -519,6 +519,7 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
     closeComputerUsePermissionSetup: async () => undefined,
     openExternal: async () => undefined,
     connectProvider: async () => clone(agentStatus),
+    updateProviderCli: async () => clone(agentStatus),
     refreshAgentProviders: async () => clone(agentStatus),
     providerRuntimes: {
       getStatus: async () => clone(runtimeSnapshot),

--- a/src/renderer/src/providers.tsx
+++ b/src/renderer/src/providers.tsx
@@ -3,6 +3,7 @@ import { createSignal, flush, onSettled } from "solid-js";
 import { desktopAnalytics } from "./analytics";
 import { useAgents } from "./features/agents/agents-context";
 import { createProviderRuntimeStore } from "./features/provider-updates/provider-runtime-store";
+import { useServers } from "./features/servers/servers-context";
 import { createSimpleContext } from "./simple-context";
 
 /**
@@ -28,6 +29,7 @@ const Providers = createSimpleContext({
   name: "Providers",
   init: () => {
     const { agentStatus, setAgentStatus } = useAgents();
+    const { activeServer } = useServers();
     const [refreshingProviders, setRefreshingProviders] = createSignal(false);
     /**
      * A CLI the user installed themselves, and the version it reports. Only the agent status knows
@@ -41,6 +43,7 @@ const Providers = createSimpleContext({
     const runtimes = createProviderRuntimeStore(window.openbot.providerRuntimes, {
       systemCliVersion,
       updateSystemCli: (provider) => updateProviderCli(provider),
+      isLocalServer: () => activeServer()?.kind === "local",
     });
     /** Connect attempts still waiting for the status that says how they ended. */
     const pendingProviderConnections = new Map<AgentProviderId, ReturnType<typeof desktopAnalytics.scope>>();

--- a/src/renderer/src/providers.tsx
+++ b/src/renderer/src/providers.tsx
@@ -29,7 +29,19 @@ const Providers = createSimpleContext({
   init: () => {
     const { agentStatus, setAgentStatus } = useAgents();
     const [refreshingProviders, setRefreshingProviders] = createSignal(false);
-    const runtimes = createProviderRuntimeStore(window.openbot.providerRuntimes);
+    /**
+     * A CLI the user installed themselves, and the version it reports. Only the agent status knows
+     * this, and the runtime store needs it to offer that install the same update a managed runtime
+     * gets - and to run the right updater for it.
+     */
+    function systemCliVersion(provider: AgentProviderId): string | null {
+      const row = agentStatus().providers?.find((candidate) => candidate.id === provider);
+      return row?.cliSource === "system" ? (row.version ?? null) : null;
+    }
+    const runtimes = createProviderRuntimeStore(window.openbot.providerRuntimes, {
+      systemCliVersion,
+      updateSystemCli: (provider) => updateProviderCli(provider),
+    });
     /** Connect attempts still waiting for the status that says how they ended. */
     const pendingProviderConnections = new Map<AgentProviderId, ReturnType<typeof desktopAnalytics.scope>>();
 
@@ -88,6 +100,29 @@ const Providers = createSimpleContext({
           action: "connect_completed",
           result: "failed",
           failure_code: "connect_failed",
+        });
+        throw error;
+      }
+    }
+
+    /**
+     * Runs the provider CLI's own updater, for an install the user made. Nothing is downloaded by
+     * OpenBot, so this shares nothing with the managed runtime download in `runtimes`; what comes
+     * back is the status the restarted provider reports, with the version it now runs.
+     */
+    async function updateProviderCli(provider: AgentProviderId): Promise<void> {
+      const analytics = desktopAnalytics.scope();
+      analytics.track("provider_action", { provider, action: "cli_update_started", result: "succeeded" });
+      try {
+        const status = await window.openbot.updateProviderCli(provider);
+        flush(() => applyAgentStatus(status));
+        analytics.track("provider_action", { provider, action: "cli_update_completed", result: "succeeded" });
+      } catch (error) {
+        analytics.track("provider_action", {
+          provider,
+          action: "cli_update_completed",
+          result: "failed",
+          failure_code: "cli_update_failed",
         });
         throw error;
       }

--- a/src/renderer/stories/ProviderModelPicker.stories.tsx
+++ b/src/renderer/stories/ProviderModelPicker.stories.tsx
@@ -36,7 +36,7 @@ export const Disabled: Story = {
 export const Opens: Story = {
   args: { reasoningEffort: "medium", onReasoningEffortChange: fn() },
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(canvas.getByRole("button", { name: /Agent model: Luna/ }));
+    await userEvent.click(canvas.getByRole("button", { name: /Agent model: GPT-5.6 Luna/ }));
     await canvas.findByRole("dialog", { name: "Choose agent model" });
   },
 };

--- a/src/renderer/stories/ProviderPicker.stories.tsx
+++ b/src/renderer/stories/ProviderPicker.stories.tsx
@@ -104,6 +104,28 @@ export const UpdateFailed: Story = {
   },
 };
 
+/**
+ * A CLI the user installed themselves, with a newer version pinned by this OpenBot release. The row
+ * reads exactly like a managed update - same badge, same button - because only the work behind the
+ * button differs, and the row does not choose it.
+ */
+export const UserOwnedCliUpdate: Story = {
+  args: {
+    value: "codex",
+    options: options.map((option) =>
+      option.id === "codex"
+        ? {
+            ...option,
+            runtimeStatus: { phase: "ready", progress: null, message: null, version: "0.146.0" },
+            availableVersion: "0.153.4",
+          }
+        : option,
+    ),
+    onConnectProvider: fn(),
+    onUpdateProvider: fn(),
+  },
+};
+
 export const AllowUnavailableSelection: Story = {
   args: {
     value: "claude",

--- a/src/renderer/stories/QuestionPromptBubble.stories.tsx
+++ b/src/renderer/stories/QuestionPromptBubble.stories.tsx
@@ -106,7 +106,7 @@ function QuestionPromptChatPreview(props: QuestionPromptBubbleProps) {
             class="provider-model-trigger question-prompt-chat-model"
             aria-label="Change model"
           >
-            <span class="provider-model-trigger-name">Luna</span>
+            <span class="provider-model-trigger-name">GPT-5.6 Luna</span>
             <ChevronDown aria-hidden="true" />
           </Button>
         </div>


### PR DESCRIPTION
## What changed

Three things a user sees, all about the provider CLIs OpenBot does not own.

**Every model the CLI lists is shown, and named by the model.** Claude Code names a model by the
part it plays in that CLI ("Default (recommended)", "Opus"), which says which pick it is there, not
which model an agent runs here. `claudeModelName` derives the product name from the id instead, and
falls back to the CLI's own label for an id that does not read as one.

| Claude tab, before | Claude tab, after |
| --- | --- |
| Default (recommended) | Claude Opus 5 |
| Fable | Claude Fable 5.1 (1M context) |
| Opus (default) | Claude Sonnet 5 *(default)* |
| Haiku | Claude Haiku 4.5 |

**Each provider names a default model.** `DEFAULT_PROVIDER_MODELS` in the contracts package replaces
the same ternary written out in three places plus a renderer map: `gpt-5.6-luna`, `claude-sonnet-5`,
`grok-4.6`. Claude moves from Opus to Sonnet, and Grok gains a default it never had - it used to take
whatever model the CLI listed first. Every caller still falls back to the provider's first model, so
an id a given CLI does not list is not an error.

**A CLI the user installed can update itself.** The provider row already compared a `system` install
against the pinned lock; the Update button on such a row now runs that CLI's own updater
(`codex update`) rather than doing nothing. OpenBot downloads nothing on this path, so the pinned
artifact checksums are untouched, and the managed copy still refuses the command - the runtime
manager replaces that install whole.

That updater decides for itself what "latest" means, and its channel can name an older version than
the lock: `grok update` reports success and leaves the CLI on 1.0.13 while the lock pins 1.0.22.
Without a record, the offer returned at every start and every click walked the user through an update
that cannot happen. `ProviderRuntimeManager.noteSystemCliUpdate` now records an update that finishes
on the version it started on, in `cli-update-refusals.json` beside the managed runtimes, and drops
the offer. The record holds the installed and the pinned version together, so a new pinned version is
a new offer, and so is a CLI the user moves by other means.

Surfaces: desktop renderer, IPC contracts (`app:update-provider-cli`) and `mock-openbot.ts`, the
preload boundary, main-process provider handlers, `docs/ARCHITECTURE.md`. No migration, no mobile,
no `apps/auth-api`, no palette change. Reverse states covered: the offer appears again once the
updater installs something, and once a different version is pinned.

## Verification

- [x] Narrow checks for what changed: `biome check --write <paths>`, `bun run lint`,
      `bun run typecheck`, `bun run check:ui`, and the affected test files -
      `provider-runtime-manager.test.ts` (14), `provider-update-toast.test.tsx` (10),
      `provider-runtime.test.ts` (18), `ProviderModelPicker.test.tsx` (3),
      `profile-generation.test.ts` (7), `claude-client.test.ts` (15). CI owns the full suite.
- [x] Surfaces touched are named under "What changed"
- [x] Manual smoke test in the dev app: the Grok row offered v1.0.13 -> v1.0.22, Update ran the CLI's
      own updater, the notification settled on "Grok is up to date v1.0.13",
      `cli-update-refusals.json` recorded `{"grok":{"version":"1.0.13","pinnedVersion":"1.0.22"}}`,
      and after a main-process restart no offer returned. The picker showed
      "Claude Sonnet 5, default" and "Grok 4.6, default".
- [x] No credentials, private data, generated output, or real user files are included

Each added assertion was broken and confirmed to fail for the intended reason, then restored:
removing the refusal check in `getStatus()`, removing `#readRefusedUpdates()` from `initialize()`,
and removing the record's delete branch each failed exactly one of the new manager tests; naming
Opus as the Claude default failed the picker test.

Model: Claude Opus 5. Harness: Claude Code in T3 Code.

## Risk and security impact

One new IPC request, `app:update-provider-cli`, taking a provider id parsed by the existing
`parseProviderId` and returning a decoded `AgentStatus`. It spawns the provider CLI that is already
resolved and already spawned for every session, with `argv: ["update"]`, no shell, an empty added
environment, `stdio: ["ignore", "ignore", "pipe"]` and a ten-minute timeout; the managed copy is
refused. New persisted state is one small JSON file of version strings in the provider-runtimes
directory, written atomically through a temp file and a rename, and read behind runtime guards - a
missing or malformed file only costs the user one more refused offer. No new network access, no new
filesystem reach, no change to sandboxing, context isolation, navigation policy or sender validation.

## Screenshots

Text over pixels here: the change is the accessible names in the model picker, which the tables above
give before and after. The `dev:automation` accessibility snapshot from the running app reads
`option "Claude Sonnet 5, default"` and `option "Grok 4.6, default"`.


## Review follow-ups

Added after the first review round, each with its own commit.

**The update no longer cuts a turn short.** The updater replaces the binary under a running client,
and the client is restarted after it, so a turn in flight would lose its process. A provider that has
an agent in a turn - or a delivery on its way to one, which holds no turn id yet - refuses the
command and asks the user to wait. `ProviderHooks` gains `isProviderBusy` and `onProviderResumed`;
`DrainScheduler` counts deliveries between their first await and their turn, and skips an agent whose
provider reports `isReplacingCli`. Deliveries wait in the mailbox instead of the event loop, and
`onProviderResumed` schedules the held ones when the replacement ends, after a failure as well as
after a success.

**A stale refusal is cleared.** A CLI that moves by other means is a different install, so the
renderer store keys the refusal on the installed version as well as the offered one and offers the
pinned version again.

**The composer stays on screen.** `.usage-workspace-content` (from #321) uses `display: contents`,
so `.app-frame > * { min-height: 0 }` no longer reached the conversation panel: the panel took its
automatic minimum size, 1970px in an 820px frame, and pushed the composer under the window edge.
`usage.css` restores `min-height: 0` for the wrapper's children. Measured live in the dev app, the
composer moved from top 1926 (off screen) to top 776 / bottom 804 in an 820px viewport, and
"Message Chief" is on screen again. This is a main-branch regression the rebase brought in, not a
change this PR made.

Tests for these: "refuses to replace a CLI that is running a turn", "refuses to replace a CLI while a
delivery is on its way to a turn", and "delivers a message queued while a failed update held the CLI"
in `provider-runtime.test.ts`, and the reoffer assertion in `provider-update-toast.test.tsx`. Each was
break-checked and restored: blocking `turn/start` and dropping `isProviderBusy` failed the first two;
removing `onProviderResumed` timed out the third. Removing the `isReplacingCli` guard in
`DrainScheduler` alone does not fail the third test, because the global `isReady()` guard also holds
while the provider is "connecting" - the guard is kept as the explicit per-provider rule.


### Second review round (P2)

**A compaction holds the update too.** A compaction is a provider turn the agent never owns -
`ContextCompaction.claimTurn` takes its `turn/started` away, so it sets no active turn id.
`isProviderBusy` now asks `ContextCompaction.mayDrain` as well.

**The offer is for this computer only.** Every runtime the store reaches is local, while the agent
status beside it describes whichever server is open, so a remote workspace could be announced an
update to a runtime the user is not looking at. The store takes `isLocalServer`, bound in
`providers.tsx` to `activeServer()?.kind === "local"` - the guard the provider row and the picker
already use. A remote workspace announces nothing, and `startProviderUpdate` rejects.

Tests: "refuses to replace a CLI that is compacting a thread" (`provider-runtime.test.ts`) and
"offers no CLI update while a workspace on another computer is open"
(`provider-update-toast.test.tsx`). Break-checked and restored: removing the compaction clause fails
the first; removing the effect guard, and separately the action guard, each fails the second.


### Third review round (P1, P2)

**A replacement is not a restart.** `#reloadProviderCli` ended in `onProvidersReady`, which is
restart recovery: it settles every unresolved delivery, and the other providers keep running through
the replacement, so a live turn was recorded as `interrupted` - a state `MailboxStore.markTerminal`
then refuses to correct. `#activateProviderClient` takes `notifyReady`, the replacement passes
`false`, and `onProviderResumed` still schedules the deliveries it held back.

**A closed notification stays closed across a server switch.** The switch rebuilds the runtime store,
so the version each notification was closed on is kept by the notification module, which outlives it.
Teardown hides its notifications instead of ending the offer; an update that was acted on, cancelled
or settled still clears the record.

Tests: "leaves another provider's running turn alone while a CLI is replaced"
(`provider-runtime.test.ts`) and "keeps an offer the user closed closed when the workspace is opened
again" (`provider-update-toast.test.tsx`). Break-checked and restored - restoring `notifyReady: true`
fails the first with `expected 'interrupted' to be 'running'`; removing the announce-loop skip, and
separately making teardown dismiss instead of hide, each fails the second.


### Fourth review round (P1, P2)

**Both replacement paths skip restart recovery.** `notifyReady: false` covered only the provider that
still has a client. A provider whose client is gone is connected again through `#connect`, which also
ended in `onProvidersReady`, so updating it while another provider ran a turn still recorded that live
delivery as `interrupted`. `#connect` takes the same option. The test is now a loop over both
branches; reverting only the `#connect` guard fails the "with no client is connected again" variant
with `expected 'interrupted' to be 'running'`.

**One queue for the refusal record.** Two providers can finish an update at once. Each write
serialized the record as it stood when it ran and renamed its own temporary file, so an older snapshot
could land last and drop a newer refusal - which the user would meet as an offer they had already
turned down. `#writeRefusedUpdates` now writes one at a time. No test: making the broken code fail
needs two renames to complete in a chosen order, which is a timing-based test.


### Fifth review round (P1, P2)

**The updater's own reason is redacted.** That line goes into the provider row, and the Team API
broadcasts the row to the team's connected clients. A CLI that fails on authentication prints the
header or key it sent, so `readProcessReason` redacts before it bounds the line.

**The CLI owner survives a signed-out provider.** `cliSource` came only from the CLI a client runs
on, and a signed-out provider has no client although its binary is resolved and its version is on the
row - so the row named no owner, and an unowned CLI reads as the managed copy, which would send the
user's own install to a download. Resolution records the owner and drops it when nothing resolves.

Tests: "redacts a secret in the reason the updater printed" and "keeps the owner of a CLI whose
provider is signed out". Break-checked and restored.
