### PR TITLE
fix: keep Dynamic Island out of AltTab during mouse interaction

### DIFF
--- a/src/main/dynamic-island-window.test.ts
+++ b/src/main/dynamic-island-window.test.ts
@@ -181,7 +181,8 @@ describe("dynamic island window geometry", () => {
 
     controller.setInteractive(43, true);
     expect(windows[0]?.setFocusable).not.toHaveBeenCalledWith(true);
-    expect(windows[1]?.setFocusable).toHaveBeenCalledWith(true);
+    expect(windows[1]?.setFocusable).not.toHaveBeenCalledWith(true);
+    expect(windows[1]?.setIgnoreMouseEvents).toHaveBeenLastCalledWith(false, { forward: true });
     expect(windows[1]?.setBounds).toHaveBeenCalledWith({ x: 2165, y: -120, width: 614, height: 380 }, false);
 
     displays = [
@@ -200,9 +201,13 @@ describe("dynamic island window geometry", () => {
     // renderer's collapse animation has landed - otherwise the lower half is cut off at once.
     vi.useFakeTimers();
     controller.setInteractive(43, false);
+    expect(windows[1]?.setIgnoreMouseEvents).toHaveBeenLastCalledWith(true, { forward: true });
     expect(windows[1]?.setBounds).not.toHaveBeenCalledWith({ x: 1793, y: 20, width: 614, height: 50 }, false);
     await vi.advanceTimersByTimeAsync(DYNAMIC_ISLAND_COLLAPSE_SETTLE_MS);
     expect(windows[1]?.setBounds).toHaveBeenCalledWith({ x: 1793, y: 20, width: 614, height: 50 }, false);
+    controller.setInteractive(43, true);
+    expect(windows[1]?.setFocusable).not.toHaveBeenCalledWith(true);
+    expect(windows[1]?.setIgnoreMouseEvents).toHaveBeenLastCalledWith(false, { forward: true });
   });
 
   it("publishes updated geometry without reloading an existing overlay", async () => {

--- a/src/main/dynamic-island-window.ts
+++ b/src/main/dynamic-island-window.ts
@@ -128,7 +128,8 @@ export class DynamicIslandWindowController {
     const bounds = display ? dynamicIslandWindowBounds(display) : undefined;
     this.#cancelCollapse(displayId);
     if (interactive && bounds) window.setBounds(dynamicIslandInteractiveWindowBounds(bounds, true), false);
-    window.setFocusable(interactive);
+    // On macOS, focusability also allows the panel to become a main window in AltTab.
+    // Keep it non-focusable; mouse interaction does not require keyboard focus.
     window.setIgnoreMouseEvents(!interactive, { forward: true });
     if (interactive || !bounds) return;
     this.#collapseTimers.set(


### PR DESCRIPTION
## What changed

Dynamic Island enabled window focus when mouse interaction started. On macOS, Electron also allows a focusable panel to become the main window, which can make it a separate AltTab destination after a click. Keep the island non-focusable and continue to enable mouse events during interaction.

| State | Before | After |
| --- | --- | --- |
| Mouse enters the island | Mouse events and window focus enabled | Mouse events enabled; window stays non-focusable |
| Mouse leaves, then returns | Window focus disabled, then enabled again | Window stays non-focusable throughout |

Affected surface: desktop main-process window control. Direct keyboard interaction with island buttons is no longer available; keyboard users can use the main OpenBot window. No IPC, renderer, persistence, or dependency changes.

Closes #339. The target is the third-party AltTab app, as clarified by the reporter.

## Verification

- [x] `bun run test:desktop -- src/main/dynamic-island-window.test.ts` — 17 tests pass.
- [x] Approved wider check: `bun run test:desktop -- src/main/dynamic-island-window.test.ts src/main/dynamic-island-actions.test.ts` — 20 tests pass across both files.
- [x] `bun run lint` — passes with 13 existing module-mocking warnings in unrelated mobile tests. Those tests model native boundaries; this PR leaves them unchanged.
- [x] `bun run typecheck` — all projects pass.
- [x] Regression verification: temporarily restored `setFocusable(interactive)` and both focus assertions failed. Temporarily reversed mouse-event handling and all three mouse assertions failed. Restored the fix and confirmed the test file passes.
- [x] No credentials, private data, generated output, or user files are included.

Local smoke check: started a fresh isolated dev profile on macOS 15.3.1 with Electron 44.0.0. Used `bun run dev:automation` against the named worktree instance to inspect the main window and idle island and send an island button click. Stopped only that worktree's stack afterward.

Native AltTab exclusion is **not yet verified**. AltTab 11.6.0 is installed, but the available computer-control tool cannot send global shortcuts. The idle profile also had no pending approvals or questions. Before merge, manually check AltTab after expansion, clicks, collapse, and repeated interaction; approvals and suggested answers; opening the main window; minimized/hidden main-window switching; display reconnection and full-screen spaces. Other macOS versions and native Cmd+Tab remain untested. Mock tests do not prove native switcher behavior.

Model: GPT-6. Harness: Codex, Vitest, repository `dev:automation`, and Computer Use for AltTab inspection.

## Risk and security impact

No change to the renderer-to-main trust boundary, permissions, persistence, or network access. The intentional behavior change is that the island cannot receive keyboard focus. Native switcher and mouse interaction checks above remain required before merge.
