### PR TITLE
fix: report a provider CLI update OpenBot refuses to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to OpenBot will be documented here. The project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Report a provider CLI update that OpenBot refuses to start, instead of leaving the offer on screen.
+
 ## [0.6.1] - 2026-09-08
 
 ### Fixed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -462,23 +462,26 @@ because the two arrive separately and either one can complete an offer. An expli
 the same notification; revisioned snapshots move it through progress, failure, retry, and
 completion. Only the crossing into "update available" is announced, so a dismissed notification
 stays dismissed until the offer changes. Closing the notification does not cancel the download,
-and later reports do not reopen it. Fresh provider downloads retain their existing flow. These
-actions apply only to the local desktop host.
+and later reports do not reopen it. A refusal that reaches neither the download nor the report it
+makes - an update started while a workspace on another computer is open - is put on that same
+notification with a Retry, because the user pressed a button and the outcome belongs on screen.
+Fresh provider downloads retain their existing flow. These actions apply only to the local desktop
+host.
 
 A CLI the user installed themselves is not managed, but it is still compared against the lock.
 Each provider status row reports `cliSource`, and main passes the version of a `system` row to
 `ProviderRuntimeManager.setSystemVersion`, which compares it against the pinned version exactly as
-it compares a managed installation. The row and the notification therefore use the one update offer, the
-one Update button, and one entry point in the runtime store, `startProviderUpdate`. Only the work
-behind it differs: a `system` install goes to `updateProviderCli`, which runs that CLI's own updater
-(`codex update`) and then restarts the provider on the binary now on disk. That updater reports no
-progress, so the notification holds its indeterminate step until the provider comes back, and a
-failure keeps the reason the CLI gave, redacted, in one error that goes to the provider row and to
-the caller - and on, through the Team API, to the team's connected clients.
-The owner comes from the last resolution of the binary, not from the client that runs it, so a
-provider that is signed out still reports its own install rather than reading as the managed copy.
-OpenBot downloads nothing on this path, so the pinned artifact checksums are untouched. The managed
-copy refuses this command, because the runtime manager replaces that installation whole.
+it compares a managed installation. The row and the notification therefore use the one update offer,
+the one Update button, and one entry point in the runtime store, `startProviderUpdate`. One path
+runs behind it, whoever owns the CLI: the download installs the pinned managed copy and
+`updateProviderCli` activates it, and CLI resolution then prefers that copy to the system install,
+which is left where it is. OpenBot never runs the CLI's own updater, so no version it offers depends
+on another release channel. An explicit `OPENBOT_*_PATH` suppresses the offer, because that path
+names the binary to run and the managed copy is not it. The owner comes from the last resolution of
+the binary, not from the client that runs it, so a provider that is signed out still reports its own
+install rather than reading as the managed copy. A failure keeps the reason the CLI gave, redacted,
+in one error that goes to the provider row and to the caller - and on, through the Team API, to the
+team's connected clients.
 
 Every runtime the store reaches is on this computer: `window.openbot.providerRuntimes` addresses no
 other one, while the agent status beside it describes whichever server is open. The store therefore

