### PR TITLE
Add mobile chat reply and message action flows

### DIFF
--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -1,3 +1,4 @@
+import { useSegments } from "expo-router";
 import { Stack } from "expo-router/stack";
 import { useThemeColor } from "heroui-native/hooks";
 import { useState } from "react";
@@ -6,6 +7,7 @@ import { AgentPinTransitionProvider } from "@/features/agents/components/agent-p
 import { ChatNavigationGateContext } from "@/features/agents/components/chat-link-pressable";
 import { createChatNavigationGate } from "@/features/agents/model/chat-navigation-gate";
 import { useMobileSession } from "@/features/auth/context/mobile-session-context";
+import { MessageActionsProvider } from "@/features/chat/context/message-actions-context";
 import { AppDrawerShell } from "@/features/servers/components/app-drawer-shell";
 import { MobileWorkspaceProvider } from "@/features/workspace/context/mobile-workspace-context";
 import { isIOS } from "@/shared/lib/platform";
@@ -15,6 +17,7 @@ export const unstable_settings = {
 };
 
 function AuthenticatedStack() {
+  const segments = useSegments();
   const background = useThemeColor("background");
   const sheetBackground = String(useCSSVariable("--openbot-bg-sheet") ?? background);
   const [navigationGate] = useState(createChatNavigationGate);
@@ -120,6 +123,16 @@ function AuthenticatedStack() {
           }}
         />
         <Stack.Screen
