### PR TITLE
fix: repair a stored agent profile instead of refusing to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to OpenBot will be documented here. The project follows
 ### Fixed
 
 - Report a provider CLI update that OpenBot refuses to start, instead of leaving the offer on screen.
+- Keep an agent whose stored profile holds a value this release cannot read, instead of refusing to
+  start. The startup error now names the field it cannot read.
 
 ## [0.6.1] - 2026-09-08
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -58,6 +58,27 @@ sqlite3 "$HOME/Library/Application Support/OpenBot/openbot.db" \
 Any row means the messages are still on disk and are recoverable. Report the output with the details
 below, and keep the folder where it is until then.
 
+## OpenBot will not start and names a stored agent profile
+
+The message reads `Stored agent profile <id> has an unreadable "<field>" value`. Your data is intact:
+OpenBot stops before it writes anything, which is what keeps the profile as it is.
+
+Do not follow the reset steps below, and do not move the folder. Install the current version first:
+OpenBot now repairs a stored profile field it cannot read and keeps the agent, its chat and its
+workspace, while a release from before that repair refuses to start over the same profile.
+
+If the current version still stops, quit OpenBot and read the profile it names. On macOS:
+
+```sh
+sqlite3 "$HOME/Library/Application Support/OpenBot/openbot.db" \
+  "SELECT agent_json FROM projection_agents WHERE agent_id = '<id>';"
+```
+
+On Windows, the same file is at `%APPDATA%\OpenBot\openbot.db`.
+
+Report the field the message names, together with the details below. The output holds your own file
+paths, so review it before you publish it.
+
 ## Reset OpenBot
 
 Quit OpenBot before moving data. To reset application state and the shared browser profile while

