### PR TITLE
style: unify agent interaction cards

### DIFF
--- a/src/renderer/src/App.queue.test.tsx
+++ b/src/renderer/src/App.queue.test.tsx
@@ -1077,10 +1077,10 @@ describe("OpenBot connected desktop shell", () => {
       },
     });
 
-    expect(await screen.findByText("Run this command?")).toBeInTheDocument();
+    expect(await screen.findByText("Run a command")).toBeInTheDocument();
     expect(screen.getByText("npm test -- --runInBand")).toBeInTheDocument();
     expect(screen.getByText("Run the verification suite.")).toBeInTheDocument();
-    await fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Allow" }));
     expect(screen.getByRole("button", { name: "Sending…" })).toBeDisabled();
     expect(window.openbot.agent.respondToApproval).toHaveBeenCalledWith({
       requestId: "approval-1",
@@ -1088,7 +1088,7 @@ describe("OpenBot connected desktop shell", () => {
     });
 
     resolveApproval?.();
-    await waitFor(() => expect(screen.queryByText("Run this command?")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText("Run a command")).not.toBeInTheDocument());
   });
 
   // A queue belongs to one server, and a server switch now discards that

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1106,9 +1106,9 @@ describe("OpenBot connected desktop shell", () => {
       },
     });
 
-    expect(await screen.findByText("Grant permissions?")).toBeInTheDocument();
+    expect(await screen.findByText("Grant permissions")).toBeInTheDocument();
     expect(screen.getByText("Network access")).toBeInTheDocument();
