### PR TITLE
Add local and GitHub Actions iOS TestFlight releases

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -1,0 +1,106 @@
+name: Release iOS to TestFlight
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-ios
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build iOS and upload to TestFlight
+    if: github.ref == 'refs/heads/main'
+    runs-on: macos-26
+    timeout-minutes: 90
+    environment: release-ios
+    permissions:
+      contents: read
+    env:
+      CI: "1"
+      FASTLANE_SKIP_UPDATE_CHECK: "1"
+      FASTLANE_HIDE_CHANGELOG: "1"
+      FASTLANE_OPT_OUT_USAGE: "1"
+    steps:
+      - name: Check out release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Require release credentials
+        shell: bash
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+        run: |
+          missing=()
+          for name in EXPO_TOKEN ASC_KEY_ID ASC_ISSUER_ID ASC_PRIVATE_KEY; do
+            if [[ -z "${!name}" ]]; then missing+=("$name"); fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing release-ios secrets: ${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Set up Bun and Node
+        uses: ./.github/actions/setup-bun
+        with:
+          install: none
+
+      - name: Select and verify iOS tools
+        shell: bash
+        run: |
+          echo "IPA_PATH=$RUNNER_TEMP/openbot-testflight.ipa" >> "$GITHUB_ENV"
+          sudo xcode-select --switch /Applications/Xcode_26.6.app/Contents/Developer
+          xcodebuild -version
+          pod --version
+          fastlane --version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check source
+        run: |
+          bun run lint
+          bun run typecheck
+          bun run test:desktop -- apps/mobile/src packages/contracts packages/team-client scripts/mobile-release.test.ts
+
+      - name: Build production iOS on this runner
+        working-directory: apps/mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: >-
+          bunx eas-cli@24.1.2 build
+          --platform ios --profile production --local --non-interactive
+          --output "$IPA_PATH"
+
+      - name: Save signed IPA
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.IPA_PATH }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload to App Store Connect
+        working-directory: apps/mobile
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+        run: fastlane ios beta
+
+      - name: Summarize upload
+        shell: bash
+        run: |
+          {
+            echo '## iOS upload complete'
+            echo "Commit: $GITHUB_SHA"
+            echo "Artifact: ios-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+            echo 'Apple must process the build before it is available in TestFlight.'
+            echo 'Manage tester groups in App Store Connect. This workflow does not publish to the App Store.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Seed the approved OpenBot team catalog locally with `bun run marketplace:seed:lo
 | `bun run preview` | Preview the built Electron client with the green preview icon. |
 | `bun run mobile:go` | Start the mobile app in Expo Go and clear the Metro cache. |
 | `bun mobile:ios` | Build and launch the iOS simulator app without RocketSim. |
+| `bun run mobile:ios:build:local` | Build a production iOS `.ipa` locally for upload with Transporter. See [TestFlight setup](apps/mobile/README.md#local-testflight-build). |
+| `bun run mobile:ios:release:testflight` | Start the GitHub Actions iOS build from `main` and upload to TestFlight. Requires authenticated GitHub CLI. See [iOS release setup](apps/mobile/README.md#github-actions-testflight-release). |
 | `bun mobile:ios:rocketsim` | Start RocketSim and build and launch the iOS simulator app with RocketSim Connect. See [mobile setup](apps/mobile/README.md#development). |
 | `bun run mobile:go:tunnel` | Start the mobile app in Expo Go through a Metro tunnel and clear the cache. The OpenBot API and Signal still need their own reachable addresses. |
 | `bun run dev:api` | Start the TanStack Start API and its local D1 database on `127.0.0.1:3100`. |

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -254,6 +254,84 @@ bunx eas-cli@latest build --profile development --platform android
 
 Cloud builds require the final `ios.bundleIdentifier` and `android.package` values in `app.json`. Store submission also requires Apple Developer and Google Play Console credentials.
 
+### Local TestFlight build
+
+On a Mac with Xcode, CocoaPods, Fastlane, and this project's Node and Bun versions installed,
+sign in to Expo with `bunx eas-cli@latest login` from `apps/mobile`. An active Apple Developer
+membership is required for signing and TestFlight distribution.
+
+From the repository root, run:
+
+```bash
+bun run mobile:ios:build:local
+```
+
+From `apps/mobile`, the equivalent command is `bun run ios:build:local`.
+This runs EAS Build locally with the `production` profile and writes
+`/private/tmp/openbot-testflight.ipa`. Each successful build replaces that output file.
+The profile uses remote build numbers and increments the build number automatically.
+EAS CLI prompts for signing credentials when needed.
+
+The build loads `Plain text` and `Sensitive` variables from the EAS `production` environment.
+Variables with `Secret` visibility must be supplied in the local environment.
+See [OpenPanel configuration](#openpanel-product-analytics) for the required analytics variables.
+
+To upload, open Apple's Transporter app, sign in, add the `.ipa`, and select **Deliver**.
+After Apple processes the build, select it in App Store Connect under **TestFlight** and assign
+it to a tester group. Upload is manual; the command does not run EAS Submit.
+
+### GitHub Actions TestFlight release
+
+The `Release iOS to TestFlight` workflow builds the selected `main` commit on a GitHub-hosted
+`macos-26` runner with Xcode 26.6. Expo SDK 57 requires Xcode 26.4 or newer; the desktop release's
+`macos-14` runner is not suitable. EAS CLI 24.1.2 runs with `--local --non-interactive`, so compilation
+uses GitHub Actions compute. Fastlane uploads directly to Apple without EAS Submit.
+
+One-time setup:
+
+1. In GitHub repository settings, create the `release-ios` environment. Under deployment branches
+   and tags, select only the `main` branch.
+2. Add environment secrets `EXPO_TOKEN`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, and `ASC_PRIVATE_KEY`.
+   The Expo token needs access to the OpenBot project. The Apple secrets are the Key ID, Issuer ID,
+   and full `.p8` contents of an App Store Connect team API key with the App Manager role.
+3. Keep the iOS distribution certificate and provisioning profile configured in EAS. CI downloads
+   these existing credentials. If they expire or need repair, update them interactively through
+   EAS before retrying; the upload API key is not passed to the build step.
+4. Keep the OpenPanel variables in EAS `production` with `Plain text` or `Sensitive` visibility.
+   `Secret` variables are unavailable to this local build. Do not copy these values into source.
+5. Ensure App Store Connect has the app `run.openbot.mobile` and the intended TestFlight group.
+
+After this workflow is merged into `main`, authenticate GitHub CLI with `gh auth login`, then run
+from the repository root:
+
+```bash
+bun run mobile:ios:release:testflight
+```
+
+From `apps/mobile`, run `bun run ios:release:testflight`.
+
+This dispatches a release of remote `main`, including no local or uncommitted changes. The command
+returns after dispatch; follow the run in GitHub Actions under **Release iOS to TestFlight**.
+You can also select **Run workflow** on `main` in GitHub. The workflow does not run on pushes,
+pull requests, or desktop release tags. Concurrent iOS releases are serialized; GitHub can replace
+an older pending run with a newer request, so avoid dispatching the same release repeatedly.
+
+The workflow checks source before building. EAS increments the remote iOS build number; a failed
+build can consume a number. The marketing version stays in `app.json` and is not changed by dispatch.
+The signed `.ipa` is saved as a GitHub Actions artifact for seven days before upload. If upload
+fails, download that artifact and retry with Transporter to avoid rebuilding. Re-running the full
+workflow creates a new build number.
+
+A successful workflow means Apple accepted the upload. Fastlane does not wait for Apple processing
+or assign tester groups. Configure automatic distribution for an internal group in App Store Connect,
+or assign the processed build manually. External testing can require Beta App Review. This workflow
+does not submit the app for public App Store release.
+
+The workflow uses the runner's installed Fastlane and CocoaPods and prints their versions. Update
+the selected Xcode and EAS CLI versions when upgrading Expo. GitHub Actions usage and limits apply.
+See [local EAS builds](https://docs.expo.dev/build-reference/local-builds/) and
+[Fastlane TestFlight upload](https://docs.fastlane.tools/actions/upload_to_testflight/).
+
 ## OpenPanel product analytics
 
 The app uses the official [`@openpanel/react-native` SDK](https://openpanel.dev/docs/sdks/react-native)

--- a/apps/mobile/fastlane/Fastfile
+++ b/apps/mobile/fastlane/Fastfile
@@ -1,0 +1,24 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Upload the signed IPA to TestFlight without EAS Submit"
+  lane :beta do
+    ipa = ENV.fetch("IPA_PATH")
+    UI.user_error!("IPA_PATH must point to an existing .ipa file") unless File.file?(ipa) && File.extname(ipa) == ".ipa"
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("ASC_KEY_ID"),
+      issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+      key_content: ENV.fetch("ASC_PRIVATE_KEY"),
+      in_house: false
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: ipa,
+      app_identifier: "run.openbot.mobile",
+      skip_waiting_for_build_processing: true,
+      distribute_external: false
+    )
+  end
+end

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -91,6 +91,8 @@
     "android": "expo run:android",
     "ios": "bun ../../scripts/mobile-ios.ts",
     "ios:rocketsim": "bun ../../scripts/mobile-ios.ts --rocketsim",
+    "ios:build:local": "bunx eas-cli@latest build --platform ios --profile production --local --output /private/tmp/openbot-testflight.ipa",
+    "ios:release:testflight": "gh workflow run release-ios.yml --ref main",
     "lint": "biome check --max-diagnostics=none src",
     "codegen": "expo customize tsconfig.json && uniwind generate-artifacts --css ./global.css --dts ./src/uniwind-types.d.ts",
     "typecheck": "bun run codegen && tsc --noEmit",

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,5 +1,9 @@
 # Releasing OpenBot
 
+For iOS builds uploaded to TestFlight through GitHub Actions, see
+[the mobile release guide](../apps/mobile/README.md#github-actions-testflight-release).
+The mobile workflow is separate from the desktop tag release described below.
+
 OpenBot updates are published through GitHub Releases and installed with `electron-updater`.
 macOS requires every auto-updatable build to be signed with a Developer ID Application certificate.
 The release workflow also notarizes and staples the macOS application before publishing it. Windows

--- a/package.json
+++ b/package.json
@@ -99,6 +99,8 @@
     "mobile:android": "bun run --cwd apps/mobile android",
     "mobile:ios": "bun run --cwd apps/mobile ios",
     "mobile:ios:rocketsim": "bun run --cwd apps/mobile ios:rocketsim",
+    "mobile:ios:build:local": "bun run --cwd apps/mobile ios:build:local",
+    "mobile:ios:release:testflight": "bun run --cwd apps/mobile ios:release:testflight",
     "mobile:lint": "bun run --cwd apps/mobile lint",
     "mobile:typecheck": "bun run typecheck:mobile",
     "mobile:doctor": "bun run --cwd apps/mobile doctor",

--- a/scripts/mobile-release.test.ts
+++ b/scripts/mobile-release.test.ts
@@ -1,0 +1,128 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { z } from "zod";
+
+const root = resolve(import.meta.dirname, "..");
+const workflow = z
+  .object({
+    jobs: z.object({
+      release: z.object({ steps: z.array(z.object({ name: z.string(), run: z.string().optional() })) }),
+    }),
+  })
+  .parse(parse(readFileSync(join(root, ".github/workflows/release-ios.yml"), "utf8")));
+
+describe("iOS release", () => {
+  it("dispatches remote main without building or uploading on the caller's machine", () => {
+    const manifest = z
+      .object({ scripts: z.record(z.string(), z.string()) })
+      .parse(JSON.parse(readFileSync(join(root, "package.json"), "utf8")));
+    const directory = mkdtempSync(join(tmpdir(), "openbot-ios-dispatch-"));
+    try {
+      writeFileSync(join(directory, "package.json"), JSON.stringify({ scripts: manifest.scripts }));
+      mkdirSync(join(directory, "apps/mobile"), { recursive: true });
+      writeFileSync(join(directory, "apps/mobile/package.json"), readFileSync(join(root, "apps/mobile/package.json")));
+      writeFileSync(join(directory, "gh"), '#!/bin/sh\nprintf "%s\\n" "$@"\n', { mode: 0o755 });
+      const output = execFileSync("bun", ["run", "mobile:ios:release:testflight"], {
+        cwd: directory,
+        env: { ...process.env, PATH: `${directory}:${process.env.PATH}` },
+        encoding: "utf8",
+      });
+      expect(output.trim().split("\n")).toEqual(["workflow", "run", "release-ios.yml", "--ref", "main"]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("stops when any credential is missing without printing credential values", () => {
+    const check = workflow.jobs.release.steps.find((step) => step.name === "Require release credentials")?.run;
+    if (!check) throw new Error("Release credential check is missing");
+    const credentials = {
+      EXPO_TOKEN: "test-expo-token",
+      ASC_KEY_ID: "test-apple-key-id",
+      ASC_ISSUER_ID: "test-apple-issuer",
+      ASC_PRIVATE_KEY: "test-private-key-content",
+    };
+    for (const name of Object.keys(credentials)) {
+      const result = spawnSync("bash", ["-e", "-c", check], {
+        env: { ...process.env, ...credentials, [name]: "" },
+        encoding: "utf8",
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`Missing release-ios secrets: ${name}`);
+      for (const value of Object.values(credentials)) {
+        expect(result.stdout + result.stderr).not.toContain(value);
+      }
+    }
+    const valid = spawnSync("bash", ["-e", "-c", check], {
+      env: { ...process.env, ...credentials },
+      encoding: "utf8",
+    });
+    expect(valid.status).toBe(0);
+    expect(valid.stdout + valid.stderr).toBe("");
+  });
+
+  it("uploads only an existing IPA using the API key and propagates upload failures", () => {
+    const directory = mkdtempSync(join(tmpdir(), "openbot-ios-upload-"));
+    const ipa = join(directory, "release.ipa");
+    // Execute the Fastfile with a small Fastlane DSL fake. No Apple request or signing occurs.
+    const harness = `
+      def default_platform(value); end
+      def platform(value); yield; end
+      def desc(value); end
+      def lane(value); yield; end
+      module UI
+        def self.user_error!(message); raise message; end
+      end
+      def app_store_connect_api_key(**options)
+        expected = {key_id: "test-id", issuer_id: "test-issuer", key_content: "test-private-key", in_house: false}
+        raise "Wrong API credentials" unless options == expected
+        {token: "fake-token"}
+      end
+      def upload_to_testflight(**options)
+        expected = {api_key: {token: "fake-token"}, ipa: ENV.fetch("IPA_PATH"),
+          app_identifier: "run.openbot.mobile", skip_waiting_for_build_processing: true, distribute_external: false}
+        raise "Wrong upload destination or options" unless options == expected
+        raise "Apple rejected the upload" if ENV["TEST_UPLOAD_FAILURE"] == "1"
+        puts "uploaded"
+      end
+      load ARGV.fetch(0)
+    `;
+    const run = (path: string, fail = false) =>
+      spawnSync("ruby", ["-e", harness, join(root, "apps/mobile/fastlane/Fastfile")], {
+        env: {
+          ...process.env,
+          IPA_PATH: path,
+          ASC_KEY_ID: "test-id",
+          ASC_ISSUER_ID: "test-issuer",
+          ASC_PRIVATE_KEY: "test-private-key",
+          TEST_UPLOAD_FAILURE: fail ? "1" : "0",
+        },
+        encoding: "utf8",
+      });
+    try {
+      writeFileSync(ipa, "test archive");
+      const success = run(ipa);
+      expect({ status: success.status, stdout: success.stdout, stderr: success.stderr }).toEqual({
+        status: 0,
+        stdout: "uploaded\n",
+        stderr: "",
+      });
+      const other = join(directory, "release.txt");
+      writeFileSync(other, "not an IPA");
+      for (const invalid of [join(directory, "missing.ipa"), other]) {
+        const missing = run(invalid);
+        expect(missing.status).toBe(1);
+        expect(missing.stderr).toContain("IPA_PATH must point to an existing .ipa file");
+      }
+      const rejected = run(ipa, true);
+      expect(rejected.status).toBe(1);
+      expect(rejected.stderr).toContain("Apple rejected the upload");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add local production iOS IPA builds for Transporter uploads.
- Add a GitHub Actions workflow to build and upload iOS releases to TestFlight.
- Add Fastlane upload configuration and credential validation.
- Document local and CI-based TestFlight release setup.

## Testing

Not run (not requested).