### PR TITLE
fix: keep channel reads, signed-out authorship, and sidebar order correct

### DIFF
--- a/scripts/seed-dev-state.test.ts
+++ b/scripts/seed-dev-state.test.ts
@@ -204,7 +204,7 @@ describe("development state seed", () => {
     // The seed reads as `local`, but the app resolves a team member id once the owner signs in.
     // Adoption is what keeps the seeded read state, and the unread count, on that reader.
     channels.adoptReads("local", owner?.id ?? "");
-    expect(channels.list(owner?.id ?? "")[0]?.unreadCount).toBe(2);
+    expect(channels.list(owner?.id ?? "", true)[0]?.unreadCount).toBe(2);
     expect(channelSummaries[1]?.archived).toBe(true);
     const channelMessages = channelSummaries.flatMap((channel) => channels.messages(channel.id));
     expect(channelMessages).toHaveLength(12);

--- a/src/backend/channel-service.test.ts
+++ b/src/backend/channel-service.test.ts
@@ -1914,8 +1914,37 @@ describe("shared channel coordination", () => {
     );
 
     // The signed-in reader holds no cursor here, so only authorship can hold this message out of
-    // the count. It carries the signed-out id, and that is the same person as the member.
-    expect(required(service.store.list("member-9")[0]).unreadCount).toBe(0);
+    // the count. It carries the signed-out id, and that is the same person as the host member.
+    expect(required(service.store.list("member-9", true)[0]).unreadCount).toBe(0);
+
+    // A remote member is another person. The host wrote this message, so it is unread for them.
+    expect(required(service.store.list("member-9")[0]).unreadCount).toBe(1);
+  });
+
+  it("carries every read channel to the reader that signs in", async () => {
+    await service.command({ type: "save", channelId: "channel-2", operationId: operationId(), draft }, actor);
+    await send("Draft the release note.");
+    await service.command(
+      {
+        type: "send",
+        channelId: "channel-2",
+        operationId: operationId(),
+        text: "Check the changelog.",
+        recipientAgentId: "agent-a",
+        replyToMessageId: null,
+        attachmentDraftIds: [],
+      },
+      actor,
+    );
+    for (const channelId of ["channel-1", "channel-2"]) {
+      service.store.markRead(channelId, "local", service.store.page(channelId).throughSequence, operationId());
+    }
+
+    service.store.adoptReads("local", "member-9");
+
+    // Each channel needs its own command, or the second adoption answers with the first receipt
+    // and the reader that signs in sees a channel it has read as unread.
+    expect(service.store.list("member-9").map((channel) => channel.unreadCount)).toEqual([0, 0]);
   });
 
   it("serializes overlapping workspaces and permits independent declared resources", () => {

--- a/src/backend/channel-store.ts
+++ b/src/backend/channel-store.ts
@@ -99,7 +99,13 @@ export class ChannelStore {
     );
   }
 
-  list(memberId: string): ChannelSummary[] {
+  /**
+   * @param signedOutMessagesAreTheirs true only when `memberId` is the host user of this computer.
+   * Their messages from before they signed in carry `SIGNED_OUT_CHANNEL_MEMBER_ID`, so those
+   * messages are their own and are never unread for them. A remote member is a different person:
+   * the host's signed-out messages are unread for them until they read them.
+   */
+  list(memberId: string, signedOutMessagesAreTheirs = false): ChannelSummary[] {
     return databaseRows(
       this.database.connection.prepare("SELECT channel_json FROM projection_channels ORDER BY rowid").all(),
     ).map((row) => {
@@ -110,7 +116,7 @@ export class ChannelStore {
       const latest = this.messages(channel.id, Number.MAX_SAFE_INTEGER, 1).at(-1);
       return {
         ...channel,
-        unreadCount: this.#unreadCount(channel.id, memberId),
+        unreadCount: this.#unreadCount(channel.id, memberId, signedOutMessagesAreTheirs),
         activeTasks: this.#countTasksInState(channel.id, "running"),
         lastMessage: latest
           ? { authorName: latest.author.name, text: previewText(latest), at: latest.message.createdAt }
@@ -478,7 +484,9 @@ export class ChannelStore {
       const channelId = requiredStringColumn(row, "channel_id");
       if (this.#hasReadCursor(channelId, targetMemberId)) continue;
       const throughSequence = requiredNumberColumn(row, "through_sequence");
-      this.markRead(channelId, targetMemberId, throughSequence, `adopt:${sourceMemberId}`);
+      // The command key holds the target member and this operation id, not the channel. Without the
+      // channel here, every channel after the first would answer with the first channel's receipt.
+      this.markRead(channelId, targetMemberId, throughSequence, `adopt:${sourceMemberId}:${channelId}`);
     }
   }
 
@@ -603,7 +611,7 @@ export class ChannelStore {
   }
 
   /** The unread messages of one member, over the sequence index. A member's own message is read. */
-  #unreadCount(channelId: string, memberId: string): number {
+  #unreadCount(channelId: string, memberId: string, signedOutMessagesAreTheirs: boolean): number {
     const row = databaseRow(
       this.database.connection
         .prepare(
@@ -612,7 +620,12 @@ export class ChannelStore {
              AND json_extract(message_json, '$.author.id') IS NOT ?
              AND json_extract(message_json, '$.author.id') IS NOT ?`,
         )
-        .get(channelId, this.readSequence(channelId, memberId), memberId, SIGNED_OUT_CHANNEL_MEMBER_ID),
+        .get(
+          channelId,
+          this.readSequence(channelId, memberId),
+          memberId,
+          signedOutMessagesAreTheirs ? SIGNED_OUT_CHANNEL_MEMBER_ID : memberId,
+        ),
     );
     return row ? requiredNumberColumn(row, "count") : 0;
   }

--- a/src/main/ipc/agent-handlers.ts
+++ b/src/main/ipc/agent-handlers.ts
@@ -162,7 +162,9 @@ export function agentIpcHandlers({
       }),
       listChannels: payloadHandler(parseAgentRequest, (scoped) =>
         routeToServer(scoped.serverId, {
-          local: () => service.channels.store.list(host.channelActor().id),
+          // The reader here is the host user of this computer, so messages they wrote before they
+          // signed in are their own.
+          local: () => service.channels.store.list(host.channelActor().id, true),
           remote: (serverId) => remoteServers.request(serverId, CHANNEL_ROUTES.list, decodeChannelSummaries),
         }),
       ),
@@ -485,10 +487,7 @@ async function duplicateAgentLocally(
 ): Promise<DuplicateAgentResult> {
   const agent = await service.duplicateAgent(agentId);
   try {
-    const layout = await sidebarLayout.placeDuplicateAfter(agentId, agent.id, [
-      ...service.listAgents().map((candidate) => candidate.id),
-      agent.id,
-    ]);
+    const layout = await sidebarLayout.placeDuplicateAfter(agentId, agent.id, [...service.sidebarChatIds(), agent.id]);
     return service.commitAgentDuplication(agent.id, layout);
   } catch (error) {
     const rollbackResults = await Promise.allSettled([

--- a/src/main/team-api-server.agents.test.ts
+++ b/src/main/team-api-server.agents.test.ts
@@ -169,8 +169,13 @@ describe("TeamApiServer agents", () => {
     const deleteAgent = vi.fn(async (agentId: string) => {
       agents = agents.filter((agent) => agent.id !== agentId);
     });
+    // A channel the user filed in the sidebar. The layout prunes every id outside the set it is
+    // given, so duplication must offer the channels as well as the agents.
+    const channelId = "channel-launch-room";
+    const chatIds = () => new Set([...agents.map((agent) => agent.id), channelId]);
     const agentService = createAgents({
       listAgents: () => agents,
+      sidebarChatIds: chatIds,
       committedAgentDuplication: () => committedDuplicate,
       duplicateAgent,
       commitAgentDuplication,
@@ -180,6 +185,8 @@ describe("TeamApiServer agents", () => {
       { type: "create", name: "Core", agentId: source.id },
       new Set([source.id]),
     );
+    const sectionId = section.sections[0]?.id ?? null;
+    await sidebarLayout.mutate({ type: "move-agent", agentId: channelId, sectionId, beforeAgentId: null }, chatIds());
     const { base } = await start({
       agents: agentService,
       sidebarLayout,
@@ -202,17 +209,24 @@ describe("TeamApiServer agents", () => {
     await expect(response.json()).resolves.toMatchObject({
       bot: { id: duplicate.id, threadId: null },
       layout: {
-        agentAssignments: { [source.id]: section.sections[0]?.id, [duplicate.id]: section.sections[0]?.id },
-        agentOrder: [source.id, duplicate.id],
+        agentAssignments: {
+          [source.id]: sectionId,
+          [duplicate.id]: sectionId,
+          // The channel keeps the section the user filed it in.
+          [channelId]: sectionId,
+        },
       },
     });
+    const placed = sidebarLayout.getSnapshot().agentOrder;
+    expect(placed.indexOf(duplicate.id)).toBe(placed.indexOf(source.id) + 1);
+    expect(placed).toContain(channelId);
     expect(duplicateAgent).toHaveBeenCalledWith(source.id, "7674b664-cd72-4cf9-88ed-6f2e189d551f");
-    expect(commitAgentDuplication).toHaveBeenCalledWith(duplicate.id, expect.objectContaining({ revision: 2 }));
+    expect(commitAgentDuplication).toHaveBeenCalledWith(duplicate.id, expect.objectContaining({ revision: 3 }));
     expect(deleteAgent).not.toHaveBeenCalled();
 
     const currentLayout = await sidebarLayout.mutate(
       { type: "create", name: "Later", agentId: duplicate.id },
-      new Set([source.id, duplicate.id]),
+      new Set([...chatIds(), duplicate.id]),
     );
 
     const retry = await fetch(`${base}/v1/agents/${source.id}/duplicate`, {

--- a/src/main/team-api-server.ts
+++ b/src/main/team-api-server.ts
@@ -990,7 +990,7 @@ export class TeamApiServer {
     const agent = await this.#options.agents.duplicateAgent(sourceAgentId, operationId);
     try {
       const layout = await this.#options.sidebarLayout.placeDuplicateAfter(sourceAgentId, agent.id, [
-        ...this.#options.agents.listAgents().map((candidate) => candidate.id),
+        ...this.#options.agents.sidebarChatIds(),
         agent.id,
       ]);
       return await this.#options.agents.commitAgentDuplication(agent.id, layout);

--- a/src/renderer/src/features/channels/ChannelConversation.tsx
+++ b/src/renderer/src/features/channels/ChannelConversation.tsx
@@ -1,6 +1,6 @@
 import { expandAttachmentReferences } from "@openbot/contracts/attachment-references";
 import { chatTagReferences, expandChatTagReferences } from "@openbot/contracts/chat-tag-references";
-import { type DraftAttachment, SIGNED_OUT_CHANNEL_MEMBER_ID } from "@openbot/contracts/ipc";
+import type { DraftAttachment } from "@openbot/contracts/ipc";
 import { createEffect, createMemo, createSignal, createStore, For, onCleanup, Show, untrack } from "solid-js";
 import { QuestionPromptBubble } from "../../components/QuestionPromptBubble";
 import {
@@ -33,11 +33,12 @@ import {
   UnreadMessagesDivider,
   unreadMessagesDividerIsVisible,
 } from "../conversation/UnreadMessages";
+import { useServers } from "../servers/servers-context";
 import { usePresence } from "../team/team-context";
 import { ChannelActivityIndicator, type ChannelWorker } from "./ChannelActivityIndicator";
 import { ChannelAvatar } from "./ChannelAvatar";
 import { ChannelEditor } from "./ChannelEditor";
-import { channelTimelineEntries, firstUnreadChannelMessageId } from "./channel-timeline";
+import { channelTimelineEntries, firstUnreadChannelMessageId, isOwnChannelAuthor } from "./channel-timeline";
 import { useChannels } from "./channels-context";
 
 export function ChannelConversation() {
@@ -45,15 +46,14 @@ export function ChannelConversation() {
   const { selectAgent } = useNavigation();
   const { centralAuth } = useAuth();
   const { currentTeamMember } = usePresence();
+  const { activeServer } = useServers();
   const isOwnMessage = (authorId: string) => {
     const auth = centralAuth();
-    // A message written before the reader signed in carries the signed-out id. It is the same
-    // person, so it stays their own message, the way its read cursor stays their read cursor.
-    return (
-      authorId === SIGNED_OUT_CHANNEL_MEMBER_ID ||
-      authorId === currentTeamMember()?.id ||
-      (auth.status === "signed_in" && authorId === `local-user:${auth.user.id}`)
-    );
+    return isOwnChannelAuthor(authorId, {
+      memberId: currentTeamMember()?.id ?? null,
+      accountUserId: auth.status === "signed_in" ? auth.user.id : null,
+      onOwnComputer: activeServer()?.kind === "local",
+    });
   };
   /**
    * Memories and routines live here rather than in `ChannelEditor`, because the routines view

--- a/src/renderer/src/features/channels/channel-timeline.test.ts
+++ b/src/renderer/src/features/channels/channel-timeline.test.ts
@@ -1,7 +1,7 @@
 import type { ChannelMessage, ChannelPage } from "@openbot/contracts/ipc";
 import { describe, expect, it } from "vitest";
 import type { AgentProfile } from "../../data";
-import { channelTimelineEntries, firstUnreadChannelMessageId } from "./channel-timeline";
+import { channelTimelineEntries, firstUnreadChannelMessageId, isOwnChannelAuthor } from "./channel-timeline";
 
 const now = new Date(2026, 8, 9, 14, 0);
 const options = { now, locale: "en-US" };
@@ -275,5 +275,26 @@ describe("channelTimelineEntries", () => {
       options,
     );
     expect(entries.map((entry) => entry.id)).toEqual(["m2"]);
+  });
+});
+
+describe("isOwnChannelAuthor", () => {
+  const host = { memberId: "member-9", accountUserId: "user-1", onOwnComputer: true };
+
+  it("keeps a message the host wrote before signing in their own", () => {
+    expect(isOwnChannelAuthor("local", host)).toBe(true);
+    expect(isOwnChannelAuthor("local", { memberId: null, accountUserId: null, onOwnComputer: true })).toBe(true);
+  });
+
+  it("reads the signed-out author as the host, not as the reader, on a server they joined", () => {
+    // The reader here is a member of another person's server. That person wrote the message.
+    expect(isOwnChannelAuthor("local", { ...host, onOwnComputer: false })).toBe(false);
+  });
+
+  it("answers for the reader's own member and account ids", () => {
+    expect(isOwnChannelAuthor("member-9", host)).toBe(true);
+    expect(isOwnChannelAuthor("local-user:user-1", host)).toBe(true);
+    expect(isOwnChannelAuthor("member-2", host)).toBe(false);
+    expect(isOwnChannelAuthor("local-user:user-2", host)).toBe(false);
   });
 });

--- a/src/renderer/src/features/channels/channel-timeline.ts
+++ b/src/renderer/src/features/channels/channel-timeline.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ChannelMessage, ChannelPage } from "@openbot/contracts/ipc";
+import { SIGNED_OUT_CHANNEL_MEMBER_ID } from "@openbot/contracts/ipc";
 import type { AgentMessage, AgentProfile } from "../../data";
 import type { ChatMessageAuthor } from "../conversation/ChatMessageRow";
 import { type DayMarkerOptions, dayMarkerLabel } from "../conversation/chat-day-markers";
@@ -55,6 +56,30 @@ function toAgentMessage(entry: ChannelMessage, own: boolean, options: DayMarkerO
     questionPrompt: message.questionPrompt,
     turnId: message.turnId,
   };
+}
+
+/** Who the reader is, as the three ids a channel message can carry for them. */
+export interface ChannelReaderIdentity {
+  /** The reader's id in the team roster, or null while the roster holds none for them. */
+  memberId: string | null;
+  /** The account the reader signed in to, or null while they are signed out. */
+  accountUserId: string | null;
+  /** True while the reader reads the channels of their own computer, not those of a server they joined. */
+  onOwnComputer: boolean;
+}
+
+/**
+ * Does this author id stand for the reader?
+ *
+ * A message the host user wrote before they signed in carries the signed-out id. It is the same
+ * person, so it stays their own message, the way its read cursor stays their read cursor. That
+ * holds on their own computer alone: on a server they joined, the signed-out id is the host, who is
+ * another person.
+ */
+export function isOwnChannelAuthor(authorId: string, reader: ChannelReaderIdentity): boolean {
+  if (authorId === SIGNED_OUT_CHANNEL_MEMBER_ID) return reader.onOwnComputer;
+  if (reader.memberId !== null && authorId === reader.memberId) return true;
+  return reader.accountUserId !== null && authorId === `local-user:${reader.accountUserId}`;
 }
 
 /**


### PR DESCRIPTION
## Three review fixes for the shared channels change

Follow-up to #322, merged into `main` as `6ec2d702`. Each item is a P2 finding from the review of
that PR, so each one fixes code that is already on `main`.

### Include the channel id in read-adoption command keys

`ChannelStore.adoptReads` reused one operation id for every channel, and a `markRead` command key
holds the target member and that id but not the channel. `DatabaseCore.dispatch` therefore answered
the second channel with the first channel's receipt and never moved its cursor, so a reader that
signed in after reading several channels saw the read ones as unread. The operation id now carries
the channel id.

### Restrict signed-out authorship to the host user

The signed-out id belongs to the host user of this computer alone. `ChannelStore.list` now takes
`signedOutMessagesAreTheirs`: the local IPC reader passes `true`, and the Team API route, whose
reader is a remote member, does not. So a remote member no longer has the host's messages held out
of their unread count. The renderer answers the same question through the new pure
`isOwnChannelAuthor`, which reads the signed-out id as the reader only on their own computer, so a
remote member no longer sees host-written messages labelled as their own.

### Preserve channel order when duplicating an agent

Both callers of `placeDuplicateAfter` passed agent ids alone. `normalizedAgentOrder` drops every id
outside that set, so duplicating an agent removed the channels from the saved sidebar order. Both
callers now offer `sidebarChatIds()`, which is what the sibling sidebar `mutate` path already did.

## Tests

The renderer predicate moved into `channel-timeline.ts` as pure logic instead of a DOM test: an own
row renders as `{ kind: "you", name: "You" }`, and the stored author name of a signed-out message is
also `"You"`, so a rendered assertion cannot separate the two.

- `src/backend/channel-service.test.ts` (57): a two-channel adoption carries both cursors; a host
  message written before sign-in stays out of the host's unread count and stays in a remote
  member's.
- `src/main/team-api-server.agents.test.ts` (8): a duplicated agent keeps its place and the channel
  keeps its section and its place in the sidebar order.
- `src/renderer/src/features/channels/channel-timeline.test.ts` (15): `isOwnChannelAuthor` for the
  signed-out id on the reader's own computer and on a server they joined, and for member and account
  ids.
- `src/renderer/src/App.channels.test.tsx` (26) and `scripts/seed-dev-state.test.ts` (6) pass
  unchanged.

Full lint, type checking, and the UI check pass. Lint reports 63 warnings, none in the changed
files: 62 in `apps/mobile/**` and one in `src/backend/browser-host.test.ts`, all of which arrived
with `main`. No suppressions were added. Full suites and the Storybook build remain with CI.

## Break checks

Each was confirmed to fail for its intended reason, then the working code was restored.

| Break | Failure |
| --- | --- |
| Adoption key without the channel id | `expected [ 0, 1 ] to deeply equal [ 0, 0 ]` |
| Unread count always excluding the signed-out author | `expected 0 to be 1` |
| Signed-out author own on every server | `expected true to be false` |
| Duplication offering agent ids alone | `expected [ 'chief', 'chief-copy' ] to include 'channel-launch-room'` |

## Surfaces

Backend persistence (`ChannelStore`), the main process (IPC agent handlers, Team API server), and the
desktop renderer. No schema change, no IPC contract change, and no change to a released Team API
adapter's meaning. These fixes change no pixels: they correct unread counts, read-cursor transfer,
and the saved sidebar order, so no new screenshots are included.

Model and harness: Claude Opus 5 in Claude Code, in an isolated worktree of this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
