### PR TITLE
fix: make desktop agent purpose optional

### DIFF
--- a/src/renderer/src/App.onboarding.test.tsx
+++ b/src/renderer/src/App.onboarding.test.tsx
@@ -466,9 +466,20 @@ describe("OpenBot connected desktop shell", () => {
     render(() => <App />);
 
     expect(await screen.findByRole("heading", { name: "Create your first agent" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Create agent" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Create agent" })).toBeEnabled();
     expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
     expect(window.openbot.agent.createAgent).not.toHaveBeenCalled();
+    await fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() =>
+      expect(window.openbot.agent.createAgent).toHaveBeenCalledWith({
+        name: "New agent",
+        description: "General-purpose assistant",
+        initialMessage: "Greet me briefly.",
+        avatarSeed: expect.any(String),
+        avatarHue: null,
+      }),
+    );
+    expect(await screen.findByRole("heading", { name: "New agent" })).toBeInTheDocument();
   });
 
   it("guides signed-out users before enabling chat", async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -18,7 +18,6 @@ import {
   testConversationPage,
   testServer,
 } from "./app-test-harness";
-import { createAgentInitialMessage } from "./features/agents/agent-initial-message";
 import { AGENT_SELECTION_STORAGE_KEY } from "./features/agents/agent-selection";
 import { useAgents } from "./features/agents/agents-context";
 import { useConversation } from "./features/conversation/conversation-context";
@@ -442,6 +441,36 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.getByRole("button", { name: "Create your first agent" })).toBeInTheDocument();
   });
 
