### PR TITLE
fix: show local dates for older desktop chat messages

### DIFF
--- a/src/renderer/src/app-message-projection.test.ts
+++ b/src/renderer/src/app-message-projection.test.ts
@@ -5,7 +5,7 @@ import {
   routineConversationEventItemType,
   routineRunConversationEventItemType,
 } from "@openbot/contracts/ipc";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { agentProfilesEqual, toAgentMessage, toAgentMessages, toAgentProfile } from "./app-message-projection";
 
 describe("toAgentProfile", () => {
@@ -210,3 +210,42 @@ function agentSummary(updatedAt: string): AgentSummary {
     avatarUrl: null,
   };
 }
+
+describe.each(["en-US", "pl-PL"])("chat timestamps in %s", (locale) => {
+  const DateTimeFormat = Intl.DateTimeFormat;
+
+  beforeEach(() => {
+    vi.stubEnv("TZ", "America/Los_Angeles");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-09T07:05:00Z"));
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(function dateTimeFormat(locales, options) {
+      return new DateTimeFormat(locales ?? locale, options);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  const examples = [
+    ["2026-09-09T07:00:00Z", { hour: "2-digit", minute: "2-digit" }],
+    ["2026-09-09T06:59:00Z", { dateStyle: "medium", timeStyle: "short" }],
+    ["2026-09-08T07:00:00Z", { dateStyle: "medium", timeStyle: "short" }],
+    ["2025-09-09T07:00:00Z", { dateStyle: "medium", timeStyle: "short" }],
+    ["2026-08-09T07:00:00Z", { dateStyle: "medium", timeStyle: "short" }],
+    ["2026-09-10T07:00:00Z", { dateStyle: "medium", timeStyle: "short" }],
+  ] satisfies [string, Intl.DateTimeFormatOptions][];
+
+  it.each(examples)("shows the local timestamp for %s", (createdAt, options) => {
+    const message: ConversationMessage = {
+      id: "dated-message",
+      author: "assistant",
+      text: "Daily report",
+      createdAt,
+      status: "completed",
+    };
+    expect(toAgentMessage(message).time).toBe(new DateTimeFormat(locale, options).format(new Date(createdAt)));
+  });
+});

--- a/src/renderer/src/app-message-projection.ts
+++ b/src/renderer/src/app-message-projection.ts
@@ -6,6 +6,7 @@ import {
 } from "@openbot/contracts/ipc";
 import type { AgentDeliveryMarkerStatus, AgentMessage, AgentProfile, ChatActionMarkerModel } from "./data";
 import { cleanAgentMessageText } from "./features/agents/agent-message-text";
+import { formatChatTimestamp } from "./features/conversation/chat-timestamp";
 import { isRoutineEventItem } from "./features/conversation/conversation-read-state";
 
 export function toAgentProfile(stored: AgentSummary): AgentProfile {
@@ -40,7 +41,7 @@ export function toAgentMessage(message: ConversationMessage, ownerAgentId?: stri
     turnId: message.turnId,
     author: message.author === "user" ? "you" : "agent",
     body: message.author === "user" ? message.text : cleanAgentMessageText(message.text),
-    time: formatTime(message.createdAt),
+    time: formatMessageTime(message.createdAt),
     createdAt: message.createdAt,
     streaming: message.status === "streaming",
     itemType: message.itemType,
@@ -99,7 +100,7 @@ export function toAgentMessages(messages: ConversationMessage[], ownerAgentId?: 
       turnId: message.turnId,
       author: "agent",
       body: "",
-      time: formatTime(message.createdAt),
+      time: formatMessageTime(message.createdAt),
       createdAt: message.createdAt,
       streaming: message.status === "streaming",
       itemType: "commentary",
@@ -317,4 +318,10 @@ export function formatTime(value: string): string {
     hour: "2-digit",
     minute: "2-digit",
   }).format(date);
+}
+
+export function formatMessageTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "now";
+  return formatChatTimestamp(date);
 }

--- a/src/renderer/src/features/conversation/ChatActionMarker.tsx
+++ b/src/renderer/src/features/conversation/ChatActionMarker.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../components/ui";
 import type { AgentProfile, ChatActionMarkerModel, ChatActionMarkerStatus } from "../../data";
 import { AgentAvatar } from "../agents/AgentAvatar";
+import { formatChatTimestamp } from "./chat-timestamp";
 
 interface ChatActionMarkerProps {
   marker: ChatActionMarkerModel;
@@ -385,5 +386,5 @@ function statusIcon(status: ChatActionMarkerStatus) {
 function formatMarkerTime(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Unknown time";
-  return new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" }).format(date);
+  return formatChatTimestamp(date);
 }

--- a/src/renderer/src/features/conversation/DirectConversation.tsx
+++ b/src/renderer/src/features/conversation/DirectConversation.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../components/ui";
 import { errorMessage } from "../../error-message";
 import { TeamPersonAvatar, teamMemberName } from "../team/TeamPersonAvatar";
+import { formatChatTimestamp } from "./chat-timestamp";
 import { calculateChatScrollMargin, createChatVirtualizer } from "./createChatVirtualizer";
 import { ScrollToLatestButton, scrollToLatestMessage } from "./MessageNavigation";
 import {
@@ -399,10 +400,7 @@ export function DirectConversation(props: DirectConversationProps) {
 }
 
 function messageTime(value: string): string {
-  return new Intl.DateTimeFormat(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(new Date(value));
+  return formatChatTimestamp(new Date(value));
 }
 
 function LockIcon() {

--- a/src/renderer/src/features/conversation/chat-timestamp.ts
+++ b/src/renderer/src/features/conversation/chat-timestamp.ts
@@ -1,0 +1,11 @@
+export function formatChatTimestamp(date: Date): string {
+  const today = new Date();
+  const isToday =
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate();
+  return new Intl.DateTimeFormat(
+    undefined,
+    isToday ? { hour: "2-digit", minute: "2-digit" } : { dateStyle: "medium", timeStyle: "short" },
+  ).format(date);
+}

--- a/src/renderer/src/features/conversation/conversation-context.tsx
+++ b/src/renderer/src/features/conversation/conversation-context.tsx
@@ -10,7 +10,7 @@ import { createEffect, createMemo, createStore, onCleanup } from "solid-js";
 import { desktopAnalytics } from "../../analytics";
 import {
   agentMessagesEqual,
-  formatTime,
+  formatMessageTime,
   retainThinkingMessages,
   toAgentMessage,
   toAgentMessages,
@@ -431,7 +431,7 @@ const Conversation = createSimpleContext({
           turnId: event.turnId,
           author: "agent",
           body: cleanAgentMessageText(rawBody),
-          time: formatTime(event.createdAt),
+          time: formatMessageTime(event.createdAt),
           createdAt: event.createdAt,
           streaming: true,
           animate: conversations[event.agentId]?.loaded === true,

--- a/src/renderer/src/ui-errors.tsx
+++ b/src/renderer/src/ui-errors.tsx
@@ -1,5 +1,5 @@
 import { createSignal } from "solid-js";
-import { formatTime } from "./app-message-projection";
+import { formatMessageTime } from "./app-message-projection";
 import type { AgentMessage } from "./data";
 import { errorMessage } from "./error-message";
 import { agentConversationKey } from "./features/conversation/conversation-keys";
@@ -34,7 +34,7 @@ const UiErrors = createSimpleContext({
             id: `ui-${Date.now()}-${Math.random()}`,
             author: "agent",
             body,
-            time: formatTime(new Date().toISOString()),
+            time: formatMessageTime(new Date().toISOString()),
             status,
           },
         ],

--- a/src/renderer/stories/ChatActionMarker.stories.tsx
+++ b/src/renderer/stories/ChatActionMarker.stories.tsx
@@ -252,3 +252,25 @@ function agent(id: string, name: string): AgentProfile {
     preview: "",
   };
 }
+
+export const MessageDates: Story = {
+  render: () => (
+    <main class="foundation-story">
+      <Heading as="h1" size="lg">
+        Daily routine history
+      </Heading>
+      {[1, 0].map((daysAgo) => {
+        const date = new Date();
+        date.setDate(date.getDate() - daysAgo);
+        return (
+          <ChatActionMarker
+            marker={{ ...routineMarker("succeeded"), timestamp: date.toISOString() }}
+            agents={agents}
+            onSelectAgent={onSelectAgent}
+            onOpenRoutine={onOpenRoutine}
+          />
+        );
+      })}
+    </main>
+  ),
+};

--- a/src/renderer/stories/ChatPrimitives.stories.tsx
+++ b/src/renderer/stories/ChatPrimitives.stories.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "@solidjs/web";
 import { createMemo, createSignal, Show } from "solid-js";
 import { expect, fn, waitFor, within } from "storybook/test";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { toAgentMessage } from "../src/app-message-projection";
 import {
   Bubble,
   BubbleContent,
@@ -412,4 +413,29 @@ export const NarrowConversation: Story = {
     const stage = canvas.getByRole("region", { name: "Integrated chat example" });
     await expect(stage.scrollWidth).toBeLessThanOrEqual(stage.clientWidth);
   },
+};
+
+export const MessageDates: Story = {
+  render: () => (
+    <main class="foundation-story">
+      <Heading as="h1" size="lg">
+        Chat message dates
+      </Heading>
+      {[1, 0].map((daysAgo) => {
+        const date = new Date();
+        date.setDate(date.getDate() - daysAgo);
+        return (
+          <PrototypeMessage
+            message={toAgentMessage({
+              id: `dated-message-${daysAgo}`,
+              author: daysAgo ? "user" : "assistant",
+              text: daysAgo ? "Yesterday’s request" : "Today’s response",
+              createdAt: date.toISOString(),
+              status: "completed",
+            })}
+          />
+        );
+      })}
+    </main>
+  ),
 };

--- a/src/renderer/stories/DirectConversation.stories.tsx
+++ b/src/renderer/stories/DirectConversation.stories.tsx
@@ -161,3 +161,16 @@ export const Loading: Story = {
 export const ErrorState: Story = {
   args: { snapshot: undefined, loadError: "The team server is temporarily unavailable." },
 };
+
+export const MessageDates: Story = {
+  args: {
+    snapshot: {
+      ...STORY_DIRECT_SNAPSHOTS[member.id],
+      messages: STORY_DIRECT_SNAPSHOTS[member.id].messages.map((message, index) => {
+        const date = new Date();
+        date.setDate(date.getDate() - (index === 0 ? 1 : 0));
+        return { ...message, createdAt: date.toISOString() };
+      }),
+    },
+  },
+};


### PR DESCRIPTION
## What changed

Desktop chats previously showed only the time, so messages from different days looked the same. Agent messages, direct messages, and chat action markers now show the local date and time unless the message is from today. Today's messages show hours and minutes. Both formats follow the user's locale and local time zone.

This includes routine messages, thinking messages, and live updates. Sidebar formatting stays unchanged. No mobile, IPC, Team API, or stored-data changes. Dates are formatted when projected or rendered; there is no midnight refresh timer.

Closes #383.

## Verification

- Passed `bun run test:desktop -- src/renderer/src/app-message-projection.test.ts` (19 tests).
- Passed `bun run test:desktop -- src/renderer/src/features/conversation/ChatActionMarker.test.tsx` (4 tests).
- The 12 new timestamp cases cover en-US and pl-PL, local midnight, previous day/month/year, and future dates. Reversing the today condition made all 12 fail for the expected timestamp mismatch; restoring it made them pass.
- Passed `bun run lint`, `bun run typecheck`, and `bun run check:ui`. Lint retains 46 existing warnings in mobile tests about module mocks and test patterns; those files are outside this change.
- Passed the approved `bun run test:browser`, including cross-process persistence. An earlier run failed with “Inspected target navigated or closed”; the rerun passed. Electron emitted cache and macOS task-policy diagnostics without failing the suite.
- Captured and inspected before/after Storybook examples for chat messages, direct messages, and routine history using headless Chrome.
- No credentials, private data, generated output, or real user files are included.

## Before and after

Example with a US locale, when today is September 10, 2026:

| Message date | Before | After |
| --- | --- | --- |
| September 9 | 09:21 AM | Sep 9, 2026, 9:21 AM |
| September 10 | 09:21 AM | 09:21 AM |

Before/after PNGs were captured locally and are not committed. The available GitHub tools do not support image attachment uploads. Reproduce the visual comparison using the new `MessageDates` stories in Chat Primitives, DirectConversation, and Chat Action Marker.

Model: GPT-6. Harness: Codex, Vitest, Storybook, and Playwright with local Chrome.

## Risk and security impact

None. Display formatting only; no changes to permissions, persistence, IPC, filesystem access, or network behavior.