+          name="message-actions"
+          options={{
+            contentStyle: { backgroundColor: sheetBackground },
+            headerShown: false,
+            presentation: "formSheet",
+            sheetAllowedDetents: [segments.at(-1) === "select-text" ? 0.85 : 0.4],
+            sheetGrabberVisible: true,
+          }}
+        />
+        <Stack.Screen
           name="settings"
           options={{
             contentStyle: { backgroundColor: sheetBackground },
@@ -142,7 +155,9 @@ export default function AuthenticatedLayout() {
     <MobileWorkspaceProvider key={workspaceKey}>
       <AgentPinTransitionProvider>
         <AppDrawerShell>
-          <AuthenticatedStack />
+          <MessageActionsProvider>
+            <AuthenticatedStack />
+          </MessageActionsProvider>
         </AppDrawerShell>
       </AgentPinTransitionProvider>
     </MobileWorkspaceProvider>

--- a/apps/mobile/src/app/(app)/message-actions/_layout.tsx
+++ b/apps/mobile/src/app/(app)/message-actions/_layout.tsx
@@ -1,0 +1,30 @@
+import { Stack } from "expo-router/stack";
+import { useEffect } from "react";
+import { useCSSVariable } from "uniwind";
+import { useMessageActions } from "@/features/chat/context/message-actions-context";
+import { isIOS } from "@/shared/lib/platform";
+
+export const unstable_settings = { initialRouteName: "index" };
+
+export default function MessageActionsLayout() {
+  const background = String(useCSSVariable("--openbot-bg-sheet"));
+  const { select } = useMessageActions();
+  useEffect(() => () => select(null), [select]);
+  return (
+    <Stack
+      screenOptions={{
+        presentation: "card",
+        headerBackButtonDisplayMode: "minimal",
+        headerShadowVisible: false,
+        headerTransparent: isIOS,
+        headerStyle: { backgroundColor: isIOS ? "transparent" : background },
+        headerBlurEffect: "none",
+        scrollEdgeEffects: { top: "soft" },
+        contentStyle: { backgroundColor: background },
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: "Message options" }} />
+      <Stack.Screen name="select-text" options={{ title: "Message" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/src/app/(app)/message-actions/index.tsx
+++ b/apps/mobile/src/app/(app)/message-actions/index.tsx
@@ -1,0 +1,46 @@
+import { router } from "expo-router";
+import { Typography } from "heroui-native";
+import { useThemeColor } from "heroui-native/hooks";
+import { Copy, Reply, TextSelect } from "lucide-react-native";
+import { useCopyMessage } from "@/features/chat/components/use-copy-message";
+import { useMessageActions } from "@/features/chat/context/message-actions-context";
+import { SettingsContent, SettingsRow, SettingsSection } from "@/features/settings/components/settings-content";
+
+export default function MessageActionsScreen() {
+  const { selected } = useMessageActions();
+  const foreground = useThemeColor("foreground");
+  const { copy } = useCopyMessage(selected?.message.body ?? "");
+  if (!selected) return null;
+  return (
+    <SettingsContent>
+      <SettingsSection>
+        <SettingsRow
+          leading={<Reply color={foreground} size={22} />}
+          disclosure={false}
+          disabled={!selected.onReply}
+          onPress={() => {
+            selected.onReply?.();
+            router.back();
+          }}
+        >
+          <Typography>Reply</Typography>
+        </SettingsRow>
+        <SettingsRow
+          leading={<Copy color={foreground} size={22} />}
+          disclosure={false}
+          onPress={async () => {
+            if (await copy()) router.back();
+          }}
+        >
+          <Typography>Copy</Typography>
+        </SettingsRow>
+        <SettingsRow
+          leading={<TextSelect color={foreground} size={22} />}
+          onPress={() => router.push("/message-actions/select-text")}
+        >
+          <Typography>Select Text</Typography>
+        </SettingsRow>
+      </SettingsSection>
+    </SettingsContent>
+  );
+}

--- a/apps/mobile/src/app/(app)/message-actions/select-text.tsx
+++ b/apps/mobile/src/app/(app)/message-actions/select-text.tsx
@@ -1,0 +1,43 @@
+import { Stack } from "expo-router";
+import { Typography } from "heroui-native";
+import { TextInput } from "react-native";
+import { useCopyMessage } from "@/features/chat/components/use-copy-message";
+import { useMessageActions } from "@/features/chat/context/message-actions-context";
+import { SheetScrollView } from "@/shared/components/sheet-scroll-view";
+import { isIOS } from "@/shared/lib/platform";
+
+export default function SelectMessageTextScreen() {
+  const { selected } = useMessageActions();
+  const { copy, copied } = useCopyMessage(selected?.message.body ?? "");
+  return (
+    <>
+      <Stack.Toolbar placement="right">
+        <Stack.Toolbar.Button
+          icon={copied ? "checkmark" : "doc.on.doc"}
+          accessibilityLabel={copied ? "Message copied" : "Copy message"}
+          onPress={() => {
+            void copy();
+          }}
+        >
+          {copied ? "Copied" : "Copy"}
+        </Stack.Toolbar.Button>
+      </Stack.Toolbar>
+      <SheetScrollView contentContainerClassName="px-4 pb-safe-offset-5 pt-5">
+        {isIOS ? (
+          // iOS Text offers whole-message Copy only. UITextView supports range selection handles.
+          <TextInput
+            accessibilityLabel="Message text"
+            value={selected?.message.body ?? ""}
+            multiline
+            editable={false}
+            showSoftInputOnFocus={false}
+            scrollEnabled={false}
+            className="bg-transparent p-0 font-sans text-base leading-6 text-foreground"
+          />
+        ) : (
+          <Typography.Paragraph selectable>{selected?.message.body}</Typography.Paragraph>
+        )}
+      </SheetScrollView>
+    </>
+  );
+}

--- a/apps/mobile/src/features/chat/components/chat-code-block.tsx
+++ b/apps/mobile/src/features/chat/components/chat-code-block.tsx
@@ -7,7 +7,15 @@ import { useEffect, useState } from "react";
 import { Alert, type ColorValue, ScrollView, useWindowDimensions, View } from "react-native";
 import { type CodeToken, codeLanguage, highlightCode } from "../model/code-highlight";
 
-export function ChatCodeBlock({ text, language }: { text: string; language?: string }) {
+export function ChatCodeBlock({
+  text,
+  language,
+  selectable = true,
+}: {
+  text: string;
+  language?: string;
+  selectable?: boolean;
+}) {
   const { fontScale } = useWindowDimensions();
   const [foreground, muted, keyword, string, number, error] = useThemeColor([
     "foreground",
@@ -79,7 +87,7 @@ export function ChatCodeBlock({ text, language }: { text: string; language?: str
         contentContainerStyle={{ paddingHorizontal: 12, paddingTop: 6, paddingBottom: 14, alignItems: "flex-start" }}
       >
         <Typography.Code
-          selectable
+          selectable={selectable}
           className="bg-transparent p-0"
           style={{ color: foreground, fontSize: 14, lineHeight: 20 }}
         >

--- a/apps/mobile/src/features/chat/components/chat-composer.tsx
+++ b/apps/mobile/src/features/chat/components/chat-composer.tsx
@@ -2,8 +2,9 @@ import { MenuView } from "@expo/ui/community/menu";
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type { AgentPromptQuestion } from "@openbot/contracts/ipc";
 import { GlassView } from "expo-glass-effect";
+import { useIsFocused } from "expo-router";
 import { Button, Typography } from "heroui-native";
-import { ArrowUp, Mic, Plus } from "lucide-react-native";
+import { ArrowUp, Mic, Plus, Reply, X } from "lucide-react-native";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
@@ -18,7 +19,9 @@ import {
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { scheduleOnRN } from "react-native-worklets";
 import { BloubAvatar } from "@/features/agents/components/bloub-avatar";
+import type { ChatBubbleMessage } from "@/features/chat/context/message-actions-context";
 import type { MobileAgent } from "@/features/workspace/model/workspace-types";
+import { SheetScrollEdgeEffect } from "@/shared/components/sheet-scroll-edge-effect";
 import { editMentionDraft, insertMention, mentionDraft, mentionQuery } from "../model/chat-mentions";
 import { largePastedText } from "../model/composer-paste";
 import { createComposerSendGate } from "../model/composer-send";
@@ -44,6 +47,9 @@ interface ChatComposerProps {
   attachments: ChatAttachments;
   sending: boolean;
   sendRetryVersion: number;
+  replyTarget: ChatBubbleMessage | null;
+  replyFocusVersion: number;
+  onCancelReply: () => void;
 }
 
 export function ChatComposer({
@@ -65,6 +71,9 @@ export function ChatComposer({
   attachments,
   sending,
   sendRetryVersion,
+  replyTarget,
+  replyFocusVersion,
+  onCancelReply,
 }: ChatComposerProps) {
   const display = mentionDraft(answerQuestion ? "" : draft);
   const displayText = answerQuestion ? draft : display.text;
@@ -79,6 +88,14 @@ export function ChatComposer({
     : [];
   const hasDraft = Boolean(draft.trim()) || attachments.items.length > 0;
   const inputRef = useRef<TextInput>(null);
+  const isFocused = useIsFocused();
+  const focusedReplyVersion = useRef(0);
+  useEffect(() => {
+    if (isFocused && !disabled && !answerQuestion && replyTarget && focusedReplyVersion.current !== replyFocusVersion) {
+      focusedReplyVersion.current = replyFocusVersion;
+      inputRef.current?.focus();
+    }
+  }, [isFocused, disabled, answerQuestion, replyTarget, replyFocusVersion]);
   const pendingCursor = useRef<number | null>(null);
   useLayoutEffect(() => {
     if (pendingCursor.current === null) return;
@@ -138,6 +155,30 @@ export function ChatComposer({
 
   return (
     <View>
+      {liquidGlassAvailable ? (
+        <SheetScrollEdgeEffect
+          edge="bottom"
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            // Keep the original 32 pt fade above the input, independent of the reply preview.
+            height: inputHeight + 8 + Math.max(bottomInset, 10) + 32,
+          }}
+        />
+      ) : null}
+      {replyTarget ? (
+        <View className="flex-row items-center gap-2 pl-6 pr-4">
+          <Reply color={String(muted)} size={18} />
+          <Typography.Paragraph numberOfLines={1} type="body-sm" className="flex-1 text-text-secondary">
+            {mentionDraft(replyTarget.body).text || "Attachment"}
+          </Typography.Paragraph>
+          <Button isIconOnly variant="ghost" accessibilityLabel="Cancel reply" onPress={onCancelReply}>
+            <X color={String(muted)} size={18} />
+          </Button>
+        </View>
+      ) : null}
       {focused && query && suggestions.length > 0 && !disabled ? (
         <GlassView
           glassEffectStyle={liquidGlassAvailable ? "regular" : "none"}

--- a/apps/mobile/src/features/chat/components/chat-markdown.tsx
+++ b/apps/mobile/src/features/chat/components/chat-markdown.tsx
@@ -41,6 +41,7 @@ function tokenIs<K extends keyof MarkdownTokenByType>(token: Token, type: K): to
 }
 
 interface TextPresentation {
+  selectable: boolean;
   type: "body" | "body-sm" | "h4" | "h5";
   style: TextStyle;
   codeColor: ColorValue;
@@ -86,7 +87,7 @@ function CodeSpan({ text, presentation }: { text: string; presentation: TextPres
       className={`max-w-full self-start rounded-xl bg-control px-1 ${presentation.type === "body-sm" ? "py-px" : "py-0.5"}`}
     >
       <Typography.Code
-        selectable
+        selectable={presentation.selectable}
         className={presentation.type === "body-sm" ? "bg-transparent p-0 text-xs leading-4" : "bg-transparent p-0"}
         style={{ ...presentation.style, color: presentation.codeColor }}
       >
@@ -236,7 +237,7 @@ function ListParagraph({ tokens, presentation }: { tokens: Token[]; presentation
             return (
               <Typography
                 key={offset}
-                selectable
+                selectable={presentation.selectable}
                 className="max-w-full"
                 type={presentation.type}
                 style={textContainerStyle(source(run), presentation)}
@@ -278,7 +279,7 @@ function MarkdownBlocks({
           return (
             <Typography
               key={offset}
-              selectable
+              selectable={presentation.selectable}
               type={presentation.type}
               style={textContainerStyle(token.raw, presentation)}
             >
@@ -291,7 +292,7 @@ function MarkdownBlocks({
           return (
             <Typography.Heading
               key={offset}
-              selectable
+              selectable={presentation.selectable}
               type={heading.type === "h4" ? "h4" : "h5"}
               style={textContainerStyle(token.raw, presentation)}
             >
@@ -302,7 +303,7 @@ function MarkdownBlocks({
         if (tokenIs(token, "code")) {
           return (
             <StreamingBlock key={offset} enabled={presentation.animateTail}>
-              <ChatCodeBlock text={token.text} language={token.lang} />
+              <ChatCodeBlock selectable={presentation.selectable} text={token.text} language={token.lang} />
             </StreamingBlock>
           );
         }
@@ -352,7 +353,7 @@ function MarkdownBlocks({
                       {sourceEntries(row, (cell) => cell.text).map(({ value: cell, offset: cellOffset }) => (
                         <View key={cellOffset} className="w-44 px-2 py-2">
                           <Typography
-                            selectable
+                            selectable={presentation.selectable}
                             type={presentation.type}
                             style={{
                               ...textContainerStyle(cell.text, presentation),
@@ -376,7 +377,12 @@ function MarkdownBlocks({
         }
         if (token.type === "hr") return <View key={offset} className="h-px bg-separator" />;
         return (
-          <Typography key={offset} selectable type={presentation.type} style={presentation.style}>
+          <Typography
+            key={offset}
+            selectable={presentation.selectable}
+            type={presentation.type}
+            style={presentation.style}
+          >
             {token.raw}
           </Typography>
         );
@@ -391,6 +397,7 @@ export const ChatMarkdown = memo(function ChatMarkdown({
   compact = false,
   streaming = false,
   animationEnabled = true,
+  selectable = true,
   agents = [],
 }: {
   body: string;
@@ -398,6 +405,7 @@ export const ChatMarkdown = memo(function ChatMarkdown({
   compact?: boolean;
   streaming?: boolean;
   animationEnabled?: boolean;
+  selectable?: boolean;
   agents?: readonly MobileAgent[];
 }) {
   const reducedMotion = useReducedMotion();
@@ -409,6 +417,7 @@ export const ChatMarkdown = memo(function ChatMarkdown({
       <MarkdownBlocks
         tokens={tokens}
         presentation={{
+          selectable,
           type: compact ? "body-sm" : "body",
           style: { color: color ?? codeColor },
           codeColor,

--- a/apps/mobile/src/features/chat/components/chat-message-gesture.tsx
+++ b/apps/mobile/src/features/chat/components/chat-message-gesture.tsx
@@ -1,4 +1,5 @@
 import * as Haptics from "expo-haptics";
+import { Button } from "heroui-native";
 import { useThemeColor } from "heroui-native/hooks";
 import { Reply } from "lucide-react-native";
 import type { PropsWithChildren } from "react";
@@ -9,9 +10,11 @@ import { scheduleOnRN } from "react-native-worklets";
 
 export function ChatMessageGesture({
   children,
+  screenReaderEnabled,
   onReply,
   onOpenActions,
 }: PropsWithChildren<{
+  screenReaderEnabled: boolean;
   onReply?: () => void;
   onOpenActions: () => void;
 }>) {
@@ -49,20 +52,20 @@ export function ChatMessageGesture({
         <Reply color={muted} size={22} />
       </Animated.View>
       <GestureDetector gesture={Gesture.Race(swipe, hold)}>
-        <Animated.View
-          style={bubbleStyle}
-          accessible
-          accessibilityRole="text"
-          accessibilityActions={[
-            { name: "longpress", label: "Message actions" },
-            ...(onReply ? [{ name: "reply", label: "Reply" }] : []),
-          ]}
-          onAccessibilityAction={({ nativeEvent }) => {
-            if (nativeEvent.actionName === "reply" && onReply) reply();
-            else if (nativeEvent.actionName === "longpress") openActions();
-          }}
-        >
+        <Animated.View style={bubbleStyle}>
           {children}
+          {screenReaderEnabled ? (
+            <Button
+              variant="ghost"
+              onPress={openActions}
+              accessibilityActions={onReply ? [{ name: "reply", label: "Reply" }] : []}
+              onAccessibilityAction={({ nativeEvent }) => {
+                if (nativeEvent.actionName === "reply" && onReply) reply();
+              }}
+            >
+              <Button.Label>Message actions</Button.Label>
+            </Button>
+          ) : null}
         </Animated.View>
       </GestureDetector>
     </View>

--- a/apps/mobile/src/features/chat/components/chat-message-gesture.tsx
+++ b/apps/mobile/src/features/chat/components/chat-message-gesture.tsx
@@ -1,0 +1,70 @@
+import * as Haptics from "expo-haptics";
+import { useThemeColor } from "heroui-native/hooks";
+import { Reply } from "lucide-react-native";
+import type { PropsWithChildren } from "react";
+import { View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, { ReduceMotion, useAnimatedStyle, useSharedValue, withSpring } from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+
+export function ChatMessageGesture({
+  children,
+  onReply,
+  onOpenActions,
+}: PropsWithChildren<{
+  onReply?: () => void;
+  onOpenActions: () => void;
+}>) {
+  const muted = useThemeColor("muted");
+  const offset = useSharedValue(0);
+  const bubbleStyle = useAnimatedStyle(() => ({ transform: [{ translateX: offset.get() }] }));
+  const iconStyle = useAnimatedStyle(() => ({ opacity: Math.min(1, offset.get() / 64) }));
+  const reply = () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onReply?.();
+  };
+  const openActions = () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onOpenActions();
+  };
+  const swipe = Gesture.Pan()
+    .enabled(Boolean(onReply))
+    .activeOffsetX(16)
+    .failOffsetX(-8)
+    .failOffsetY([-12, 12])
+    .onUpdate((event) => {
+      offset.set(Math.max(0, Math.min(event.translationX, 64) + Math.max(0, event.translationX - 64) * 0.15));
+    })
+    .onEnd((event) => {
+      if (event.translationX >= 64 || (event.translationX >= 24 && event.velocityX >= 650)) scheduleOnRN(reply);
+    })
+    .onFinalize(() => {
+      offset.set(withSpring(0, { duration: 400, dampingRatio: 1, reduceMotion: ReduceMotion.System }));
+    });
+  const hold = Gesture.LongPress().onStart(() => scheduleOnRN(openActions));
+
+  return (
+    <View className="max-w-[88%] self-start">
+      <Animated.View pointerEvents="none" className="absolute bottom-0 left-0 top-0 justify-center" style={iconStyle}>
+        <Reply color={muted} size={22} />
+      </Animated.View>
+      <GestureDetector gesture={Gesture.Race(swipe, hold)}>
+        <Animated.View
+          style={bubbleStyle}
+          accessible
+          accessibilityRole="text"
+          accessibilityActions={[
+            { name: "longpress", label: "Message actions" },
+            ...(onReply ? [{ name: "reply", label: "Reply" }] : []),
+          ]}
+          onAccessibilityAction={({ nativeEvent }) => {
+            if (nativeEvent.actionName === "reply" && onReply) reply();
+            else if (nativeEvent.actionName === "longpress") openActions();
+          }}
+        >
+          {children}
+        </Animated.View>
+      </GestureDetector>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/chat/components/chat-message-list.tsx
+++ b/apps/mobile/src/features/chat/components/chat-message-list.tsx
@@ -1,7 +1,8 @@
 import { useIsFocused } from "expo-router";
 import { Button, Typography } from "heroui-native";
 import { CornerUpRight, X } from "lucide-react-native";
-import { Pressable, View, type ViewStyle } from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import { AccessibilityInfo, Pressable, View, type ViewStyle } from "react-native";
 import { KeyboardChatScrollView } from "react-native-keyboard-controller";
 import Animated, {
   Easing,
@@ -18,7 +19,7 @@ import { ChatQuestionPrompt } from "@/features/chat/components/chat-question-pro
 import type { ChatMotion } from "@/features/chat/components/use-chat-motion";
 import { useMessageArrivals } from "@/features/chat/components/use-message-arrivals";
 import type { QuestionPromptController } from "@/features/chat/components/use-question-prompt";
-import type { ChatMessage } from "@/features/chat/model/chat-messages";
+import { type ChatMessage, indexChatMessages } from "@/features/chat/model/chat-messages";
 import { useAgentActivity } from "@/features/workspace/components/use-agent-activity";
 import { useConnectionAppearance } from "@/features/workspace/components/use-connection-appearance";
 import type { MobileAgent } from "@/features/workspace/context/mobile-workspace-context";
@@ -54,6 +55,7 @@ interface ChatMessageListProps {
   foreground: ViewStyle["backgroundColor"];
   historyState: "ready" | "connecting" | "waiting" | "loading" | "error";
   messages: ChatMessage[];
+  messageAliases: ReadonlyMap<string, string>;
   muted: ViewStyle["backgroundColor"];
   raised: ViewStyle["backgroundColor"];
   showStarter: boolean;
@@ -79,6 +81,7 @@ export function ChatMessageList({
   foreground,
   historyState,
   messages,
+  messageAliases,
   muted,
   raised,
   showStarter,
@@ -90,6 +93,19 @@ export function ChatMessageList({
   onOpenActions,
 }: ChatMessageListProps) {
   const isFocused = useIsFocused();
+  const messagesById = useMemo(() => indexChatMessages(messages, messageAliases), [messages, messageAliases]);
+  const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
+  useEffect(() => {
+    let active = true;
+    void AccessibilityInfo.isScreenReaderEnabled().then((enabled) => {
+      if (active) setScreenReaderEnabled(enabled);
+    });
+    const subscription = AccessibilityInfo.addEventListener("screenReaderChanged", setScreenReaderEnabled);
+    return () => {
+      active = false;
+      subscription.remove();
+    };
+  }, []);
   const replyColor = String(useCSSVariable("--openbot-text-dim"));
   const reducedMotion = useReducedMotion();
   const animateMessages = isFocused && canSend && appActive;
@@ -214,6 +230,7 @@ export function ChatMessageList({
       return (
         <ChatMessageGesture
           key={message.id}
+          screenReaderEnabled={screenReaderEnabled}
           onReply={onReply ? () => onReply(message) : undefined}
           onOpenActions={() => onOpenActions(message)}
         >
@@ -221,7 +238,7 @@ export function ChatMessageList({
         </ChatMessageGesture>
       );
     }
-    const source = messages.find((candidate) => candidate.id === message.replyToMessageId);
+    const source = message.replyToMessageId ? messagesById.get(message.replyToMessageId) : undefined;
     return (
       <View
         key={message.id}

--- a/apps/mobile/src/features/chat/components/chat-message-list.tsx
+++ b/apps/mobile/src/features/chat/components/chat-message-list.tsx
@@ -1,6 +1,6 @@
 import { useIsFocused } from "expo-router";
 import { Button, Typography } from "heroui-native";
-import { X } from "lucide-react-native";
+import { CornerUpRight, X } from "lucide-react-native";
 import { Pressable, View, type ViewStyle } from "react-native";
 import { KeyboardChatScrollView } from "react-native-keyboard-controller";
 import Animated, {
@@ -11,6 +11,7 @@ import Animated, {
   useAnimatedStyle,
   useReducedMotion,
 } from "react-native-reanimated";
+import { useCSSVariable } from "uniwind";
 import { BloubAvatar, getBloubAvatarColor } from "@/features/agents/components/bloub-avatar";
 import { ChatMarkdown } from "@/features/chat/components/chat-markdown";
 import { ChatQuestionPrompt } from "@/features/chat/components/chat-question-prompt";
@@ -21,6 +22,9 @@ import type { ChatMessage } from "@/features/chat/model/chat-messages";
 import { useAgentActivity } from "@/features/workspace/components/use-agent-activity";
 import { useConnectionAppearance } from "@/features/workspace/components/use-connection-appearance";
 import type { MobileAgent } from "@/features/workspace/context/mobile-workspace-context";
+import type { ChatBubbleMessage } from "../context/message-actions-context";
+import { mentionDraft } from "../model/chat-mentions";
+import { ChatMessageGesture } from "./chat-message-gesture";
 import { StreamingTailText, StreamRevealProvider } from "./streaming-tail-text";
 import { ThinkingTextGradient } from "./thinking-text-gradient";
 
@@ -57,6 +61,8 @@ interface ChatMessageListProps {
   onDismissStarter: () => void;
   onSelectStarter: (value: string) => void;
   onRetryHistory: () => void;
+  onReply?: (message: ChatBubbleMessage) => void;
+  onOpenActions: (message: ChatBubbleMessage) => void;
 }
 
 export function ChatMessageList({
@@ -80,8 +86,11 @@ export function ChatMessageList({
   onDismissStarter,
   onSelectStarter,
   onRetryHistory,
+  onReply,
+  onOpenActions,
 }: ChatMessageListProps) {
   const isFocused = useIsFocused();
+  const replyColor = String(useCSSVariable("--openbot-text-dim"));
   const reducedMotion = useReducedMotion();
   const animateMessages = isFocused && canSend && appActive;
   const arrivals = useMessageArrivals(agent.id, messages, animateMessages && historyState === "ready");
@@ -133,72 +142,109 @@ export function ChatMessageList({
       groups[groups.length - 1].replies.push(message);
     }
   }
-  const renderMessage = (message: (typeof visibleMessages)[number], isTailUser: boolean, isFirstUser: boolean) =>
-    message.kind === "exchange" ? (
-      <View key={message.id} className="flex-row flex-wrap items-center justify-center gap-2 py-2">
-        <Typography.Paragraph type="body-sm" style={{ color: muted }}>
-          {message.exchange.direction === "outgoing" ? "Messaged" : "Message from"}
-        </Typography.Paragraph>
-        {(message.exchange.direction === "incoming"
-          ? [message.exchange.senderAgentId]
-          : message.exchange.recipientAgentIds
-        ).map((id) => {
-          const participant = agents.find((candidate) => candidate.id === id);
-          return (
-            <View key={id} className="flex-row items-center gap-1">
-              {participant ? (
-                <BloubAvatar agentId={id} hue={participant.avatarHue} seed={participant.avatarSeed} size={22} />
-              ) : null}
-              <Typography.Paragraph type="body-sm" style={{ color: muted }}>
-                {participant?.name ?? "Unknown agent"}
-              </Typography.Paragraph>
-            </View>
-          );
-        })}
-      </View>
-    ) : message.kind === "question" ? (
-      <ChatQuestionPrompt
-        key={message.id}
-        prompt={message.prompt}
-        controller={message.id === questionForm.messageId ? questionForm : undefined}
-        canSend={canSend}
-      />
-    ) : (
-      <Animated.View
-        key={message.id}
-        onLayout={isTailUser ? motion.onUserLayout : undefined}
-        entering={
-          arrivals.has(message.id) && !isFirstUser
-            ? message.author === "user"
-              ? USER_MESSAGE_ENTRANCE
-              : AGENT_MESSAGE_ENTRANCE
-            : undefined
-        }
-        className={`max-w-[88%] rounded-[30px] px-4 py-3 ${message.author === "user" ? "self-end" : "self-start bg-control/60"}`}
-        style={[
-          { borderCurve: "circular" },
-          message.author === "user" ? userBubbleStyle : undefined,
-          isFirstUser ? motion.firstMessageStyle : undefined,
-        ]}
-      >
-        {message.attachments?.map((attachment) => (
-          <Typography.Paragraph
-            key={attachment.id}
-            type="body-sm"
-            style={{ color: message.author === "user" ? "#0a0a0c" : foreground }}
-          >
-            {attachment.name}
+  const renderMessage = (message: (typeof visibleMessages)[number], isTailUser: boolean, isFirstUser: boolean) => {
+    const rendered =
+      message.kind === "exchange" ? (
+        <View key={message.id} className="flex-row flex-wrap items-center justify-center gap-2 py-2">
+          <Typography.Paragraph type="body-sm" style={{ color: muted }}>
+            {message.exchange.direction === "outgoing" ? "Messaged" : "Message from"}
           </Typography.Paragraph>
-        ))}
-        <ChatMarkdown
-          agents={agents}
-          body={message.body}
-          color={message.author === "user" ? "#0a0a0c" : foreground}
-          streaming={message.author === "agent" && message.streaming}
-          animationEnabled={animateMessages && arrivals.has(message.id) && motion.responseVisible}
+          {(message.exchange.direction === "incoming"
+            ? [message.exchange.senderAgentId]
+            : message.exchange.recipientAgentIds
+          ).map((id) => {
+            const participant = agents.find((candidate) => candidate.id === id);
+            return (
+              <View key={id} className="flex-row items-center gap-1">
+                {participant ? (
+                  <BloubAvatar agentId={id} hue={participant.avatarHue} seed={participant.avatarSeed} size={22} />
+                ) : null}
+                <Typography.Paragraph type="body-sm" style={{ color: muted }}>
+                  {participant?.name ?? "Unknown agent"}
+                </Typography.Paragraph>
+              </View>
+            );
+          })}
+        </View>
+      ) : message.kind === "question" ? (
+        <ChatQuestionPrompt
+          key={message.id}
+          prompt={message.prompt}
+          controller={message.id === questionForm.messageId ? questionForm : undefined}
+          canSend={canSend}
         />
-      </Animated.View>
+      ) : (
+        <Animated.View
+          key={message.id}
+          entering={
+            arrivals.has(message.id) && !isFirstUser
+              ? message.author === "user"
+                ? USER_MESSAGE_ENTRANCE
+                : AGENT_MESSAGE_ENTRANCE
+              : undefined
+          }
+          className={`max-w-full rounded-[30px] px-4 py-3 ${message.author === "user" ? "self-end" : "self-start bg-control/60"}`}
+          style={[
+            { borderCurve: "circular" },
+            message.author === "user" ? userBubbleStyle : undefined,
+            isFirstUser ? motion.firstMessageStyle : undefined,
+          ]}
+        >
+          {message.attachments?.map((attachment) => (
+            <Typography.Paragraph
+              key={attachment.id}
+              type="body-sm"
+              style={{ color: message.author === "user" ? "#0a0a0c" : foreground }}
+            >
+              {attachment.name}
+            </Typography.Paragraph>
+          ))}
+          <ChatMarkdown
+            agents={agents}
+            body={message.body}
+            selectable={message.author === "user"}
+            color={message.author === "user" ? "#0a0a0c" : foreground}
+            streaming={message.author === "agent" && message.streaming}
+            animationEnabled={animateMessages && arrivals.has(message.id) && motion.responseVisible}
+          />
+        </Animated.View>
+      );
+    if (message.kind !== "message") return rendered;
+    if (message.author === "agent") {
+      return (
+        <ChatMessageGesture
+          key={message.id}
+          onReply={onReply ? () => onReply(message) : undefined}
+          onOpenActions={() => onOpenActions(message)}
+        >
+          {rendered}
+        </ChatMessageGesture>
+      );
+    }
+    const source = messages.find((candidate) => candidate.id === message.replyToMessageId);
+    return (
+      <View
+        key={message.id}
+        className="max-w-[88%] self-end gap-1"
+        onLayout={isTailUser ? motion.onUserLayout : undefined}
+      >
+        {message.replyToMessageId ? (
+          <View className="flex-row items-center gap-1 self-end">
+            <CornerUpRight size={14} color={replyColor} />
+            <Typography.Paragraph
+              type="body-xs"
+              numberOfLines={1}
+              className="shrink text-text-dim"
+              accessibilityLabel={`Reply to: ${source?.kind === "message" ? mentionDraft(source.body).text || "Attachment" : "Message unavailable"}`}
+            >
+              {source?.kind === "message" ? mentionDraft(source.body).text || "Attachment" : "Message unavailable"}
+            </Typography.Paragraph>
+          </View>
+        ) : null}
+        {rendered}
+      </View>
     );
+  };
   const renderActivity = () =>
     activity || sending ? (
       <View

--- a/apps/mobile/src/features/chat/components/chat-view.tsx
+++ b/apps/mobile/src/features/chat/components/chat-view.tsx
@@ -19,6 +19,7 @@ import { ChatMessageList } from "@/features/chat/components/chat-message-list";
 import { useChatAttachments } from "@/features/chat/components/use-chat-attachments";
 import { useChatMotion } from "@/features/chat/components/use-chat-motion";
 import { useQuestionPrompt } from "@/features/chat/components/use-question-prompt";
+import { type ChatBubbleMessage, useMessageActions } from "@/features/chat/context/message-actions-context";
 import {
   latestReadableMessage,
   type PendingChatMessage,
@@ -29,7 +30,6 @@ import { ConnectionStatus } from "@/features/workspace/components/connection-sta
 import { useAgentActivity } from "@/features/workspace/components/use-agent-activity";
 import type { MobileAgent } from "@/features/workspace/context/mobile-workspace-context";
 import { useMobileWorkspace } from "@/features/workspace/context/mobile-workspace-context";
-import { SheetScrollEdgeEffect } from "@/shared/components/sheet-scroll-edge-effect";
 import { isIOS } from "@/shared/lib/platform";
 
 interface MobileChatViewProps {
@@ -60,6 +60,9 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
     "accent-foreground",
     "background",
   ]);
+  const { select: selectMessageActions } = useMessageActions();
+  const [replyTarget, setReplyTarget] = useState<ChatBubbleMessage | null>(null);
+  const [replyFocusVersion, setReplyFocusVersion] = useState(0);
   const [draft, setDraft] = useState("");
   const [sendError, setSendError] = useState<{ agentId: string; message: string } | null>(null);
   const [sending, setSending] = useState(false);
@@ -207,6 +210,8 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
     setDraft("");
     sendingRef.current = true;
     setSending(true);
+    const submittedReply = replyTarget;
+    setReplyTarget(null);
     const files = attachments.items;
     const localId = `local-message-${++sendSequence.current}`;
     setPendingMessage({
@@ -216,6 +221,7 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
         author: "user",
         body,
         streaming: false,
+        replyToMessageId: submittedReply?.id ?? null,
         attachments: files.map((file) => ({
           id: file.id,
           name: file.name,
@@ -233,13 +239,14 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
     void (async () => {
       try {
         for (const file of files) uploaded.push((await uploadAttachment(agent.id, file)).id);
-        const serverId = await sendTeamMessage(agent.id, body, uploaded);
+        const serverId = await sendTeamMessage(agent.id, body, uploaded, submittedReply?.id ?? null);
         setMessageAliases((current) => new Map(current).set(serverId, localId));
         setPendingMessage((current) => (current?.message.id === localId ? { ...current, serverId } : current));
         attachments.clear();
       } catch (error) {
         motion.cancelSend();
         setPendingMessage((current) => (current?.message.id === localId ? null : current));
+        setReplyTarget((current) => current ?? submittedReply);
         setDraft((current) => (current ? `${body}\n${current}` : body));
         // Only discard drafts created by this attempt. Keep the local files and text for retry.
         await Promise.allSettled(uploaded.map((id) => discardAttachment(agent.id, id)));
@@ -300,6 +307,27 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
             fieldBackground={fieldBackground}
             foreground={foreground}
             messages={messages}
+            onReply={
+              !questionForm.question
+                ? (message) => {
+                    setReplyTarget(message);
+                    setReplyFocusVersion((version) => version + 1);
+                  }
+                : undefined
+            }
+            onOpenActions={(message) => {
+              Keyboard.dismiss();
+              selectMessageActions({
+                message,
+                onReply: !questionForm.question
+                  ? () => {
+                      setReplyTarget(message);
+                      setReplyFocusVersion((version) => version + 1);
+                    }
+                  : null,
+              });
+              router.push("/message-actions");
+            }}
             muted={muted}
             raised={raised}
             showStarter={showStarter && serverOnline && !activity && conversation?.messages.length === 0}
@@ -317,12 +345,6 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
               setComposerGestureHeight(event.nativeEvent.layout.height);
             }}
           >
-            {liquidGlassAvailable ? (
-              <SheetScrollEdgeEffect
-                edge="bottom"
-                style={{ position: "absolute", top: -32, bottom: 0, left: 0, right: 0 }}
-              />
-            ) : null}
             {!atLatest && motion.historyVisible && messages.length > 0 ? (
               <View className="absolute -top-14 self-center">
                 <ChatGlassIconButton
@@ -343,6 +365,9 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
             ) : null}
             <ChatComposer
               sendRetryVersion={sendRetryVersion}
+              replyTarget={questionForm.question ? null : replyTarget}
+              replyFocusVersion={replyFocusVersion}
+              onCancelReply={() => setReplyTarget(null)}
               mentionAgents={agents.filter(
                 (candidate) => candidate.serverId === agent.serverId && candidate.id !== agent.id,
               )}

--- a/apps/mobile/src/features/chat/components/chat-view.tsx
+++ b/apps/mobile/src/features/chat/components/chat-view.tsx
@@ -307,6 +307,7 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
             fieldBackground={fieldBackground}
             foreground={foreground}
             messages={messages}
+            messageAliases={messageAliases}
             onReply={
               !questionForm.question
                 ? (message) => {

--- a/apps/mobile/src/features/chat/components/use-copy-message.ts
+++ b/apps/mobile/src/features/chat/components/use-copy-message.ts
@@ -1,0 +1,18 @@
+import * as Clipboard from "expo-clipboard";
+import { useState } from "react";
+import { Alert } from "react-native";
+
+export function useCopyMessage(text: string) {
+  const [copied, setCopied] = useState(false);
+  async function copy() {
+    try {
+      await Clipboard.setStringAsync(text);
+      setCopied(true);
+      return true;
+    } catch {
+      Alert.alert("Could not copy message", "Please try again.");
+      return false;
+    }
+  }
+  return { copy, copied };
+}

--- a/apps/mobile/src/features/chat/context/message-actions-context.test.tsx
+++ b/apps/mobile/src/features/chat/context/message-actions-context.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, screen } from "@testing-library/dom";
+import { act, type PropsWithChildren, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+import MessageActionsScreen from "@/app/(app)/message-actions";
+import SelectMessageTextScreen from "@/app/(app)/message-actions/select-text";
+import { MessageActionsProvider, useMessageActions } from "./message-actions-context";
+
+const mocks = vi.hoisted(() => ({
+  copy: vi.fn(async (_text: string) => {}),
+  back: vi.fn(),
+  push: vi.fn(),
+  alert: vi.fn(),
+}));
+const Container = ({ children }: PropsWithChildren) => <div>{children}</div>;
+vi.mock("react-native", () => ({
+  Alert: { alert: mocks.alert },
+  TextInput: ({
+    value,
+    editable,
+    accessibilityLabel,
+  }: {
+    value: string;
+    editable: boolean;
+    accessibilityLabel: string;
+  }) => <textarea aria-label={accessibilityLabel} value={value} readOnly={!editable} />,
+}));
+vi.mock("@/shared/lib/platform", () => ({ isIOS: true }));
+vi.mock("expo-clipboard", () => ({ setStringAsync: mocks.copy }));
+vi.mock("heroui-native/hooks", () => ({ useThemeColor: () => "black" }));
+vi.mock("heroui-native", () => ({
+  Typography: Object.assign(({ children }: PropsWithChildren) => <span>{children}</span>, {
+    Paragraph: ({ children }: PropsWithChildren) => <p>{children}</p>,
+  }),
+}));
+vi.mock("lucide-react-native", () => ({ Copy: () => null, Reply: () => null, TextSelect: () => null }));
+vi.mock("@/shared/components/sheet-scroll-view", () => ({
+  SheetScrollView: ({ children }: PropsWithChildren) => <div>{children}</div>,
+}));
+vi.mock("@/features/settings/components/settings-content", () => ({
+  SettingsContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SettingsSection: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SettingsRow: ({ children, onPress, disabled }: PropsWithChildren<{ onPress: () => void; disabled?: boolean }>) => (
+    <button type="button" disabled={disabled} onClick={onPress}>
+      {children}
+    </button>
+  ),
+}));
+vi.mock("expo-router", () => ({
+  router: { back: mocks.back, push: mocks.push },
+  Stack: {
+    Toolbar: Object.assign(({ children }: PropsWithChildren) => <div>{children}</div>, {
+      Button: ({
+        children,
+        onPress,
+        accessibilityLabel,
+      }: PropsWithChildren<{ onPress: () => void; accessibilityLabel: string }>) => (
+        <button type="button" aria-label={accessibilityLabel} onClick={onPress}>
+          {children}
+        </button>
+      ),
+    }),
+  },
+}));
+
+const message = {
+  id: "answer",
+  kind: "message" as const,
+  author: "agent" as const,
+  body: "First line\nSecond line",
+  streaming: false,
+};
+function Harness({ canReply = true }: { canReply?: boolean }) {
+  const { select, selected } = useMessageActions();
+  const [reply, setReply] = useState("");
+  return (
+    <Container>
+      <button type="button" onClick={() => select({ message, onReply: canReply ? () => setReply(message.id) : null })}>
+        Open actions
+      </button>
+      <output aria-label="Reply target">{reply}</output>
+      {selected ? (
+        <>
+          <MessageActionsScreen />
+          <SelectMessageTextScreen />
+        </>
+      ) : null}
+    </Container>
+  );
+}
+const container = document.createElement("div");
+document.body.append(container);
+let root = createRoot(container);
+afterEach(async () => {
+  await act(() => root.unmount());
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+async function open(canReply = true) {
+  await act(() =>
+    root.render(
+      <MessageActionsProvider>
+        <Harness canReply={canReply} />
+      </MessageActionsProvider>,
+    ),
+  );
+  await act(async () => fireEvent.click(screen.getByRole("button", { name: "Open actions" })));
+}
+
+it("replies to the selected message and returns to chat", async () => {
+  await open();
+  await act(async () => fireEvent.click(screen.getByRole("button", { name: "Reply" })));
+  expect({
+    target: screen.getByRole("status", { name: "Reply target" }).textContent,
+    dismissals: mocks.back.mock.calls.length,
+  }).toEqual({ target: "answer", dismissals: 1 });
+});
+
+it("opens text selection without placing message text in the route", async () => {
+  await open();
+  await act(async () => fireEvent.click(screen.getByRole("button", { name: "Select Text" })));
+  expect(mocks.push.mock.calls).toEqual([["/message-actions/select-text"]]);
+});
+
+it("copies the full message and keeps the selection page open", async () => {
+  await open();
+  await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy message" })));
+  expect({
+    copied: mocks.copy.mock.calls,
+    dismissed: mocks.back.mock.calls.length,
+    confirmed: screen.getByRole("button", { name: "Message copied" }).textContent,
+  }).toEqual({ copied: [[message.body]], dismissed: 0, confirmed: "Copied" });
+});
+
+it("keeps actions open when copying fails", async () => {
+  mocks.copy.mockRejectedValueOnce(new Error("Clipboard unavailable"));
+  await open(false);
+  await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy" })));
+  expect({ error: mocks.alert.mock.calls, dismissed: mocks.back.mock.calls.length }).toEqual({
+    error: [["Could not copy message", "Please try again."]],
+    dismissed: 0,
+  });
+});

--- a/apps/mobile/src/features/chat/context/message-actions-context.test.tsx
+++ b/apps/mobile/src/features/chat/context/message-actions-context.test.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, expect, it, vi } from "vitest";
 import MessageActionsScreen from "@/app/(app)/message-actions";
 import SelectMessageTextScreen from "@/app/(app)/message-actions/select-text";
+import { ChatMessageGesture } from "../components/chat-message-gesture";
 import { MessageActionsProvider, useMessageActions } from "./message-actions-context";
 
 const mocks = vi.hoisted(() => ({
@@ -15,6 +16,10 @@ const mocks = vi.hoisted(() => ({
 const Container = ({ children }: PropsWithChildren) => <div>{children}</div>;
 vi.mock("react-native", () => ({
   Alert: { alert: mocks.alert },
+  // iOS accessible containers combine their children into one accessibility element.
+  View: ({ children, accessible }: PropsWithChildren<{ accessible?: boolean }>) => (
+    <div>{accessible ? <div aria-hidden="true">{children}</div> : children}</div>
+  ),
   TextInput: ({
     value,
     editable,
@@ -27,8 +32,62 @@ vi.mock("react-native", () => ({
 }));
 vi.mock("@/shared/lib/platform", () => ({ isIOS: true }));
 vi.mock("expo-clipboard", () => ({ setStringAsync: mocks.copy }));
+vi.mock("expo-haptics", () => ({ impactAsync: async () => {}, ImpactFeedbackStyle: { Light: "light" } }));
+vi.mock("react-native-reanimated", async () => {
+  const { View } = await import("react-native");
+  return {
+    default: { View },
+    ReduceMotion: { System: "system" },
+    useAnimatedStyle: () => ({}),
+    useSharedValue: (initial: number) => ({ get: () => initial, set: () => {} }),
+    withSpring: (value: number) => value,
+  };
+});
+vi.mock("react-native-worklets", () => ({ scheduleOnRN: (callback: () => void) => callback() }));
+vi.mock("react-native-gesture-handler", () => {
+  function gesture() {
+    return {
+      enabled() {
+        return this;
+      },
+      activeOffsetX() {
+        return this;
+      },
+      failOffsetX() {
+        return this;
+      },
+      failOffsetY() {
+        return this;
+      },
+      onUpdate() {
+        return this;
+      },
+      onEnd() {
+        return this;
+      },
+      onFinalize() {
+        return this;
+      },
+      onStart() {
+        return this;
+      },
+    };
+  }
+  return {
+    Gesture: { Pan: gesture, LongPress: gesture, Race: gesture },
+    GestureDetector: ({ children }: PropsWithChildren) => children,
+  };
+});
 vi.mock("heroui-native/hooks", () => ({ useThemeColor: () => "black" }));
 vi.mock("heroui-native", () => ({
+  Button: Object.assign(
+    ({ children, onPress }: PropsWithChildren<{ onPress: () => void }>) => (
+      <button type="button" onClick={onPress}>
+        {children}
+      </button>
+    ),
+    { Label: ({ children }: PropsWithChildren) => <span>{children}</span> },
+  ),
   Typography: Object.assign(({ children }: PropsWithChildren) => <span>{children}</span>, {
     Paragraph: ({ children }: PropsWithChildren) => <p>{children}</p>,
   }),
@@ -95,6 +154,26 @@ afterEach(async () => {
   await act(() => root.unmount());
   root = createRoot(container);
   vi.clearAllMocks();
+});
+
+it("keeps code copy and message actions separately accessible with a screen reader", async () => {
+  const copyCode = vi.fn();
+  const openActions = vi.fn();
+  await act(() =>
+    root.render(
+      <ChatMessageGesture screenReaderEnabled onOpenActions={openActions}>
+        <button type="button" onClick={copyCode}>
+          Copy code
+        </button>
+      </ChatMessageGesture>,
+    ),
+  );
+  await act(async () => fireEvent.click(screen.getByRole("button", { name: "Copy code" })));
+  await act(async () => fireEvent.click(screen.getByRole("button", { name: "Message actions" })));
+  expect({ copiedCode: copyCode.mock.calls.length, openedActions: openActions.mock.calls.length }).toEqual({
+    copiedCode: 1,
+    openedActions: 1,
+  });
 });
 async function open(canReply = true) {
   await act(() =>

--- a/apps/mobile/src/features/chat/context/message-actions-context.tsx
+++ b/apps/mobile/src/features/chat/context/message-actions-context.tsx
@@ -1,0 +1,26 @@
+import { createContext, type PropsWithChildren, useContext, useState } from "react";
+import type { ChatMessage } from "../model/chat-messages";
+
+export type ChatBubbleMessage = Extract<ChatMessage, { kind: "message" }>;
+
+interface MessageActions {
+  message: ChatBubbleMessage;
+  onReply: (() => void) | null;
+}
+
+const MessageActionsContext = createContext<{
+  selected: MessageActions | null;
+  select: (value: MessageActions | null) => void;
+} | null>(null);
+
+// Keep message text and callbacks out of navigation URLs and route state.
+export function MessageActionsProvider({ children }: PropsWithChildren) {
+  const [selected, select] = useState<MessageActions | null>(null);
+  return <MessageActionsContext value={{ selected, select }}>{children}</MessageActionsContext>;
+}
+
+export function useMessageActions() {
+  const context = useContext(MessageActionsContext);
+  if (!context) throw new Error("MessageActionsProvider is missing.");
+  return context;
+}

--- a/apps/mobile/src/features/chat/model/chat-messages.ts
+++ b/apps/mobile/src/features/chat/model/chat-messages.ts
@@ -25,6 +25,16 @@ export interface PendingChatMessage {
   serverId: string | null;
 }
 
+export function indexChatMessages(messages: readonly ChatMessage[], aliases: ReadonlyMap<string, string>) {
+  const index = new Map(messages.map((message) => [message.id, message]));
+  // Reply references use host IDs even when a delivered bubble keeps its local render key.
+  for (const [hostId, localId] of aliases) {
+    const message = index.get(localId);
+    if (message) index.set(hostId, message);
+  }
+  return index;
+}
+
 export function presentChatMessages(
   messages: ChatMessage[],
   pending: PendingChatMessage | null,

--- a/apps/mobile/src/features/chat/model/chat-messages.ts
+++ b/apps/mobile/src/features/chat/model/chat-messages.ts
@@ -14,6 +14,7 @@ export type ChatMessage =
       author: "agent" | "user";
       body: string;
       streaming: boolean;
+      replyToMessageId?: string | null;
       attachments?: AttachmentSummary[];
     }
   | { id: string; kind: "thinking"; turnId: string | undefined; steps: { id: string; text: string }[] };
@@ -72,6 +73,7 @@ export function projectChatMessages(messages: ConversationMessage[]): ChatMessag
         body: message.exchange ? "" : message.text,
         streaming: message.status === "streaming",
         attachments: message.attachments,
+        replyToMessageId: message.replyToMessageId,
       });
     }
   }

--- a/apps/mobile/src/features/workspace/context/mobile-workspace-context.tsx
+++ b/apps/mobile/src/features/workspace/context/mobile-workspace-context.tsx
@@ -816,7 +816,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
         if (!serverId) throw new Error("The agent is unavailable.");
         await request("DELETE", TEAM_API_ROUTES.attachment(attachmentId), ignoreResponse, undefined, serverId);
       },
-      sendMessage: async (agentId, text, attachmentDraftIds = []) => {
+      sendMessage: async (agentId, text, attachmentDraftIds = [], replyToMessageId = null) => {
         const serverId = agents.find((candidate) => candidate.id === agentId)?.serverId;
         if (!serverId) throw new Error("The agent is unavailable.");
         const receipt = await request(
@@ -829,7 +829,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
           {
             text,
             attachmentDraftIds,
-            replyToMessageId: null,
+            replyToMessageId,
           },
           serverId,
         );

--- a/apps/mobile/src/features/workspace/model/workspace-types.ts
+++ b/apps/mobile/src/features/workspace/model/workspace-types.ts
@@ -93,7 +93,12 @@ export interface MobileWorkspaceContextValue {
   loadAgentAnalytics: (input: AgentAnalyticsInput, serverId: string) => Promise<AgentAnalytics | null>;
   loadConversation: (agentId: string) => Promise<ConversationSnapshot>;
   respondToPrompt: (agentId: string, input: RespondToPromptInput) => Promise<void>;
-  sendMessage: (agentId: string, text: string, attachmentDraftIds?: string[]) => Promise<string>;
+  sendMessage: (
+    agentId: string,
+    text: string,
+    attachmentDraftIds?: string[],
+    replyToMessageId?: string | null,
+  ) => Promise<string>;
   uploadAttachment: (agentId: string, input: RemoteFileUpload) => Promise<DraftAttachment>;
   discardAttachment: (agentId: string, attachmentId: string) => Promise<void>;
   hideAgent: (agentId: string) => void;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -273,8 +273,12 @@ Mobile acknowledges rendered replies only in the foreground, focused chat at the
 Mobile chat keeps viewport, tail-group, and composer measurements in its motion controller. The
 last user message anchors a native blank-space inset; streamed replies consume that inset without
 autoscrolling. Initial history positioning and the first-send/first-response animation are separate
-states. Pending message bubbles reconcile through the host receipt ID, not message text. Selected
-mobile attachments use the existing WebRTC file frames followed by the attachment upload endpoint;
+states. Pending message bubbles reconcile through the host receipt ID, not message text.
+Mobile replies use the existing `replyToMessageId` field and retain their source after delivery.
+Agent bubbles support swipe-to-reply and a long-press action sheet with haptic feedback. The
+sheet has one nested native stack for actions and text selection; message text stays in memory,
+outside route parameters. Failed sends restore the reply target, and the composer can cancel it.
+Selected mobile attachments use the existing WebRTC file frames followed by the attachment upload endpoint;
 the native/DOM bridge limits each file to 10 MB and cancels transfers when its connection is replaced.
 The optional `conversation-unread` capability adds a separate `POST /v1/agents/:id/conversation/unread`
 operation. Ordinary read acknowledgements remain monotonic; explicit unread resets persist in the

--- a/scripts/mobile-question-prompts.test.ts
+++ b/scripts/mobile-question-prompts.test.ts
@@ -1,6 +1,7 @@
 import type { AgentPromptQuestion, ConversationSnapshot } from "@openbot/contracts/ipc";
 import { describe, expect, it } from "vitest";
 import {
+  indexChatMessages,
   latestReadableMessage,
   type PendingChatMessage,
   presentChatMessages,
@@ -46,6 +47,26 @@ function conversation(): ConversationSnapshot {
 }
 
 describe("mobile question forms", () => {
+  it("resolves a desktop reply to a mobile message whose render ID has been replaced", () => {
+    const snapshot = conversation();
+    snapshot.messages = [
+      { id: "mobile-delivery", author: "user", text: "Sent from mobile", status: "completed", createdAt: "now" },
+      {
+        id: "desktop-reply",
+        author: "user",
+        text: "Reply from desktop",
+        replyToMessageId: "mobile-delivery",
+        status: "completed",
+        createdAt: "now",
+      },
+    ];
+    const aliases = new Map([["mobile-delivery", "local-1"]]);
+    const messages = presentChatMessages(projectChatMessages(snapshot.messages), null, aliases);
+    const index = indexChatMessages(messages, aliases);
+    const reply = messages[1];
+    const source = reply.kind === "message" && reply.replyToMessageId ? index.get(reply.replyToMessageId) : null;
+    expect(source).toMatchObject({ id: "local-1", body: "Sent from mobile" });
+  });
   it("keeps a reply attached to its source after the pending message receives its host ID", () => {
     const snapshot = conversation();
     snapshot.messages = [

--- a/scripts/mobile-question-prompts.test.ts
+++ b/scripts/mobile-question-prompts.test.ts
@@ -46,6 +46,26 @@ function conversation(): ConversationSnapshot {
 }
 
 describe("mobile question forms", () => {
+  it("keeps a reply attached to its source after the pending message receives its host ID", () => {
+    const snapshot = conversation();
+    snapshot.messages = [
+      { id: "source", author: "assistant", text: "Original answer", status: "completed", createdAt: "now" },
+      {
+        id: "delivered",
+        author: "user",
+        text: "Follow up",
+        replyToMessageId: "source",
+        status: "completed",
+        createdAt: "now",
+      },
+    ];
+    const projected = projectChatMessages(decodeConversation(snapshot).messages);
+    const result = presentChatMessages(projected, null, new Map([["delivered", "local"]]));
+    expect(result.find((message) => message.id === "local")).toMatchObject({
+      body: "Follow up",
+      replyToMessageId: "source",
+    });
+  });
   it("keeps attachment-only messages visible and advances their read boundary", () => {
     const snapshot = conversation();
     const attachment = {


### PR DESCRIPTION
## Summary

- Add reply gestures and composer support in mobile chat.
- Add message actions for copying, selecting text, and viewing code blocks.
- Update chat state, workspace types, navigation, and architecture documentation.
- Add coverage for message action context behavior and mobile question prompts.
- Keep child controls such as Copy code accessible to VoiceOver. A separate Message actions button provides message actions when a screen reader is enabled.
- Resolve reply references through a cached index of host and local message IDs. Ordinary messages do not perform a reply-source lookup.

## Testing

- `bun run test:desktop -- apps/mobile/src/features/chat/context/message-actions-context.test.tsx`: 5 passed.
- `bun run test:desktop -- scripts/mobile-question-prompts.test.ts`: 11 passed.
- `bun run lint`: passed with 60 warnings. The message-action tests retain module mocks for native, animation, and UI boundaries that cannot run in jsdom. No lint rules were disabled.
- `bun run typecheck`: passed across all projects.
- Commit hook: staged checks, `bun run check:ui`, and full typecheck passed.
- Regression verification: temporarily restored the grouped accessibility wrapper and confirmed that the Copy code accessibility test failed. Temporarily removed the host-ID index entry and confirmed that the desktop-to-mobile reply-source test failed. Restored both fixes and reran both test files successfully.

Model and harness: Codex (GPT-6), Vitest Node and React DOM/jsdom with native boundary mocks. No device, simulator, build, or screenshot checks ran. Native VoiceOver behavior remains to be checked on a device.
