### PR TITLE
fix: tell users to wait when the mail provider refuses a sign-in code

### DIFF
--- a/apps/auth-api/README.md
+++ b/apps/auth-api/README.md
@@ -87,8 +87,10 @@ If `EMAIL_DELIVERY_WEBHOOK_SECRET` is set, the request includes a Bearer token.
 Do not enable `AUTH_EXPOSE_DEVELOPMENT_CODE` in production.
 
 When the provider itself refuses a message with a sender limit, the Worker
-answers 429 `email_delivery_rate_limited` instead of 502. The sign-in code is
-never sent in that case, so the app can ask for a new code later.
+answers 429 `email_delivery_rate_limited` instead of 502, for a sign-in code and
+for a team invitation. The message is never sent in that case, so the app can
+ask again later. Namecheap Private Email allows 500 messages an hour for each
+mailbox, and every sign-in code and invitation spends that same quota.
 
 ## Cloudflare deployment
 

--- a/apps/auth-api/README.md
+++ b/apps/auth-api/README.md
@@ -86,6 +86,10 @@ sends this JSON:
 If `EMAIL_DELIVERY_WEBHOOK_SECRET` is set, the request includes a Bearer token.
 Do not enable `AUTH_EXPOSE_DEVELOPMENT_CODE` in production.
 
+When the provider itself refuses a message with a sender limit, the Worker
+answers 429 `email_delivery_rate_limited` instead of 502. The sign-in code is
+never sent in that case, so the app can ask for a new code later.
+
 ## Cloudflare deployment
 
 Create the D1 database and replace the placeholder `database_id` in

--- a/apps/auth-api/src/routes/v1/team-invitations/email.ts
+++ b/apps/auth-api/src/routes/v1/team-invitations/email.ts
@@ -2,7 +2,7 @@ import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import { isCanonicalInviteUrl } from "@openbot/contracts/invite-links";
 import { isString } from "@openbot/contracts/runtime-values";
 import { createFileRoute } from "@tanstack/solid-router";