-    await fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Deny" }));
     await waitFor(() =>
       expect(window.openbot.agent.respondToApproval).toHaveBeenCalledWith({
         requestId: 14,

--- a/src/renderer/src/components/QuestionPromptBubble.tsx
+++ b/src/renderer/src/components/QuestionPromptBubble.tsx
@@ -2,6 +2,7 @@ import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type { AgentPromptQuestion, AgentPromptResolution } from "@openbot/contracts/ipc";
 import { createEffect, createSignal, For, onCleanup, Show, untrack } from "solid-js";
 import {
+  Badge,
   Bubble,
   BubbleContent,
   ChevronLeft,
@@ -14,6 +15,7 @@ import {
   ItemMedia,
   ItemTitle,
   Kbd,
+  LoaderCircle,
   PencilLine,
   Questionnaire,
   Spinner,
@@ -391,8 +393,12 @@ export function QuestionPromptBubble(props: QuestionPromptBubbleProps) {
             onKeyDown={(event) => handleShortcut(event, current(), pageProps.index)}
             onSubmit={(event) => event.preventDefault()}
           >
-            <header class="question-prompt-header">
+            <header class="question-prompt-header conversation-interaction-header">
               <Questionnaire.Title>{current().question}</Questionnaire.Title>
+              <Badge variant="warning-light" class="conversation-interaction-status">
+                <LoaderCircle data-icon="inline-start" aria-hidden="true" />
+                Input required
+              </Badge>
             </header>
             <Questionnaire.Choices role="radiogroup" aria-label={current().question}>
               <ItemGroup class="question-prompt-options">
@@ -462,7 +468,7 @@ export function QuestionPromptBubble(props: QuestionPromptBubbleProps) {
 
   return (
     <Bubble variant="muted" class="question-prompt-bubble" data-state={busy() ? "pending" : "idle"}>
-      <BubbleContent>
+      <BubbleContent class="conversation-interaction-card">
         <Show
           when={initialContent()}
           fallback={
@@ -473,9 +479,6 @@ export function QuestionPromptBubble(props: QuestionPromptBubbleProps) {
           }
         >
           <div class="question-prompt-layout">
-            <Show when={slotPages()[activeSlot()]?.kind === "question"}>
-              <PromptNavigation />
-            </Show>
             <div
               ref={stage}
               class="question-prompt-stage t-page-slide"
@@ -516,6 +519,9 @@ export function QuestionPromptBubble(props: QuestionPromptBubbleProps) {
                 )}
               </For>
             </div>
+            <Show when={slotPages()[activeSlot()]?.kind === "question"}>
+              <PromptNavigation />
+            </Show>
           </div>
         </Show>
       </BubbleContent>

--- a/src/renderer/src/features/account/auth.css
+++ b/src/renderer/src/features/account/auth.css
@@ -1356,8 +1356,6 @@ body,
   color: var(--openbot-text-primary);
 }
 
-.choice-options,
-.choice-option,
 .provider-picker-option,
 .provider-model-option {
   border-color: var(--openbot-border);
@@ -1365,8 +1363,6 @@ body,
   color: var(--openbot-text-secondary);
 }
 
-.choice-option:hover,
-.choice-option-selected,
 .provider-picker-option:hover:not(.provider-picker-option-unavailable),
 .provider-picker-option:focus-within,
 .provider-model-option:hover,

--- a/src/renderer/src/features/conversation/ConversationPrompts.test.tsx
+++ b/src/renderer/src/features/conversation/ConversationPrompts.test.tsx
@@ -1,6 +1,7 @@
+import type { AgentApproval } from "@openbot/contracts/ipc";
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { describe, expect, it, vi } from "vitest";
-import { ChoiceCard } from "./ConversationPrompts";
+import { ApprovalCard, BrowserTakeoverCard, ChoiceCard } from "./ConversationPrompts";
 
 describe("ChoiceCard", () => {
   it("uses radio semantics and submits a selected predefined answer", async () => {
@@ -33,5 +34,63 @@ describe("ChoiceCard", () => {
     await fireEvent.input(input, { target: { value: "Build a prototype" } });
     await fireEvent.keyDown(input, { key: "Enter" });
     expect(onSubmit).toHaveBeenCalledWith("Build a prototype");
+  });
+});
+
+const approval: AgentApproval = {
+  requestId: "approval-test",
+  agentId: "agent-test",
+  threadId: "thread-test",
+  turnId: "turn-test",
+  kind: "command",
+  command: "bun run lint",
+  cwd: null,
+  reason: null,
+  grantRoot: null,
+  permissions: null,
+};
+
+describe("ApprovalCard", () => {
+  it.each(["Allow", "Deny"])("sends %s once and permits retry when the response fails", async (action) => {
+    const response = Promise.withResolvers<boolean>();
+    const send = vi.fn(() => response.promise);
+    const other = async () => false;
+    render(() => (
+      <ApprovalCard
+        approval={approval}
+        onApprove={action === "Allow" ? send : other}
+        onReject={action === "Deny" ? send : other}
+      />
+    ));
+    const button = screen.getByRole("button", { name: action });
+    await fireEvent.click(button);
+    await fireEvent.click(button);
+    expect(send).toHaveBeenCalledTimes(1);
+    response.resolve(false);
+    await vi.waitFor(() => expect(button).toBeEnabled());
+  });
+});
+
+describe("BrowserTakeoverCard", () => {
+  it.each(["I’m done", "Cancel"])("sends %s once and permits retry when the response fails", async (action) => {
+    const response = Promise.withResolvers<boolean>();
+    const send = vi.fn(() => response.promise);
+    const other = async () => false;
+    render(() => (
+      <BrowserTakeoverCard
+        agentName="Rico"
+        tab={undefined}
+        preview={null}
+        previewStatus="failed"
+        onComplete={action === "I’m done" ? send : other}
+        onCancel={action === "Cancel" ? send : other}
+      />
+    ));
+    const button = screen.getByRole("button", { name: action });
+    await fireEvent.click(button);
+    await fireEvent.click(button);
+    expect(send).toHaveBeenCalledTimes(1);
+    response.resolve(false);
+    await vi.waitFor(() => expect(button).toBeEnabled());
   });
 });

--- a/src/renderer/src/features/conversation/ConversationPrompts.tsx
+++ b/src/renderer/src/features/conversation/ConversationPrompts.tsx
@@ -20,13 +20,15 @@ export function ChoiceCard(props: {
     if (value && !props.pending) await props.onSubmit(value);
   };
   return (
-    <div class="choice-card">
-      <div class="choice-card-heading">
-        <div>
-          <strong>{props.title}</strong>
-          <span>{props.hint ?? "Pick whatever fits, or type your own."}</span>
-        </div>
-      </div>
+    <div class="choice-card conversation-interaction-card" aria-busy={props.pending ? "true" : undefined}>
+      <header class="conversation-interaction-header">
+        <strong>{props.title}</strong>
+        <Badge variant="warning-light" class="conversation-interaction-status" role="status">
+          <LoaderCircle data-icon="inline-start" aria-hidden="true" />
+          {props.pending ? "Sending…" : "Input required"}
+        </Badge>
+      </header>
+      <p class="choice-card-hint">{props.hint ?? "Pick whatever fits, or type your own."}</p>
       <RadioGroup.Root
         class="choice-options"
         aria-label={props.title}

--- a/src/renderer/src/features/conversation/ConversationPrompts.tsx
+++ b/src/renderer/src/features/conversation/ConversationPrompts.tsx
@@ -1,7 +1,7 @@
 import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type { AgentApproval, BrowserPreview, BrowserTab } from "@openbot/contracts/ipc";
 import { createMemo, createSignal, For, Show } from "solid-js";
-import { Badge, Button, Check, Input, Monitor, RadioGroup, Skeleton, TriangleAlert, X } from "../../components/ui";
+import { Badge, Button, Check, Input, LoaderCircle, Monitor, RadioGroup, Skeleton, X } from "../../components/ui";
 
 export function ChoiceCard(props: {
   title: string;
@@ -97,15 +97,19 @@ export function ApprovalCard(props: {
   };
 
   return (
-    <section class="approval-card approval-card-approval" aria-label="Agent approval">
-      <header class="approval-card-header">
-        <span class="approval-card-icon" data-kind="approval">
-          <ApprovalIcon />
-        </span>
-        <div>
-          <strong>{approvalTitle(props.approval)}</strong>
-        </div>
+    <section
+      class="approval-card conversation-interaction-card"
+      aria-label="Agent approval"
+      aria-busy={submitting() ? "true" : undefined}
+    >
+      <header class="approval-card-header conversation-interaction-header">
+        <strong>{approvalTitle(props.approval)}</strong>
+        <Badge variant="warning-light" class="conversation-interaction-status" role="status">
+          <LoaderCircle data-icon="inline-start" aria-hidden="true" />
+          Approval
+        </Badge>
       </header>
+      <Show when={props.approval.reason}>{(reason) => <p class="approval-reason">{reason()}</p>}</Show>
       <div class="approval-card-content">
         <Show when={props.approval.command}>
           {(command) => (
@@ -126,30 +130,26 @@ export function ApprovalCard(props: {
         <Show when={props.approval.kind === "permissions"}>
           <PermissionDetails permissions={props.approval.permissions} />
         </Show>
-        <Show when={props.approval.reason}>{(reason) => <p class="approval-reason">{reason()}</p>}</Show>
       </div>
-      <footer class="approval-card-footer approval-card-footer-end">
-        <div class="approval-card-actions">
-          <Button
-            variant="ghost"
-            type="button"
-            class="approval-button approval-button-ghost"
-            disabled={submitting()}
-            onClick={() => void submit("decline")}
-          >
-            {submitting() ? "Waiting…" : "Reject"}
-          </Button>
-          <Button
-            variant="default"
-            type="button"
-            class="approval-button approval-button-primary"
-            disabled={submitting()}
-            onClick={() => void submit("accept")}
-          >
-            {submitting() ? "Sending…" : "Approve"}
-            <ReturnIcon />
-          </Button>
-        </div>
+      <footer class="approval-card-footer">
+        <Button
+          variant="default"
+          type="button"
+          class="approval-button"
+          disabled={submitting()}
+          onClick={() => void submit("accept")}
+        >
+          {submitting() ? "Sending…" : "Allow"}
+        </Button>
+        <Button
+          variant="secondary"
+          type="button"
+          class="approval-button"
+          disabled={submitting()}
+          onClick={() => void submit("decline")}
+        >
+          {submitting() ? "Waiting…" : "Deny"}
+        </Button>
       </footer>
     </section>
   );
@@ -179,31 +179,12 @@ export function BrowserTakeoverCard(props: {
 
   return (
     <section
-      class="browser-takeover-card"
+      class="browser-takeover-card conversation-interaction-card"
       data-decision={props.decision ?? undefined}
       aria-label={accessibleLabel()}
       aria-busy={submitting() ? "true" : undefined}
     >
-      <header class="browser-takeover-header">
-        <span>Browser</span>
-        <Show
-          when={!props.decision}
-          fallback={
-            <Badge variant={completed() ? "success-light" : "secondary"} role="status">
-              <Show when={completed()} fallback={<X data-icon="inline-start" aria-hidden="true" />}>
-                <Check data-icon="inline-start" aria-hidden="true" />
-              </Show>
-              {completed() ? "Done" : "Cancelled"}
-            </Badge>
-          }
-        >
-          <Badge variant="warning-light" role="status">
-            <TriangleAlert data-icon="inline-start" aria-hidden="true" />
-            Action required
-          </Badge>
-        </Show>
-      </header>
-      <div class="browser-takeover-copy">
+      <header class="browser-takeover-header conversation-interaction-header">
         <h2>
           {completed()
             ? `Step completed on ${pageDetails().host}`
@@ -211,6 +192,28 @@ export function BrowserTakeoverCard(props: {
               ? `Step cancelled on ${pageDetails().host}`
               : `Complete the step on ${pageDetails().host}`}
         </h2>
+        <Show
+          when={!props.decision}
+          fallback={
+            <Badge
+              variant={completed() ? "success-light" : "secondary"}
+              class="conversation-interaction-status"
+              role="status"
+            >
+              <Show when={completed()} fallback={<X data-icon="inline-start" aria-hidden="true" />}>
+                <Check data-icon="inline-start" aria-hidden="true" />
+              </Show>
+              {completed() ? "Done" : "Cancelled"}
+            </Badge>
+          }
+        >
+          <Badge variant="warning-light" class="conversation-interaction-status" role="status">
+            <LoaderCircle data-icon="inline-start" aria-hidden="true" />
+            Action required
+          </Badge>
+        </Show>
+      </header>
+      <div class="browser-takeover-copy">
         <p>
           {completed()
             ? `${props.agentName} is continuing.`
@@ -259,18 +262,6 @@ export function BrowserTakeoverCard(props: {
       <Show when={!props.decision}>
         <footer class="browser-takeover-actions">
           <Button
-            variant="ghost"
-            size="sm"
-            type="button"
-            class="approval-button"
-            loading={submitting() === "cancel"}
-            loadingLabel="Cancelling…"
-            disabled={Boolean(submitting())}
-            onClick={() => void submit("cancel")}
-          >
-            Cancel
-          </Button>
-          <Button
             variant="default"
             size="sm"
             type="button"
@@ -281,6 +272,18 @@ export function BrowserTakeoverCard(props: {
             onClick={() => void submit("complete")}
           >
             I’m done
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            type="button"
+            class="approval-button"
+            loading={submitting() === "cancel"}
+            loadingLabel="Cancelling…"
+            disabled={Boolean(submitting())}
+            onClick={() => void submit("cancel")}
+          >
+            Cancel
           </Button>
         </footer>
       </Show>
@@ -299,9 +302,9 @@ function browserPageDetails(tab: BrowserTab | undefined): { title: string; host:
 }
 
 function approvalTitle(approval: AgentApproval | undefined) {
-  if (approval?.kind === "command") return "Run this command?";
-  if (approval?.kind === "file-change") return "Approve file changes?";
-  return "Grant permissions?";
+  if (approval?.kind === "command") return "Run a command";
+  if (approval?.kind === "file-change") return "Change files";
+  return "Grant permissions";
 }
 
 function PermissionDetails(props: { permissions: AgentApproval["permissions"] }) {
@@ -318,22 +321,5 @@ function PermissionDetails(props: { permissions: AgentApproval["permissions"] })
     <section class="approval-permissions" aria-label="Requested permissions">
       <For each={details()}>{(detail) => <span>{detail}</span>}</For>
     </section>
-  );
-}
-
-function ApprovalIcon() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 20 20">
-      <path d="M10 2.5 16.2 5v4.3c0 3.8-2.4 6.5-6.2 8.2-3.8-1.7-6.2-4.4-6.2-8.2V5L10 2.5Z" />
-      <path d="m7.3 10 1.8 1.8 3.7-4" />
-    </svg>
-  );
-}
-
-function ReturnIcon() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 16 16">
-      <path d="M4 4.5h5.5a2.5 2.5 0 0 1 0 5H6.8M6.8 7.5l-2.8 2 2.8 2" />
-    </svg>
   );
 }

--- a/src/renderer/src/features/conversation/conversation.css
+++ b/src/renderer/src/features/conversation/conversation.css
@@ -6808,64 +6808,66 @@ button.chat-action-target:active,
   background: var(--openbot-border);
 }
 
-.browser-takeover-card {
-  display: flex;
-  width: min(460px, 100%);
+.conversation-interaction-card {
   box-sizing: border-box;
-  margin: var(--openbot-space-3) 0 20px;
-  flex-direction: column;
-  gap: var(--openbot-space-3);
-  border: 0;
-  border-radius: var(--openbot-radius-bubble);
-  background: var(--openbot-bg-surface);
-  box-shadow:
-    0 0 0 0.5px var(--openbot-border),
-    0 1px 2px var(--openbot-bg-overlay),
-    0 2px 4px var(--openbot-shadow-popover-ambient);
+  min-width: 0;
+  border: 1px solid var(--openbot-border);
+  border-radius: var(--openbot-radius-card);
+  background: var(--openbot-bg-canvas);
   color: var(--openbot-text-primary);
-  padding: var(--openbot-space-3);
-  animation: browser-takeover-in var(--openbot-duration-slow) var(--openbot-ease-out) both;
+  padding: var(--openbot-space-4);
 }
 
-.browser-takeover-header {
+.conversation-interaction-header {
   display: flex;
-  height: var(--openbot-control-xs);
   min-width: 0;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: var(--openbot-space-3);
 }
 
-.browser-takeover-header > span {
-  overflow: hidden;
-  font-size: var(--openbot-text-sm);
+.conversation-interaction-header > :is(strong, h2) {
+  min-width: 0;
+  margin: 0;
+  color: var(--openbot-text-secondary);
+  font-size: var(--openbot-text-lg);
   font-weight: var(--openbot-weight-medium);
-  line-height: var(--openbot-leading-sm);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: var(--openbot-leading-lg);
+  overflow-wrap: anywhere;
 }
 
-.browser-takeover-header [data-slot="badge"] svg {
-  width: var(--openbot-icon-xs);
-  height: var(--openbot-icon-xs);
+.conversation-interaction-status[data-slot="badge"] {
+  flex: 0 0 auto;
+  gap: var(--openbot-space-1-5);
+  border-radius: var(--openbot-radius-md);
+  font-size: var(--openbot-text-sm);
+  font-weight: var(--openbot-weight-medium);
+}
+
+.conversation-interaction-status svg {
+  width: var(--openbot-icon-sm);
+  height: var(--openbot-icon-sm);
   flex: 0 0 auto;
   stroke-width: var(--openbot-icon-stroke);
 }
 
+.browser-takeover-card {
+  display: flex;
+  width: min(540px, 100%);
+  margin: var(--openbot-space-3) 0 var(--openbot-space-6);
+  flex-direction: column;
+  gap: var(--openbot-space-4);
+  animation: browser-takeover-in var(--openbot-duration-slow) var(--openbot-ease-out) both;
+}
+
 .browser-takeover-copy {
+  margin-top: calc(-1 * var(--openbot-space-2));
   display: grid;
   gap: var(--openbot-space-1);
 }
 
-.browser-takeover-copy h2,
 .browser-takeover-copy p {
   margin: 0;
-}
-
-.browser-takeover-copy h2 {
-  font-size: var(--openbot-text-lg);
-  font-weight: var(--openbot-weight-medium);
-  line-height: var(--openbot-leading-lg);
 }
 
 .browser-takeover-copy p {
@@ -6983,8 +6985,8 @@ button.chat-action-target:active,
 .browser-takeover-actions {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: var(--openbot-space-1-5);
+  justify-content: space-between;
+  gap: var(--openbot-space-2);
 }
 
 .browser-takeover-actions .ui-button {
@@ -7015,8 +7017,7 @@ button.chat-action-target:active,
 .question-prompt-bubble > .ui-bubble-content {
   width: 100%;
   border-color: var(--openbot-border);
-  background: var(--openbot-bg-surface);
-  padding: var(--openbot-space-4);
+  background: var(--openbot-bg-canvas);
 }
 
 .question-prompt-bubble:focus-within > .ui-bubble-content {
@@ -7094,8 +7095,7 @@ button.chat-action-target:active,
 
 .question-prompt-header {
   min-width: 0;
-  min-height: 22px;
-  padding-right: 136px;
+  min-height: var(--openbot-control-xs);
 }
 
 .question-prompt-header h2 {
@@ -7120,11 +7120,9 @@ button.chat-action-target:active,
 }
 
 .question-prompt-navigation-root.ui-questionnaire {
-  position: absolute;
-  z-index: 2;
-  top: 0;
-  right: 0;
-  display: block;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--openbot-space-4);
 }
 
 .question-prompt-navigation-button.ui-button {
@@ -7195,8 +7193,9 @@ button.chat-action-target:active,
 }
 
 .question-prompt-options.ui-item-group {
-  border-radius: var(--openbot-radius-bubble-inset);
-  background: transparent;
+  border: 1px solid var(--openbot-border);
+  border-radius: var(--openbot-radius-md);
+  background: var(--openbot-bg-surface);
 }
 
 .question-prompt-options > :is(.ui-questionnaire-choice, .question-prompt-custom-row) {
@@ -7435,235 +7434,108 @@ button.chat-action-target:active,
 
 .approval-card {
   display: flex;
-  width: min(460px, 100%);
-  overflow: hidden;
-  margin: 12px 0 20px;
-  border: 0;
-  border-radius: var(--openbot-radius-lg);
-  background: var(--openbot-bg-surface);
-  box-shadow:
-    0 0 0 0.5px var(--openbot-border),
-    0 1px 2px var(--openbot-bg-overlay),
-    0 2px 4px var(--openbot-shadow-popover-ambient);
-  color: var(--openbot-text-primary);
+  width: min(540px, 100%);
+  margin: var(--openbot-space-3) 0 var(--openbot-space-6);
   flex-direction: column;
-  gap: 12px;
-  padding: 12px;
-  animation: approval-card-in var(--openbot-duration-slow) cubic-bezier(0.23, 1, 0.32, 1) both;
-}
-
-.approval-card-header {
-  display: flex;
-  height: 24px;
-  align-items: center;
-  gap: 8px;
-  padding: 0;
-}
-
-.approval-card-header > div {
-  min-width: 0;
-}
-
-.approval-card-header strong,
-.approval-card-header > div > span {
-  display: block;
-}
-
-.approval-card-header strong {
-  font-size: var(--openbot-text-md);
-  font-weight: 500;
-  line-height: 16.875px;
-}
-
-.approval-card-header div > span {
-  margin-top: 1px;
-  color: var(--openbot-text-muted);
-  font-size: var(--openbot-text-sm);
-  line-height: 16px;
-}
-
-.approval-card-icon {
-  display: grid;
-  width: 24px;
-  height: 24px;
-  flex: 0 0 auto;
-  place-items: center;
-  border-radius: var(--openbot-radius-sm);
-  background: var(--openbot-accent-soft);
-  color: var(--openbot-accent-hover);
-}
-
-.approval-card-icon[data-kind="approval"] {
-  background: var(--openbot-success-soft);
-  color: var(--openbot-success);
-}
-
-.approval-card-icon svg {
-  display: block;
-  width: 14px;
-  height: 14px;
-  fill: none;
-  stroke: currentColor;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: var(--openbot-icon-stroke);
+  gap: var(--openbot-space-4);
+  animation: approval-card-in var(--openbot-duration-slow) var(--openbot-ease-out) both;
 }
 
 .approval-card-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 0 0 0 2px;
-}
-
-.approval-card-footer-end {
-  justify-content: flex-end;
-}
-
-.approval-card-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.approval-button svg {
-  width: 14px;
-  height: 14px;
-  fill: none;
-  stroke: currentColor;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: var(--openbot-icon-stroke);
+  gap: var(--openbot-space-2);
 }
 
 .approval-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  border: 0;
   border-radius: var(--openbot-radius-pill);
-  padding: 5px 11px;
-  font-size: var(--openbot-text-sm);
-  font-weight: 520;
-  transition:
-    background-color var(--openbot-duration-hover) ease,
-    border-color var(--openbot-duration-hover) ease,
-    color var(--openbot-duration-hover) ease,
-    transform var(--openbot-duration-fast) ease;
-}
-
-.approval-button:active:not(:disabled) {
-  transform: scale(0.97);
-}
-
-.approval-button-ghost {
-  background: var(--openbot-bg-control);
-  color: var(--openbot-text-secondary);
-}
-
-.approval-button-ghost:hover:not(:disabled) {
-  background: var(--openbot-bg-control-hover);
-  color: var(--openbot-text-primary);
-}
-
-.approval-button-primary {
-  background: var(--openbot-success);
-  color: var(--openbot-text-on-light);
-}
-
-.approval-button-primary:hover:not(:disabled) {
-  background: var(--openbot-success);
-  box-shadow: 0 0 0 3px var(--openbot-success-soft);
-}
-
-.approval-button:disabled {
-  cursor: default;
-  opacity: 0.38;
+  font-size: var(--openbot-text-lg);
+  font-weight: var(--openbot-weight-regular);
 }
 
 .approval-card-content {
   display: grid;
-  gap: 10px;
-  padding: 4px 13px 14px;
+  min-width: 0;
+  gap: var(--openbot-space-3);
 }
 
-.approval-command-block {
+.approval-card-content:empty {
+  display: none;
+}
+
+.approval-command-block,
+.approval-detail-row,
+.approval-permissions {
+  min-width: 0;
   overflow: hidden;
   border: 1px solid var(--openbot-border);
   border-radius: var(--openbot-radius-md);
-  background: var(--openbot-bg-canvas);
+  background: var(--openbot-bg-surface);
 }
 
 .approval-command-block code {
   display: block;
   overflow-x: auto;
-  padding: 10px;
-  color: var(--openbot-text-primary);
-  font-family: "SFMono-Regular", Consolas, monospace;
+  padding: var(--openbot-space-3);
+  color: var(--openbot-text-secondary);
+  font-family: var(--openbot-font-mono);
   font-size: var(--openbot-text-sm);
-  line-height: 17px;
+  line-height: var(--openbot-leading-md);
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .approval-cwd {
-  overflow: hidden;
   border-bottom: 1px solid var(--openbot-border);
-  padding: 7px 10px;
+  padding: var(--openbot-space-2) var(--openbot-space-3);
   color: var(--openbot-text-muted);
-  font-family: "SFMono-Regular", Consolas, monospace;
+  font-family: var(--openbot-font-mono);
   font-size: var(--openbot-text-sm);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .approval-detail-row {
   display: grid;
-  gap: 3px;
-  border: 1px solid var(--openbot-border);
-  border-radius: var(--openbot-radius-md);
-  background: var(--openbot-bg-control);
-  padding: 9px 10px;
+  gap: var(--openbot-space-1);
+  padding: var(--openbot-space-3);
 }
 
 .approval-detail-label {
   color: var(--openbot-text-muted);
   font-size: var(--openbot-text-sm);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
 .approval-detail-row strong {
-  overflow: hidden;
-  color: var(--openbot-text-primary);
-  font-family: "SFMono-Regular", Consolas, monospace;
+  color: var(--openbot-text-secondary);
+  font-family: var(--openbot-font-mono);
   font-size: var(--openbot-text-sm);
-  font-weight: 520;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-weight: var(--openbot-weight-medium);
+  overflow-wrap: anywhere;
 }
 
 .approval-permissions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  display: grid;
+  gap: var(--openbot-space-2);
+  padding: var(--openbot-space-3);
+}
+
+.approval-permissions:empty {
+  display: none;
 }
 
 .approval-permissions span {
-  border: 1px solid var(--openbot-border);
-  border-radius: var(--openbot-radius-pill);
-  background: var(--openbot-bg-control);
-  padding: 5px 8px;
   color: var(--openbot-text-secondary);
   font-size: var(--openbot-text-sm);
+  overflow-wrap: anywhere;
 }
 
 .approval-reason {
-  margin: 0;
+  margin: calc(-1 * var(--openbot-space-2)) 0 0;
   color: var(--openbot-text-muted);
-  font-size: var(--openbot-text-sm);
-  line-height: 16px;
+  font-size: var(--openbot-text-lg);
+  line-height: var(--openbot-leading-lg);
+  overflow-wrap: anywhere;
 }
 
 @keyframes approval-card-in {

--- a/src/renderer/src/features/conversation/conversation.css
+++ b/src/renderer/src/features/conversation/conversation.css
@@ -5288,40 +5288,17 @@ button.chat-action-target:active,
 }
 
 .choice-card {
-  width: 560px;
-  max-width: 100%;
-  overflow: hidden;
-  border: 1px solid var(--openbot-border);
-  border-radius: var(--openbot-radius-lg);
-  background: var(--openbot-border);
-  padding: 10px;
+  display: grid;
+  width: min(540px, 100%);
+  gap: var(--openbot-space-4);
 }
 
-.choice-card-heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 0 2px 9px;
-}
-
-.choice-card-heading strong,
-.choice-card-heading span {
-  display: block;
-}
-
-.choice-card-heading strong {
-  color: var(--openbot-text-primary);
-  font-size: var(--openbot-text-lg);
-  font-weight: 600;
-  line-height: 20px;
-}
-
-.choice-card-heading span {
-  margin-top: 1px;
+.choice-card-hint {
+  margin: calc(-1 * var(--openbot-space-2)) 0 0;
   color: var(--openbot-text-muted);
-  font-size: var(--openbot-text-sm);
-  line-height: 17px;
+  font-size: var(--openbot-text-lg);
+  line-height: var(--openbot-leading-lg);
+  overflow-wrap: anywhere;
 }
 
 .media-close {
@@ -5342,61 +5319,66 @@ button.chat-action-target:active,
 }
 
 .choice-options {
+  min-width: 0;
   overflow: hidden;
-  border: 1px solid var(--openbot-hover);
+  border: 1px solid var(--openbot-border);
   border-radius: var(--openbot-radius-md);
+  background: var(--openbot-bg-surface);
 }
 
 .choice-option {
   display: flex;
   width: 100%;
-  min-height: 35px;
+  min-height: var(--openbot-control-xl);
   align-items: center;
-  gap: 9px;
+  gap: var(--openbot-space-2);
   border: 0;
-  border-bottom: 1px solid var(--openbot-hover);
-  background: var(--openbot-hover);
-  padding: 5px 8px;
+  border-bottom: 1px solid var(--openbot-border);
+  padding: var(--openbot-space-2) var(--openbot-space-3);
   color: var(--openbot-text-secondary);
-  font-size: var(--openbot-text-md);
+  font-size: var(--openbot-text-lg);
   text-align: left;
+  overflow-wrap: anywhere;
 }
 
 .choice-option-item:last-child .choice-option {
   border-bottom: 0;
 }
 
-.choice-option:hover,
+.choice-option-item:not([data-disabled]) .choice-option:hover,
 .choice-option-selected {
-  background: var(--openbot-border);
+  background: var(--openbot-bg-control-hover);
   color: var(--openbot-text-primary);
+}
+
+.choice-option-item:focus-within .choice-option {
+  outline: 1px solid var(--openbot-border-focus);
+  outline-offset: -1px;
+}
+
+.choice-option-item[data-disabled] {
+  opacity: 0.5;
 }
 
 .choice-key {
   display: grid;
-  width: 18px;
-  height: 18px;
+  width: var(--openbot-icon-lg);
+  height: var(--openbot-icon-lg);
   flex: 0 0 auto;
   place-items: center;
   border-radius: var(--openbot-radius-xs);
-  background: var(--openbot-border);
+  background: var(--openbot-bg-control-hover);
   color: var(--openbot-text-muted);
-  font-family: "SFMono-Regular", Consolas, monospace;
+  font-family: var(--openbot-font-mono);
   font-size: var(--openbot-text-sm);
 }
 
 .choice-input {
-  display: block;
   width: 100%;
-  height: 28px;
-  margin-top: 8px;
-  border: 0;
-  border-radius: var(--openbot-radius-sm);
-  outline: 0;
-  background: var(--openbot-bg-canvas);
-  padding: 0 9px;
-  color: var(--openbot-text-primary);
-  font-size: var(--openbot-text-sm);
+  min-width: 0;
+  border-radius: var(--openbot-radius-pill);
+  background: var(--openbot-bg-surface);
+  font-size: var(--openbot-text-lg);
 }
 
 .choice-input::placeholder {

--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -3077,7 +3077,6 @@ textarea {
 
 .agent-settings-model,
 .agent-settings-notifications,
-.choice-card,
 .agent-setup-card,
 .provider-model-panel,
 .provider-model-rail,

--- a/src/renderer/src/styles/app-shell.css
+++ b/src/renderer/src/styles/app-shell.css
@@ -3077,7 +3077,6 @@ textarea {
 
 .agent-settings-model,
 .agent-settings-notifications,
-.approval-card,
 .choice-card,
 .agent-setup-card,
 .provider-model-panel,

--- a/src/renderer/stories/ApprovalCard.stories.tsx
+++ b/src/renderer/stories/ApprovalCard.stories.tsx
@@ -1,0 +1,93 @@
+import type { AgentApproval } from "@openbot/contracts/ipc";
+import { fn, userEvent, within } from "storybook/test";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { ApprovalCard } from "../src/features/conversation/ConversationPrompts";
+
+const approval: AgentApproval = {
+  requestId: "approval-story",
+  agentId: "agent-story",
+  threadId: "thread-story",
+  turnId: "turn-story",
+  kind: "command",
+  command: "bun run lint",
+  cwd: "~/OpenBot/Agents/agent-story/project",
+  reason: "Check the project before continuing.",
+  grantRoot: null,
+  permissions: null,
+};
+
+const meta = {
+  title: "Conversation/ApprovalCard",
+  component: ApprovalCard,
+  args: { approval, onApprove: fn(async () => false), onReject: fn(async () => false) },
+  decorators: [
+    (Story) => (
+      <main class="foundation-story">
+        <Story />
+      </main>
+    ),
+  ],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof ApprovalCard>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Command: Story = {};
+export const FileChange: Story = {
+  args: {
+    approval: {
+      ...approval,
+      kind: "file-change",
+      command: null,
+      cwd: null,
+      grantRoot: "~/OpenBot/Agents/agent-story/project",
+      reason: "Update the project files.",
+    },
+  },
+};
+export const Permissions: Story = {
+  args: {
+    approval: {
+      ...approval,
+      kind: "permissions",
+      command: null,
+      cwd: null,
+      reason: "Read the source files and download dependencies.",
+      permissions: {
+        fileSystem: { read: ["~/Projects/site"], write: ["~/Projects/site/node_modules"] },
+        network: true,
+      },
+    },
+  },
+};
+export const Minimal: Story = {
+  args: { approval: { ...approval, command: null, cwd: null, reason: null } },
+};
+export const LongContent: Story = {
+  args: {
+    approval: {
+      ...approval,
+      command:
+        "bun run test:desktop -- src/renderer/src/features/conversation/ConversationPrompts.test.tsx src/renderer/src/components/QuestionPromptBubble.test.tsx",
+      cwd: "~/OpenBot/Agents/agent-story/projects/a-project-with-a-long-directory-name/packages/desktop",
+      reason: "Run the conversation interaction checks before sharing the updated project with the team.",
+    },
+  },
+};
+export const Narrow: Story = {
+  ...Permissions,
+  decorators: [
+    (Story) => (
+      <div style={{ width: "280px", "max-width": "100%" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export const Pending: Story = {
+  args: { onApprove: fn(async () => true) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Allow" }));
+  },
+};

--- a/src/renderer/stories/BrowserTakeoverCard.stories.tsx
+++ b/src/renderer/stories/BrowserTakeoverCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { BrowserPreview, BrowserTab } from "@openbot/contracts/ipc";
-import { fn } from "storybook/test";
+import { fn, userEvent, within } from "storybook/test";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import { BrowserTakeoverCard } from "../src/features/conversation/ConversationPrompts";
 import browserTakeoverPreviewUrl from "./assets/browser-takeover-preview.svg";
@@ -30,7 +30,14 @@ const meta = {
     onComplete: fn(async () => true),
     onCancel: fn(async () => true),
   },
-  parameters: { layout: "centered", a11y: { test: "error" } },
+  decorators: [
+    (Story) => (
+      <main class="foundation-story">
+        <Story />
+      </main>
+    ),
+  ],
+  parameters: { layout: "fullscreen", a11y: { test: "error" } },
 } satisfies Meta<typeof BrowserTakeoverCard>;
 
 export default meta;
@@ -48,7 +55,7 @@ export const PreviewUnavailable: Story = {
 
 export const Narrow: Story = {
   render: (args) => (
-    <div style={{ width: "340px" }}>
+    <div style={{ width: "280px", "max-width": "100%" }}>
       <BrowserTakeoverCard {...args} />
     </div>
   ),
@@ -60,4 +67,15 @@ export const Completed: Story = {
 
 export const Cancelled: Story = {
   args: { decision: "cancel" },
+};
+
+export const TabUnavailable: Story = {
+  args: { tab: undefined, preview: null, previewStatus: "failed" },
+};
+
+export const Submitting: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "I’m done" }));
+  },
 };

--- a/src/renderer/stories/ConversationPrompts.stories.tsx
+++ b/src/renderer/stories/ConversationPrompts.stories.tsx
@@ -1,3 +1,4 @@
+import { userEvent, within } from "storybook/test";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import { ChoiceCard } from "../src/features/conversation/ConversationPrompts";
 
@@ -13,7 +14,14 @@ const meta = {
   title: "Conversation/ChoiceCard",
   component: ChoiceCard,
   args: choiceArgs,
-  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <main class="foundation-story">
+        <Story />
+      </main>
+    ),
+  ],
+  parameters: { layout: "fullscreen" },
 } satisfies Meta<typeof ChoiceCard>;
 
 export default meta;
@@ -23,4 +31,41 @@ export const Choices: Story = {};
 
 export const Pending: Story = {
   args: { pending: true },
+};
+
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: "280px", "max-width": "100%" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const LongContent: Story = {
+  args: {
+    title: "Which part of the project should the agent work on before the next team review?",
+    hint: "Choose a suggested task, or enter the instructions that best fit your project.",
+    choices: [
+      "Review the account settings and document the changes needed for the next release",
+      "Investigate the report from the customer support team",
+      "Something else",
+    ],
+  },
+};
+
+export const Selected: Story = {
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole("radio", { name: "Research & writing" }));
+  },
+};
+
+export const CustomAnswer: Story = {
+  args: { choices: [...choiceArgs.choices, "Something else"] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("radio", { name: "Something else" }));
+    await userEvent.type(canvas.getByRole("textbox", { name: "Custom answer" }), "Prepare the release notes");
+  },
 };


### PR DESCRIPTION
Agent approvals, questions, choices, and browser takeover requests used different card layouts. They now share the reference design: a bordered card, title and status badge at the top, inset details, and rounded actions. Approval actions read **Allow** and **Deny**, with the main action first. Question navigation moves below the answers so the title and status remain clear.

This changes the desktop renderer and Storybook. Existing decision callbacks, private answers, keyboard controls, cancellation, and resolved states stay supported. No IPC, provider, storage, mobile, or Dynamic Island changes. Status badges use the existing amber warning token; the desktop supports a dark theme only.

### Before and after

| Component | Before | After |
| --- | --- | --- |
| Approvals | Shield icon, green Approve button, actions at the right | Status badge at upper right, inset details, Allow at left and Deny at right |
| Questions | Navigation beside the title | Input required badge beside the title, inset answers, navigation below |
| Choices | Compact options, plain input, no status badge | Shared card and input badge, inset options, rounded custom-answer field |
| Browser takeover | Separate Browser heading, actions at the right | Title and status share the header, primary action at left, Cancel at right |

Before and after screenshots are saved outside the repository in `/tmp/interaction-cards-review/review.md` on the development machine, with links to all 38 stories. Image attachments are not hosted on GitHub.

### Storybook

The worktree's Storybook is running at http://localhost:6006. These links are local to the development machine.

- [Command approval](http://localhost:6006/?path=/story/conversation-approvalcard--command)
- [File changes](http://localhost:6006/?path=/story/conversation-approvalcard--file-change)
- [Permissions](http://localhost:6006/?path=/story/conversation-approvalcard--permissions)
- [Agent questions](http://localhost:6006/?path=/story/conversation-questionpromptbubble--in-chat)
- [Choice card](http://localhost:6006/?path=/story/conversation-choicecard--choices)
- [Browser takeover](http://localhost:6006/?path=/story/conversation-browsertakeovercard--ready)

### Validation

- Approved two-file component test command: 16 tests passed.
- `App.test.tsx`: 32 tests passed. `App.queue.test.tsx`: 22 tests passed. Used `NODE_OPTIONS=--no-experimental-webstorage` for Node 26's localStorage incompatibility with the harness. Filtered single cases exposed an unrelated lazy-import teardown error; both complete test files passed.
- Mutation checks: swapped callbacks failed with zero calls, removed pending state failed with duplicate calls, and disabled retry controls failed the enabled assertions. Restored the code; all 16 component tests passed.
- Full `bun run lint`, `bun run typecheck`, and `bun run check:ui` passed. Lint retains 63 existing warnings, primarily module mocks in untouched tests; no warnings were added in changed files.
- Choice-card follow-up: six component tests passed, plus full lint, typecheck, and UI checks. Added selected, custom-answer, long-content, and narrow stories.
- All 38 stories rendered without browser errors or card overflow, including narrow, pending, private-answer, expired, and completed states.

Model: GPT-6. Harness: Codex desktop app, Storybook 10.5.10, Vitest, and local Chrome through Playwright with an isolated temporary profile (Browser tool had no available browser).
