### PR TITLE
Improve mobile theme text contrast and semantic color usage

### DIFF
--- a/apps/mobile/DESIGN.md
+++ b/apps/mobile/DESIGN.md
@@ -134,7 +134,7 @@ maps them to utilities. Do not copy these hex values into components.
 | --- | --- | --- | --- |
 | Sheet background | `bg-sheet` | `#fcfcfc` | `#121212` |
 | Group background | `bg-grouped` | `#f2f2f2` | `#212121` |
-| Supporting text | `text-grouped-secondary` | `#858589` | `#96969b` |
+| Supporting text | `text-grouped-secondary` | `#69696e` | `#96969b` |
 | Inset separator | `bg-grouped-border` | `#dddddf` | `#333335` |
 | Group corners | `rounded-grouped` | 16 pt | 16 pt |
 
@@ -150,7 +150,7 @@ labels, uppercase section titles, decorative cards and tinted gray backgrounds. 
 can use `ProfileAvatar neutral`; agent colors still convey their own identities.
 
 Action rows use the same flat grouped surface as navigation rows. Sign-out and photo-removal
-rows do not have chevrons; destructive actions use `text-danger` instead of a filled red block.
+rows do not have chevrons; destructive actions use `text-danger-text` instead of a filled red block.
 Keep pending/disabled behavior and confirmation for sign-out. Do not add account deletion or other
 unsupported actions just because a visual reference shows them.
 
@@ -190,6 +190,14 @@ build without the authorization required by `AGENTS.md`; inspecting an already r
 does not prove a changed screen was exercised.
 
 ## Theme and visual consistency
+
+Use `text-muted` for readable timestamps, reply references and code labels. Reserve dim colors
+for decoration or inactive controls. Status text on neutral surfaces uses `text-success-text`,
+`text-warning-text` or `text-danger-text`; `success`, `warning` and `danger` remain fill colors.
+The text colors must retain at least 4.5:1 contrast on the surfaces that use them in both modes.
+
+Fixed colors in camera overlays, QR codes, SVG alpha masks and agent artwork serve their
+respective media or identity roles. Do not replace these with foreground/background theme colors.
 
 - `packages/brand/src/tokens.css` is the single source of truth for OpenBot color, typography, radius, shadow, and motion tokens, shared with the desktop and web apps; `tokens-native.css` beside it carries the light and dark values for the tokens mobile themes. `global.css` imports both and declares none of its own — it maps them to Tailwind utilities and HeroUI semantic aliases.
 - Use HeroUI semantic variants and existing utility classes. Do not add raw colors, arbitrary radii, or one-off shadows to a screen when a token or component variant can express the intent.

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -20,6 +20,9 @@
   --color-text-secondary: var(--openbot-text-secondary);
   --color-text-dim: var(--openbot-text-dim);
   --color-accent-text: var(--openbot-accent-text);
+  --color-success-text: var(--openbot-success-text);
+  --color-warning-text: var(--openbot-warning-text);
+  --color-danger-text: var(--openbot-danger-text);
   --color-brand-logo: var(--openbot-logo-production);
   --color-action: var(--openbot-action);
   --color-action-foreground: var(--openbot-action-foreground);

