### PR TITLE
Virtualize mobile chat history and support loading older messages

### DIFF
--- a/apps/mobile/src/features/chat/components/chat-message-list.tsx
+++ b/apps/mobile/src/features/chat/components/chat-message-list.tsx
@@ -1,9 +1,9 @@
 import { useIsFocused } from "expo-router";
 import { Button, Typography } from "heroui-native";
 import { CornerUpRight, X } from "lucide-react-native";
-import { useEffect, useMemo, useState } from "react";
-import { AccessibilityInfo, Pressable, View, type ViewStyle } from "react-native";
-import { KeyboardChatScrollView } from "react-native-keyboard-controller";
+import { createContext, forwardRef, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { AccessibilityInfo, type CellRendererProps, FlatList, Pressable, View, type ViewStyle } from "react-native";
+import { KeyboardChatScrollView, type KeyboardChatScrollViewProps } from "react-native-keyboard-controller";
 import Animated, {
   Easing,
   FadeIn,
@@ -28,6 +28,39 @@ import { mentionDraft } from "../model/chat-mentions";
 import { ChatMessageGesture } from "./chat-message-gesture";
 import { StreamingTailText, StreamRevealProvider } from "./streaming-tail-text";
 import { ThinkingTextGradient } from "./thinking-text-gradient";
+
+type VisibleMessage = Exclude<ChatMessage, { kind: "thinking" }>;
+const TailLayoutContext = createContext<{ id: string | null; motion: ChatMotion } | null>(null);
+
+function MessageCell({ children, item, onLayout, onFocusCapture, style }: CellRendererProps<VisibleMessage>) {
+  const tail = useContext(TailLayoutContext);
+  const nativeProps = { style, onFocusCapture };
+  return (
+    <View
+      {...nativeProps}
+      onLayout={(event) => {
+        onLayout?.(event);
+        if (item.id === tail?.id) tail.motion.onTailStartLayout(item.id, event);
+      }}
+    >
+      {children}
+    </View>
+  );
+}
+
+const ChatScrollView = forwardRef<Animated.ScrollView, KeyboardChatScrollViewProps & { motion: ChatMotion }>(
+  function ChatScrollView({ motion, ...props }, ref) {
+    const setRef = useCallback(
+      (instance: Animated.ScrollView | null) => {
+        motion.setScrollRef(instance);
+        if (typeof ref === "function") ref(instance);
+        else if (ref) ref.current = instance;
+      },
+      [motion.setScrollRef, ref],
+    );
+    return <KeyboardChatScrollView {...props} ref={setRef} />;
+  },
+);
 
 const STARTER_OPTIONS = [
   { id: "plan", label: "Plan the next steps", detail: "Turn a goal into a clear plan" },
@@ -56,6 +89,11 @@ interface ChatMessageListProps {
   historyState: "ready" | "connecting" | "waiting" | "loading" | "error";
   messages: ChatMessage[];
   messageAliases: ReadonlyMap<string, string>;
+  referenceMessages: ChatMessage[];
+  hasOlder: boolean;
+  olderLoading: boolean;
+  olderError: boolean;
+  onLoadOlder: () => void;
   muted: ViewStyle["backgroundColor"];
   raised: ViewStyle["backgroundColor"];
   showStarter: boolean;
@@ -82,6 +120,11 @@ export function ChatMessageList({
   historyState,
   messages,
   messageAliases,
+  referenceMessages,
+  hasOlder,
+  olderLoading,
+  olderError,
+  onLoadOlder,
   muted,
   raised,
   showStarter,
@@ -93,7 +136,10 @@ export function ChatMessageList({
   onOpenActions,
 }: ChatMessageListProps) {
   const isFocused = useIsFocused();
-  const messagesById = useMemo(() => indexChatMessages(messages, messageAliases), [messages, messageAliases]);
+  const messagesById = useMemo(
+    () => indexChatMessages(messages, messageAliases, referenceMessages),
+    [messages, messageAliases, referenceMessages],
+  );
   const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
   useEffect(() => {
     let active = true;
@@ -148,16 +194,17 @@ export function ChatMessageList({
     return { backgroundColor: `rgb(${r}, ${g}, ${b})` };
   });
 
-  const visibleMessages = messages.filter((message) => message.kind !== "thinking");
-  const groups: { id: string; user?: (typeof visibleMessages)[number]; replies: typeof visibleMessages }[] = [];
-  for (const message of visibleMessages) {
-    if (message.kind === "message" && message.author === "user") {
-      groups.push({ id: message.id, user: message, replies: [] });
-    } else {
-      if (groups.length === 0) groups.push({ id: "preamble", replies: [] });
-      groups[groups.length - 1].replies.push(message);
-    }
-  }
+  const visibleMessages = useMemo(() => messages.filter((message) => message.kind !== "thinking"), [messages]);
+  const tailIndex = visibleMessages.findLastIndex((message) => message.kind === "message" && message.author === "user");
+  const tailId = visibleMessages[tailIndex]?.id ?? null;
+  const listRef = useRef<FlatList<VisibleMessage>>(null);
+  const tailLayout = useMemo(() => ({ id: tailId, motion }), [tailId, motion]);
+  const seekLatest = useCallback(() => {
+    if (!motion.historyVisible && visibleMessages.length) listRef.current?.scrollToEnd({ animated: false });
+  }, [motion.historyVisible, visibleMessages.length]);
+  useEffect(() => {
+    if (tailId && motion.needsSendPosition() && !motion.atLatest) listRef.current?.scrollToEnd({ animated: false });
+  }, [tailId, motion.needsSendPosition, motion.atLatest]);
   const renderMessage = (message: (typeof visibleMessages)[number], isTailUser: boolean, isFirstUser: boolean) => {
     const rendered =
       message.kind === "exchange" ? (
@@ -309,138 +356,166 @@ export function ChatMessageList({
       accessibilityElementsHidden={historyState === "ready" && !motion.historyVisible}
       importantForAccessibility={historyState !== "ready" || motion.historyVisible ? "auto" : "no-hide-descendants"}
     >
-      <KeyboardChatScrollView
-        ref={motion.setScrollRef}
-        style={{ flex: 1 }}
-        contentContainerStyle={{
-          gap: 10,
-          paddingHorizontal: 16,
-          paddingTop: topInset + 84,
-        }}
-        contentInsetAdjustmentBehavior="never"
-        automaticallyAdjustKeyboardInsets={false}
-        keyboardLiftBehavior="whenAtEnd"
-        offset={keyboardOffset}
-        keyboardDismissMode="interactive"
-        keyboardShouldPersistTaps="handled"
-        // RN Fabric otherwise ignores drags that start in the contentInset area.
-        applyWorkaroundForContentInsetHitTestBug
-        alwaysBounceVertical
-        blankSpace={motion.blankSpace}
-        extraContentPadding={motion.composerHeight}
-        onContentInsetChange={motion.onContentInsetChange}
-        onContentSizeChange={motion.onContentSizeChange}
-        onLayout={motion.onViewportLayout}
-        onScroll={motion.onScroll}
-        onScrollBeginDrag={motion.cancelSend}
-        scrollEventThrottle={16}
-        showsVerticalScrollIndicator={false}
-      >
-        {historyState === "connecting" || historyState === "loading" ? (
-          <View
-            className="flex-1"
-            accessible
-            accessibilityLabel={historyState === "connecting" ? "Connecting to server" : "Loading chat history"}
-            accessibilityState={{ busy: true }}
-          />
-        ) : historyState !== "ready" ? (
-          <View className="flex-1 items-center justify-center gap-2">
-            <Typography.Paragraph align="center" className="text-text-secondary">
-              {historyState === "waiting" ? "Waiting for connection" : "Could not load chat history"}
-            </Typography.Paragraph>
-            {historyState === "waiting" ? (
-              <Typography.Paragraph type="body-xs" align="center" className="text-text-dim">
-                Your chat history will load when the server reconnects.
-              </Typography.Paragraph>
-            ) : null}
-            {historyState === "error" ? (
-              <Button variant="tertiary" onPress={onRetryHistory}>
-                <Button.Label>Try again</Button.Label>
-              </Button>
-            ) : null}
-          </View>
-        ) : null}
-
-        {groups.map((group, index) => {
-          const last = index === groups.length - 1;
-          return (
-            <View
-              key={group.id}
-              style={{ gap: 10 }}
-              onLayout={last && group.user ? (event) => motion.onTailLayout(group.id, event) : undefined}
+      <TailLayoutContext.Provider value={tailLayout}>
+        <FlatList
+          ref={listRef}
+          data={visibleMessages}
+          keyExtractor={(message) => message.id}
+          CellRendererComponent={MessageCell}
+          initialNumToRender={50}
+          maxToRenderPerBatch={8}
+          windowSize={7}
+          removeClippedSubviews={false}
+          maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
+          onStartReached={() => {
+            if (motion.historyVisible && canSend && hasOlder && !olderLoading && !olderError) onLoadOlder();
+          }}
+          onStartReachedThreshold={0.5}
+          renderItem={({ item, index }) => (
+            <Animated.View
+              style={[{ paddingBottom: 10 }, index > tailIndex ? motion.responseStyle : undefined]}
+              accessibilityElementsHidden={index > tailIndex && !motion.responseVisible}
+              importantForAccessibility={index > tailIndex && !motion.responseVisible ? "no-hide-descendants" : "auto"}
             >
-              {group.user ? renderMessage(group.user, last, index === 0) : null}
-              <Animated.View
-                style={[{ gap: 10 }, last ? motion.responseStyle : undefined]}
-                accessibilityElementsHidden={last && !motion.responseVisible}
-                importantForAccessibility={last && !motion.responseVisible ? "no-hide-descendants" : "auto"}
-              >
-                {group.replies.map((message) => renderMessage(message, false, false))}
-                {last ? renderActivity() : null}
-              </Animated.View>
-            </View>
-          );
-        })}
-        {groups.length === 0 ? renderActivity() : null}
-
-        {showStarter ? (
-          <View
-            className="gap-4 rounded-[26px] p-4"
-            style={{ backgroundColor: fieldBackground, borderCurve: "continuous" }}
-          >
-            <View className="flex-row items-start gap-3">
-              <View className="min-w-0 flex-1 gap-1">
-                <Typography.Heading type="h4">What should we work on first?</Typography.Heading>
-                <Typography.Paragraph className="text-text-secondary">
-                  Pick one, or type your own — we can change course anytime.
-                </Typography.Paragraph>
-              </View>
-              <Pressable
-                accessibilityLabel="Dismiss suggestions"
-                accessibilityRole="button"
-                hitSlop={8}
-                onPress={onDismissStarter}
-              >
-                <X color={String(muted)} size={21} strokeWidth={1.8} />
-              </Pressable>
-            </View>
-
-            <View className="overflow-hidden rounded-[18px]" style={{ backgroundColor: raised }}>
-              {STARTER_OPTIONS.map((option, index) => (
-                <Pressable
-                  key={option.id}
-                  accessibilityRole="button"
-                  accessibilityState={{ disabled: !canSend }}
-                  disabled={!canSend}
-                  className="flex-row gap-3 px-3 py-3"
-                  style={({ pressed }) => ({
-                    borderBottomColor: index < STARTER_OPTIONS.length - 1 ? String(muted) : "transparent",
-                    borderBottomWidth: index < STARTER_OPTIONS.length - 1 ? 0.5 : 0,
-                    opacity: !canSend ? 0.45 : pressed ? 0.55 : 1,
-                  })}
-                  onPress={() => onSelectStarter(option.label)}
+              {renderMessage(item, index === tailIndex, index === 0 && !hasOlder)}
+            </Animated.View>
+          )}
+          renderScrollComponent={(props) => (
+            <ChatScrollView
+              {...props}
+              motion={motion}
+              automaticallyAdjustKeyboardInsets={false}
+              keyboardLiftBehavior="whenAtEnd"
+              offset={keyboardOffset}
+              applyWorkaroundForContentInsetHitTestBug
+              blankSpace={motion.blankSpace}
+              extraContentPadding={motion.composerHeight}
+              onContentInsetChange={motion.onContentInsetChange}
+            />
+          )}
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingHorizontal: 16, paddingTop: topInset + 84 }}
+          contentInsetAdjustmentBehavior="never"
+          keyboardDismissMode="interactive"
+          keyboardShouldPersistTaps="handled"
+          alwaysBounceVertical
+          onContentSizeChange={(width, height) => {
+            motion.onContentSizeChange(width, height);
+            seekLatest();
+          }}
+          onLayout={(event) => {
+            motion.onViewportLayout(event);
+            seekLatest();
+          }}
+          onScroll={motion.onScroll}
+          onScrollBeginDrag={motion.cancelSend}
+          scrollEventThrottle={16}
+          showsVerticalScrollIndicator={false}
+          ListHeaderComponent={
+            <>
+              {hasOlder ? (
+                <View className="items-center pb-3">
+                  <Button variant="tertiary" isDisabled={!canSend || olderLoading} onPress={onLoadOlder}>
+                    <Button.Label>
+                      {olderLoading
+                        ? "Loading older messages…"
+                        : olderError
+                          ? "Try loading older messages again"
+                          : "Load older messages"}
+                    </Button.Label>
+                  </Button>
+                </View>
+              ) : null}
+              {historyState === "connecting" || historyState === "loading" ? (
+                <View
+                  className="flex-1"
+                  accessible
+                  accessibilityLabel={historyState === "connecting" ? "Connecting to server" : "Loading chat history"}
+                  accessibilityState={{ busy: true }}
+                />
+              ) : historyState !== "ready" ? (
+                <View className="flex-1 items-center justify-center gap-2">
+                  <Typography.Paragraph align="center" className="text-text-secondary">
+                    {historyState === "waiting" ? "Waiting for connection" : "Could not load chat history"}
+                  </Typography.Paragraph>
+                  {historyState === "waiting" ? (
+                    <Typography.Paragraph type="body-xs" align="center" className="text-text-dim">
+                      Your chat history will load when the server reconnects.
+                    </Typography.Paragraph>
+                  ) : null}
+                  {historyState === "error" ? (
+                    <Button variant="tertiary" onPress={onRetryHistory}>
+                      <Button.Label>Try again</Button.Label>
+                    </Button>
+                  ) : null}
+                </View>
+              ) : null}
+            </>
+          }
+          ListFooterComponent={
+            <>
+              <Animated.View style={motion.responseStyle}>{renderActivity()}</Animated.View>
+              {showStarter ? (
+                <View
+                  className="gap-4 rounded-[26px] p-4"
+                  style={{ backgroundColor: fieldBackground, borderCurve: "continuous" }}
                 >
-                  <View className="size-7 items-center justify-center rounded-lg bg-control">
-                    <Typography.Paragraph type="body-xs" className="text-text-secondary">
-                      {String.fromCharCode(65 + index)}
-                    </Typography.Paragraph>
+                  <View className="flex-row items-start gap-3">
+                    <View className="min-w-0 flex-1 gap-1">
+                      <Typography.Heading type="h4">What should we work on first?</Typography.Heading>
+                      <Typography.Paragraph className="text-text-secondary">
+                        Pick one, or type your own — we can change course anytime.
+                      </Typography.Paragraph>
+                    </View>
+                    <Pressable
+                      accessibilityLabel="Dismiss suggestions"
+                      accessibilityRole="button"
+                      hitSlop={8}
+                      onPress={onDismissStarter}
+                    >
+                      <X color={String(muted)} size={21} strokeWidth={1.8} />
+                    </Pressable>
                   </View>
-                  <View className="min-w-0 flex-1">
-                    <Typography.Paragraph weight="medium">{option.label}</Typography.Paragraph>
-                    <Typography.Paragraph type="body-xs" className="text-text-secondary">
-                      {option.detail}
-                    </Typography.Paragraph>
-                  </View>
-                </Pressable>
-              ))}
-            </View>
 
-            <Typography.Paragraph type="body-xs" className="text-text-secondary">
-              Or answer in the chat below
-            </Typography.Paragraph>
-          </View>
-        ) : null}
-      </KeyboardChatScrollView>
+                  <View className="overflow-hidden rounded-[18px]" style={{ backgroundColor: raised }}>
+                    {STARTER_OPTIONS.map((option, index) => (
+                      <Pressable
+                        key={option.id}
+                        accessibilityRole="button"
+                        accessibilityState={{ disabled: !canSend }}
+                        disabled={!canSend}
+                        className="flex-row gap-3 px-3 py-3"
+                        style={({ pressed }) => ({
+                          borderBottomColor: index < STARTER_OPTIONS.length - 1 ? String(muted) : "transparent",
+                          borderBottomWidth: index < STARTER_OPTIONS.length - 1 ? 0.5 : 0,
+                          opacity: !canSend ? 0.45 : pressed ? 0.55 : 1,
+                        })}
+                        onPress={() => onSelectStarter(option.label)}
+                      >
+                        <View className="size-7 items-center justify-center rounded-lg bg-control">
+                          <Typography.Paragraph type="body-xs" className="text-text-secondary">
+                            {String.fromCharCode(65 + index)}
+                          </Typography.Paragraph>
+                        </View>
+                        <View className="min-w-0 flex-1">
+                          <Typography.Paragraph weight="medium">{option.label}</Typography.Paragraph>
+                          <Typography.Paragraph type="body-xs" className="text-text-secondary">
+                            {option.detail}
+                          </Typography.Paragraph>
+                        </View>
+                      </Pressable>
+                    ))}
+                  </View>
+
+                  <Typography.Paragraph type="body-xs" className="text-text-secondary">
+                    Or answer in the chat below
+                  </Typography.Paragraph>
+                </View>
+              ) : null}
+            </>
+          }
+        />
+      </TailLayoutContext.Provider>
     </Animated.View>
   );
 }

--- a/apps/mobile/src/features/chat/components/chat-view.tsx
+++ b/apps/mobile/src/features/chat/components/chat-view.tsx
@@ -5,7 +5,7 @@ import { router, useIsFocused } from "expo-router";
 import { Typography } from "heroui-native";
 import { useThemeColor } from "heroui-native/hooks";
 import { ArrowDown } from "lucide-react-native";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { AccessibilityInfo, AppState, Keyboard, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { KeyboardGestureArea } from "react-native-keyboard-controller";
@@ -79,7 +79,8 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
   const historyRequestRef = useRef(0);
   const {
     agents,
-    conversations,
+    conversationStore,
+    loadOlderMessages,
     loadConversation,
     markAgentRead,
     servers,
@@ -88,9 +89,22 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
     uploadAttachment,
     discardAttachment,
   } = useMobileWorkspace();
-  const conversation = conversations[agent.id];
+  const subscribeConversation = useCallback(
+    (notify: () => void) => conversationStore.subscribe(agent.id, notify),
+    [agent.id, conversationStore],
+  );
+  const getConversation = useCallback(() => conversationStore.get(agent.id), [agent.id, conversationStore]);
+  const conversation = useSyncExternalStore(subscribeConversation, getConversation);
+  const serverAgents = useMemo(
+    () => agents.filter((candidate) => candidate.serverId === agent.serverId),
+    [agents, agent.serverId],
+  );
   const activity = useAgentActivity(agent.id);
-  const projectedMessages = useMemo(() => projectChatMessages(conversation?.messages ?? []), [conversation]);
+  const projectedMessages = useMemo(() => projectChatMessages(conversation?.messages ?? []), [conversation?.messages]);
+  const referenceMessages = useMemo(
+    () => projectChatMessages(Object.values(conversation?.references ?? {})),
+    [conversation?.references],
+  );
   const messages = useMemo(
     () => presentChatMessages(projectedMessages, pendingMessage, messageAliases),
     [projectedMessages, pendingMessage, messageAliases],
@@ -285,7 +299,7 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
             onBack={handleLeaveConversation}
           />
           <ChatMessageList
-            agents={agents.filter((candidate) => candidate.serverId === agent.serverId)}
+            agents={serverAgents}
             agent={agent}
             motion={motion}
             sending={sending}
@@ -309,6 +323,13 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
             foreground={foreground}
             messages={messages}
             messageAliases={messageAliases}
+            referenceMessages={referenceMessages}
+            hasOlder={conversation?.pageInfo.hasOlder ?? false}
+            olderLoading={conversation?.olderLoading ?? false}
+            olderError={conversation?.olderError ?? false}
+            onLoadOlder={() => {
+              void loadOlderMessages(agent.id);
+            }}
             onReply={
               !questionForm.question
                 ? (message) => {

--- a/apps/mobile/src/features/chat/components/use-chat-motion.test.tsx
+++ b/apps/mobile/src/features/chat/components/use-chat-motion.test.tsx
@@ -123,3 +123,46 @@ it("keeps replies visible and does not scroll after keyboard dismissal, includin
   await flush();
   expect(motion.atLatest).toBe(false);
 });
+
+it("reveals a virtualized history and does not jump to the end when older messages load", async () => {
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    const id = ++native.nextFrame;
+    native.frames.set(id, callback);
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => native.frames.delete(id));
+  let motion: ChatMotion | undefined;
+  function Chat() {
+    const current = useChatMotion(100, 0, true, "user");
+    useLayoutEffect(() => {
+      motion = current;
+    });
+    return null;
+  }
+  async function flush() {
+    await act(() => {
+      while (native.frames.size) {
+        const frames = [...native.frames.values()];
+        native.frames.clear();
+        for (const frame of frames) frame(0);
+      }
+    });
+  }
+  await act(() => root.render(<Chat />));
+  if (!motion) throw new Error("Chat motion is not mounted");
+  motion.onViewportLayout(layout(800));
+  motion.onComposerLayout(layout(80));
+  motion.onTailStartLayout("user", layout(100, 600));
+  motion.onContentSizeChange(390, 1000);
+  motion.onContentInsetChange({ bottom: 400 });
+  await flush();
+  expect(motion.historyVisible).toBe(true);
+  native.scrollTo.mockClear();
+
+  motion.onTailStartLayout("user", layout(100, 2600));
+  motion.onContentSizeChange(390, 3000);
+  await flush();
+  expect(native.scrollTo).not.toHaveBeenCalled();
+  motion.scrollToLatest();
+  expect(native.scrollTo).toHaveBeenLastCalledWith({ y: 2600, animated: false });
+});

--- a/apps/mobile/src/features/chat/components/use-chat-motion.ts
+++ b/apps/mobile/src/features/chat/components/use-chat-motion.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { LayoutChangeEvent } from "react-native";
+import type { LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from "react-native";
 import { useKeyboardHandler } from "react-native-keyboard-controller";
 import type Animated from "react-native-reanimated";
 import {
@@ -7,7 +7,6 @@ import {
   ReduceMotion,
   useAnimatedReaction,
   useAnimatedRef,
-  useAnimatedScrollHandler,
   useAnimatedStyle,
   useDerivedValue,
   useReducedMotion,
@@ -58,7 +57,9 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
   }));
   const layout = useSharedValue<ChatLayout>({ viewport: 0, content: 0, header, tailY: 0, tailHeight: 0 });
   const composerHeight = useSharedValue(0);
-  const blankSpace = useDerivedValue(() => (lastUserId ? chatBlankSpace(layout.get()) : 0));
+  const blankSpace = useDerivedValue(() =>
+    lastUserId && layout.get().tailHeight > 0 ? chatBlankSpace(layout.get()) : 0,
+  );
   const scrollY = useSharedValue(0);
   const firstOffset = useSharedValue(0);
   const firstOpacity = useSharedValue(1);
@@ -76,6 +77,7 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     userHeight: number;
     tailId: string | null;
     initialized: boolean;
+    virtualized: boolean;
   }>({
     layout: { viewport: 0, content: 0, header, tailY: 0, tailHeight: 0 },
     inset: 0,
@@ -83,6 +85,7 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     userHeight: 0,
     tailId: null,
     initialized: false,
+    virtualized: false,
   });
   const current = useRef({ ready, lastUserId });
   current.current = { ready, lastUserId };
@@ -173,7 +176,13 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
   );
   const onContentSizeChange = useCallback(
     (_width: number, height: number) => {
-      measurements.current.layout = { ...measurements.current.layout, content: height };
+      measurements.current.layout = {
+        ...measurements.current.layout,
+        content: height,
+        ...(measurements.current.virtualized
+          ? { tailHeight: Math.max(0, height - measurements.current.layout.tailY) }
+          : {}),
+      };
       layout.set(measurements.current.layout);
       position();
     },
@@ -189,6 +198,22 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     },
     [layout, position],
   );
+  const onTailStartLayout = useCallback(
+    (id: string, event: Pick<LayoutChangeEvent, "nativeEvent">) => {
+      const m = measurements.current;
+      m.virtualized = true;
+      m.tailId = id;
+      m.layout = {
+        ...m.layout,
+        tailY: event.nativeEvent.layout.y,
+        tailHeight: Math.max(event.nativeEvent.layout.height, m.layout.content - event.nativeEvent.layout.y),
+      };
+      layout.set(m.layout);
+      position();
+    },
+    [layout, position],
+  );
+
   const onUserLayout = useCallback(
     (event: Pick<LayoutChangeEvent, "nativeEvent">) => {
       measurements.current.userHeight = event.nativeEvent.layout.height;
@@ -213,11 +238,12 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     [position],
   );
 
-  const onScroll = useAnimatedScrollHandler({
-    onScroll: (event) => {
-      scrollY.set(event.contentOffset.y);
+  const onScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollY.set(event.nativeEvent.contentOffset.y);
     },
-  });
+    [scrollY],
+  );
   useAnimatedReaction(
     () =>
       revealed.get() &&
@@ -238,6 +264,8 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     transform: [{ translateY: firstOffset.get() }],
   }));
   const responseStyle = useAnimatedStyle(() => ({ opacity: responseOpacity.get() }));
+
+  const needsSendPosition = useCallback(() => pending.current !== null, []);
 
   function beginSend() {
     const first = current.current.lastUserId === null;
@@ -276,11 +304,13 @@ export function useChatMotion(header: number, keyboardOffset: number, ready: boo
     onViewportLayout,
     onContentSizeChange,
     onTailLayout,
+    onTailStartLayout,
     onUserLayout,
     onComposerLayout,
     onContentInsetChange,
     onScroll,
     beginSend,
+    needsSendPosition,
     cancelSend,
     scrollToLatest,
   };

--- a/apps/mobile/src/features/chat/components/use-message-arrivals.ts
+++ b/apps/mobile/src/features/chat/components/use-message-arrivals.ts
@@ -10,12 +10,21 @@ export function useMessageArrivals(agentId: string, messages: ChatMessage[], ena
     enabled,
     arriving: new Set<string>(),
   }));
-  if (snapshot.agentId !== agentId || snapshot.messages !== messages || snapshot.enabled !== enabled) {
+  if (
+    snapshot.agentId !== agentId ||
+    snapshot.enabled !== enabled ||
+    snapshot.messages.length !== messages.length ||
+    snapshot.messages[0]?.id !== messages[0]?.id ||
+    snapshot.messages.at(-1)?.id !== messages.at(-1)?.id
+  ) {
     const known = new Set(snapshot.messages.map((message) => message.id));
     const arriving = new Set<string>();
     if (enabled && snapshot.enabled && snapshot.agentId === agentId) {
-      for (const message of messages) {
-        if (!known.has(message.id) || snapshot.arriving.has(message.id)) arriving.add(message.id);
+      const previousTail = snapshot.messages.at(-1)?.id;
+      const tailIndex = previousTail ? messages.findIndex((message) => message.id === previousTail) : -1;
+      for (const [index, message] of messages.entries()) {
+        if (snapshot.arriving.has(message.id) || (tailIndex >= 0 && index > tailIndex && !known.has(message.id)))
+          arriving.add(message.id);
       }
     }
     setSnapshot({ agentId, messages, enabled, arriving });

--- a/apps/mobile/src/features/chat/model/chat-messages.ts
+++ b/apps/mobile/src/features/chat/model/chat-messages.ts
@@ -25,8 +25,12 @@ export interface PendingChatMessage {
   serverId: string | null;
 }
 
-export function indexChatMessages(messages: readonly ChatMessage[], aliases: ReadonlyMap<string, string>) {
-  const index = new Map(messages.map((message) => [message.id, message]));
+export function indexChatMessages(
+  messages: readonly ChatMessage[],
+  aliases: ReadonlyMap<string, string>,
+  references: readonly ChatMessage[] = [],
+) {
+  const index = new Map([...references, ...messages].map((message) => [message.id, message]));
   // Reply references use host IDs even when a delivered bubble keeps its local render key.
   for (const [hostId, localId] of aliases) {
     const message = index.get(localId);
@@ -50,6 +54,8 @@ export function presentChatMessages(
   if (pending && !messages.some((message) => message.id === pending.serverId)) result.push(pending.message);
   return result;
 }
+
+const projectedBubbles = new WeakMap<ConversationMessage, ChatMessage>();
 
 export function projectChatMessages(messages: ConversationMessage[]): ChatMessage[] {
   const result: ChatMessage[] = [];
@@ -76,15 +82,20 @@ export function projectChatMessages(messages: ConversationMessage[]): ChatMessag
       }
       thinking.steps.push({ id: message.id, text: message.text });
     } else {
-      result.push({
-        id: message.id,
-        kind: "message",
-        author: message.author === "user" ? "user" : "agent",
-        body: message.exchange ? "" : message.text,
-        streaming: message.status === "streaming",
-        attachments: message.attachments,
-        replyToMessageId: message.replyToMessageId,
-      });
+      let bubble = projectedBubbles.get(message);
+      if (!bubble) {
+        bubble = {
+          id: message.id,
+          kind: "message",
+          author: message.author === "user" ? "user" : "agent",
+          body: message.exchange ? "" : message.text,
+          streaming: message.status === "streaming",
+          attachments: message.attachments,
+          replyToMessageId: message.replyToMessageId,
+        };
+        projectedBubbles.set(message, bubble);
+      }
+      result.push(bubble);
     }
   }
   return result;

--- a/apps/mobile/src/features/workspace/context/mobile-workspace-context.tsx
+++ b/apps/mobile/src/features/workspace/context/mobile-workspace-context.tsx
@@ -1,7 +1,6 @@
 import {
   type AgentEvent,
   type AgentSummary,
-  type ConversationSnapshot,
   type CreateAgentInput,
   isAgentMemory,
   isAgentModel,
@@ -31,7 +30,6 @@ import {
   type RemoteTeamHost,
   type RemoteWorkspacePreferences,
   readAgentAnalytics,
-  resyncRemoteConversations,
   watchRemoteDirectory,
 } from "@openbot/team-client";
 import type { RemoteFileUpload } from "@openbot/team-client/remote-peer";
@@ -60,7 +58,8 @@ import {
   type ServerLoadContext,
 } from "@/features/workspace/components/server-connection";
 import { type MobileAgentActivities, reduceAgentActivity } from "@/features/workspace/model/agent-activity";
-import { conversationMessageId, decodeConversation } from "@/features/workspace/model/conversation";
+import { conversationMessageId, decodeConversationPage } from "@/features/workspace/model/conversation";
+import { MobileConversationStore } from "@/features/workspace/model/conversation-store";
 import { saveAgentRecord } from "@/features/workspace/model/save-agent-record";
 import { applyServerRecovery, serverKind } from "@/features/workspace/model/server-status";
 import { trustedHostKeys } from "@/features/workspace/model/trusted-host-keys";
@@ -141,10 +140,16 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
   const [activeServerId, setActiveServerId] = useState<string | null>(session.host?.hostId ?? null);
   const activeServerIdRef = useRef(activeServerId);
   activeServerIdRef.current = activeServerId;
-  const [conversations, setConversations] = useState<Record<string, ConversationSnapshot>>({});
+  const conversationStore = useMemo(
+    () =>
+      new MobileConversationStore((flush) => {
+        const frame = requestAnimationFrame(flush);
+        return () => cancelAnimationFrame(frame);
+      }),
+    [],
+  );
+  useEffect(() => () => conversationStore.dispose(), [conversationStore]);
   const [activityByServer, setActivityByServer] = useState<Record<string, MobileAgentActivities>>({});
-  const conversationsRef = useRef(conversations);
-  conversationsRef.current = conversations;
   const preferenceStore = useMemo(
     () =>
       createWorkspacePreferences(session.apiUrl, session.user.id, {
@@ -178,9 +183,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
       for (const host of hosts) removedServers.current.delete(host.hostId);
       if (removed.length) {
         setAgents((current) => current.filter((agent) => available.has(agent.serverId)));
-        setConversations((current) =>
-          Object.fromEntries(Object.entries(current).filter(([id]) => !removedAgentIds.has(id))),
-        );
+        for (const id of removedAgentIds) conversationStore.remove(id);
         setUnreadAgentIds((current) => current.filter((id) => !removedAgentIds.has(id)));
         setActivityByServer((current) =>
           Object.fromEntries(Object.entries(current).filter(([id]) => available.has(id))),
@@ -208,7 +211,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
       });
       setActiveServerId((current) => (hosts.some((host) => host.hostId === current) ? current : null));
     },
-    [session.host?.hostId, session.apiUrl, session.user.id, sessionScope, queryClient, readRefresh],
+    [session.host?.hostId, session.apiUrl, session.user.id, sessionScope, queryClient, readRefresh, conversationStore],
   );
 
   const directoryRefresh = useMemo(
@@ -301,16 +304,27 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
       );
       if (!context.isCurrent()) return;
       context.stage = "conversations";
-      await resyncRemoteConversations({
-        agentIds: summaries.map((agent) => agent.id),
-        cached: conversationsRef.current,
-        load: (agentId) => client.request("GET", TEAM_API_ROUTES.agent.conversation(agentId), decodeConversation),
-        apply: (snapshot) => setConversations((current) => storeNewestSnapshot(current, snapshot)),
-        isCurrent: context.isCurrent,
-      });
+      const ordered = [...summaries].sort(
+        (a, b) => Number(conversationStore.isObserved(b.id)) - Number(conversationStore.isObserved(a.id)),
+      );
+      for (const agent of ordered) {
+        if (!context.isCurrent()) return;
+        if (!conversationStore.get(agent.id)) continue;
+        await conversationStore.loadLatest(
+          agent.id,
+          () =>
+            client.request(
+              "GET",
+              `${TEAM_API_ROUTES.agent.conversationPage(agent.id)}?limit=50`,
+              decodeConversationPage,
+            ),
+          context.isCurrent,
+          true,
+        );
+      }
       context.stage = "connection";
     },
-    [replaceServerAgents, preferenceStore, readRefresh],
+    [replaceServerAgents, preferenceStore, readRefresh, conversationStore],
   );
 
   const registerConnection = useCallback((hostId: string, handle: ServerConnectionHandle | null) => {
@@ -334,10 +348,12 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
       setForeground(active);
       if (!active) {
         loadGeneration.current += 1;
+        conversationStore.cancelRequests();
+        conversationStore.flush();
       }
     });
     return () => subscription.remove();
-  }, []);
+  }, [conversationStore]);
 
   useEffect(() => {
     if (!foreground) return;
@@ -345,19 +361,42 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
   }, [foreground, directoryRefresh]);
 
   const loadConversation = useCallback(
-    async (agentId: string, serverId = activeServerIdRef.current) => {
+    async (agentId: string, serverId = activeServerIdRef.current, refresh = false) => {
       const generation = loadGeneration.current;
-      const snapshot = await request(
-        "GET",
-        TEAM_API_ROUTES.agent.conversation(agentId),
-        decodeConversation,
-        undefined,
-        serverId,
+      return conversationStore.loadLatest(
+        agentId,
+        () =>
+          request(
+            "GET",
+            `${TEAM_API_ROUTES.agent.conversationPage(agentId)}?limit=50`,
+            decodeConversationPage,
+            undefined,
+            serverId,
+          ),
+        () => generation === loadGeneration.current && Boolean(serverId) && !removedServers.current.has(serverId ?? ""),
+        refresh,
       );
-      if (generation === loadGeneration.current) setConversations((current) => storeNewestSnapshot(current, snapshot));
-      return snapshot;
     },
-    [request],
+    [request, conversationStore],
+  );
+  const loadOlderMessages = useCallback(
+    async (agentId: string) => {
+      const generation = loadGeneration.current;
+      const serverId = activeServerIdRef.current;
+      await conversationStore.loadOlder(
+        agentId,
+        (cursor) =>
+          request(
+            "GET",
+            `${TEAM_API_ROUTES.agent.conversationPage(agentId)}?limit=50&before=${encodeURIComponent(cursor ?? "")}`,
+            decodeConversationPage,
+            undefined,
+            serverId,
+          ),
+        () => generation === loadGeneration.current && Boolean(serverId) && !removedServers.current.has(serverId ?? ""),
+      );
+    },
+    [request, conversationStore],
   );
 
   const refreshConversationReads = useCallback(
@@ -392,7 +431,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
       }
       if (
         event.type !== "conversation" ||
-        event.snapshot.revision >= (conversationsRef.current[event.snapshot.agentId]?.revision ?? 0)
+        event.snapshot.revision >= (conversationStore.get(event.snapshot.agentId)?.revision ?? 0)
       ) {
         setActivityByServer((current) => {
           const previous = current[serverId] ?? {};
@@ -417,50 +456,20 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
         const knownIds = serverAgentIds.current.get(serverId) ?? new Set<string>();
         knownIds.add(event.snapshot.agentId);
         serverAgentIds.current.set(serverId, knownIds);
-        setConversations((current) => storeNewestSnapshot(current, event.snapshot));
+        if (conversationStore.get(event.snapshot.agentId))
+          void loadConversation(event.snapshot.agentId, serverId, true).catch(() => undefined);
       } else if (event.type === "conversation-delta") {
-        setConversations((current) => {
-          const snapshot = current[event.agentId];
-          if (!snapshot || event.revision <= snapshot.revision) return current;
-          const messageIndex = snapshot.messages.findIndex((message) => message.id === event.messageId);
-          const messages = [...snapshot.messages];
-          if (messageIndex === -1) {
-            messages.push({
-              id: event.messageId,
-              turnId: event.turnId,
-              author: "assistant",
-              source: "assistant",
-              text: event.delta,
-              createdAt: event.createdAt,
-              status: "streaming",
-            });
-          } else {
-            const message = messages[messageIndex];
-            if (!message) return current;
-            messages[messageIndex] = { ...message, text: message.text + event.delta, status: "streaming" };
-          }
-          return {
-            ...current,
-            [event.agentId]: {
-              ...snapshot,
-              threadId: event.threadId,
-              activeTurnId: event.turnId,
-              revision: event.revision,
-              messages,
-            },
-          };
-        });
+        conversationStore.enqueue(event);
       } else if (event.type === "conversation-page") {
         const readState = event.page.readState;
         if (readState) {
           readRefresh.invalidate(serverId);
           setUnreadAgentIds((current) => mergeRemoteUnreadIds(current, { [event.page.agentId]: readState }));
         } else void refreshConversationReads(serverId).catch(() => undefined);
-        if (conversationsRef.current[event.page.agentId])
-          void loadConversation(event.page.agentId, serverId).catch(() => undefined);
+        if (conversationStore.get(event.page.agentId)) conversationStore.applyPage(event.page);
       } else if (event.type === "conversation-invalidated" || event.type === "turn-completed") {
-        if (conversationsRef.current[event.agentId])
-          void loadConversation(event.agentId, serverId).catch(() => undefined);
+        if (conversationStore.get(event.agentId))
+          void loadConversation(event.agentId, serverId, true).catch(() => undefined);
       } else if (event.type === "team-identity") {
         setServers((current) =>
           current.map((server) => (server.id === serverId ? { ...server, name: event.serverName } : server)),
@@ -470,6 +479,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
     [
       loadConversation,
       replaceServerAgents,
+      conversationStore,
       refreshConversationReads,
       readRefresh,
       queryClient,
@@ -501,7 +511,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
           const snapshot =
             visibleMessageId !== undefined
               ? null
-              : (conversationsRef.current[agentId] ?? (await loadConversation(agentId)));
+              : (conversationStore.get(agentId) ?? (await loadConversation(agentId)));
           if (generation !== loadGeneration.current) return;
           const throughMessageId = visibleMessageId !== undefined ? visibleMessageId : snapshot?.messages.at(-1)?.id;
           if (throughMessageId === undefined) return;
@@ -527,7 +537,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
         if (readWrites.current.get(agentId) === write) readWrites.current.delete(agentId);
       });
     },
-    [request, refreshConversationReads, loadConversation, activeServerId, readRefresh],
+    [request, refreshConversationReads, loadConversation, activeServerId, readRefresh, conversationStore],
   );
 
   const updatePreferences = useCallback(
@@ -560,10 +570,11 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
       hiddenAgents: agents.filter((agent) => agent.serverId === activeServer.id && hiddenAgentIds.includes(agent.id)),
       pinnedAgentIds,
       unreadAgentIds,
-      conversations,
+      conversationStore,
       activityByServer,
       selectServer: (id) => {
         loadGeneration.current += 1;
+        conversationStore.cancelRequests();
         setActiveServerId(id);
       },
       leaveServer: async (serverId) => {
@@ -589,9 +600,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
           delete next[serverId];
           return next;
         });
-        setConversations((current) =>
-          Object.fromEntries(Object.entries(current).filter(([id]) => !removedIds.has(id))),
-        );
+        for (const id of removedIds) conversationStore.remove(id);
         updatePreferences(serverId, () => ({ hidden: [], pinned: [] }));
         setUnreadAgentIds((current) => current.filter((id) => !removedIds.has(id)));
       },
@@ -795,6 +804,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
         });
       },
       loadConversation,
+      loadOlderMessages,
       uploadAttachment: async (agentId, input) => {
         const serverId = agents.find((candidate) => candidate.id === agentId)?.serverId;
         if (!serverId) throw new Error("The agent is unavailable.");
@@ -837,7 +847,7 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
       },
       respondToPrompt: async (agentId, input) => {
         const agent = agents.find((candidate) => candidate.id === agentId);
-        const snapshot = conversationsRef.current[agentId];
+        const snapshot = conversationStore.get(agentId);
         const message = snapshot?.messages.find(
           (item) =>
             item.turnId === snapshot.activeTurnId &&
@@ -898,11 +908,12 @@ export function MobileWorkspaceProvider({ children }: PropsWithChildren) {
     activeServerId,
     activityByServer,
     agents,
-    conversations,
+    conversationStore,
     directory,
     directoryRefresh,
     hiddenAgentIds,
     loadConversation,
+    loadOlderMessages,
     markAgentRead,
     pinnedAgentIds,
     refreshHosts,
@@ -1044,14 +1055,4 @@ function updateAgentPayload(input: UpdateAgentInput): TeamProtocolV2Json {
     ...(input.avatarSeed === undefined ? {} : { avatarSeed: input.avatarSeed }),
     ...(input.avatarHue === undefined ? {} : { avatarHue: input.avatarHue }),
   };
-}
-
-function storeNewestSnapshot(
-  conversations: Record<string, ConversationSnapshot>,
-  snapshot: ConversationSnapshot,
-): Record<string, ConversationSnapshot> {
-  const current = conversations[snapshot.agentId];
-  return current && current.revision > snapshot.revision
-    ? conversations
-    : { ...conversations, [snapshot.agentId]: snapshot };
 }

--- a/apps/mobile/src/features/workspace/model/agent-activity.ts
+++ b/apps/mobile/src/features/workspace/model/agent-activity.ts
@@ -40,6 +40,8 @@ export function reduceAgentActivity(
   }
   if (event.type === "turn-started" || event.type === "turn-progress" || event.type === "conversation-delta") {
     const previous = current[event.agentId];
+    if (event.type === "conversation-delta" && previous?.turnId === event.turnId && previous.phase === "responding")
+      return current;
     return {
       ...current,
       [event.agentId]: {

--- a/apps/mobile/src/features/workspace/model/conversation-store.test.ts
+++ b/apps/mobile/src/features/workspace/model/conversation-store.test.ts
@@ -1,0 +1,280 @@
+import type { AgentEvent, ConversationMessage, ConversationPage } from "@openbot/contracts/ipc";
+import { describe, expect, it } from "vitest";
+import { indexChatMessages, projectChatMessages } from "../../chat/model/chat-messages";
+import { reduceAgentActivity } from "./agent-activity";
+import { decodeConversationPage } from "./conversation";
+import { MobileConversationStore } from "./conversation-store";
+
+function message(id: string, text = id): ConversationMessage {
+  return { id, text, author: "assistant", source: "assistant", createdAt: "2026-09-10T10:00:00Z", status: "completed" };
+}
+function page(ids: string[], revision = 1): ConversationPage {
+  return {
+    agentId: "agent",
+    threadId: "thread",
+    activeTurnId: null,
+    revision,
+    messages: ids.map((id) => message(id)),
+    references: {},
+    pageInfo: { hasOlder: true, olderCursor: ids[0] ?? null },
+  };
+}
+function delta(revision: number, text: string): Extract<AgentEvent, { type: "conversation-delta" }> {
+  return {
+    type: "conversation-delta",
+    agentId: "agent",
+    threadId: "thread",
+    turnId: "turn",
+    messageId: "reply",
+    revision,
+    delta: text,
+    createdAt: "2026-09-10T10:00:00Z",
+  };
+}
+function setup() {
+  const frames = new Set<() => void>();
+  const store = new MobileConversationStore((flush) => {
+    frames.add(flush);
+    return () => frames.delete(flush);
+  });
+  return {
+    store,
+    frame: () => {
+      for (const flush of [...frames]) flush();
+    },
+  };
+}
+
+describe("mobile conversation windows", () => {
+  it("does not let an older page advance the live revision and discard queued text", () => {
+    const { store, frame } = setup();
+    store.applyPage(page(["reply"], 10));
+    store.applyPage(page(["old"], 20), "reply");
+    store.enqueue(delta(11, " still arriving"));
+    frame();
+    expect(store.get("agent")?.messages.map((item) => item.text)).toEqual(["old", "reply still arriving"]);
+  });
+
+  it("streams the first response into a chat that did not have a thread", () => {
+    const { store, frame } = setup();
+    store.applyPage({ ...page([]), threadId: null, pageInfo: { hasOlder: false, olderCursor: null } });
+    store.enqueue(delta(2, "Hello"));
+    frame();
+    expect({ threadId: store.get("agent")?.threadId, text: store.get("agent")?.messages[0]?.text }).toEqual({
+      threadId: "thread",
+      text: "Hello",
+    });
+  });
+
+  it("loads older messages without duplicates or losing newer streamed text and reply references", () => {
+    const { store } = setup();
+    store.applyPage(page(["recent", "reply"], 10));
+    store.enqueue(delta(11, " latest"));
+    const older = page(["old", "recent"], 9);
+    older.references = { source: message("source", "Referenced outside the window") };
+    store.applyPage(older, "recent");
+    const latest = store.get("agent");
+    const index = indexChatMessages(
+      projectChatMessages(latest?.messages ?? []),
+      new Map(),
+      projectChatMessages(Object.values(latest?.references ?? {})),
+    );
+    expect({
+      messages: latest?.messages.map((item) => [item.id, item.text]),
+      revision: latest?.revision,
+      cursor: latest?.pageInfo.olderCursor,
+      reference: index.get("source"),
+    }).toEqual({
+      messages: [
+        ["old", "old"],
+        ["recent", "recent"],
+        ["reply", "reply latest"],
+      ],
+      revision: 11,
+      cursor: "old",
+      reference: {
+        id: "source",
+        kind: "message",
+        author: "agent",
+        body: "Referenced outside the window",
+        streaming: false,
+      },
+    });
+  });
+
+  it("keeps a continuous window on refresh and resets it if a reconnect leaves a gap", () => {
+    const { store } = setup();
+    store.applyPage(page(["a", "b", "c"]));
+    store.applyPage(page(["c", "d"], 2));
+    const continuous = store.get("agent");
+    store.applyPage(page(["x", "y"], 3));
+    const reset = store.get("agent");
+    store.applyPage(page(["old"], 2), "a");
+    expect({
+      continuous: continuous?.messages.map((item) => item.id),
+      cursor: continuous?.pageInfo.olderCursor,
+      reset: reset?.messages.map((item) => item.id),
+      staleOlderIgnored: store.get("agent") === reset,
+    }).toEqual({
+      continuous: ["a", "b", "c", "d"],
+      cursor: "a",
+      reset: ["x", "y"],
+      staleOlderIgnored: true,
+    });
+  });
+
+  it("publishes one streamed update per frame only to the changed chat and ignores stale data", () => {
+    const { store, frame } = setup();
+    let updates = 0;
+    let unrelatedUpdates = 0;
+    store.subscribe("agent", () => updates++);
+    store.subscribe("another-agent", () => unrelatedUpdates++);
+    store.applyPage(page([...Array.from({ length: 9999 }, (_, index) => `old-${index}`), "reply"], 10));
+    const old = projectChatMessages(store.get("agent")?.messages ?? [])[0];
+    updates = 0;
+    store.enqueue(delta(11, " one"));
+    store.enqueue(delta(12, " two"));
+    store.enqueue(delta(11, " duplicate"));
+    frame();
+    store.applyPage(page(["reply"], 9));
+    const projected = projectChatMessages(store.get("agent")?.messages ?? []);
+    expect({ updates, unrelatedUpdates, oldRetained: projected[0] === old, reply: projected.at(-1) }).toEqual({
+      updates: 1,
+      unrelatedUpdates: 0,
+      oldRetained: true,
+      reply: { id: "reply", kind: "message", author: "agent", body: "reply one two", streaming: true },
+    });
+  });
+
+  it("shares a pending page request and refreshes again when invalidated during the request", async () => {
+    const { store } = setup();
+    const first = Promise.withResolvers<ConversationPage>();
+    const started = Promise.withResolvers<void>();
+    let reads = 0;
+    const read = () => {
+      reads++;
+      started.resolve();
+      return reads === 1 ? first.promise : Promise.resolve(page(["new"], 2));
+    };
+    const pending = store.loadLatest("agent", read, () => true);
+    await started.promise;
+    const duplicate = store.loadLatest("agent", read, () => true, true);
+    first.resolve(page(["old"]));
+    await pending;
+    expect({
+      shared: duplicate === pending,
+      reads,
+      messages: store.get("agent")?.messages.map((item) => item.id),
+    }).toEqual({ shared: true, reads: 2, messages: ["new"] });
+  });
+
+  it("does not restore a removed chat from an in-flight response", async () => {
+    const { store } = setup();
+    const response = Promise.withResolvers<ConversationPage>();
+    const started = Promise.withResolvers<void>();
+    const pending = store.loadLatest(
+      "agent",
+      () => {
+        started.resolve();
+        return response.promise;
+      },
+      () => true,
+    );
+    await started.promise;
+    store.remove("agent");
+    response.resolve(page(["private"]));
+    await pending;
+    expect(store.get("agent")).toBeUndefined();
+  });
+
+  it("lets a new connection load while the old connection still has an outstanding request", async () => {
+    const { store } = setup();
+    const response = Promise.withResolvers<ConversationPage>();
+    const started = Promise.withResolvers<void>();
+    const previous = store.loadLatest(
+      "agent",
+      () => {
+        started.resolve();
+        return response.promise;
+      },
+      () => true,
+    );
+    await started.promise;
+    store.cancelRequests();
+    await store.loadLatest(
+      "agent",
+      async () => page(["current"], 2),
+      () => true,
+    );
+    response.resolve(page(["obsolete"], 5));
+    await previous;
+    expect(store.get("agent")?.messages.map((item) => item.id)).toEqual(["current"]);
+  });
+
+  it("keeps existing messages after an older-page failure and permits retry", async () => {
+    const { store } = setup();
+    store.applyPage(page(["recent"]));
+    await store.loadOlder(
+      "agent",
+      async () => {
+        throw new Error("offline");
+      },
+      () => true,
+    );
+    const failure = store.get("agent");
+    await store.loadOlder(
+      "agent",
+      async () => ({ ...page(["old"]), pageInfo: { hasOlder: false, olderCursor: null } }),
+      () => true,
+    );
+    const retry = store.get("agent");
+    expect({
+      retained: failure?.messages.map((item) => item.id),
+      failed: failure?.olderError,
+      pending: failure?.olderLoading,
+      retry: retry?.messages.map((item) => item.id),
+      error: retry?.olderError,
+      hasOlder: retry?.pageInfo.hasOlder,
+    }).toEqual({
+      retained: ["recent"],
+      failed: true,
+      pending: false,
+      retry: ["old", "recent"],
+      error: false,
+      hasOlder: false,
+    });
+  });
+
+  it("releases large inactive windows and cancels queued streaming work on disposal", () => {
+    const { store, frame } = setup();
+    const release = store.subscribe("agent", () => {});
+    store.applyPage(page(Array.from({ length: 1000 }, (_, index) => String(index))));
+    store.enqueue(delta(2, "pending"));
+    release();
+    store.dispose();
+    frame();
+    expect(store.get("agent")).toBeUndefined();
+  });
+
+  it("rejects invalid page cursors and invalid reply references", () => {
+    const badCursor = { ...page(["a"]), pageInfo: { hasOlder: true, olderCursor: null } };
+    const badReference = { ...page(["a"]), references: { secret: { text: "invalid" } } };
+    const errors = [badCursor, badReference].map((input) => {
+      try {
+        decodeConversationPage(input);
+        return null;
+      } catch (error) {
+        return error instanceof Error ? error.message : "unexpected";
+      }
+    });
+    expect(errors).toEqual([
+      "The server returned an invalid conversation page.",
+      "The server returned an invalid conversation message.",
+    ]);
+  });
+
+  it("does not update workspace activity for each token of the same response", () => {
+    const current = reduceAgentActivity({}, delta(1, "first"));
+    expect(reduceAgentActivity(current, delta(2, "second"))).toBe(current);
+  });
+});

--- a/apps/mobile/src/features/workspace/model/conversation-store.ts
+++ b/apps/mobile/src/features/workspace/model/conversation-store.ts
@@ -1,0 +1,230 @@
+import type { AgentEvent, ConversationMessage, ConversationPage } from "@openbot/contracts/ipc";
+
+type Delta = Extract<AgentEvent, { type: "conversation-delta" }>;
+export interface MobileConversation extends ConversationPage {
+  olderLoading: boolean;
+  olderError: boolean;
+}
+type ReadPage = (cursor?: string) => Promise<ConversationPage>;
+
+/** In-memory chat windows. Only subscribers to a changed agent are notified. */
+export class MobileConversationStore {
+  #entries = new Map<string, MobileConversation>();
+  #listeners = new Map<string, Set<() => void>>();
+  #indices = new Map<string, Map<string, number>>();
+  #deltas = new Map<string, Delta[]>();
+  #cancelFrame: (() => void) | null = null;
+  #olderLoads = new Map<string, symbol>();
+  #loads = new Map<string, { promise: Promise<ConversationPage>; dirty: boolean }>();
+
+  constructor(private schedule: (flush: () => void) => () => void) {}
+
+  get(agentId: string) {
+    return this.#entries.get(agentId);
+  }
+
+  isObserved(agentId: string) {
+    return Boolean(this.#listeners.get(agentId)?.size);
+  }
+
+  subscribe(agentId: string, listener: () => void) {
+    let listeners = this.#listeners.get(agentId);
+    if (!listeners) {
+      listeners = new Set();
+      this.#listeners.set(agentId, listeners);
+    }
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+      if (!listeners.size) {
+        this.#listeners.delete(agentId);
+        if ((this.get(agentId)?.messages.length ?? 0) > 50) this.remove(agentId);
+      }
+    };
+  }
+
+  remove(agentId: string) {
+    this.#entries.delete(agentId);
+    this.#indices.delete(agentId);
+    this.#deltas.delete(agentId);
+    this.#loads.delete(agentId);
+    this.#olderLoads.delete(agentId);
+    for (const listener of this.#listeners.get(agentId) ?? []) listener();
+  }
+
+  cancelRequests() {
+    this.#loads.clear();
+    this.#olderLoads.clear();
+    for (const [id, entry] of this.#entries) {
+      if (entry.olderLoading) this.#publish(id, { ...entry, olderLoading: false }, false);
+    }
+  }
+
+  dispose() {
+    this.#cancelFrame?.();
+    this.#cancelFrame = null;
+    this.#deltas.clear();
+    this.cancelRequests();
+  }
+
+  #publish(agentId: string, entry: MobileConversation, reindex = true) {
+    if (!this.isObserved(agentId) && entry.messages.length > 50) {
+      this.remove(agentId);
+      return;
+    }
+    this.#entries.set(agentId, entry);
+    if (reindex) this.#indices.set(agentId, new Map(entry.messages.map((message, index) => [message.id, index])));
+    for (const listener of this.#listeners.get(agentId) ?? []) listener();
+  }
+
+  applyPage(page: ConversationPage, cursor?: string) {
+    this.flush();
+    const current = this.get(page.agentId);
+    if (cursor && (!current || current.threadId !== page.threadId || current.pageInfo.olderCursor !== cursor)) return;
+    if (!cursor && current && page.revision < current.revision) return;
+    const sameThread = current?.threadId === page.threadId;
+    const indices = sameThread ? this.#indices.get(page.agentId) : undefined;
+    const overlap = page.messages.find((message) => indices?.has(message.id));
+    // A disconnected latest page must not leave an invisible gap in the history.
+    const retain = Boolean(sameThread && (cursor || overlap));
+    const oldMessages = retain && current ? current.messages : [];
+    const oldById = new Map(oldMessages.map((message) => [message.id, message]));
+    const fetched = page.messages.map((message) => {
+      const old = oldById.get(message.id);
+      if (!old) return message;
+      if (cursor) return old;
+      return JSON.stringify(old) === JSON.stringify(message) ? old : message;
+    });
+    const fetchedById = new Map(fetched.map((message) => [message.id, message]));
+    const fetchedIds = new Set(fetchedById.keys());
+    const first = overlap ? (indices?.get(overlap.id) ?? 0) : 0;
+    let messages: ConversationMessage[];
+    if (cursor)
+      messages = [
+        ...fetched.filter((message) => !oldById.has(message.id)),
+        ...oldMessages.map((message) =>
+          fetchedIds.has(message.id) ? (fetchedById.get(message.id) ?? message) : message,
+        ),
+      ];
+    else {
+      messages = [...oldMessages.slice(0, first).filter((message) => !fetchedIds.has(message.id)), ...fetched];
+    }
+    this.#publish(page.agentId, {
+      ...page,
+      ...(cursor && current ? { revision: current.revision, activeTurnId: current.activeTurnId } : {}),
+      messages,
+      references: { ...(retain ? current?.references : {}), ...page.references },
+      pageInfo: !cursor && retain && current && first > 0 ? current.pageInfo : page.pageInfo,
+      olderLoading: current?.olderLoading ?? false,
+      olderError: false,
+    });
+  }
+
+  loadLatest(agentId: string, read: ReadPage, isCurrent: () => boolean, refresh = false): Promise<ConversationPage> {
+    const pending = this.#loads.get(agentId);
+    if (pending) {
+      if (refresh) pending.dirty = true;
+      return pending.promise;
+    }
+    const load: { promise: Promise<ConversationPage>; dirty: boolean } = {
+      dirty: false,
+      promise: Promise.resolve()
+        .then(async () => {
+          let page: ConversationPage;
+          do {
+            load.dirty = false;
+            page = await read();
+            if (page.agentId !== agentId) throw new Error("The server returned a page for another conversation.");
+            if (!isCurrent() || this.#loads.get(agentId) !== load) return page;
+            this.applyPage(page);
+          } while (load.dirty);
+          return page;
+        })
+        .finally(() => {
+          if (this.#loads.get(agentId) === load) this.#loads.delete(agentId);
+        }),
+    };
+    this.#loads.set(agentId, load);
+    return load.promise;
+  }
+
+  async loadOlder(agentId: string, read: ReadPage, isCurrent: () => boolean) {
+    const current = this.get(agentId);
+    const cursor = current?.pageInfo.olderCursor;
+    if (!current || current.olderLoading || !current.pageInfo.hasOlder || !cursor) return;
+    const token = Symbol();
+    this.#olderLoads.set(agentId, token);
+    const valid = () => isCurrent() && this.#olderLoads.get(agentId) === token;
+    this.#publish(agentId, { ...current, olderLoading: true, olderError: false }, false);
+    try {
+      const page = await read(cursor);
+      if (page.agentId !== agentId) throw new Error("The server returned a page for another conversation.");
+      if (valid()) this.applyPage(page, cursor);
+    } catch {
+      const latest = this.get(agentId);
+      if (valid() && latest?.pageInfo.olderCursor === cursor)
+        this.#publish(agentId, { ...latest, olderError: true }, false);
+    } finally {
+      const latest = this.get(agentId);
+      if (this.#olderLoads.get(agentId) === token) {
+        this.#olderLoads.delete(agentId);
+        if (latest) this.#publish(agentId, { ...latest, olderLoading: false }, false);
+      }
+    }
+  }
+
+  enqueue(delta: Delta) {
+    if (!this.get(delta.agentId)) return;
+    const pending = this.#deltas.get(delta.agentId) ?? [];
+    pending.push(delta);
+    this.#deltas.set(delta.agentId, pending);
+    this.#cancelFrame ??= this.schedule(() => this.flush());
+  }
+
+  flush() {
+    this.#cancelFrame?.();
+    this.#cancelFrame = null;
+    const pending = this.#deltas;
+    this.#deltas = new Map();
+    for (const [agentId, deltas] of pending) {
+      const current = this.get(agentId);
+      const indices = this.#indices.get(agentId);
+      if (!current || !indices) continue;
+      let revision = current.revision;
+      let threadId = current.threadId;
+      let activeTurnId = current.activeTurnId;
+      const updates = new Map<string, { event: Delta; parts: string[] }>();
+      for (const event of deltas) {
+        if (event.revision <= revision || (threadId !== null && event.threadId !== threadId)) continue;
+        threadId = event.threadId;
+        const update = updates.get(event.messageId);
+        if (update) update.parts.push(event.delta);
+        else updates.set(event.messageId, { event, parts: [event.delta] });
+        revision = event.revision;
+        activeTurnId = event.turnId;
+      }
+      if (!updates.size) continue;
+      const messages = [...current.messages];
+      for (const [messageId, { event, parts }] of updates) {
+        const text = parts.join("");
+        const index = indices.get(messageId);
+        if (index === undefined) {
+          indices.set(messageId, messages.length);
+          messages.push({
+            id: messageId,
+            turnId: event.turnId,
+            author: "assistant",
+            source: "assistant",
+            text,
+            createdAt: event.createdAt,
+            status: "streaming",
+          });
+        } else {
+          const message = messages[index];
+          messages[index] = { ...message, text: message.text + text, status: "streaming" };
+        }
+      }
+      this.#publish(agentId, { ...current, messages, revision, activeTurnId, threadId }, false);
+    }
+  }
+}

--- a/apps/mobile/src/features/workspace/model/conversation.ts
+++ b/apps/mobile/src/features/workspace/model/conversation.ts
@@ -1,4 +1,4 @@
-import type { QueuedMessageReceipt } from "@openbot/contracts/ipc";
+import type { ConversationPage, QueuedMessageReceipt } from "@openbot/contracts/ipc";
 import { type ConversationMessage, type ConversationSnapshot, isConversationMessage } from "@openbot/contracts/ipc";
 import { isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
 
@@ -27,6 +27,27 @@ export function decodeConversation(value: unknown): ConversationSnapshot {
 function decodeConversationMessage(value: unknown): ConversationMessage {
   if (!isConversationMessage(value)) throw new Error("The server returned an invalid conversation message.");
   return value;
+}
+
+export function decodeConversationPage(value: unknown): ConversationPage {
+  const snapshot = decodeConversation(value);
+  if (
+    !isDynamicRecord(value) ||
+    !isDynamicRecord(value.pageInfo) ||
+    typeof value.pageInfo.hasOlder !== "boolean" ||
+    (value.pageInfo.olderCursor !== null && !isString(value.pageInfo.olderCursor)) ||
+    (value.pageInfo.hasOlder && !value.pageInfo.olderCursor) ||
+    !isDynamicRecord(value.references)
+  ) {
+    throw new Error("The server returned an invalid conversation page.");
+  }
+  return {
+    ...snapshot,
+    pageInfo: { hasOlder: value.pageInfo.hasOlder, olderCursor: value.pageInfo.olderCursor },
+    references: Object.fromEntries(
+      Object.entries(value.references).map(([id, message]) => [id, decodeConversationMessage(message)]),
+    ),
+  };
 }
 
 /** Conversation projections identify user bubbles by recipient delivery, not mailbox message. */

--- a/apps/mobile/src/features/workspace/model/workspace-types.ts
+++ b/apps/mobile/src/features/workspace/model/workspace-types.ts
@@ -19,6 +19,7 @@ import type {
 import type { RemoteRecoveryStatus, RemoteTeamDirectoryClient } from "@openbot/team-client";
 import type { RemoteFileUpload } from "@openbot/team-client/remote-peer";
 import type { MobileAgentActivities } from "./agent-activity";
+import type { MobileConversationStore } from "./conversation-store";
 
 export type MobileServerKind = "local" | "remote";
 export type MobileServerState = "unknown" | "connecting" | "online" | "offline" | "error";
@@ -71,7 +72,7 @@ export interface MobileWorkspaceContextValue {
   hiddenAgents: MobileAgent[];
   pinnedAgentIds: string[];
   unreadAgentIds: string[];
-  conversations: Record<string, ConversationSnapshot>;
+  conversationStore: MobileConversationStore;
   activityByServer: Record<string, MobileAgentActivities>;
   selectServer: (serverId: string) => void;
   leaveServer: (serverId: string) => Promise<void>;
@@ -92,6 +93,7 @@ export interface MobileWorkspaceContextValue {
   loadAgentRoutines: (agentId: string, serverId: string) => Promise<Routine[]>;
   loadAgentAnalytics: (input: AgentAnalyticsInput, serverId: string) => Promise<AgentAnalytics | null>;
   loadConversation: (agentId: string) => Promise<ConversationSnapshot>;
+  loadOlderMessages: (agentId: string) => Promise<void>;
   respondToPrompt: (agentId: string, input: RespondToPromptInput) => Promise<void>;
   sendMessage: (
     agentId: string,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -270,7 +270,14 @@ Conversation read cursors belong to a team member and are shared across that mem
 Advancing a cursor emits a conversation invalidation without the reader's identity or cursor;
 clients reload their own read state even when the conversation content revision is unchanged.
 Mobile acknowledges rendered replies only in the foreground, focused chat at the latest messages.
-Mobile chat keeps viewport, tail-group, and composer measurements in its motion controller. The
+Mobile chat loads the latest 50 messages through `conversation-page` and loads older pages by cursor.
+Its `FlatList` virtualizes messages and retains the visible position when older pages are added.
+Reply references travel with each page. A page with no overlap replaces the cached window so a
+reconnect cannot leave an invisible gap. Older-page responses do not advance the live revision.
+The in-memory conversation store notifies subscribers per agent and combines streamed text once
+per animation frame. Windows above 50 messages are released when their last subscriber leaves;
+the complete history remains in the host database. Connection recovery prioritizes observed chats.
+Mobile chat keeps viewport, latest-user, and composer measurements in its motion controller. The
 last user message anchors a native blank-space inset; streamed replies consume that inset without
 autoscrolling. Initial history positioning and the first-send/first-response animation are separate
 states. Pending message bubbles reconcile through the host receipt ID, not message text.


### PR DESCRIPTION
## Summary

- Virtualize mobile chat messages with `FlatList` for improved performance.
- Add loading for older conversation pages with preserved scroll position.
- Keep message references available for reply rendering.
- Stabilize projected message identities and external conversation updates.
- Preserve send-position and response-motion behavior during virtualization.

## Testing

- Added coverage for virtualized history reveal and older-message loading behavior.
- Not run (not requested)