--- a/src/backend/agent-store.test.ts
+++ b/src/backend/agent-store.test.ts
@@ -242,12 +242,16 @@ describe("AgentStore", () => {
     // the roster is intact, which is what a persist made with an agent missing leaves behind. The agent
     // has no chat in the sidebar, a later `getOrCreate` rebuilds it with no thread, and both read paths
     // then report an empty history -- while the thread and every message stay on disk.
+    store.database.connection
+      .prepare("UPDATE projection_agents SET agent_json = json_set(agent_json, '$.model', ?) WHERE agent_id = ?")
+      .run("claude fable 5.1 (1m)", "sales-outbound");
     store.database.connection.prepare("DELETE FROM projection_agents WHERE agent_id = ?").run("chief");
 
     const restored = new AgentStore(userData, home);
     await restored.initialize();
 
     expect(restored.list().map((agent) => agent.id)).toEqual(["sales-outbound", "chief"]);
+    expect(restored.list().find((agent) => agent.id === "sales-outbound")?.model).toBe("gpt-5.6-luna");
     expect(restored.list().find((agent) => agent.id === "chief")?.threadId).toBe(threadId);
     expect(restored.database.readConversationPage("chief", threadId).messages).toEqual([
       expect.objectContaining({ id: "message-1", text: "Where did my chat go?" }),
@@ -504,7 +508,15 @@ describe("AgentStore", () => {
     const chief = await store.getOrCreate("chief");
 
     // `AgentService` passes ids straight out of `listModels()`, so the value here is a provider CLI's,
-    // not a user's. Stored, it made the *next* launch the failure.
+    // not a user's. Stored, it made the *next* launch the failure. The provider must also stay unchanged
+    // when validation of the later model field fails.
+    await expect(
+      store.updateAgent({ agentId: "chief", provider: "claude", model: "claude fable 5.1 (1m)" }),
+    ).rejects.toThrow("Invalid agent model.");
+    expect(store.list().find((agent) => agent.id === "chief")).toMatchObject({
+      provider: "codex",
+      model: chief.model,
+    });
     await expect(store.updateAgent({ agentId: "chief", model: "claude fable 5.1 (1m)" })).rejects.toThrow(
       "Invalid agent model.",
     );

--- a/src/backend/agent-store.test.ts
+++ b/src/backend/agent-store.test.ts
@@ -411,6 +411,113 @@ describe("AgentStore", () => {
     await expect(readFile(statePath, "utf8")).resolves.toBe(source);
   });
 
+  it("resets a stored profile field it cannot read and keeps the agent, its thread and its workspace", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-store-unreadable-"));
+    temporaryRoots.push(root);
+    const userData = join(root, "user-data");
+    const home = join(root, "home");
+    const store = new AgentStore(userData, home);
+    await store.initialize();
+    await store.getOrCreate("chief");
+    await store.updateAgent({
+      agentId: "chief",
+      provider: "claude",
+      model: "claude-fable-5-1",
+      reasoningEffort: "high",
+      avatarSeed: "chief:picked",
+      avatarHue: 30,
+    });
+    const threadId = await store.ensureThreadId("chief");
+    const workspacePath = store.list().find((agent) => agent.id === "chief")?.workspacePath;
+
+    // Four values a released build stored and a later one cannot read: a model id the provider CLI
+    // renamed under a running install, an effort and a hue from a release the user has since left, and
+    // a marketplace source written as SQL `null`. Every one of them used to stop the app from starting.
+    store.database.connection
+      .prepare(
+        `UPDATE projection_agents SET agent_json = json_set(agent_json,
+           '$.model', ?, '$.reasoningEffort', ?, '$.avatarSeed', ?, '$.avatarHue', ?,
+           '$.marketplaceSource', json('null'))
+         WHERE agent_id = ?`,
+      )
+      .run("claude fable 5.1 (1m)", "ultra", "Chief Seed", 7, "chief");
+
+    const repaired = new AgentStore(userData, home);
+    await repaired.initialize();
+
+    // The identity survives: same agent, same thread, same workspace, and the chat is still readable.
+    expect(repaired.list().find((agent) => agent.id === "chief")).toMatchObject({
+      id: "chief",
+      threadId,
+      workspacePath,
+      provider: "claude",
+      // The default of the provider the profile names, not the default of a new agent, which is Codex.
+      model: "claude-sonnet-5",
+      reasoningEffort: "medium",
+      avatarSeed: "chief",
+      avatarHue: null,
+    });
+    expect(repaired.list().find((agent) => agent.id === "chief")?.marketplaceSource).toBeUndefined();
+
+    // Written back at once, so the next launch reads a profile it accepts instead of repairing again.
+    expect(repaired.database.listAgents().find((agent) => agent.id === "chief")).toMatchObject({
+      model: "claude-sonnet-5",
+      reasoningEffort: "medium",
+      avatarSeed: "chief",
+      avatarHue: null,
+    });
+  });
+
+  it("refuses to start on a stored profile field no default can stand in for", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-store-unusable-"));
+    temporaryRoots.push(root);
+    const userData = join(root, "user-data");
+    const home = join(root, "home");
+    const store = new AgentStore(userData, home);
+    await store.initialize();
+    await store.getOrCreate("chief");
+    const threadId = await store.ensureThreadId("chief");
+    store.database.connection
+      .prepare(
+        "UPDATE projection_agents SET agent_json = json_set(agent_json, '$.workspacePath', ?) WHERE agent_id = ?",
+      )
+      .run(42, "chief");
+
+    const blocked = new AgentStore(userData, home);
+    // The field is the diagnosis a support report can carry; the value is a path from the user's home
+    // directory, and this message reaches a dialog, the log and any diagnostics export.
+    await expect(blocked.initialize()).rejects.toThrow(
+      'Stored agent profile chief has an unreadable "workspacePath" value',
+    );
+
+    // Refusing is what keeps the row: nothing about the agent, its thread or its messages is rewritten.
+    expect(store.database.listAgents().map((agent) => agent.id)).toEqual(["chief"]);
+    expect(store.database.readConversation("chief", threadId).threadId).toBe(threadId);
+  });
+
+  it("refuses to store a profile value the next launch could not read", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openbot-store-rejects-"));
+    temporaryRoots.push(root);
+    const userData = join(root, "user-data");
+    const store = new AgentStore(userData, join(root, "home"));
+    await store.initialize();
+    const chief = await store.getOrCreate("chief");
+
+    // `AgentService` passes ids straight out of `listModels()`, so the value here is a provider CLI's,
+    // not a user's. Stored, it made the *next* launch the failure.
+    await expect(store.updateAgent({ agentId: "chief", model: "claude fable 5.1 (1m)" })).rejects.toThrow(
+      "Invalid agent model.",
+    );
+    await expect(store.updateAgent({ agentId: "chief", avatarSeed: "Chief Seed" })).rejects.toThrow(
+      "Invalid avatar seed.",
+    );
+
+    expect(store.list().find((agent) => agent.id === "chief")).toMatchObject({
+      model: chief.model,
+      avatarSeed: chief.avatarSeed,
+    });
+  });
+
   it("creates unique new agents at the top of the persistent list", async () => {
     const root = await mkdtemp(join(tmpdir(), "openbot-store-"));
     temporaryRoots.push(root);

--- a/src/backend/agent-store.ts
+++ b/src/backend/agent-store.ts
@@ -27,6 +27,7 @@ import {
   type AgentSummary,
   type AvatarImageInput,
   type CreateAgentInput,
+  DEFAULT_PROVIDER_MODELS,
   type DuplicateAgentResult,
   decodeAgentProfileDraft,
   decodeSaveAgentProfileResult,
@@ -85,6 +86,7 @@ const LEGACY_AVATAR_COLORS = [
   "gray",
 ] as const;
 
+export const NEW_AGENT_PREVIEW = "No messages yet";
 export const DEFAULT_AGENT_MODEL: AgentModelId = "gpt-5.6-luna";
 export const DEFAULT_AGENT_PROVIDER: AgentProviderId = "codex";
 export const DEFAULT_REASONING_EFFORT: AgentReasoningEffort = "medium";
@@ -157,14 +159,31 @@ export class AgentStore {
     await this.#database.initialize();
     const persisted = this.#database.listAgents();
     if (persisted.length > 0 || this.#database.hasAggregateEvents("agents", "agents")) {
-      if (!persisted.every(isStoredAgent)) {
-        throw new Error("Stored agent profiles use the old role field; update the data before starting OpenBot.");
+      // Repaired field by field rather than accepted or refused as a whole. One stored value this build
+      // cannot read -- a model id a provider CLI has since renamed, an effort or a hue added by a later
+      // release, a marketplace source written as `null` -- used to stop the app from starting at all,
+      // and the message named the one cause this branch never tests: a `role` field cannot reach the
+      // database, because the `bots.json` import below rejects it before anything is written. Dropping
+      // the profile instead is not an option either: `replaceAgents` truncates the roster and re-inserts
+      // this list, so a dropped agent takes its chat out of the sidebar while its thread and every
+      // message stay on disk, unreachable. What `readStoredAgent` cannot guess -- the id, the workspace
+      // path, the thread -- still refuses to start, because guessing one of those three would point an
+      // agent at another agent's files or at an empty history.
+      const agents: StoredAgent[] = [];
+      const repairs: string[] = [];
+      for (const stored of persisted) {
+        const read = readStoredAgent(stored);
+        if ("unreadable" in read) throw new Error(unreadableProfileMessage(read));
+        agents.push(normalizeStoredAgent(read.agent));
+        if (read.repaired.length > 0) repairs.push(`${read.agent.id}: ${read.repaired.join(", ")}`);
       }
-      this.#state = {
-        version: 2,
-        examplesInitialized: true,
-        agents: persisted.map(normalizeStoredAgent),
-      };
+      this.#state = { version: 2, examplesInitialized: true, agents };
+      if (repairs.length > 0) {
+        logger.warn("Stored agent profile fields could not be read and were reset.", toLogValue(repairs));
+        // Written back at once, so the repair survives the next launch instead of running again on every
+        // start. The persist carries the whole roster, so the profiles that needed no repair are unchanged.
+        this.#persist("agents.repaired");
+      }
       this.#restoreRosterFromEvents();
     } else {
       const legacy = await this.#readState();
@@ -473,13 +492,31 @@ export class AgentStore {
       agent.description = limitedText(input.description, "Agent description", INPUT_LIMITS.agentDescription);
     }
     if (input.notifications !== undefined) agent.notifications = input.notifications;
-    if (input.provider !== undefined) agent.provider = input.provider;
+    // Checked here and not only in the IPC decoder, because the caller closest to the data is not a
+    // user: `AgentService` writes the provider, model and effort straight out of `listModels()`, which
+    // is a list of ids a provider CLI minted and can rename under a running install. A value the read
+    // guards reject must not reach the roster at all -- before `readStoredAgent`, storing one made the
+    // app refuse to start on its next launch.
+    if (input.provider !== undefined) {
+      if (!isOneOf(AGENT_PROVIDERS, input.provider)) throw new Error("Invalid agent provider.");
+      agent.provider = input.provider;
+    }
     if (input.model !== undefined) {
+      if (!isAgentModel(input.model)) throw new Error("Invalid agent model.");
       agent.model = input.model;
     }
-    if (input.reasoningEffort !== undefined) agent.reasoningEffort = input.reasoningEffort;
-    if (input.avatarSeed !== undefined) agent.avatarSeed = input.avatarSeed;
-    if (input.avatarHue !== undefined) agent.avatarHue = input.avatarHue;
+    if (input.reasoningEffort !== undefined) {
+      if (!isReasoningEffort(input.reasoningEffort)) throw new Error("Invalid reasoning effort.");
+      agent.reasoningEffort = input.reasoningEffort;
+    }
+    if (input.avatarSeed !== undefined) {
+      if (!isAvatarSeed(input.avatarSeed)) throw new Error("Invalid avatar seed.");
+      agent.avatarSeed = input.avatarSeed;
+    }
+    if (input.avatarHue !== undefined) {
+      if (input.avatarHue !== null && !isAvatarHue(input.avatarHue)) throw new Error("Invalid avatar hue.");
+      agent.avatarHue = input.avatarHue;
+    }
     agent.updatedAt = new Date().toISOString();
     this.#persist("agent.updated");
     return { ...agent };
@@ -1022,7 +1059,12 @@ export class AgentStore {
   #restoreRosterFromEvents(): void {
     const replayed = this.#database.latestRosterAgents();
     if (replayed.length === 0) return;
-    const readable = replayed.filter(isStoredAgent).map(normalizeStoredAgent);
+    const readable: StoredAgent[] = [];
+    for (const value of replayed) {
+      const read = readStoredAgent(value);
+      if ("unreadable" in read) continue;
+      readable.push(normalizeStoredAgent(read.agent));
+    }
     const present = new Set(this.#state.agents.map((agent) => agent.id));
     // Appended rather than put back at its old index: the sidebar orders agents by the layout's own
     // `agentOrder`, so the position here is not what the user sees, and appending keeps the agents that
@@ -1053,7 +1095,7 @@ export class AgentStore {
       reasoningEffort: DEFAULT_REASONING_EFFORT,
       threadId: null,
       workspacePath: join(this.#agentsRoot, id),
-      preview: "No messages yet",
+      preview: NEW_AGENT_PREVIEW,
       updatedAt: null,
       avatarSeed: id,
       avatarHue: null,
@@ -1266,6 +1308,96 @@ function isStoredAgent(value: unknown): value is PersistedStoredAgent {
     (record.avatarHue === null || isAvatarHue(record.avatarHue)) &&
     isMarketplaceSource(record.marketplaceSource)
   );
+}
+
+interface ReadStoredAgent {
+  agent: PersistedStoredAgent;
+  /** The names of the fields this build could not read, in the order they are checked. */
+  repaired: string[];
+}
+
+interface UnreadableStoredAgent {
+  unreadable: string;
+  id: string | null;
+}
+
+/**
+ * A stored profile, with every field this build cannot read put back to a value it can.
+ *
+ * The three fields it refuses on instead are the ones no default can stand in for. `id` names the
+ * avatar directory, the workspace under `~/OpenBot/Agents` and the agent every thread and receipt
+ * points at; `workspacePath` is the directory the agent reads and writes, and a guessed one is either
+ * another agent's files or an empty new directory beside the real one; `threadId` is the whole
+ * conversation, and reading a broken one as `null` reports an empty history and mints a second thread
+ * over the first. Everything else is a preference, a label or a drawn face: resetting one costs the
+ * user a setting they can see and set again, while refusing costs them the application.
+ *
+ * `avatarUrl` is absent from the repair list on purpose -- `normalizeStoredAgent` already drops a URL
+ * that does not parse, and has since before this reader existed.
+ */
+function readStoredAgent(value: unknown): ReadStoredAgent | UnreadableStoredAgent {
+  if (!isRecord(value)) return { unreadable: "profile", id: null };
+  const id = value.id;
+  if (!isString(id) || !isValidAgentId(id)) return { unreadable: "id", id: null };
+  if (!isString(value.workspacePath)) return { unreadable: "workspacePath", id };
+  if (value.threadId !== null && !isString(value.threadId)) return { unreadable: "threadId", id };
+
+  const repaired: string[] = [];
+  const reset = <T>(field: string, fallback: T): T => {
+    repaired.push(field);
+    return fallback;
+  };
+  const provider =
+    value.provider === undefined || isOneOf(AGENT_PROVIDERS, value.provider)
+      ? value.provider
+      : reset("provider", undefined);
+  const model = isAgentModel(value.model)
+    ? value.model
+    : reset("model", provider === undefined ? DEFAULT_AGENT_MODEL : DEFAULT_PROVIDER_MODELS[provider]);
+  let marketplaceSource: StoredAgent["marketplaceSource"];
+  if (value.marketplaceSource !== undefined) {
+    if (isMarketplaceSource(value.marketplaceSource)) {
+      marketplaceSource = normalizeMarketplaceSource(value.marketplaceSource);
+    } else {
+      // Reset to "installed by hand" rather than kept: the listing and version ids are what an update
+      // check compares, and a half-read pair reports the wrong version. Installing the marketplace
+      // agent again over this one binds it back.
+      reset("marketplaceSource", undefined);
+    }
+  }
+  const agent: PersistedStoredAgent = {
+    id,
+    name: isString(value.name) ? value.name : reset("name", titleFromId(id)),
+    title: isString(value.title) ? value.title : reset("title", ""),
+    description: isString(value.description) ? value.description : reset("description", ""),
+    notifications: isBoolean(value.notifications) ? value.notifications : reset("notifications", true),
+    model,
+    reasoningEffort: isReasoningEffort(value.reasoningEffort)
+      ? value.reasoningEffort
+      : reset("reasoningEffort", DEFAULT_REASONING_EFFORT),
+    threadId: value.threadId,
+    workspacePath: value.workspacePath,
+    preview: isString(value.preview) ? value.preview : reset("preview", NEW_AGENT_PREVIEW),
+    updatedAt: isString(value.updatedAt) || value.updatedAt === null ? value.updatedAt : reset("updatedAt", null),
+    avatarSeed: isAvatarSeed(value.avatarSeed) ? value.avatarSeed : reset("avatarSeed", id),
+    avatarHue: value.avatarHue === null || isAvatarHue(value.avatarHue) ? value.avatarHue : reset("avatarHue", null),
+    avatarUrl: isString(value.avatarUrl) ? value.avatarUrl : null,
+    ...(provider === undefined ? {} : { provider }),
+    ...(marketplaceSource === undefined ? {} : { marketplaceSource }),
+  };
+  return { agent, repaired };
+}
+
+/**
+ * The one message the startup dialog shows for a profile that cannot be read.
+ *
+ * It names the field, because the field is the whole diagnosis and a screenshot is usually all a
+ * report carries. It never carries the *value*: `workspacePath` holds the user's home directory, and
+ * this string reaches a dialog, a log and any diagnostics export.
+ */
+function unreadableProfileMessage({ unreadable, id }: UnreadableStoredAgent): string {
+  const subject = id === null ? "A stored agent profile" : `Stored agent profile ${id}`;
+  return `${subject} has an unreadable "${unreadable}" value; update the data before starting OpenBot.`;
 }
 
 function isMarketplaceSource(value: unknown): boolean {

--- a/src/backend/agent-store.ts
+++ b/src/backend/agent-store.ts
@@ -178,13 +178,16 @@ export class AgentStore {
         if (read.repaired.length > 0) repairs.push(`${read.agent.id}: ${read.repaired.join(", ")}`);
       }
       this.#state = { version: 2, examplesInitialized: true, agents };
+      // Recover missing agents before writing repairs. The latest roster event may still contain a
+      // complete roster, and writing the shortened projection first would make that incomplete list
+      // the newest event and erase the only source from which the missing agents can be restored.
+      this.#restoreRosterFromEvents();
       if (repairs.length > 0) {
         logger.warn("Stored agent profile fields could not be read and were reset.", toLogValue(repairs));
         // Written back at once, so the repair survives the next launch instead of running again on every
         // start. The persist carries the whole roster, so the profiles that needed no repair are unchanged.
         this.#persist("agents.repaired");
       }
-      this.#restoreRosterFromEvents();
     } else {
       const legacy = await this.#readState();
       await this.#database.backupLegacyFile(this.#statePath);
@@ -482,16 +485,17 @@ export class AgentStore {
 
   async updateAgent(input: UpdateAgentInput): Promise<AgentSummary> {
     const agent = this.#requireAgent(input.agentId);
+    const next = { ...agent };
     if (input.name !== undefined) {
-      agent.name = requiredText(input.name, "Agent name", INPUT_LIMITS.agentName);
+      next.name = requiredText(input.name, "Agent name", INPUT_LIMITS.agentName);
     }
     if (input.title !== undefined) {
-      agent.title = limitedText(input.title, "Agent title", INPUT_LIMITS.agentTitle);
+      next.title = limitedText(input.title, "Agent title", INPUT_LIMITS.agentTitle);
     }
     if (input.description !== undefined) {
-      agent.description = limitedText(input.description, "Agent description", INPUT_LIMITS.agentDescription);
+      next.description = limitedText(input.description, "Agent description", INPUT_LIMITS.agentDescription);
     }
-    if (input.notifications !== undefined) agent.notifications = input.notifications;
+    if (input.notifications !== undefined) next.notifications = input.notifications;
     // Checked here and not only in the IPC decoder, because the caller closest to the data is not a
     // user: `AgentService` writes the provider, model and effort straight out of `listModels()`, which
     // is a list of ids a provider CLI minted and can rename under a running install. A value the read
@@ -499,26 +503,33 @@ export class AgentStore {
     // app refuse to start on its next launch.
     if (input.provider !== undefined) {
       if (!isOneOf(AGENT_PROVIDERS, input.provider)) throw new Error("Invalid agent provider.");
-      agent.provider = input.provider;
+      next.provider = input.provider;
     }
     if (input.model !== undefined) {
       if (!isAgentModel(input.model)) throw new Error("Invalid agent model.");
-      agent.model = input.model;
+      next.model = input.model;
     }
     if (input.reasoningEffort !== undefined) {
       if (!isReasoningEffort(input.reasoningEffort)) throw new Error("Invalid reasoning effort.");
-      agent.reasoningEffort = input.reasoningEffort;
+      next.reasoningEffort = input.reasoningEffort;
     }
     if (input.avatarSeed !== undefined) {
       if (!isAvatarSeed(input.avatarSeed)) throw new Error("Invalid avatar seed.");
-      agent.avatarSeed = input.avatarSeed;
+      next.avatarSeed = input.avatarSeed;
     }
     if (input.avatarHue !== undefined) {
       if (input.avatarHue !== null && !isAvatarHue(input.avatarHue)) throw new Error("Invalid avatar hue.");
-      agent.avatarHue = input.avatarHue;
+      next.avatarHue = input.avatarHue;
     }
-    agent.updatedAt = new Date().toISOString();
-    this.#persist("agent.updated");
+    next.updatedAt = new Date().toISOString();
+    const previous = { ...agent };
+    Object.assign(agent, next);
+    try {
+      this.#persist("agent.updated");
+    } catch (error) {
+      Object.assign(agent, previous);
+      throw error;
+    }
     return { ...agent };
   }
 


### PR DESCRIPTION
A Windows user reported this dialog, and the app would not open:

> **OpenBot couldn't start**
> Stored agent profiles use the old role field; update the data before starting OpenBot.

The message named a cause the failing branch never tests. `AgentStore.initialize` threw it whenever
*any* row in `projection_agents` failed `isStoredAgent`, for any reason. A `role` field cannot even
reach the database: the `bots.json` import path rejects it first, and that check is the only one that
looks for it. So one unreadable preference — a model id a provider CLI renamed under a running
install, an effort or a hue from a release the user has since left, a marketplace source stored as
`null` — took the whole application away and pointed the report at the wrong data.

## What changed

- **`readStoredAgent` repairs field by field.** Each unreadable preference, label or avatar value is
  reset to a default, and the agent keeps its id, its thread, its workspace and its history. The
  repair is written back at once, so the next launch reads a profile this build accepts.
- **Three fields still refuse to start**: `id`, `workspacePath` and `threadId`. No default can stand
  in for them — a guessed workspace is another agent's files or an empty directory beside the real
  one, and a broken `threadId` read as `null` reports an empty chat and mints a second thread over
  the first. Dropping the row instead was the other option and is worse: `replaceAgents` truncates
  the roster and re-inserts the list, so a dropped agent loses its chat from the sidebar while the
  thread and every message stay on disk, unreachable.
- **The message names the field, never the value.** `workspacePath` holds the user's home directory,
  and this string reaches a dialog, the log and any diagnostics export.
- **`updateAgent` now validates** the provider, model, effort, avatar seed and hue. This is the write
  hole behind the report: `AgentService` sets the provider, model and effort straight out of
  `listModels()` (`agent-service.ts:577`), which is a list of ids a provider CLI minted and can
  rename, and `agent-store.ts` stored them unchecked. Only the *next* launch failed.
- `#restoreRosterFromEvents` reads through the same repair, so a replayed profile older than this
  build's shape is recovered rather than dropped. It still never throws.

Error copy, before and after:

| | Message |
| --- | --- |
| Before | `Stored agent profiles use the old role field; update the data before starting OpenBot.` |
| After | `Stored agent profile agent-<uuid> has an unreadable "workspacePath" value; update the data before starting OpenBot.` |

The `bots.json` import keeps the `role` check and its original message, which is the one place a
`role` field can be real.

## Documentation

- `CHANGELOG.md`: an `Unreleased` entry, as #370 did.
- `docs/TROUBLESHOOTING.md`: the startup dialog tells the user to see the troubleshooting guide, and
  the guide said nothing about this failure. The new section states that the data is intact, that the
  current version repairs the profile, and how to read the row the message names — with the Windows
  path beside the macOS one, because the report came from Windows. The rest of that guide is still
  macOS-only, which is a gap this PR does not close.

## Surfaces

`src/backend`, plus the two documents above: the startup read of persisted agent state, and the roster write path. No IPC
contract, no schema, no migration, no renderer change.

## Tests

Three tests added to `src/backend/agent-store.test.ts`, at the store boundary:

- a repaired profile keeps its id, thread, workspace, and falls back to the default model **of the
  provider it names**, with the repair written back to the projection;
- an unusable `workspacePath` still refuses to start, names the field, and leaves the row, the thread
  and the messages untouched;
- `updateAgent` rejects a model id and an avatar seed that the read guards would refuse.

Each new assertion was checked by breaking the code and confirming the intended failure:

| Break | Failure |
| --- | --- |
| model falls back to the *new agent* default, not the provider's | repaired profile expected `claude-sonnet-5` |
| remove `#persist("agents.repaired")` | the projection row still holds the unreadable model |
| report `"profile"` instead of `"workspacePath"` | the message no longer names the field |
| remove the `isAgentModel` check in `updateAgent` | the update resolves instead of rejecting |
| remove the `isAvatarSeed` check in `updateAgent` | the update resolves instead of rejecting |
| repair reads `threadId` as `null` | `persists stable OpenBot thread ids in SQLite` loses the thread |

Ran locally: `bun run test:desktop -- src/backend/agent-store.test.ts` (35 passed),
`agent-service.providers/restart/queue.test.ts` (61 passed), `bun run lint`, `bun run typecheck`.
The wider suites are left to CI.

## Note on the report

This does not repair the reporting user's install by itself until she upgrades, and her failing field
is still unknown — the version window is v0.1.18 (first Windows build) to v0.6.1, because the copy is
identical in every release, and logs go to stdout only, so `openbot.db` is the only evidence. After
this change her next upgrade recovers by itself, whatever the field was.

Model: Claude Opus 5. Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
