### PR TITLE
Fix mobile chat composer dismissal handling

### DIFF
--- a/apps/mobile/src/features/chat/components/chat-view.tsx
+++ b/apps/mobile/src/features/chat/components/chat-view.tsx
@@ -8,7 +8,8 @@ import { ArrowDown } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AccessibilityInfo, AppState, Keyboard, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
-import { KeyboardGestureArea, KeyboardStickyView } from "react-native-keyboard-controller";
+import { KeyboardGestureArea } from "react-native-keyboard-controller";
+import Animated from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { scheduleOnRN } from "react-native-worklets";
 import { useAgentPinTransition } from "@/features/agents/components/agent-pin-transition";
@@ -337,9 +338,8 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
             onSelectStarter={sendMessage}
             onRetryHistory={fetchHistory}
           />
-          <KeyboardStickyView
-            style={{ position: "absolute", left: 0, right: 0, bottom: 0 }}
-            offset={{ opened: keyboardOffset }}
+          <Animated.View
+            style={[{ position: "absolute", left: 0, right: 0, bottom: 0 }, motion.composerStyle]}
             pointerEvents="box-none"
             onLayout={(event) => {
               motion.onComposerLayout(event);
@@ -394,7 +394,7 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
               onChangeDraft={questionForm.question ? questionForm.setDraft : setDraft}
               onSend={sendMessage}
             />
-          </KeyboardStickyView>
+          </Animated.View>
         </KeyboardGestureArea>
       </View>
     </GestureDetector>

--- a/apps/mobile/src/features/chat/components/use-chat-motion.test.tsx
+++ b/apps/mobile/src/features/chat/components/use-chat-motion.test.tsx
@@ -1,0 +1,125 @@
+import { act, useLayoutEffect } from "react";
+import { createRoot } from "react-dom/client";
+import type { LayoutChangeEvent } from "react-native";
+import { afterEach, expect, it, vi } from "vitest";
+import { type ChatMotion, useChatMotion } from "./use-chat-motion";
+
+const native = vi.hoisted(() => {
+  const keyboard: Record<string, (event: { height: number }) => void> = {};
+  const reactions: (() => void)[] = [];
+  return { keyboard, reactions, frames: new Map<number, FrameRequestCallback>(), nextFrame: 0, scrollTo: vi.fn() };
+});
+
+// Replace the native event/runtime boundary; run the real chat hook and React lifecycle.
+vi.mock("react-native-keyboard-controller", () => ({
+  useKeyboardHandler: (handlers: typeof native.keyboard) => {
+    native.keyboard = handlers;
+  },
+}));
+vi.mock("react-native-worklets", () => ({
+  scheduleOnRN: (callback: (value: boolean) => void, value: boolean) => callback(value),
+}));
+vi.mock("react-native-reanimated", async () => {
+  const { useRef } = await import("react");
+  function useSharedValue<T>(initial: T) {
+    return useRef({
+      value: initial,
+      get() {
+        return this.value;
+      },
+      set(value: T) {
+        this.value = value;
+      },
+    }).current;
+  }
+  return {
+    ReduceMotion: { System: "system" },
+    useSharedValue,
+    useAnimatedRef: () => useRef({ current: { scrollTo: native.scrollTo } }).current,
+    useReducedMotion: () => true,
+    useAnimatedStyle: () => ({}),
+    useAnimatedScrollHandler: (handler: unknown) => handler,
+    useDerivedValue: (get: () => number) => ({ get }),
+    useAnimatedReaction: (prepare: () => boolean, react: (value: boolean, previous: boolean | null) => void) => {
+      native.reactions.push(() => react(prepare(), null));
+    },
+    cancelAnimation: () => {},
+    withTiming: (value: number) => value,
+    withSpring: (value: number) => value,
+  };
+});
+
+const container = document.createElement("div");
+let root = createRoot(container);
+afterEach(async () => {
+  await act(() => root.unmount());
+  root = createRoot(container);
+  native.frames.clear();
+  native.reactions = [];
+  vi.unstubAllGlobals();
+});
+
+function layout(height: number, y = 0): Pick<LayoutChangeEvent, "nativeEvent"> {
+  return { nativeEvent: { layout: { height, y, x: 0, width: 390 } } };
+}
+
+it("keeps replies visible and does not scroll after keyboard dismissal, including an interrupted final frame", async () => {
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    const id = ++native.nextFrame;
+    native.frames.set(id, callback);
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => native.frames.delete(id));
+  let motion: ChatMotion | undefined;
+  function Chat() {
+    const current = useChatMotion(100, 24, true, "user-1");
+    useLayoutEffect(() => {
+      motion = current;
+    });
+    return null;
+  }
+  async function flush() {
+    await act(() => {
+      while (native.frames.size) {
+        const frames = [...native.frames.values()];
+        native.frames.clear();
+        for (const frame of frames) frame(0);
+      }
+      native.reactions.at(-1)?.();
+    });
+  }
+  await act(() => root.render(<Chat />));
+  if (!motion) throw new Error("Chat motion is not mounted");
+  motion.onViewportLayout(layout(800));
+  motion.onComposerLayout(layout(80));
+  motion.onTailLayout("user-1", layout(550, 100));
+  motion.onContentSizeChange(390, 650);
+  motion.onContentInsetChange({ bottom: 150 });
+  await flush();
+  native.scrollTo.mockClear();
+
+  native.keyboard.onMove({ height: 300 });
+  native.keyboard.onEnd({ height: 300 });
+  await flush();
+  expect(motion.atLatest).toBe(false);
+
+  native.keyboard.onInteractive({ height: 150 });
+  // Dismissal can finish without an onMove frame at height zero.
+  native.keyboard.onEnd({ height: 0 });
+  await flush();
+  expect(motion.atLatest).toBe(true);
+
+  // A streamed reply changes both content measurements and the React render.
+  await act(() => root.render(<Chat />));
+  motion.onTailLayout("user-1", layout(580, 100));
+  motion.onContentSizeChange(390, 680);
+  motion.onContentInsetChange({ bottom: 120 });
+  await flush();
+  expect(motion.atLatest).toBe(true);
+  expect(native.scrollTo).not.toHaveBeenCalled();
+
+  // The user can open the keyboard again while the agent is replying.
+  native.keyboard.onMove({ height: 300 });
+  await flush();
+  expect(motion.atLatest).toBe(false);
+});

--- a/apps/mobile/src/features/chat/components/use-chat-motion.ts
+++ b/apps/mobile/src/features/chat/components/use-chat-motion.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { LayoutChangeEvent } from "react-native";
-import { useReanimatedKeyboardAnimation } from "react-native-keyboard-controller";
+import { useKeyboardHandler } from "react-native-keyboard-controller";
 import type Animated from "react-native-reanimated";
 import {
   cancelAnimation,
@@ -33,7 +33,29 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     [ref],
   );
   const reducedMotion = useReducedMotion();
-  const keyboard = useReanimatedKeyboardAnimation();
+  const keyboardHeight = useSharedValue(0);
+  // Track actual frames and completion, not the iOS provider's start-only target.
+  // A render while the reply streams must not restore a dismissed keyboard's lift.
+  useKeyboardHandler(
+    {
+      onMove: (event) => {
+        "worklet";
+        keyboardHeight.set(event.height);
+      },
+      onInteractive: (event) => {
+        "worklet";
+        keyboardHeight.set(event.height);
+      },
+      onEnd: (event) => {
+        "worklet";
+        keyboardHeight.set(event.height);
+      },
+    },
+    [keyboardHeight],
+  );
+  const composerStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: -Math.max(0, keyboardHeight.get() - keyboardOffset) }],
+  }));
   const layout = useSharedValue<ChatLayout>({ viewport: 0, content: 0, header, tailY: 0, tailHeight: 0 });
   const composerHeight = useSharedValue(0);
   const blankSpace = useDerivedValue(() => (lastUserId ? chatBlankSpace(layout.get()) : 0));
