### PR TITLE
Preserve mobile profile names when blank

### DIFF
--- a/apps/mobile/src/features/auth/api/mobile-auth.test.ts
+++ b/apps/mobile/src/features/auth/api/mobile-auth.test.ts
@@ -13,6 +13,7 @@ import {
   updateMobileProfile,
   validateMobileSession,
 } from "./mobile-auth";
+import { mobileUserName } from "./mobile-user-name";
 
 // The native Keychain and HTTP transport are the boundary; exercise the real session storage logic.
 const native = vi.hoisted(() => ({ storage: new Map<string, string>(), fetch: vi.fn<typeof fetch>() }));
@@ -177,6 +178,24 @@ describe("mobile session revocation", () => {
 });
 
 describe("stored mobile desktop binding", () => {
+  it.each([
+    [null, "user"],
+    ["", "user"],
+    ["Saved name", "Saved name"],
+  ])("keeps the profile name available through connection and restore (%j)", async (name, expected) => {
+    native.storage.clear();
+    native.storage.set("openbot.mobile.device-id.v1", "existing-device");
+    const connected = { ...session, user: { ...session.user, name } };
+    native.fetch.mockResolvedValueOnce(Response.json(connected));
+    const redeemed = await redeemMobileConnectUrl(qrCode);
+    expect(mobileUserName(redeemed.user)).toBe(expected);
+    const restored = await readMobileSession();
+    expect(restored && mobileUserName(restored.user)).toBe(expected);
+    native.fetch.mockResolvedValueOnce(Response.json({ ...connected.user, name: "Updated name" }));
+    const refreshed = await validateMobileSession(redeemed);
+    expect(refreshed && mobileUserName(refreshed.user)).toBe("Updated name");
+  });
+
   it("restores a bound session without changing its identity or contacting the service", async () => {
     expect(await readMobileSession()).toEqual(session);
     expect(native.fetch).not.toHaveBeenCalled();

--- a/apps/mobile/src/features/auth/api/mobile-user-name.ts
+++ b/apps/mobile/src/features/auth/api/mobile-user-name.ts
@@ -1,0 +1,7 @@
+import type { CentralAuthUser } from "@openbot/contracts/ipc";
+
+export function mobileUserName(user: CentralAuthUser): string {
+  if (user.name) return user.name;
+  const separator = user.email.indexOf("@");
+  return separator > 0 ? user.email.slice(0, separator) : user.email;
+}

--- a/apps/mobile/src/features/servers/components/server-drawer-content.tsx
+++ b/apps/mobile/src/features/servers/components/server-drawer-content.tsx
@@ -5,6 +5,7 @@ import { Monitor, Plus, Server, Settings } from "lucide-react-native";
 import { Pressable, ScrollView, View, type ViewStyle } from "react-native";
 
 import type { MobileSession } from "@/features/auth/api/mobile-auth";
+import { mobileUserName } from "@/features/auth/api/mobile-user-name";
 import type { MobileServer } from "@/features/workspace/context/mobile-workspace-context";
 import { serverStatusLabel } from "@/features/workspace/model/server-status";
 import { ProfileAvatar } from "@/shared/components/profile-avatar";
@@ -37,10 +38,7 @@ export function ServerDrawerContent({
   onNavigate,
   onSelectServer,
 }: ServerDrawerContentProps) {
-  const emailSeparatorIndex = session.user.email.indexOf("@");
-  const displayName =
-    session.user.name ||
-    (emailSeparatorIndex > 0 ? session.user.email.slice(0, emailSeparatorIndex) : session.user.email);
+  const displayName = mobileUserName(session.user);
   const avatarUrl = session.user.avatarUrl ? new URL(session.user.avatarUrl, session.apiUrl).toString() : null;
   const mutedColor = String(muted);
 

--- a/apps/mobile/src/features/settings/screens/profile-settings-screen.tsx
+++ b/apps/mobile/src/features/settings/screens/profile-settings-screen.tsx
@@ -11,13 +11,15 @@ import { Pencil } from "lucide-react-native";
 import { useEffect, useRef, useState } from "react";
 import { Alert, Keyboard, Pressable, View } from "react-native";
 import { useResolveClassNames, useUniwind } from "uniwind";
+import { mobileUserName } from "@/features/auth/api/mobile-user-name";
 import { useMobileSession } from "@/features/auth/context/mobile-session-context";
 import { SettingsContent, SettingsRow, SettingsSection } from "@/features/settings/components/settings-content";
 import { ProfileAvatar } from "@/shared/components/profile-avatar";
 
 export function ProfileSettingsScreen() {
   const { session, updateProfile, signOut } = useMobileSession();
-  const [name, setName] = useState(session?.user.name ?? "");
+  const savedName = session ? mobileUserName(session.user) : "";
+  const [name, setName] = useState(savedName);
   const [editingName, setEditingName] = useState(false);
   const nativeName = useNativeState(name);
   const nameInput = useRef<TextInputRef>(null);
@@ -29,18 +31,17 @@ export function ProfileSettingsScreen() {
   const nameTextStyle = useResolveClassNames("text-title font-semibold");
   useEffect(() => {
     if (!editingName) {
-      const savedName = session?.user.name ?? "";
       nativeName.value = savedName;
       setName(savedName);
     }
-  }, [editingName, nativeName, session?.user.name]);
+  }, [editingName, nativeName, savedName]);
   const [busy, setBusy] = useState(false);
   const locked = useRef(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   if (!session) return null;
   const validatedName = validateProfileName(name);
-  const nameChanged = validatedName.name !== (session.user.name ?? "");
+  const nameChanged = name !== savedName;
   const profileError =
     error ||
     (editingName && nameChanged && validatedName.error
@@ -98,7 +99,7 @@ export function ProfileSettingsScreen() {
     <SettingsContent>
       <View>
         <View className="items-center gap-3 py-3">
-          <ProfileAvatar neutral name={session.user.name || session.user.email} imageUrl={avatarUrl} size={72} />
+          <ProfileAvatar neutral name={savedName} imageUrl={avatarUrl} size={72} />
           <View className="w-full items-center gap-0">
             <View
               className="w-full flex-row items-center justify-center"
@@ -192,8 +193,8 @@ export function ProfileSettingsScreen() {
               accessibilityLabel="Cancel name edit"
               disabled={busy}
               onPress={() => {
-                setName(session.user.name ?? "");
-                nativeName.value = session.user.name ?? "";
+                setName(savedName);
+                nativeName.value = savedName;
                 setEditingName(false);
                 setError(null);
                 Keyboard.dismiss();

--- a/apps/mobile/src/features/settings/screens/settings-screen.tsx
+++ b/apps/mobile/src/features/settings/screens/settings-screen.tsx
@@ -1,11 +1,13 @@
 import { router } from "expo-router";
 import { Typography } from "heroui-native";
+import { mobileUserName } from "@/features/auth/api/mobile-user-name";
 import { useMobileSession } from "@/features/auth/context/mobile-session-context";
 import { SettingsContent, SettingsRow, SettingsSection } from "@/features/settings/components/settings-content";
 import { ProfileAvatar } from "@/shared/components/profile-avatar";
 
 export function SettingsScreen() {
   const { session } = useMobileSession();
+  const displayName = session ? mobileUserName(session.user) : "Profile";
   return (
     <SettingsContent>
       <SettingsSection>
@@ -15,13 +17,13 @@ export function SettingsScreen() {
           leading={
             <ProfileAvatar
               neutral
-              name={session?.user.name || session?.user.email || "Profile"}
+              name={displayName}
               imageUrl={session?.user.avatarUrl ? new URL(session.user.avatarUrl, session.apiUrl).toString() : null}
               size={40}
             />
           }
         >
-          <Typography.Paragraph type="body-sm">{session?.user.name || "Profile"}</Typography.Paragraph>
+          <Typography.Paragraph type="body-sm">{displayName}</Typography.Paragraph>
         </SettingsRow>
       </SettingsSection>
       <SettingsSection title="Preferences">


### PR DESCRIPTION
## Summary

- Centralize mobile user-name fallback behavior.
- Keep profile names available across connection, restore, refresh, and settings views.
- Add coverage for blank, null, and saved names.

## Testing

- Added unit tests for mobile session name persistence and refresh behavior.
- Not run (not requested).