--- a/src/renderer/src/features/provider-updates/provider-runtime-store.ts
+++ b/src/renderer/src/features/provider-updates/provider-runtime-store.ts
@@ -2,6 +2,7 @@ import type { AgentProviderId, ProviderRuntimeSnapshot, ProviderRuntimesDesktopA
 import { createEffect, createSignal, flush, onSettled } from "solid-js";
 import { desktopAnalytics } from "../../analytics";
 import { FALLBACK_PROVIDER_RUNTIMES } from "../../app-defaults";
+import { errorMessage } from "../../error-message";
 import { type ProviderUpdate, providerUpdatesToAnnounce } from "./provider-update";
 import {
   dismissProviderUpdateToast,
@@ -59,8 +60,35 @@ export function createProviderRuntimeStore(
    * Retry the notification offers after a failure. OpenBot installs its pinned runtime.
    */
   function startProviderUpdate(provider: AgentProviderId): Promise<void> {
+    return runProviderUpdate(provider).catch((error: unknown) => {
+      // A user pressed a button, so the outcome belongs on screen. `downloadProviderRuntime`
+      // reports its own failures and settles; what reaches here failed before it owned the
+      // notification, and was discarded by the caller that started it.
+      failProviderUpdate(provider, error);
+      throw error;
+    });
+  }
+
+  function runProviderUpdate(provider: AgentProviderId): Promise<void> {
     if (!isLocalServer()) return Promise.reject(new Error("Provider CLI updates run on the computer that hosts them."));
     return downloadProviderRuntime(provider);
+  }
+
+  /** Puts a failure the update never got far enough to report on the notification, with a Retry. */
+  function failProviderUpdate(provider: AgentProviderId, error: unknown): void {
+    if (disposed) return;
+    const update = providerUpdate(provider);
+    showProviderUpdateToast(
+      {
+        ...update,
+        runtime: {
+          ...update.runtime,
+          phase: "download-error",
+          message: errorMessage(error, "The update could not start. Try again."),
+        },
+      },
+      () => void startProviderUpdate(provider),
+    );
   }
 
   /** Revisioned, because the pushed event and the awaited call can land out of order. */

--- a/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
+++ b/src/renderer/src/features/provider-updates/provider-update-toast.test.tsx
@@ -288,6 +288,27 @@ it("offers no CLI update while a workspace on another computer is open", async (
   expect(await screen.findByText("ChatGPT update available")).toBeInTheDocument();
 });
 
+it("reports an update that was refused before the download could report it", async () => {
+  const { store, api, setLocal } = systemCliHarness();
+  expect(await screen.findByText("ChatGPT update available")).toBeInTheDocument();
+  setLocal(false);
+  flush();
+
+  // The workspace on screen is on another computer, and the user pressed the button before the offer
+  // went away. `downloadProviderRuntime` reports its own failures, but this one is refused before
+  // it: the refusal used to be dropped, leaving the offer on screen and nothing else said.
+  await expect(store.startProviderUpdate("codex")).rejects.toThrow(/computer that hosts them/u);
+
+  expect(await screen.findByText("ChatGPT update failed")).toBeInTheDocument();
+  expect(screen.getByText("Provider CLI updates run on the computer that hosts them.")).toBeInTheDocument();
+  expect(api.download).not.toHaveBeenCalled();
+
+  setLocal(true);
+  flush();
+  fireEvent.click(await screen.findByRole("button", { name: "Retry" }));
+  await waitFor(() => expect(api.download).toHaveBeenCalledWith("codex"));
+});
+
 it("keeps an offer the user closed closed when the workspace is opened again", async () => {
   systemCliHarness();
   fireEvent.click(await screen.findByRole("button", { name: "Close notification" }));


### PR DESCRIPTION
## Problem

A provider CLI update the user starts can be refused before any download owns the notification, and
that refusal was dropped. `startProviderUpdate` rejects when the open workspace is on another
computer, and every caller discards the rejection - the toast action is `() => void
startProviderUpdate(...)`. The user pressed Update, the offer stayed on screen unchanged, and
nothing said why nothing happened. `downloadProviderRuntime` reports its own failures, so only the
refusals before it were silent.

## Change

`startProviderUpdate` now catches what it rejects with and puts it on the same notification as a
`download-error`, with the Retry the notification already renders. The message goes through
`errorMessage`, like every other failure the store displays, so it is redacted and mapped for
display. The rejection is still rethrown for callers that await it.

`docs/ARCHITECTURE.md` records the refusal report. It also corrects the managed-updates section,
which still described `updateProviderCli` as running the CLI's own updater (`codex update`) and the
managed copy as refusing that command - both removed by #367. That section now describes the one
path both owners take: the download installs the pinned managed copy, `updateProviderCli` activates
it, resolution prefers it to the system install, and an explicit `OPENBOT_*_PATH` suppresses the
offer.

## Scope

This is what remains of #366 after #367 landed. #366 implemented the opposite design - no pinned
offer for a CLI the user installed, routed to that CLI's own updater instead - and is closed as
superseded. #366 also fixed a second silent path, an update queued behind a connection command that
waits for the user; #367 closed that one in a better place, with explicit sign-in and busy-turn
guards that answer before the wait, so nothing here touches the backend.

## Tests

One test added to `provider-update-toast.test.tsx`: an update refused while a workspace on another
computer is open reports "ChatGPT update failed" with the reason, calls no download, and retries
successfully once the local workspace is open again.

Watched it fail: with `startProviderUpdate` reduced to `return runProviderUpdate(provider)`, the
test fails with `Unable to find an element with the text: ChatGPT update failed`. Restored, and the
27 tests in `src/renderer/src/features/provider-updates` pass.

`bun run lint`, `bun run typecheck` and `bun run check:ui` are clean, with the 13 pre-existing
warnings.

## Surfaces

Desktop renderer only. No IPC contract, schema, or migration change, so
`preview/mock-openbot.ts` needs none either. No UI layout change: the notification, its states and
its Retry button are the ones already there.

Model: Claude Opus 5, in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)