--- a/apps/mobile/src/features/agents/components/agent-information.tsx
+++ b/apps/mobile/src/features/agents/components/agent-information.tsx
@@ -123,7 +123,7 @@ export function AgentInformation({
                 maxLength={10}
               />
               {rangeError ? (
-                <Typography.Paragraph accessibilityRole="alert" className="text-danger">
+                <Typography.Paragraph accessibilityRole="alert" className="text-danger-text">
                   {rangeError}
                 </Typography.Paragraph>
               ) : null}

--- a/apps/mobile/src/features/agents/components/agent-list-row.tsx
+++ b/apps/mobile/src/features/agents/components/agent-list-row.tsx
@@ -147,7 +147,7 @@ export function AgentListRow({
                   <Typography.Paragraph className="min-w-0 flex-1" weight="semibold" numberOfLines={1}>
                     {agent.name}
                   </Typography.Paragraph>
-                  <Typography.Paragraph type="body-xs" className="text-text-dim">
+                  <Typography.Paragraph type="body-xs" className="text-muted">
                     {agent.updatedLabel}
                   </Typography.Paragraph>
                 </View>

--- a/apps/mobile/src/features/agents/components/agent-record-editor.tsx
+++ b/apps/mobile/src/features/agents/components/agent-record-editor.tsx
@@ -117,12 +117,12 @@ export function MemoryEditor({
               ])
             }
           >
-            <Typography.Paragraph className="text-danger">Delete memory</Typography.Paragraph>
+            <Typography.Paragraph className="text-danger-text">Delete memory</Typography.Paragraph>
           </SettingsRow>
         </SettingsSection>
       ) : null}
       {action.error ? (
-        <Typography.Paragraph accessibilityRole="alert" className="text-danger">
+        <Typography.Paragraph accessibilityRole="alert" className="text-danger-text">
           {action.error}
         </Typography.Paragraph>
       ) : null}
@@ -397,17 +397,17 @@ export function RoutineEditor({
               ])
             }
           >
-            <Typography.Paragraph className="text-danger">Delete routine</Typography.Paragraph>
+            <Typography.Paragraph className="text-danger-text">Delete routine</Typography.Paragraph>
           </SettingsRow>
         </SettingsSection>
       ) : null}
       {toggle.error ? (
-        <Typography.Paragraph accessibilityRole="alert" className="text-danger">
+        <Typography.Paragraph accessibilityRole="alert" className="text-danger-text">
           {toggle.error}
         </Typography.Paragraph>
       ) : null}
       {action.error ? (
-        <Typography.Paragraph accessibilityRole="alert" className="text-danger">
+        <Typography.Paragraph accessibilityRole="alert" className="text-danger-text">
           {action.error}
         </Typography.Paragraph>
       ) : null}

