### PR TITLE
Start authenticated mobile navigation on the connected screen

### DIFF
--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -22,6 +22,7 @@ function AuthenticatedStack() {
   return (
     <ChatNavigationGateContext value={navigationGate}>
       <Stack
+        initialRouteName="connected"
         screenListeners={({ route }) =>
           route.name === "connected"
             ? {
@@ -41,11 +42,11 @@ function AuthenticatedStack() {
           sheetExpandsWhenScrolledToEdge: false,
         }}
       >
+        <Stack.Screen name="connected" options={{ animation: "fade", gestureEnabled: false, title: "" }} />
         <Stack.Screen
           name="agent-usage/[agentId]"
           options={{ title: "Usage", contentStyle: { backgroundColor: background } }}
         />
-        <Stack.Screen name="connected" options={{ animation: "fade", gestureEnabled: false, title: "" }} />
         <Stack.Screen
           name="chat/[agentId]"
           options={{


### PR DESCRIPTION
## Summary

- Set the authenticated stack's initial route to `connected`.
- Register the connected screen first to prevent unintended initial navigation.

## Testing

Not run (not requested).