### PR TITLE
fix: remove embedded browser size label

### DIFF
--- a/src/renderer/src/features/conversation/BrowserPanel.tsx
+++ b/src/renderer/src/features/conversation/BrowserPanel.tsx
@@ -7,16 +7,7 @@ import type {
 } from "@openbot/contracts/ipc";
 import { createEffect, createSignal, For, Show } from "solid-js";
 import { PanelResizer, readPanelWidth, savePanelWidth } from "../../components/PanelResizer";
-import {
-  Button,
-  buttonVariants,
-  CircleDot,
-  Input,
-  MonitorSmartphone,
-  PictureInPicture2,
-  Tabs,
-  TriangleAlert,
-} from "../../components/ui";
+import { Button, buttonVariants, CircleDot, Input, PictureInPicture2, Tabs, TriangleAlert } from "../../components/ui";
 import type { AgentProfile } from "../../data";
 import {
   BrowserBackIcon,
@@ -292,19 +283,6 @@ export default function BrowserPanel(props: BrowserPanelProps) {
             <BrowserReloadIcon />
           </Button>
           {addressBar()}
-          <Show when={props.activeTab?.environment}>
-            {(environment) => (
-              <span
-                class="browser-environment-status"
-                title={`Viewport ${environment().viewport.width}×${environment().viewport.height}, ${environment().colorScheme} color scheme`}
-              >
-                <MonitorSmartphone />
-                <span>
-                  {environment().viewport.width}×{environment().viewport.height}
-                </span>
-              </span>
-            )}
-          </Show>
           <Show when={props.activeTab?.recording}>
             <span class="browser-recording-status" role="status" aria-label="Browser recording active">
               <CircleDot /> REC

--- a/src/renderer/src/features/conversation/conversation.css
+++ b/src/renderer/src/features/conversation/conversation.css
@@ -1014,7 +1014,6 @@
   margin: 0 2px;
 }
 
-.browser-environment-status,
 .browser-recording-status,
 .browser-diagnostic-status {
   display: inline-flex;
@@ -1028,10 +1027,6 @@
   line-height: 1;
 }
 
-.browser-environment-status {
-  color: var(--openbot-text-muted);
-}
-
 .browser-recording-status {
   background: var(--openbot-danger-soft);
   color: var(--openbot-danger);
@@ -1042,7 +1037,6 @@
   color: var(--openbot-warning);
 }
 
-.browser-environment-status svg,
 .browser-recording-status svg,
 .browser-diagnostic-status svg {
   width: 12px;

--- a/src/renderer/stories/BrowserPanel.stories.tsx
+++ b/src/renderer/stories/BrowserPanel.stories.tsx
@@ -52,7 +52,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** A tab nobody is driving: the toolbar carries the viewport chip and nothing else. */
+/** An idle tab with no recording or diagnostic indicators. */
 export const Idle: Story = {
   args: {
     activeTab: {
@@ -66,7 +66,7 @@ export const Idle: Story = {
   },
 };
 
-/** `set_environment` moved the tab to the mobile preset, so the chip reports the emulated size. */
+/** A tab with the mobile viewport preset. */
 export const MobileViewport: Story = {
   args: {
     activeTab: {
@@ -80,7 +80,7 @@ export const MobileViewport: Story = {
   },
 };
 
-/** All three chips at once -- the widest the toolbar ever gets before the address bar starts shrinking. */
+/** Recording and diagnostic indicators appear together beside the address bar. */
 export const RecordingWithDiagnosticErrors: Story = {
   args: {
     activeTab: {
@@ -117,7 +117,7 @@ export const SingleDiagnosticError: Story = {
   },
 };
 
-/** The same three chips in a panel narrow enough to prove they never push the address bar out. */
+/** Recording and diagnostic indicators in a narrow panel. */
 export const NarrowPanel: Story = {
   args: {
     ...RecordingWithDiagnosticErrors.args,


### PR DESCRIPTION
Remove the width × height label, device icon, and viewport tooltip from the embedded browser toolbar. Remove unused styles and update Storybook descriptions. Browser resizing and viewport settings remain available.

Before: the toolbar displayed a device icon and dimensions such as `1200×800` or `390×844` beside the address bar. After: this display is removed; recording and diagnostic indicators remain.

Validation:
- 29 tests passed: `NODE_OPTIONS=--no-experimental-webstorage bun run test:desktop -- src/renderer/src/App.browser.test.tsx`. The default Node 26 run failed in setup because `window.localStorage` was undefined.
- `bun run lint`, `bun run typecheck`, and `bun run check:ui` passed. Lint retains 47 existing module-mocking warnings in unchanged tests; changing those tests is outside this UI change.
- `bun run test:browser` was run and failed with `V2 contenteditable target did not receive text`. This backend smoke check does not import the changed toolbar component. Its failure has not been resolved.
- Visual checks and before/after screenshots are unavailable: Storybook started, but the browser connection reported no available browsers. This PR remains a draft for review of those limits.

Surface: desktop renderer and Storybook. No API, persisted-data, or contract changes. No new test assertions were added for this visual removal.

Model: GPT-6. Harness: Codex, local Vitest and repository check scripts; Browser plugin connection attempted for Storybook.