--- a/apps/mobile/src/features/agents/screens/add-agent-screen.tsx
+++ b/apps/mobile/src/features/agents/screens/add-agent-screen.tsx
@@ -81,7 +81,7 @@ export function AddAgentScreen() {
       />
 
       {error ? (
-        <Typography.Paragraph align="center" className="text-danger">
+        <Typography.Paragraph align="center" className="text-danger-text">
           {error}
         </Typography.Paragraph>
       ) : null}

--- a/apps/mobile/src/features/agents/screens/edit-agent-screen.tsx
+++ b/apps/mobile/src/features/agents/screens/edit-agent-screen.tsx
@@ -200,7 +200,7 @@ function AgentForm({ agent, available, page }: { agent: MobileAgent; available: 
         </Typography.Paragraph>
       ) : null}
       {error ? (
-        <Typography.Paragraph accessibilityRole="alert" className="text-danger">
+        <Typography.Paragraph accessibilityRole="alert" className="text-danger-text">
           {error}
         </Typography.Paragraph>
       ) : null}

--- a/apps/mobile/src/features/chat/components/chat-code-block.tsx
+++ b/apps/mobile/src/features/chat/components/chat-code-block.tsx
@@ -5,6 +5,7 @@ import { useThemeColor } from "heroui-native/hooks";
 import { Check, Copy } from "lucide-react-native";
 import { useEffect, useState } from "react";
 import { Alert, type ColorValue, ScrollView, useWindowDimensions, View } from "react-native";
+import { useCSSVariable } from "uniwind";
 import { type CodeToken, codeLanguage, highlightCode } from "../model/code-highlight";
 
 export function ChatCodeBlock({
@@ -17,14 +18,12 @@ export function ChatCodeBlock({
   selectable?: boolean;
 }) {
   const { fontScale } = useWindowDimensions();
-  const [foreground, muted, keyword, string, number, error] = useThemeColor([
-    "foreground",
-    "muted",
-    "link",
-    "success",
-    "warning",
-    "danger",
-  ]);
+  const [foreground, muted, keyword] = useThemeColor(["foreground", "muted", "link"]);
+  const [string, number, error] = useCSSVariable([
+    "--openbot-success-text",
+    "--openbot-warning-text",
+    "--openbot-danger-text",
+  ]).map(String);
   const [highlight, setHighlight] = useState<{ text: string; language?: string; tokens: CodeToken[] } | null>(null);
   const [copiedText, setCopiedText] = useState<string | null>(null);
   useEffect(() => {
@@ -67,7 +66,7 @@ export function ChatCodeBlock({
   return (
     <View className="overflow-hidden bg-control/50" style={{ borderRadius: 18, borderCurve: "continuous" }}>
       <View className="flex-row items-center justify-between gap-3 pl-3 pr-1 pt-1">
-        <Typography.Paragraph type="body-xs" className="shrink text-text-dim" numberOfLines={1}>
+        <Typography.Paragraph type="body-xs" className="shrink text-muted" numberOfLines={1}>
           {codeLanguage(language).label}
         </Typography.Paragraph>
         <Button

--- a/apps/mobile/src/features/chat/components/chat-message-list.tsx
+++ b/apps/mobile/src/features/chat/components/chat-message-list.tsx
@@ -153,7 +153,11 @@ export function ChatMessageList({
       subscription.remove();
     };
   }, []);
-  const replyColor = String(useCSSVariable("--openbot-text-dim"));
+  const [userForeground, themeForeground, themeMuted] = useCSSVariable([
+    "--openbot-text-on-light",
+    "--openbot-text-primary",
+    "--openbot-text-muted",
+  ]).map(String);
   const reducedMotion = useReducedMotion();
   const animateMessages = isFocused && canSend && appActive;
   const arrivals = useMessageArrivals(agent.id, messages, animateMessages && historyState === "ready");
@@ -275,7 +279,7 @@ export function ChatMessageList({
                 agents={agents}
                 body={message.body}
                 selectable={message.author === "user"}
-                color={message.author === "user" ? "#0a0a0c" : foreground}
+                color={message.author === "user" ? userForeground : foreground}
                 streaming={message.author === "agent" && message.streaming}
                 animationEnabled={animateMessages && arrivals.has(message.id) && motion.responseVisible}
               />
@@ -305,11 +309,11 @@ export function ChatMessageList({
       >
         {message.replyToMessageId ? (
           <View className="flex-row items-center gap-1 self-end">
-            <CornerUpRight size={14} color={replyColor} />
+            <CornerUpRight size={14} color={themeMuted} />
             <Typography.Paragraph
               type="body-xs"
               numberOfLines={1}
-              className="shrink text-text-dim"
+              className="shrink text-muted"
               accessibilityLabel={`Reply to: ${source?.kind === "message" ? mentionDraft(source.body).text || "Attachment" : "Message unavailable"}`}
             >
               {source?.kind === "message" ? mentionDraft(source.body).text || "Attachment" : "Message unavailable"}
@@ -333,8 +337,8 @@ export function ChatMessageList({
         <StreamRevealProvider>
           <ThinkingTextGradient
             text={activityLabel}
-            foreground={foreground ?? "#ffffff"}
-            muted={muted ?? "#888888"}
+            foreground={foreground ?? themeForeground}
+            muted={muted ?? themeMuted}
             enabled={
               animateMessages &&
               motion.historyVisible &&
@@ -450,7 +454,7 @@ export function ChatMessageList({
                     {historyState === "waiting" ? "Waiting for connection" : "Could not load chat history"}
                   </Typography.Paragraph>
                   {historyState === "waiting" ? (
-                    <Typography.Paragraph type="body-xs" align="center" className="text-text-dim">
+                    <Typography.Paragraph type="body-xs" align="center" className="text-muted">
                       Your chat history will load when the server reconnects.
                     </Typography.Paragraph>
                   ) : null}

--- a/apps/mobile/src/features/chat/components/chat-view.tsx
+++ b/apps/mobile/src/features/chat/components/chat-view.tsx
@@ -427,7 +427,7 @@ export function MobileChatView({ animateAvatarOnExit = false, agent }: MobileCha
               ) : null}
               <ConnectionStatus server={server} />
               {sendError?.agentId === agent.id ? (
-                <Typography.Paragraph accessibilityRole="alert" className="bg-background px-4 py-2 text-danger">
+                <Typography.Paragraph accessibilityRole="alert" className="bg-background px-4 py-2 text-danger-text">
                   {sendError.message}
                 </Typography.Paragraph>
               ) : null}

--- a/apps/mobile/src/features/search/components/search-result-row.tsx
+++ b/apps/mobile/src/features/search/components/search-result-row.tsx
@@ -42,7 +42,7 @@ export function MobileSearchResultRow({ result }: { result: MobileSearchResult }
           <Typography.Paragraph className="min-w-0 flex-1" weight="semibold" numberOfLines={1}>
             {result.title}
           </Typography.Paragraph>
-          <Typography.Paragraph type="body-xs" className="text-text-dim">
+          <Typography.Paragraph type="body-xs" className="text-muted">
             {result.updatedLabel}
           </Typography.Paragraph>
         </View>

--- a/apps/mobile/src/features/servers/components/server-drawer-content.tsx
+++ b/apps/mobile/src/features/servers/components/server-drawer-content.tsx
@@ -3,6 +3,7 @@ import type { Href } from "expo-router";
 import { Typography } from "heroui-native";
 import { Monitor, Plus, Server, Settings } from "lucide-react-native";
 import { Pressable, ScrollView, View, type ViewStyle } from "react-native";
+import { useCSSVariable } from "uniwind";
 
 import type { MobileSession } from "@/features/auth/api/mobile-auth";
 import { mobileUserName } from "@/features/auth/api/mobile-user-name";
@@ -41,6 +42,7 @@ export function ServerDrawerContent({
   const displayName = mobileUserName(session.user);
   const avatarUrl = session.user.avatarUrl ? new URL(session.user.avatarUrl, session.apiUrl).toString() : null;
   const mutedColor = String(muted);
+  const serverForeground = String(useCSSVariable("--openbot-text-on-light"));
 
   return (
     <>
@@ -88,7 +90,7 @@ export function ServerDrawerContent({
                 className="size-11 items-center justify-center rounded-[15px]"
                 style={{ backgroundColor: serverItem.accent, borderCurve: "continuous" }}
               >
-                <ServerIcon color="#100d12" size={21} strokeWidth={1.8} />
+                <ServerIcon color={serverForeground} size={21} strokeWidth={1.8} />
               </View>
               <View className="min-w-0 flex-1 gap-0.5">
                 <Typography.Paragraph weight={selected ? "bold" : "semibold"} numberOfLines={1}>

--- a/apps/mobile/src/features/servers/components/server-status-label.tsx
+++ b/apps/mobile/src/features/servers/components/server-status-label.tsx
@@ -9,7 +9,11 @@ export function ServerStatusLabel({ server, prefix = "" }: { server: MobileServe
       accessibilityLabel={`${server.name}: ${serverStatusLabel(server)}`}
       accessibilityLiveRegion="polite"
       className={
-        server.state === "online" ? "text-success" : server.state === "error" ? "text-danger" : "text-text-secondary"
+        server.state === "online"
+          ? "text-success-text"
+          : server.state === "error"
+            ? "text-danger-text"
+            : "text-text-secondary"
       }
     >
       {prefix}

--- a/apps/mobile/src/features/servers/screens/add-server-screen.tsx
+++ b/apps/mobile/src/features/servers/screens/add-server-screen.tsx
@@ -28,7 +28,7 @@ export function AddServerScreen({
   initialInvite?: string;
   onJoined?: () => void;
 } = {}) {
-  const foreground = useThemeColor("foreground");
+  const [foreground, accentForeground] = useThemeColor(["foreground", "accent-foreground"]);
   const { addRemoteServer, servers } = useMobileWorkspace();
   const [joinedId, setJoinedId] = useState<string | null>(null);
   const joinedServer = servers.find((server) => server.id === joinedId);
@@ -106,7 +106,7 @@ export function AddServerScreen({
         <View className="gap-5">
           <View className="flex-row items-center gap-3 rounded-3xl bg-control px-4 py-4">
             <View className="size-12 items-center justify-center rounded-2xl bg-accent">
-              <Server color="#ffffff" size={23} strokeWidth={1.8} />
+              <Server color={accentForeground} size={23} strokeWidth={1.8} />
             </View>
             <View className="min-w-0 flex-1 gap-0.5">
               <Typography.Paragraph weight="semibold">Invitation ready</Typography.Paragraph>
@@ -117,7 +117,7 @@ export function AddServerScreen({
           </View>
 
           {error ? (
-            <Typography.Paragraph align="center" className="text-danger">
+            <Typography.Paragraph align="center" className="text-danger-text">
               {error}
             </Typography.Paragraph>
           ) : null}

--- a/apps/mobile/src/features/servers/screens/server-settings-screen.tsx
+++ b/apps/mobile/src/features/servers/screens/server-settings-screen.tsx
@@ -70,7 +70,7 @@ export function ServerSettingsScreen() {
               ])
             }
           >
-            <Typography.Paragraph type="body-sm" className="text-danger">
+            <Typography.Paragraph type="body-sm" className="text-danger-text">
               Leave server
             </Typography.Paragraph>
           </SettingsRow>

--- a/apps/mobile/src/features/settings/screens/profile-settings-screen.tsx
+++ b/apps/mobile/src/features/settings/screens/profile-settings-screen.tsx
@@ -229,7 +229,7 @@ export function ProfileSettingsScreen() {
               disabled={busy}
               onPress={() => void perform(() => updateProfile({ avatar: null }), "Photo removed.")}
             >
-              <Typography.Paragraph type="body-sm" className="text-danger">
+              <Typography.Paragraph type="body-sm" className="text-danger-text">
                 Remove photo
               </Typography.Paragraph>
             </SettingsRow>
@@ -244,7 +244,7 @@ export function ProfileSettingsScreen() {
 
       <View className="gap-3">
         {profileError ? (
-          <Typography.Paragraph accessibilityRole="alert" className="text-danger">
+          <Typography.Paragraph accessibilityRole="alert" className="text-danger-text">
             {profileError}
           </Typography.Paragraph>
         ) : null}
@@ -260,7 +260,7 @@ export function ProfileSettingsScreen() {
               ])
             }
           >
-            <Typography.Paragraph className="text-danger">Sign out</Typography.Paragraph>
+            <Typography.Paragraph className="text-danger-text">Sign out</Typography.Paragraph>
           </SettingsRow>
         </SettingsSection>
       </View>

--- a/apps/mobile/src/shared/components/profile-avatar.tsx
+++ b/apps/mobile/src/shared/components/profile-avatar.tsx
@@ -12,7 +12,9 @@ interface ProfileAvatarProps {
   neutral?: boolean;
 }
 
-export function ProfileAvatar({ name, imageUrl, accent = "#cdadec", size = 48, neutral = false }: ProfileAvatarProps) {
+export function ProfileAvatar({ name, imageUrl, accent, size = 48, neutral = false }: ProfileAvatarProps) {
+  const brandBackground = String(useCSSVariable("--openbot-logo-production"));
+  const brandForeground = String(useCSSVariable("--openbot-text-on-light"));
   const neutralBackground = String(useCSSVariable("--openbot-border-grouped"));
   const neutralForeground = String(useCSSVariable("--openbot-text-grouped-secondary"));
   const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
@@ -29,7 +31,7 @@ export function ProfileAvatar({ name, imageUrl, accent = "#cdadec", size = 48, n
     <View
       className="items-center justify-center overflow-hidden"
       style={{
-        backgroundColor: neutral ? neutralBackground : accent,
+        backgroundColor: neutral ? neutralBackground : (accent ?? brandBackground),
         borderCurve: "continuous",
         borderRadius: neutral ? size / 2 : size * 0.32,
         height: size,
@@ -43,9 +45,8 @@ export function ProfileAvatar({ name, imageUrl, accent = "#cdadec", size = 48, n
         style={{
           fontSize: Math.max(12, size * 0.3),
           lineHeight: size * 0.4,
-          ...(neutral ? { color: neutralForeground } : {}),
+          color: neutral ? neutralForeground : brandForeground,
         }}
-        className="text-[#100d12]"
       >
         {initials || "O"}
       </Typography>

--- a/packages/brand/src/tokens-native.css
+++ b/packages/brand/src/tokens-native.css
@@ -31,9 +31,10 @@
     --openbot-border-strong: rgba(20, 20, 20, 0.16);
     --openbot-text-primary: #141414;
     --openbot-text-secondary: rgba(20, 20, 20, 0.72);
-    --openbot-text-muted: rgba(20, 20, 20, 0.52);
+    --openbot-text-muted: rgba(20, 20, 20, 0.64);
     --openbot-text-dim: rgba(20, 20, 20, 0.34);
     --openbot-text-on-accent: #ffffff;
+    --openbot-text-on-light: #141414;
     --openbot-text-on-status: #07130c;
     --openbot-action: #141414;
     --openbot-action-foreground: #f2f2f2;
@@ -44,6 +45,9 @@
     --openbot-success: #32a85d;
     --openbot-warning: #c58a23;
     --openbot-danger: #d85f58;
+    --openbot-success-text: #1e6f3b;
+    --openbot-warning-text: #865700;
+    --openbot-danger-text: #b02a2f;
     --openbot-drawer-scrim: #000000;
     --openbot-scroll-edge-overlay: rgba(245, 245, 247, 0.46);
     --openbot-shadow-card: 0 1px 2px rgba(20, 20, 20, 0.05);
@@ -57,7 +61,7 @@
     --openbot-tracking-wide: 0.02em;
     --openbot-bg-sheet: #fcfcfc;
     --openbot-bg-grouped: #f2f2f2;
-    --openbot-text-grouped-secondary: #858589;
+    --openbot-text-grouped-secondary: #69696e;
     --openbot-border-grouped: #dddddf;
     --openbot-radius-grouped: 16px;
   }
@@ -78,6 +82,7 @@
     --openbot-text-muted: #979797;
     --openbot-text-dim: #6a6a6a;
     --openbot-text-on-accent: #ffffff;
+    --openbot-text-on-light: #141414;
     --openbot-text-on-status: #07130c;
     --openbot-action: #f0f0f0;
     --openbot-action-foreground: #141414;
@@ -88,6 +93,9 @@
     --openbot-success: #31cf76;
     --openbot-warning: #ff9412;
     --openbot-danger: #fd2f3b;
+    --openbot-success-text: #31cf76;
+    --openbot-warning-text: #ff9412;
+    --openbot-danger-text: #ff6069;
     --openbot-drawer-scrim: #202020;
     --openbot-scroll-edge-overlay: rgba(0, 0, 0, 0.72);
     --openbot-shadow-card: 0 0 0 transparent;

--- a/packages/brand/src/tokens.css
+++ b/packages/brand/src/tokens.css
@@ -122,6 +122,10 @@
      0.180 is the usable step, and lightness is held at the old 0.756 so contrast on
      the canvas is unchanged at 8.5:1 and no text legibility moves. */
   --openbot-success: #31cf76;
+  /* Status text sits on neutral surfaces; status fills have separate contrast needs. */
+  --openbot-success-text: #31cf76;
+  --openbot-warning-text: #ff9412;
+  --openbot-danger-text: #ff6069;
   --openbot-success-soft: rgba(49, 207, 118, 0.12);
   --openbot-success-wash: rgba(49, 207, 118, 0.045);
   /* Both warning marks in the reference measure hue 33 at full saturation (#ff9917 on


### PR DESCRIPTION
## Summary

- Add semantic status text tokens for success, warning, and danger states.
- Replace dim and fill colors with readable text variants across mobile screens.
- Use theme variables for chat colors, avatars, server icons, and accent foregrounds.
- Update mobile design guidance and grouped supporting text contrast.

## Testing

Not run (not requested)