@@ -87,7 +109,7 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
         setHistoryVisible(true);
         ref.current?.scrollTo({ y: chatSendOffset(m.layout, m.inset), animated: !send.first && !reducedMotion });
         if (send.first) {
-          const lift = Math.max(0, -keyboard.height.get() - keyboardOffset);
+          const lift = Math.max(0, keyboardHeight.get() - keyboardOffset);
           firstOffset.set(Math.max(0, m.layout.viewport - lift - m.composer - m.layout.header - m.userHeight));
           firstOpacity.set(withTiming(1, { duration: 200, reduceMotion: ReduceMotion.System }));
           firstOffset.set(
@@ -117,7 +139,7 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     finishFirstMessage,
     firstOffset,
     firstOpacity,
-    keyboard.height,
+    keyboardHeight,
     keyboardOffset,
     reducedMotion,
     ref,
@@ -138,7 +160,7 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
   );
 
   const onViewportLayout = useCallback(
-    (event: LayoutChangeEvent) => {
+    (event: Pick<LayoutChangeEvent, "nativeEvent">) => {
       measurements.current.layout = {
         ...measurements.current.layout,
         viewport: event.nativeEvent.layout.height,
@@ -158,7 +180,7 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     [layout, position],
   );
   const onTailLayout = useCallback(
-    (id: string, event: LayoutChangeEvent) => {
+    (id: string, event: Pick<LayoutChangeEvent, "nativeEvent">) => {
       const { y, height } = event.nativeEvent.layout;
       measurements.current.tailId = id;
       measurements.current.layout = { ...measurements.current.layout, tailY: y, tailHeight: height };
@@ -168,14 +190,14 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     [layout, position],
   );
   const onUserLayout = useCallback(
-    (event: LayoutChangeEvent) => {
+    (event: Pick<LayoutChangeEvent, "nativeEvent">) => {
       measurements.current.userHeight = event.nativeEvent.layout.height;
       position();
     },
     [position],
   );
   const onComposerLayout = useCallback(
-    (event: LayoutChangeEvent) => {
+    (event: Pick<LayoutChangeEvent, "nativeEvent">) => {
       const height = event.nativeEvent.layout.height + 20;
       measurements.current.composer = height;
       composerHeight.set(height);
@@ -202,7 +224,7 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
       chatContentIsVisible(
         layout.get(),
         scrollY.get(),
-        composerHeight.get() + Math.max(0, -keyboard.height.get() - keyboardOffset),
+        composerHeight.get() + Math.max(0, keyboardHeight.get() - keyboardOffset),
       ),
     (visible, previous) => {
       if (visible !== previous) scheduleOnRN(setAtLatest, visible);
@@ -246,6 +268,7 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     historyVisible,
     responseVisible,
     composerHeight,
+    composerStyle,
     blankSpace,
     historyStyle,
     firstMessageStyle,


### PR DESCRIPTION
## Summary

- Track keyboard movement and completion frames directly.
- Animate the chat composer with the measured keyboard height.
- Prevent streamed replies from restoring a dismissed keyboard lift.
- Add regression coverage for interrupted keyboard dismissal and reopening.

## Testing

- Added a hook-level regression test covering keyboard dismissal, streaming updates, and reopening.