-import { normalizeEmail } from "../../../server/auth-service";
+import { emailDeliveryFailure, isEmailDeliveryFailure, normalizeEmail } from "../../../server/auth-service";
 import { readJsonObject } from "../../../server/json-body";
 import {
   apiError,
@@ -58,8 +58,8 @@ export const Route = createFileRoute("/v1/team-invitations/email")({
           if (error instanceof SyntaxError) {
             return apiError(400, "invalid_json", "The request body is invalid.");
           }
-          if (error instanceof Error && /^smtp_[a-z_]+$/u.test(error.message)) {
-            return apiError(502, "email_delivery_failed", "OpenBot could not send the invitation.");
+          if (isEmailDeliveryFailure(error)) {
+            return authErrorResponse(emailDeliveryFailure(error.message, "OpenBot could not send the invitation."));
           }
           return authErrorResponse(error);
         }

--- a/apps/auth-api/src/server/auth-service.ts
+++ b/apps/auth-api/src/server/auth-service.ts
@@ -10,7 +10,7 @@ import {
 
 import { randomToken, sha256 } from "./crypto";
 import { PERSISTENT_SESSION_EXPIRES_AT } from "./session-policy";
-import { EMAIL_CODE_DELIVERY_BUDGET_MS } from "./smtp-email-delivery";
+import { EMAIL_CODE_DELIVERY_BUDGET_MS, RATE_LIMITED_DELIVERY_ERROR } from "./smtp-email-delivery";
 import type {
   AuthRepository,
   AuthUser,
@@ -28,6 +28,10 @@ const TEAM_TICKET_TTL_MS = 2 * 60_000;
 const MOBILE_CONNECT_SERVER_ID = "00000000-0000-4000-8000-000000000002";
 const RATE_WINDOW_MS = 15 * 60_000;
 const AMBIGUOUS_DELIVERY_ERRORS = new Set(["smtp_delivery_unknown", "email_delivery_unknown"]);
+// A provider sender limit frees again as its window rolls forward, so the client waits and retries
+// rather than reporting a permanent failure. The wait is shorter than the usual hourly window: some
+// capacity returns before the window ends, and a countdown of a whole hour reads like an outage.
+const DELIVERY_RATE_LIMIT_RETRY_MS = 5 * 60_000;
 
 interface AuthServiceOptions {
   repository: AuthRepository;
@@ -132,6 +136,14 @@ export class AuthService {
         );
       }
       await this.#repository.completeEmailChallengeDelivery(challengeHash, "failed", this.#now());
+      if (deliveryError === RATE_LIMITED_DELIVERY_ERROR) {
+        throw new AuthServiceError(
+          429,
+          "email_delivery_rate_limited",
+          "OpenBot cannot send more sign-in codes right now. Try again when the countdown ends.",
+          Math.ceil(DELIVERY_RATE_LIMIT_RETRY_MS / 1_000),
+        );
+      }
       throw new AuthServiceError(502, "email_delivery_failed", "OpenBot could not send the sign-in code.");
     }
     await this.#repository.completeEmailChallengeDelivery(challengeHash, "sent", this.#now());

--- a/apps/auth-api/src/server/auth-service.ts
+++ b/apps/auth-api/src/server/auth-service.ts
@@ -31,7 +31,7 @@ const AMBIGUOUS_DELIVERY_ERRORS = new Set(["smtp_delivery_unknown", "email_deliv
 // A provider sender limit frees again as its window rolls forward, so the client waits and retries
 // rather than reporting a permanent failure. The wait is shorter than the usual hourly window: some
 // capacity returns before the window ends, and a countdown of a whole hour reads like an outage.
-const DELIVERY_RATE_LIMIT_RETRY_MS = 5 * 60_000;
+const DELIVERY_RATE_LIMIT_RETRY_SECONDS = 5 * 60;
 
 interface AuthServiceOptions {
   repository: AuthRepository;
@@ -136,15 +136,7 @@ export class AuthService {
         );
       }
       await this.#repository.completeEmailChallengeDelivery(challengeHash, "failed", this.#now());
-      if (deliveryError === RATE_LIMITED_DELIVERY_ERROR) {
-        throw new AuthServiceError(
-          429,
-          "email_delivery_rate_limited",
-          "OpenBot cannot send more sign-in codes right now. Try again when the countdown ends.",
-          Math.ceil(DELIVERY_RATE_LIMIT_RETRY_MS / 1_000),
-        );
-      }
-      throw new AuthServiceError(502, "email_delivery_failed", "OpenBot could not send the sign-in code.");
+      throw emailDeliveryFailure(deliveryError, "OpenBot could not send the sign-in code.");
     }
     await this.#repository.completeEmailChallengeDelivery(challengeHash, "sent", this.#now());
 
@@ -415,10 +407,25 @@ export class AuthService {
 }
 
 function safeDeliveryError(error: unknown): string {
-  if (!(error instanceof Error)) return "unknown_delivery_error";
-  return /^smtp_[a-z_]+$/u.test(error.message) || /^email_delivery_[a-z_]+$/u.test(error.message)
-    ? error.message
-    : "unknown_delivery_error";
+  return isEmailDeliveryFailure(error) ? error.message : "unknown_delivery_error";
+}
+
+// The sign-in code and the team invitation leave from the same mailbox, so a refusal must read the
+// same way on both paths.
+export function isEmailDeliveryFailure(error: unknown): error is Error {
+  return error instanceof Error && /^(?:smtp|email_delivery)_[a-z_]+$/u.test(error.message);
+}
+
+export function emailDeliveryFailure(deliveryError: string, permanentMessage: string): AuthServiceError {
+  if (deliveryError === RATE_LIMITED_DELIVERY_ERROR) {
+    return new AuthServiceError(
+      429,
+      "email_delivery_rate_limited",
+      "OpenBot cannot send more email right now. Try again when the countdown ends.",
+      DELIVERY_RATE_LIMIT_RETRY_SECONDS,
+    );
+  }
+  return new AuthServiceError(502, "email_delivery_failed", permanentMessage);
 }
 
 export class AuthServiceError extends Error {

--- a/apps/auth-api/src/server/email-delivery.ts
+++ b/apps/auth-api/src/server/email-delivery.ts
@@ -1,4 +1,9 @@
-import { type SmtpEmailConfig, sendPrivateEmailCode, sendPrivateTeamInvite } from "./smtp-email-delivery";
+import {
+  RATE_LIMITED_DELIVERY_ERROR,
+  type SmtpEmailConfig,
+  sendPrivateEmailCode,
+  sendPrivateTeamInvite,
+} from "./smtp-email-delivery";
 import type { EmailCodeDelivery, TeamInviteEmailDelivery, WorkerBindings } from "./types";
 
 type EmailDeliveryBindings = Pick<
@@ -40,6 +45,7 @@ export function createEmailCodeDelivery(bindings: EmailDeliveryBindings): EmailC
       }).catch(() => {
         throw new Error("email_delivery_unknown");
       });
+      if (response.status === 429) throw new Error(RATE_LIMITED_DELIVERY_ERROR);
       if (!response.ok) throw new Error("email_delivery_webhook_failed");
     },
   };

--- a/apps/auth-api/src/server/smtp-email-delivery.ts
+++ b/apps/auth-api/src/server/smtp-email-delivery.ts
@@ -42,12 +42,33 @@ interface SmtpSocket {
   close(): void | Promise<void>;
 }
 
+// Carries the reply that refused a stage. `message` keeps the same `smtp_<stage>_failed` shape the
+// service logs and tests read, so only the added fields are new.
+class SmtpReplyError extends Error {
+  constructor(
+    readonly stage: string,
+    readonly replyCode: number,
+    readonly replyText: string,
+  ) {
+    super(`smtp_${stage}_failed`);
+  }
+}
+
 export type SmtpConnector = (
   address: { hostname: string; port: number },
   options: { secureTransport: "on"; allowHalfOpen: false },
 ) => SmtpSocket;
 
 export const EMAIL_CODE_DELIVERY_BUDGET_MS = 25_000;
+// `auth-service` answers 429 for this message instead of a permanent 502. Every delivery method
+// raises it, so the service stays free of provider detail.
+export const RATE_LIMITED_DELIVERY_ERROR = "email_delivery_rate_limited";
+// A sender-limit refusal that arrives with a permanent 5xx reply. Namecheap Private Email answers
+// `554 5.7.1 <DATA>: Data command rejected: Reject: too many messages from sender in last 60
+// minutes` when the hourly quota of the sending mailbox is spent, which is a temporary condition
+// reported with a permanent code. Recipient-side limits such as `552 Mailbox quota exceeded` must
+// not match: the sender can do nothing about those, and a countdown would be a lie.
+const SENDER_LIMIT_REPLY = /too many (?:messages|emails|recipients)|(?:sending|send|message|rate) limit|rate limited/iu;
 const SMTP_TIMEOUT_MS = 7_500;
 const SMTP_CLOSE_TIMEOUT_MS = 250;
 const SMTP_MAX_ATTEMPTS = 3;
@@ -133,6 +154,15 @@ async function sendPrivateEmail(
       return;
     } catch (error) {
       const smtpError = normalizeSmtpError(error);
+      if (smtpError instanceof SmtpReplyError && isSenderRateLimited(smtpError)) {
+        // The stage and reply code only. A reply can quote the recipient address, which belongs in
+        // the database and not in a log line.
+        console.warn("Email delivery refused by a sender limit:", {
+          stage: smtpError.stage,
+          replyCode: smtpError.replyCode,
+        });
+        throw new Error(RATE_LIMITED_DELIVERY_ERROR);
+      }
       if (!isRetryableSmtpError(smtpError) || attempt === SMTP_MAX_ATTEMPTS) throw smtpError;
       await new Promise((resolveDelay) => setTimeout(resolveDelay, attempt * 250));
     }
@@ -195,6 +225,13 @@ function wrapTransportError(): Error {
   return new Error("smtp_transport_failed");
 }
 
+// A 4xx reply is temporary by definition, so waiting is the right answer whichever stage refused.
+// A 5xx reply counts only when it names a sender-side message limit.
+function isSenderRateLimited(error: SmtpReplyError): boolean {
+  if (error.replyCode >= 400 && error.replyCode < 500) return true;
+  return SENDER_LIMIT_REPLY.test(error.replyText);
+}
+
 function isRetryableSmtpError(error: Error): boolean {
   return ["smtp_transport_failed", "smtp_timeout", "smtp_connection_closed"].includes(error.message);
 }
@@ -240,6 +277,7 @@ class SmtpResponseReader {
 
   async expect(expectedCodes: number[], stage: string): Promise<void> {
     let responseCode: number | null = null;
+    const lines: string[] = [];
     while (true) {
       const line = await this.#readLine();
       const match = /^(\d{3})([ -])/u.exec(line);
@@ -247,9 +285,12 @@ class SmtpResponseReader {
       const lineCode = Number(match[1]);
       responseCode ??= lineCode;
       if (lineCode !== responseCode) throw new Error(`smtp_${stage}_invalid_response`);
+      lines.push(line);
       if (match[2] === " ") break;
     }
-    if (!expectedCodes.includes(responseCode)) throw new Error(`smtp_${stage}_failed`);
+    if (!expectedCodes.includes(responseCode)) {
+      throw new SmtpReplyError(stage, responseCode, lines.join(" "));
+    }
   }
 
   async #readLine(): Promise<string> {

--- a/apps/auth-api/test/auth-service.test.ts
+++ b/apps/auth-api/test/auth-service.test.ts
@@ -1,7 +1,13 @@
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type { AccountSession } from "@openbot/contracts/mobile-connect";
 import { describe, expect, it, vi } from "vitest";
-import { AuthService, generateOneTimeCode, normalizeOneTimeCode } from "../src/server/auth-service";
+import {
+  AuthService,
+  emailDeliveryFailure,
+  generateOneTimeCode,
+  isEmailDeliveryFailure,
+  normalizeOneTimeCode,
+} from "../src/server/auth-service";
 import type {
   AuthRepository,
   AuthUser,
@@ -669,6 +675,24 @@ describe("email one-time codes", () => {
       service.startEmailSignIn("person@example.com", "203.0.113.4", "10000000-0000-4000-8000-000000000011"),
     ).resolves.toMatchObject({ challengeId: "10000000-0000-4000-8000-000000000011" });
     expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives every email path the same answer for a refused mailbox", () => {
+    expect(emailDeliveryFailure("email_delivery_rate_limited", "OpenBot could not send the invitation.")).toMatchObject(
+      {
+        status: 429,
+        code: "email_delivery_rate_limited",
+        retryAfterSeconds: 300,
+      },
+    );
+    expect(emailDeliveryFailure("smtp_message_failed", "OpenBot could not send the invitation.")).toMatchObject({
+      status: 502,
+      code: "email_delivery_failed",
+      message: "OpenBot could not send the invitation.",
+    });
+    expect(isEmailDeliveryFailure(new Error("email_delivery_rate_limited"))).toBe(true);
+    expect(isEmailDeliveryFailure(new Error("smtp_message_failed"))).toBe(true);
+    expect(isEmailDeliveryFailure(new SyntaxError("Unexpected end of JSON input"))).toBe(false);
   });
 
   it("rejects reuse of an idempotency key for a different email", async () => {

--- a/apps/auth-api/test/auth-service.test.ts
+++ b/apps/auth-api/test/auth-service.test.ts
@@ -653,6 +653,24 @@ describe("email one-time codes", () => {
     expect(send).toHaveBeenCalledTimes(2);
   });
 
+  it("asks the caller to wait when the provider refuses more messages", async () => {
+    const repository = new MemoryAuthRepository();
+    const send = vi.fn().mockRejectedValueOnce(new Error("email_delivery_rate_limited")).mockResolvedValue(undefined);
+    const service = new AuthService({ repository, delivery: { send }, now: () => 1_000 });
+
+    await expect(
+      service.startEmailSignIn("person@example.com", "203.0.113.4", "10000000-0000-4000-8000-000000000010"),
+    ).rejects.toMatchObject({
+      status: 429,
+      code: "email_delivery_rate_limited",
+      retryAfterSeconds: 300,
+    });
+    await expect(
+      service.startEmailSignIn("person@example.com", "203.0.113.4", "10000000-0000-4000-8000-000000000011"),
+    ).resolves.toMatchObject({ challengeId: "10000000-0000-4000-8000-000000000011" });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects reuse of an idempotency key for a different email", async () => {
     const service = new AuthService({
       repository: new MemoryAuthRepository(),

--- a/apps/auth-api/test/smtp-email-delivery.test.ts
+++ b/apps/auth-api/test/smtp-email-delivery.test.ts
@@ -486,6 +486,149 @@ describe("Private Email SMTP delivery", () => {
     expect(attempts).toBe(1);
   });
 
+  it("reports a spent sender quota as a rate-limited delivery", async () => {
+    let attempts = 0;
+    const warnings: unknown[][] = [];
+    const warn = vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args);
+    });
+    const responses = [
+      ...SUCCESS_RESPONSES.split("\r\n").slice(0, 8),
+      "554 5.7.1 <person@example.com>: Data command rejected: Reject: too many messages from sender in last 60 minutes",
+    ].join("\r\n");
+    const connector: SmtpConnector = () => {
+      attempts += 1;
+      return {
+        opened: Promise.resolve(),
+        readable: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`${responses}\r\n`));
+            controller.close();
+          },
+        }),
+        writable: new WritableStream(),
+        close() {},
+      };
+    };
+
+    try {
+      await expect(
+        sendPrivateEmailCode(
+          {
+            host: "mail.privateemail.com",
+            port: 465,
+            username: "hello@openbot.run",
+            password: "app-password-value",
+            from: "hello@openbot.run",
+          },
+          {
+            email: "person@example.com",
+            code: "ABCD-EFGH",
+            expiresAt: Date.now() + 10 * 60_000,
+          },
+          connector,
+        ),
+      ).rejects.toThrow("email_delivery_rate_limited");
+    } finally {
+      warn.mockRestore();
+    }
+
+    expect(attempts).toBe(1);
+    expect(JSON.stringify(warnings)).not.toContain("person@example.com");
+  });
+
+  it("reports any temporary refusal as a rate-limited delivery", async () => {
+    let attempts = 0;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const connector: SmtpConnector = () => {
+      attempts += 1;
+      return {
+        opened: Promise.resolve(),
+        readable: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("421 4.7.0 Service unavailable\r\n"));
+            controller.close();
+          },
+        }),
+        writable: new WritableStream(),
+        close() {},
+      };
+    };
+
+    try {
+      await expect(
+        sendPrivateEmailCode(
+          {
+            host: "mail.privateemail.com",
+            port: 465,
+            username: "hello@openbot.run",
+            password: "app-password-value",
+            from: "hello@openbot.run",
+          },
+          {
+            email: "person@example.com",
+            code: "ABCD-EFGH",
+            expiresAt: Date.now() + 10 * 60_000,
+          },
+          connector,
+        ),
+      ).rejects.toThrow("email_delivery_rate_limited");
+    } finally {
+      warn.mockRestore();
+    }
+
+    expect(attempts).toBe(1);
+  });
+
+  it("keeps a recipient mailbox refusal a delivery failure", async () => {
+    const responses = [...SUCCESS_RESPONSES.split("\r\n").slice(0, 7), "552 5.2.2 Mailbox quota exceeded"].join("\r\n");
+    const connector: SmtpConnector = () => ({
+      opened: Promise.resolve(),
+      readable: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(`${responses}\r\n`));
+          controller.close();
+        },
+      }),
+      writable: new WritableStream(),
+      close() {},
+    });
+
+    await expect(
+      sendPrivateEmailCode(
+        {
+          host: "mail.privateemail.com",
+          port: 465,
+          username: "hello@openbot.run",
+          password: "app-password-value",
+          from: "hello@openbot.run",
+        },
+        {
+          email: "person@example.com",
+          code: "ABCD-EFGH",
+          expiresAt: Date.now() + 10 * 60_000,
+        },
+        connector,
+      ),
+    ).rejects.toThrow("smtp_recipient_failed");
+  });
+
+  it("reports a rate-limited delivery webhook apart from other webhook failures", async () => {
+    const fetchCall = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 429 }))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const delivery = createEmailCodeDelivery({ EMAIL_DELIVERY_WEBHOOK_URL: "https://mail.example.test/send" });
+    const message = { email: "person@example.com", code: "ABCD-EFGH", expiresAt: Date.now() + 10 * 60_000 };
+
+    try {
+      await expect(delivery?.send(message)).rejects.toThrow("email_delivery_rate_limited");
+      await expect(delivery?.send(message)).rejects.toThrow("email_delivery_webhook_failed");
+    } finally {
+      fetchCall.mockRestore();
+    }
+  });
+
   it("rejects partial SMTP configuration", () => {
     expect(() =>
       createEmailCodeDelivery({

--- a/src/main/central-auth-manager.test.ts
+++ b/src/main/central-auth-manager.test.ts
@@ -642,32 +642,42 @@ describe("CentralAuthManager", () => {
   });
 
   it("creates a new idempotency key after a confirmed delivery failure", async () => {
-    const root = await createRoot();
-    const keys: string[] = [];
-    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-      keys.push(new Headers(init?.headers).get("Idempotency-Key") ?? "");
-      if (keys.length === 1) {
-        return Response.json(
-          { error: { code: "email_delivery_failed", message: "Delivery failed." } },
-          { status: 502 },
-        );
-      }
-      return Response.json({ challengeId: "challenge-2", expiresAt: 610_000 });
-    });
-    const manager = new CentralAuthManager({
-      apiUrl: "http://127.0.0.1:3100",
-      storagePath: join(root, "session.bin"),
-      encrypt: (value) => Buffer.from(value),
-      decrypt: (value) => value.toString(),
-      fetch: fetchMock,
-    });
+    const failures = [
+      { code: "email_delivery_failed", status: 502, retryAfterSeconds: undefined },
+      { code: "email_delivery_rate_limited", status: 429, retryAfterSeconds: 300 },
+    ];
+    for (const failure of failures) {
+      const root = await createRoot();
+      const keys: string[] = [];
+      const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        keys.push(new Headers(init?.headers).get("Idempotency-Key") ?? "");
+        if (keys.length === 1) {
+          return Response.json(
+            { error: { code: failure.code, message: "Delivery failed." } },
+            {
+              status: failure.status,
+              headers:
+                failure.retryAfterSeconds === undefined ? {} : { "Retry-After": String(failure.retryAfterSeconds) },
+            },
+          );
+        }
+        return Response.json({ challengeId: "challenge-2", expiresAt: 610_000 });
+      });
+      const manager = new CentralAuthManager({
+        apiUrl: "http://127.0.0.1:3100",
+        storagePath: join(root, "session.bin"),
+        encrypt: (value) => Buffer.from(value),
+        decrypt: (value) => value.toString(),
+        fetch: fetchMock,
+      });
 
-    await expect(manager.requestEmailCode("person@example.com")).resolves.toMatchObject({
-      status: "error",
-      issue: { code: "email_delivery_failed" },
-    });
-    await expect(manager.requestEmailCode("person@example.com")).resolves.toMatchObject({ status: "code_sent" });
-    expect(keys[1]).not.toBe(keys[0]);
+      const state = await manager.requestEmailCode("person@example.com");
+      expect(state).toMatchObject({ status: "error", issue: { code: failure.code } });
+      if (state.status !== "error") throw new Error("Expected a failed code request.");
+      expect(state.issue.retryAfterSeconds).toBe(failure.retryAfterSeconds);
+      await expect(manager.requestEmailCode("person@example.com")).resolves.toMatchObject({ status: "code_sent" });
+      expect(keys[1]).not.toBe(keys[0]);
+    }
   });
 
   it("accepts an HTTP-date Retry-After value", async () => {

--- a/src/main/central-auth-manager.ts
+++ b/src/main/central-auth-manager.ts
@@ -64,6 +64,7 @@ const EMAIL_CODE_REQUEST_TIMEOUT_MS = 35_000;
 const RESEND_FALLBACK_DELAY_MS = 60_000;
 const DEFINITIVE_EMAIL_CODE_REQUEST_FAILURES = new Set([
   "email_delivery_failed",
+  "email_delivery_rate_limited",
   "idempotency_conflict",
   "idempotency_key_completed",
   "invalid_email",

--- a/src/renderer/src/analytics.test.ts
+++ b/src/renderer/src/analytics.test.ts
@@ -251,6 +251,12 @@ describe("desktop analytics", () => {
       }),
     ).toEqual({ action: "delete", result: "failed", failure_code: "unknown" });
     expect(
+      sanitizeDesktopAnalyticsEvent("account_sign_in_started", {
+        result: "failed",
+        failure_code: "email_delivery_rate_limited",
+      }),
+    ).toEqual({ result: "failed", failure_code: "email_delivery_rate_limited" });
+    expect(
       sanitizeDesktopAnalyticsEvent(
         "routine_action",
         Object.assign(

--- a/src/renderer/src/analytics.ts
+++ b/src/renderer/src/analytics.ts
@@ -256,6 +256,7 @@ const SAFE_FAILURE_CODES = new Set([
   "edit_failed",
   "email_delivery_failed",
   "email_delivery_not_configured",
+  "email_delivery_rate_limited",
   "email_sign_in_failed",
   "email_sign_in_start_failed",
   "identity_save_failed",

--- a/src/renderer/src/features/account/account-context.tsx
+++ b/src/renderer/src/features/account/account-context.tsx
@@ -17,6 +17,7 @@ function authFailureCode(value: string | undefined): string {
     case "code_recently_sent":
     case "email_delivery_failed":
     case "email_delivery_not_configured":
+    case "email_delivery_rate_limited":
     case "email_sign_in_failed":
     case "email_sign_in_start_failed":
     case "invalid_email":


### PR DESCRIPTION
## Problem

Every sign-in failed with **"OpenBot could not send the sign-in code."** The address was innocent:
the `hello@openbot.run` mailbox had spent its hourly Namecheap Private Email quota, so the provider
refused each message for all users. I reproduced the SMTP session against production and the server
refused at `DATA` with:

```
554 5.7.1 <DATA>: Data command rejected: Reject: too many messages from sender in last 60 minutes
```

The Worker mapped that to a permanent 502 `email_delivery_failed`, so the app showed a dead end and
`account_sign_in_started` reported `failure_code: "unknown"`. (The mailbox plan is now upgraded and
sending works again; this change is about the failure behaviour.)

## Change

- **`smtp-email-delivery.ts`** — a refused stage now throws `SmtpReplyError` with the stage, reply
  code, and reply text. `isSenderRateLimited()` treats every 4xx reply as temporary, and a 5xx reply
  only when its text names a sender-side message limit. Such a refusal becomes
  `email_delivery_rate_limited` and is not retried. Recipient-side limits such as
  `552 Mailbox quota exceeded` stay `smtp_recipient_failed`, because the sender cannot wait them out.
- **`email-delivery.ts`** — the delivery webhook maps HTTP 429 to the same error.
- **`auth-service.ts`** — that error answers **429 `email_delivery_rate_limited`** with
  `Retry-After: 300` instead of 502. The code is never sent in that case. `emailDeliveryFailure()`
  and `isEmailDeliveryFailure()` hold the mapping, and the team-invitation route uses them too:
  invitations leave from the same mailbox, and that route matched only `smtp_*`, so a refusal there
  would otherwise become a generic 500.
- **`central-auth-manager.ts`** — the new code is a definitive failure, so the idempotency key resets
  and a later attempt starts a new challenge.
- **Renderer** — `authFailureCode()` and the analytics allowlist pass the code through, so
  `account_sign_in_started { result: "failed", failure_code }` names a quota block. `AccountLogin.tsx`
  already renders "Try again in mm:ss" and disables submit for any issue with `retryAfterSeconds`, so
  the UI needed no change.
- **`apps/auth-api/README.md`** — records the new 429 answer.

No new analytics event, sink, or property, so `ANALYTICS.md`, its schema version, and `PRIVACY.md`
stay unchanged. The log line for a refusal holds the stage and reply code only, because a reply can
quote the recipient address.

## Surfaces

Account Worker (`apps/auth-api`), main-process auth client (`src/main`), renderer account context and
analytics (`src/renderer`). No IPC contract, database schema, or wire protocol change.

## Tests

- `apps/auth-api/test/smtp-email-delivery.test.ts` — a DATA-stage 554 quota refusal gives
  `email_delivery_rate_limited` after one attempt and keeps the recipient address out of the log
  payload; a `421` greeting gives the same code through the 4xx rule; `552 Mailbox quota exceeded`
  stays a delivery failure; a 429 webhook is separate from a 500 webhook.
- `apps/auth-api/test/auth-service.test.ts` — a refused send answers 429 with 300 seconds, and a new
  idempotency key sends again.
- `src/main/central-auth-manager.test.ts` — the delivery-failure test now runs over both codes and
  asserts the `Retry-After` value reaches the issue.
- `src/renderer/src/analytics.test.ts` — the sanitizer keeps the new failure code.
- `apps/auth-api/test/auth-service.test.ts` — the shared mapper gives 429 with 300 seconds for a
  sender limit and 502 with the caller's own message otherwise, and `isEmailDeliveryFailure()`
  refuses an unrelated error such as a `SyntaxError`.

For each new assertion I broke the behaviour and confirmed the failure reason: classification
removed (`smtp_data_failed`), regex widened to match `quota` (recipient case rate limited), reply
text logged (address in the payload), 4xx rule removed (`smtp_greeting_failed`), webhook 429 branch
removed (`email_delivery_webhook_failed`), 429 mapping removed (502 message), the code removed from
the definitive set (same idempotency key), the code removed from the analytics allowlist
(`unknown`), the mapper's rate-limit branch disabled (502 on both paths), and the predicate widened
to any error (a `SyntaxError` accepted). All files were restored afterwards.

`bun x vitest run` for both auth-api files, `bun run test:desktop` for both desktop files,
`bun run lint` (0 errors; the 13 warnings are pre-existing in `apps/mobile`), `bun run typecheck`,
and `bun run check:ui` all pass. Model: Claude Opus 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