+  it.each(["", "   "])("creates an additional agent with a blank purpose (%j)", async (purpose) => {
+    render(() => <App />);
+    await screen.findByRole("heading", { name: "Chief" });
+    await fireEvent.pointerDown(screen.getByRole("button", { name: "New agent or channel" }), { button: 0 });
+    await fireEvent.pointerUp(await screen.findByRole("menuitem", { name: "New agent" }), { button: 0 });
+    await screen.findByRole("heading", { name: "Create a new agent" });
+
+    const name = screen.getByRole("textbox", { name: "Name" });
+    const create = screen.getByRole("button", { name: "Create agent" });
+    await fireEvent.input(name, { target: { value: "   " } });
+    expect(create).toBeDisabled();
+    await fireEvent.input(name, { target: { value: "  Helper  " } });
+    await fireEvent.input(screen.getByRole("textbox", { name: "What should this agent help with?" }), {
+      target: { value: purpose },
+    });
+    expect(create).toBeEnabled();
+    await fireEvent.click(create);
+
+    await waitFor(() =>
+      expect(window.openbot.agent.createAgent).toHaveBeenCalledWith({
+        name: "Helper",
+        description: "General-purpose assistant",
+        initialMessage: "Greet me briefly.",
+        avatarSeed: expect.any(String),
+        avatarHue: null,
+      }),
+    );
+    expect(await screen.findByRole("heading", { name: "Helper" })).toBeInTheDocument();
+  });
+
   it("creates an agent from a suggestion with one complete backend input", async () => {
     render(() => <App />);
     await screen.findByRole("heading", { name: "Chief" });
@@ -470,7 +499,8 @@ describe("OpenBot connected desktop shell", () => {
       description: draft.purpose,
       avatarSeed: expect.any(String),
       avatarHue: 215,
-      initialMessage: createAgentInitialMessage(draft),
+      initialMessage:
+        "Your ongoing role is: Compare travel options and turn my rough ideas into practical, day-by-day itineraries.",
     });
     expect(window.openbot.agent.sendMessage).not.toHaveBeenCalled();
     expect(await screen.findByRole("heading", { name: "Trip Planner" })).toBeInTheDocument();

--- a/src/renderer/src/features/agents/FirstAgentSetup.tsx
+++ b/src/renderer/src/features/agents/FirstAgentSetup.tsx
@@ -146,7 +146,7 @@ export function FirstAgentSetup(props: FirstAgentSetupProps) {
   const [canScrollSuggestionsBack, setCanScrollSuggestionsBack] = createSignal(false);
   const [canScrollSuggestionsForward, setCanScrollSuggestionsForward] = createSignal(false);
   const [draggingSuggestions, setDraggingSuggestions] = createSignal(false);
-  const canSubmit = () => Boolean(props.value.name.trim() && props.value.purpose.trim()) && !props.submitting;
+  const canSubmit = () => Boolean(props.value.name.trim()) && !props.submitting;
   const displayName = () => props.value.name.trim() || "New agent";
 
   function updateSuggestionFades(): void {
@@ -399,7 +399,7 @@ export function FirstAgentSetup(props: FirstAgentSetupProps) {
                 onValueChange={(name) => updateDraft({ name })}
               />
             </Field>
-            <Field label="What should this agent help with?" required>
+            <Field label="What should this agent help with?">
               <Textarea
                 value={props.value.purpose}
                 rows={2}

--- a/src/renderer/src/features/agents/agent-actions.tsx
+++ b/src/renderer/src/features/agents/agent-actions.tsx
@@ -69,7 +69,7 @@ const AgentActions = createSimpleContext({
       try {
         const stored = await window.openbot.agent.createAgent({
           name: submitted.name.trim(),
-          description: submitted.purpose.trim(),
+          description: submitted.purpose.trim() || "General-purpose assistant",
           avatarSeed: submitted.avatarSeed,
           avatarHue: submitted.avatarHue,
           initialMessage: createAgentInitialMessage(submitted),

--- a/src/renderer/src/features/agents/agent-initial-message.ts
+++ b/src/renderer/src/features/agents/agent-initial-message.ts
@@ -1,6 +1,7 @@
 import type { FirstAgentDraft } from "./FirstAgentSetup";
 
-/** The first message a newly created agent receives, turning its purpose into a standing role. */
+/** Give a newly created agent its standing role, or ask for a greeting when no purpose is supplied. */
 export function createAgentInitialMessage(draft: Pick<FirstAgentDraft, "purpose">): string {
-  return `Your ongoing role is: ${draft.purpose.trim()}`;
+  const purpose = draft.purpose.trim();
+  return purpose ? `Your ongoing role is: ${purpose}` : "Greet me briefly.";
 }

--- a/src/renderer/stories/FirstAgentSetup.stories.tsx
+++ b/src/renderer/stories/FirstAgentSetup.stories.tsx
@@ -75,7 +75,7 @@ export const Default: Story = {
   play: async ({ canvas, canvasElement }) => {
     const createButton = canvas.getByRole("button", { name: "Create agent" });
     await expect(canvas.getAllByRole("listitem")).toHaveLength(6);
-    await expect(createButton).toBeDisabled();
+    await expect(createButton).toBeEnabled();
     await expect(canvas.getByRole("textbox", { name: "Name" })).toHaveValue("New agent");
     await expect(canvas.getByRole("textbox", { name: "What should this agent help with?" })).toHaveValue("");
     await expect(canvas.getAllByRole("button", { name: /agent color$/ })).toHaveLength(9);


### PR DESCRIPTION
## What changed

Desktop users can create their first agent or an additional agent with only a name. The “What should this agent help with?” field has no required marker and no longer blocks submission when empty or filled with spaces.

An empty purpose uses the description `General-purpose assistant` and the initial message `Greet me briefly.`. A supplied purpose keeps the existing role message. The name remains required.

Surface: desktop renderer and its Storybook story. Mobile, IPC contracts, service validation, and database schemas are unchanged.

## Verification

- [x] Approved wider check: `NODE_OPTIONS=--no-experimental-webstorage bun run test:desktop -- src/renderer/src/App.test.tsx src/renderer/src/App.onboarding.test.tsx src/renderer/src/App.queue.test.tsx src/renderer/src/App.read-state.test.tsx` — 124 tests passed.
- [x] New empty-purpose cases failed against the original code because creation was disabled, then passed with the fix. Cases cover empty and spaces-only purposes, required name, first-agent setup, additional-agent creation, and the supplied-purpose message.
- [x] Full `bun run lint`, `bun run typecheck`, and `bun run check:ui` passed. Lint retains 98 warnings in unchanged files; no warnings were reported in the changed files. These existing warnings are outside this change.
- [x] Live Electron smoke test through `bun run dev:automation` in an isolated profile: an empty purpose created an agent, sent the greeting instruction, and received “Hello! How can I help?”.
- [x] No credentials, private data, generated output, or real user files are included.

The Node 26 test environment required `--no-experimental-webstorage` to let jsdom supply localStorage. No repository configuration was changed for this.

Implementation model: GPT-6. Harness: Codex; Vitest with the existing renderer harness and Electron dev automation. The live test agent used GPT-5.6-Luna.

## Risk and security impact

No permission, trust-boundary, protocol, or schema changes. The existing creation request receives non-empty default strings when the optional field is blank.

## Before and after

| State | Before | After |
| --- | --- | --- |
| Purpose label | Required marker shown | Required marker removed |
| Name supplied, purpose empty | Create agent disabled | Create agent enabled |
| Empty-purpose submission | Blocked | General-purpose assistant starts with a greeting |

Before/after screenshots were captured and inspected. They are retained outside Git under `.openbot-build/dev-automation/agent-purpose-before.png` and `agent-purpose-after.png` in `/tmp/openbot-optional-agent-purpose`. GitHub image attachment was unavailable because no browser connection was available; the images are provided in the Codex task instead.
