### PR TITLE
Disable scroll edge effect on the add server sheet

### DIFF
--- a/apps/mobile/src/features/servers/screens/add-server-screen.tsx
+++ b/apps/mobile/src/features/servers/screens/add-server-screen.tsx
@@ -69,6 +69,7 @@ export function AddServerScreen({
 
   return (
     <SheetScrollView
+      scrollEdgeEffect={false}
       className="bg-sheet"
       contentContainerClassName="gap-7 px-5 pb-safe-offset-5 pt-14"
       contentInsetAdjustmentBehavior="automatic"


### PR DESCRIPTION
## Summary

- Disable the scroll edge effect on the mobile add-server sheet.
- Keep the sheet content visually stable while scrolling.

## Testing

- Not run (not requested)