### PR TITLE
Fix Enter confirmation for sidebar deletion

### DIFF
--- a/src/renderer/src/features/sidebar/Sidebar.test.tsx
+++ b/src/renderer/src/features/sidebar/Sidebar.test.tsx
@@ -714,6 +714,32 @@ describe("Sidebar sections", () => {
     expect(props.onMutateLayout).toHaveBeenCalledWith({ type: "rename", sectionId: demoId, name: "Core" });
   });
 
+  it.each(["agent", "section"] as const)("focuses Delete and cancels %s deletion", async (kind) => {
+    const props = sidebarProps();
+    render(() => <Sidebar {...props} layout={sectionLayout()} />);
+    const name = kind === "agent" ? /Chief/ : "Demo";
+    const menuName = kind === "agent" ? "Agent actions" : "Section actions";
+    const actionName = kind === "agent" ? "Delete agent" : "Delete";
+
+    for (const cancelWithEscape of [true, false]) {
+      await fireEvent.contextMenu(screen.getByRole("button", { name }));
+      const menu = await screen.findByRole("menu", { name: menuName });
+      const action = within(menu).getByRole("menuitem", { name: actionName });
+      action.focus();
+      await fireEvent.keyDown(action, { key: "Enter" });
+      const dialog = await screen.findByRole("alertdialog");
+      await waitFor(() => expect(within(dialog).getByRole("button", { name: "Delete" })).toHaveFocus());
+      expect(props.onDeleteAgent).not.toHaveBeenCalled();
+      expect(props.onMutateLayout).not.toHaveBeenCalled();
+
+      if (cancelWithEscape) await fireEvent.keyDown(dialog, { key: "Escape" });
+      else await fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+      await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+      expect(props.onDeleteAgent).not.toHaveBeenCalled();
+      expect(props.onMutateLayout).not.toHaveBeenCalled();
+    }
+  });
+
   it("confirms section deletion and moves system sections through shared actions", async () => {
     const props = sidebarProps();
     render(() => <Sidebar {...props} layout={sectionLayout()} />);

--- a/src/renderer/src/features/sidebar/SidebarDialogs.tsx
+++ b/src/renderer/src/features/sidebar/SidebarDialogs.tsx
@@ -11,6 +11,8 @@ import { useSidebarScope } from "./sidebar-scope";
 export function SidebarDialogs() {
   const { closeDelete, confirmDelete, confirmSectionDelete, deleteError, deleteTarget, deleting, sectionDeleteTarget } =
     useSidebarScope();
+  let agentDeleteButton: HTMLButtonElement | undefined;
+  let sectionDeleteButton: HTMLButtonElement | undefined;
   return (
     <>
       <AlertDialog.Root
@@ -23,7 +25,13 @@ export function SidebarDialogs() {
           {(agent) => (
             <AlertDialog.Portal>
               <AlertDialog.Overlay class="agent-delete-backdrop">
-                <AlertDialog.Content class="agent-delete-dialog">
+                <AlertDialog.Content
+                  class="agent-delete-dialog"
+                  onOpenAutoFocus={(event) => {
+                    event.preventDefault();
+                    agentDeleteButton?.focus({ preventScroll: true });
+                  }}
+                >
                   <AgentAvatar
                     agent={agent()}
                     style={{
@@ -43,6 +51,9 @@ export function SidebarDialogs() {
                       Cancel
                     </Button>
                     <Button
+                      ref={(element) => {
+                        agentDeleteButton = element;
+                      }}
                       variant="destructive"
                       type="button"
                       class="agent-delete-confirm"
@@ -69,7 +80,13 @@ export function SidebarDialogs() {
           {(section) => (
             <AlertDialog.Portal>
               <AlertDialog.Overlay class="agent-delete-backdrop">
-                <AlertDialog.Content class="agent-delete-dialog sidebar-section-delete-dialog">
+                <AlertDialog.Content
+                  class="agent-delete-dialog sidebar-section-delete-dialog"
+                  onOpenAutoFocus={(event) => {
+                    event.preventDefault();
+                    sectionDeleteButton?.focus({ preventScroll: true });
+                  }}
+                >
                   <span class="sidebar-section-delete-icon" aria-hidden="true">
                     <Trash2 class="size-5" />
                   </span>
@@ -83,6 +100,9 @@ export function SidebarDialogs() {
                       Cancel
                     </Button>
                     <Button
+                      ref={(element) => {
+                        sectionDeleteButton = element;
+                      }}
                       variant="destructive"
                       type="button"
                       class="agent-delete-confirm"

--- a/src/renderer/stories/Sidebar.stories.tsx
+++ b/src/renderer/stories/Sidebar.stories.tsx
@@ -794,3 +794,60 @@ export const FirstAgentCompact: Story = {
   args: { ...FirstAgent.args, compact: true },
   decorators: [(Story) => <div style={{ width: "80px", height: "100vh" }}>{Story()}</div>],
 };
+
+export const DeleteConfirmationKeyboard: Story = {
+  args: {
+    layout: sectionedLayout,
+    pinnedItems: [],
+    onDeleteAgent: fn(async () => undefined),
+    onMutateLayout: fn(async () => undefined),
+  },
+  decorators: [(Story) => <div style={{ width: "280px", height: "100vh" }}>{Story()}</div>],
+  play: async ({ args: storyArgs, canvas, canvasElement, userEvent }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    for (const kind of ["agent", "section"] as const) {
+      const trigger = canvas.getByRole("button", { name: kind === "agent" ? /Chief, CEO/ : "Core team" });
+      const deletion = kind === "agent" ? storyArgs.onDeleteAgent : storyArgs.onMutateLayout;
+      const openConfirmation = async () => {
+        fireEvent.contextMenu(trigger);
+        const menu = await body.findByRole("menu", {
+          name: kind === "agent" ? "Agent actions" : "Section actions",
+        });
+        within(menu)
+          .getByRole("menuitem", { name: kind === "agent" ? "Delete agent" : "Delete" })
+          .focus();
+        await userEvent.keyboard("{Enter}");
+        const dialog = await body.findByRole("alertdialog");
+        await waitFor(() => expect(within(dialog).getByRole("button", { name: "Delete" })).toHaveFocus());
+        return dialog;
+      };
+
+      const dialog = await openConfirmation();
+      await expect(deletion).not.toHaveBeenCalled();
+      const confirm = within(dialog).getByRole("button", { name: "Delete" });
+      const cancel = within(dialog).getByRole("button", { name: "Cancel" });
+      await userEvent.tab();
+      await expect(cancel).toHaveFocus();
+      await userEvent.tab({ shift: true });
+      await expect(confirm).toHaveFocus();
+      await userEvent.tab({ shift: true });
+      await expect(cancel).toHaveFocus();
+      await userEvent.keyboard("{Enter}");
+      await waitFor(() => expect(body.queryByRole("alertdialog")).not.toBeInTheDocument());
+      await expect(deletion).not.toHaveBeenCalled();
+
+      await openConfirmation();
+      await userEvent.keyboard("{Escape}");
+      await waitFor(() => expect(body.queryByRole("alertdialog")).not.toBeInTheDocument());
+      await expect(deletion).not.toHaveBeenCalled();
+
+      await openConfirmation();
+      await userEvent.keyboard("{Enter}");
+      await waitFor(() => expect(deletion).toHaveBeenCalledOnce());
+      await expect(deletion).toHaveBeenCalledWith(
+        kind === "agent" ? "chief" : { type: "delete", sectionId: demoSectionId },
+      );
+      await waitFor(() => expect(body.queryByRole("alertdialog")).not.toBeInTheDocument());
+    }
+  },
+};


### PR DESCRIPTION
## What changed

Agent and section delete dialogs now focus Delete when they open. Enter activates the focused button; Tab and Shift+Tab stay within the confirmation, and Enter on Cancel or Escape cancels without deleting. The change uses the existing dialog autofocus hook and native button activation.

Surface: desktop renderer sidebar only. Initial focus on Delete is the requested behavior. Other confirmation controls are outside this change.

Closes #352.

## Verification

- [x] Focused sidebar tests: 22 passed. Full `bun run lint`, `bun run typecheck`, and `bun run check:ui` passed.
- [x] Approved wider check: `NODE_OPTIONS=--no-experimental-webstorage bun run test:desktop -- src/renderer/src/features/sidebar/Sidebar.test.tsx src/renderer/src/App.test.tsx` — 48 passed. The environment option avoids Node 26 exposing undefined native `localStorage` to Vitest; the first run without it failed in test setup.
- [x] Storybook keyboard play checks cover both dialog types: opening through menu Enter, initial focus, forward/reverse Tab containment, Enter on Cancel, Escape, and Enter confirmation with the correct callback input.
- [x] Regression checks failed with the original focus behavior and with temporary mutations that disabled Escape, made Cancel do nothing, made Cancel delete, made Delete cancel, or disabled modal focus containment. All mutations were restored.
- [x] Live isolated Electron checks confirmed Enter cancels before the change and deletes afterward, for temporary agents and sections. Before/after focus captures were inspected.
- [x] No credentials, private data, generated output, or real user files are included.

Retained findings: full lint reports 13 existing mobile-test module-mocking warnings. The Storybook keyboard steps pass, but the automatic accessibility scan reports the existing `aria-prohibited-attr` violation on the sidebar free-area context-menu trigger. The unchanged `Sections` story reports the same violation. These unrelated findings are not suppressed or changed here.

Harness: Codex, Vitest/jsdom, Storybook with headless Chrome, and `dev:automation` helpers against the isolated Electron app. Model: GPT-6.

## Before and after

| Action | Before | After |
| --- | --- | --- |
| Open agent or section confirmation | Cancel receives focus | Delete receives focus |
| Press Enter immediately after opening | Dialog closes; item remains | Confirmed item is deleted |
| Move focus to Cancel and press Enter | Cancels | Cancels |
| Press Escape | Cancels | Cancels |

No layout, text, or style changes.

## Risk and security impact

Enter after opening now confirms deletion because Delete has initial focus. Deletion still requires a separate confirmation action, and pending/error handling is unchanged. No changes to permissions, IPC, storage, network access, or released protocols.
