### PR TITLE
Move mobile save and create actions into native sheet headers

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -46,6 +46,10 @@ Follow [DESIGN.md — Sheets](./DESIGN.md#sheets) and inspect the current route 
 - Reuse `SettingsContent`/`SettingsSection`/`SettingsRow` for settings and `SheetFormField` for
   fields. Use HeroUI `Typography` for content and native Expo UI for platform controls.
   Keep groups flat, separators inset, and chevrons for navigation rather than destructive actions.
+- Save and create actions use `SheetSaveAction`: a checkmark on the right of the native header,
+  visible only for changed input or a pending save. Keep invalid drafts visible with a disabled
+  action. Do not add a Save/Create button in sheet content. Standalone creation forms have a
+  close (`×`) action on the left; nested pages keep native back navigation and draft guards.
 - Do not add a redundant Done/close button to a dismissible sheet. Add explicit actions only when
   the flow requires them, such as Save or Cancel for unsaved work.
 - Follow [DESIGN.md — Profile and About](./DESIGN.md#profile-and-about) for these settings pages:

--- a/apps/mobile/DESIGN.md
+++ b/apps/mobile/DESIGN.md
@@ -93,6 +93,25 @@ to the content scroll view, not a larger sheet detent. Native dismissal remains 
 `systemMaterial` or another `headerBlurEffect` on these sheets, or put an opaque header color back
 on iOS. The native soft scroll edge handles the transition under the title.
 
+### Save and create actions
+
+Use `SheetSaveAction` for every form with an explicit save or create action. Put its checkmark
+on the right of the native header. Do not put a second Save/Create button in the content.
+
+- Hide the action until the draft differs from the saved values (or initial creation values).
+  Restore the initial values to hide it again. Keep validity separate from change detection.
+- Show a disabled checkmark for changed but invalid input or an unavailable host. Keep validation
+  and request errors in the form. A failed request keeps the draft and permits retry.
+- Disable the action and fields during the request, expose a pending accessibility label, and
+  prevent duplicate requests and dismissal. Hide the action after a successful save. A successful
+  create returns to the previous page after the draft guard is released.
+- Use a clear accessible action name, such as `Save name` or `Create agent`, even with an icon.
+  Preserve keyboard submission where the form supports it.
+- Standalone creation forms have a native close (`×`) action on the left. Nested pages keep the
+  native back button. Closing or going back must respect existing unsaved-change guards.
+- Keep `SheetScrollView` in charge of header clearance, safe areas, and keyboard behavior.
+  Do not add footer spacing for the header action.
+
 ### Scroll ownership
 
 Use `src/shared/components/sheet-scroll-view.tsx` as the root scroll container. In particular:
@@ -166,9 +185,9 @@ in smaller secondary text. Place the pencil immediately beside the visible name,
 sheet edge. Keep the name centered and constrain long names to the available width.
 
 Edit the name inline with the same mounted native input and typography in both states. Do not
-replace the label with a separate form that moves the surrounding content. Show Save only after
+replace the label with a separate form that moves the surrounding content. Show the header checkmark only after
 the name changes, disable it for invalid input or a pending request, and let Cancel restore the
-saved name. Reserve a compact action area so showing these controls does not shift the page.
+saved name. Reserve a compact Cancel area so editing does not shift the page.
 Group the identity, action area and Profile photo section together instead of applying the
 standard section gap on both sides of the reserved area. Keep the email close to the name.
 

--- a/apps/mobile/src/features/agents/components/agent-record-editor.tsx
+++ b/apps/mobile/src/features/agents/components/agent-record-editor.tsx
@@ -83,16 +83,16 @@ export function MemoryEditor({
         onChangeText={(value) => setEditedText(value === (memory?.text ?? "") ? undefined : value)}
       />
       <SheetSaveAction
-        canSave={!disabled && Boolean(text.trim()) && dirty}
+        dirty={dirty}
+        canSave={!disabled && Boolean(text.trim())}
         pending={action.pending}
-        saved={savedText !== null && !dirty}
-        onSavedHidden={!memory ? () => setFinished(true) : undefined}
         onSave={() =>
           void action.run(
             () => workspace.saveAgentMemory(agent.id, text.trim(), agent.serverId, memory?.id),
             () => {
               setSavedText(text.trim());
               if (memory) setEditedText(undefined);
+              else setFinished(true);
             },
           )
         }
@@ -169,6 +169,7 @@ export function RoutineEditor({
   const setInstruction = (instruction: string) => setEdits((current) => ({ ...current, instruction }));
   const setSchedule = (schedule: RoutineSchedule) => setEdits((current) => ({ ...current, schedule }));
   const [timezone, setTimezone] = useState(routine?.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone);
+  const initialTimezone = useRef(timezone);
   const draft = JSON.stringify({ name, instruction, schedule, timezone });
   const nameChanged = name.trim() !== (routine?.name ?? "");
   const instructionChanged = instruction.trim() !== (routine?.instruction ?? "");
@@ -178,7 +179,12 @@ export function RoutineEditor({
     ? nameChanged || instructionChanged || scheduleChanged
     : draft !==
       (savedDraft ??
-        JSON.stringify({ name: "", instruction: "", schedule: { kind: "daily", time: "09:00" }, timezone }));
+        JSON.stringify({
+          name: "",
+          instruction: "",
+          schedule: { kind: "daily", time: "09:00" },
+          timezone: initialTimezone.current,
+        }));
   useRecordDraftGuard(dirty && !finished, action.pending);
   useEffect(() => {
     if (finished) router.back();
@@ -352,14 +358,14 @@ export function RoutineEditor({
         <SheetFormField label="Time zone" value={timezone} editable={!disabled} onChangeText={setTimezone} />
       ) : null}
       <SheetSaveAction
-        canSave={!disabled && dirty && Boolean(name.trim() && instruction.trim() && timezone.trim()) && validTime}
+        dirty={dirty}
+        canSave={!disabled && Boolean(name.trim() && instruction.trim() && timezone.trim()) && validTime}
         pending={action.pending}
-        saved={savedDraft !== null && !dirty}
-        onSavedHidden={!routine ? () => setFinished(true) : undefined}
         onSave={() =>
           void action.run(save, () => {
             setSavedDraft(draft);
             if (routine) setEdits({});
+            else setFinished(true);
           })
         }
       />

--- a/apps/mobile/src/features/agents/screens/add-agent-screen.tsx
+++ b/apps/mobile/src/features/agents/screens/add-agent-screen.tsx
@@ -2,14 +2,18 @@ import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type { AvatarHue } from "@openbot/contracts/ipc";
 import { userErrorMessage as errorMessage } from "@openbot/user-errors";
 import * as Crypto from "expo-crypto";
-import { router } from "expo-router";
-import { Button, Typography } from "heroui-native";
-import { useState } from "react";
+import { router, Stack, useNavigation } from "expo-router";
+import { usePreventRemove } from "expo-router/react-navigation";
+import { Typography } from "heroui-native";
+import { useEffect, useRef, useState } from "react";
+import { Alert } from "react-native";
 
 import { AgentAppearancePicker } from "@/features/agents/components/agent-appearance-picker";
 import { useMobileWorkspace } from "@/features/workspace/context/mobile-workspace-context";
 import { SheetFormField } from "@/shared/components/sheet-form-field";
+import { SheetSaveAction } from "@/shared/components/sheet-save-action";
 import { SheetScrollView } from "@/shared/components/sheet-scroll-view";
+import { isIOS } from "@/shared/lib/platform";
 
 export function AddAgentScreen() {
   const { createAgent } = useMobileWorkspace();
@@ -17,12 +21,31 @@ export function AddAgentScreen() {
   const [description, setDescription] = useState("");
   const [avatarSeed, setAvatarSeed] = useState(() => `mobile:${Crypto.randomUUID().replaceAll("-", "")}`);
   const [avatarHue, setAvatarHue] = useState<AvatarHue | null>(null);
+  const initialAvatarSeed = useRef(avatarSeed);
+  const pending = useRef(false);
+  const navigation = useNavigation();
+  const [finished, setFinished] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const valid = name.trim().length > 0 && description.trim().length > 0;
 
+  const dirty = Boolean(
+    name.trim() || description.trim() || avatarSeed !== initialAvatarSeed.current || avatarHue !== null,
+  );
+  usePreventRemove(!finished && (dirty || saving), ({ data }) => {
+    if (pending.current) return;
+    Alert.alert("Discard changes?", "Your changes have not been saved.", [
+      { text: "Keep editing", style: "cancel" },
+      { text: "Discard", style: "destructive", onPress: () => navigation.dispatch(data.action) },
+    ]);
+  });
+  useEffect(() => {
+    if (finished) router.back();
+  }, [finished]);
+
   async function submit(): Promise<void> {
-    if (!valid || saving) return;
+    if (!valid || pending.current || finished) return;
+    pending.current = true;
     setSaving(true);
     setError(null);
     try {
@@ -33,9 +56,10 @@ export function AddAgentScreen() {
         avatarSeed,
         avatarHue,
       });
-      router.back();
+      setFinished(true);
     } catch (cause) {
       setError(errorMessage(cause, "OpenBot could not create this agent."));
+      pending.current = false;
       setSaving(false);
     }
   }
@@ -48,12 +72,31 @@ export function AddAgentScreen() {
       keyboardDismissMode="interactive"
       keyboardShouldPersistTaps="handled"
     >
+      <Stack.Toolbar placement="left">
+        <Stack.Toolbar.Button
+          icon={isIOS ? "xmark" : undefined}
+          accessibilityLabel="Close"
+          disabled={saving}
+          onPress={() => router.back()}
+        >
+          {isIOS ? "Close" : "×"}
+        </Stack.Toolbar.Button>
+      </Stack.Toolbar>
+      <SheetSaveAction
+        dirty={dirty}
+        canSave={valid && !finished}
+        pending={saving}
+        label="Create agent"
+        pendingLabel="Creating…"
+        onSave={() => void submit()}
+      />
       <AgentAppearancePicker
         seed={avatarSeed}
         hue={avatarHue}
         name={name}
         nameField={
           <SheetFormField
+            editable={!saving}
             autoCapitalize="words"
             label="Name"
             hideLabel
@@ -71,6 +114,7 @@ export function AddAgentScreen() {
       />
 
       <SheetFormField
+        editable={!saving}
         label="What should this agent help with?"
         appearance="soft"
         multiline
@@ -80,15 +124,16 @@ export function AddAgentScreen() {
         onChangeText={setDescription}
       />
 
+      {dirty && !valid ? (
+        <Typography.Paragraph accessibilityRole="alert" className="text-danger-text">
+          Enter a name and instructions for this agent.
+        </Typography.Paragraph>
+      ) : null}
       {error ? (
-        <Typography.Paragraph align="center" className="text-danger-text">
+        <Typography.Paragraph accessibilityRole="alert" align="center" className="text-danger-text">
           {error}
         </Typography.Paragraph>
       ) : null}
-
-      <Button size="lg" isDisabled={!valid || saving} onPress={() => void submit()}>
-        <Button.Label className="font-sans font-semibold">{saving ? "Creating…" : "Create agent"}</Button.Label>
-      </Button>
     </SheetScrollView>
   );
 }

--- a/apps/mobile/src/features/agents/screens/edit-agent-screen.test.tsx
+++ b/apps/mobile/src/features/agents/screens/edit-agent-screen.test.tsx
@@ -2,6 +2,7 @@ import {
   type AgentAnalytics,
   type AgentMemory,
   analyticsRange,
+  type CreateAgentInput,
   emptyAnalyticsTotals,
   type Routine,
   type UpdateAgentInput,
@@ -17,7 +18,10 @@ import { ChatHeader } from "../../chat/components/chat-header";
 import { saveAgentRecord } from "../../workspace/model/save-agent-record";
 import type { MobileAgent, MobileServer } from "../../workspace/model/workspace-types";
 import { useAgentContextMenu } from "../components/agent-context-menu";
+import { AddAgentScreen } from "./add-agent-screen";
 import { EditAgentScreen } from "./edit-agent-screen";
+
+vi.mock("expo-crypto", () => ({ randomUUID: () => "new-agent-seed" }));
 
 vi.mock("expo-secure-store", () => ({}));
 
@@ -61,6 +65,7 @@ const workspace = {
   activityByServer: {},
   pinnedAgentIds: [],
   unreadAgentIds: [],
+  createAgent: vi.fn(async (_input: CreateAgentInput) => {}),
   updateAgent: vi.fn(async (input: UpdateAgentInput, _serverId?: string) => {
     workspace.agents = [{ ...workspace.agents[0], ...input }];
   }),
@@ -337,6 +342,7 @@ beforeEach(() => {
   workspace.agents = [{ ...original }];
   workspace.servers = [{ ...host }];
   workspace.activeServer = host;
+  workspace.createAgent.mockReset().mockResolvedValue();
   workspace.updateAgent.mockClear();
   workspace.saveAgentMemory.mockClear();
   workspace.deleteAgentMemory.mockClear();
@@ -406,7 +412,7 @@ it("saves name and instructions on the original host and shows them after reopen
     },
     "host-one",
   );
-  expect(screen.getByRole("button", { name: "Saved" })).toBeTruthy();
+  expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
   await act(() => root.unmount());
   root = createRoot(container);
   await renderSheet();
@@ -418,13 +424,13 @@ it("saves name and instructions on the original host and shows them after reopen
 it("validates input, retains failed edits, and confirms cancellation", async () => {
   await renderSheet();
   await edit("Name", " ");
-  expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+  expect(screen.getByRole("button", { name: "Save changes" })).toHaveProperty("disabled", true);
   await edit("Name", "New name");
   workspace.updateAgent.mockRejectedValueOnce(new Error("Save failed"));
   await click("Save changes");
   expect(screen.getByRole("textbox", { name: "Name" })).toHaveProperty("value", "New name");
   expect(mocks.blocked).toBe(true);
-  await click("Cancel");
+  await act(() => mocks.leave());
   const choices = mocks.alert.mock.calls[0]?.[2];
   expect(choices).toEqual([
     { text: "Keep editing", style: "cancel" },
@@ -443,7 +449,7 @@ it("keeps edits through host loss and accepts desktop changes in untouched field
   await renderSheet();
   expect(screen.getByRole("textbox", { name: "Name" })).toHaveProperty("value", "My draft");
   expect(screen.getByRole("textbox", { name: "Instructions" })).toHaveProperty("value", "Desktop update");
-  expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+  expect(screen.getByRole("button", { name: "Save changes" })).toHaveProperty("disabled", true);
   workspace.servers = [host];
   await renderSheet();
   await click("Save changes");
@@ -497,7 +503,7 @@ it("prevents duplicate saves and dismissal while a save is pending", async () =>
   expect(mocks.dispatch).not.toHaveBeenCalled();
   expect(workspace.updateAgent).toHaveBeenCalledTimes(1);
   await act(async () => finish());
-  expect(screen.getByRole("button", { name: "Saved" })).toBeTruthy();
+  expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
 });
 
 it("shows host memories, routine status, and usage on separate pages", async () => {
@@ -641,12 +647,12 @@ it("saves a supported model and reasoning level on the original host", async () 
   );
 });
 
-it("shows saved feedback in the header after saving", async () => {
+it("hides the header action after saving", async () => {
   await renderSheet("appearance");
   expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
   await click("Agent face 2", "radio");
   await click("Save changes");
-  expect(screen.getByRole("button", { name: "Saved" })).toHaveProperty("disabled", true);
+  expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
 });
 
 it("changes provider together with a compatible model and reasoning", async () => {
@@ -723,7 +729,7 @@ it("creates, edits, and deletes a memory on its host", async () => {
   workspace.servers = [{ ...host, state: "offline" }];
   await renderSheet("memory");
   expect(screen.getByRole("textbox", { name: "Memory" })).toHaveProperty("value", "Changed note");
-  expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+  expect(screen.getByRole("button", { name: "Save changes" })).toHaveProperty("disabled", true);
   expect(mocks.blocked).toBe(true);
   workspace.servers = [{ ...host }];
   workspace.loadAgentMemories.mockRejectedValueOnce(new Error("Refresh failed"));
@@ -731,7 +737,7 @@ it("creates, edits, and deletes a memory on its host", async () => {
   await waitFor(() => expect(screen.getByText("Could not refresh memory.")).toBeTruthy());
   expect(screen.getByRole("textbox", { name: "Memory" })).toHaveProperty("value", "Changed note");
   await click("Retry memory");
-  await waitFor(() => expect(screen.getByRole("button", { name: "Save changes" })).toBeTruthy());
+  await waitFor(() => expect(screen.getByRole("button", { name: "Save changes" })).toHaveProperty("disabled", false));
   workspace.saveAgentMemory.mockImplementationOnce(() =>
     saveAgentRecord(client, ["agent-info", "test", "user", 1, host.id, original.id, "memories"], async () => ({
       ...memory,
@@ -878,24 +884,61 @@ it("keeps a failed memory draft available for retry", async () => {
   expect(workspace.saveAgentMemory).toHaveBeenCalledTimes(2);
 });
 
-it("hides the saved header action after feedback and exposes the next save", async () => {
-  vi.useFakeTimers();
+it("shows the save action only for changed input and blocks invalid or pending saves", async () => {
   const save = vi.fn();
-  const hidden = vi.fn();
-  try {
-    await act(() =>
-      root.render(<SheetSaveAction canSave={false} pending={false} saved onSave={save} onSavedHidden={hidden} />),
-    );
-    expect(screen.getByRole("button", { name: "Saved" })).toHaveProperty("disabled", true);
-    await act(() => vi.runOnlyPendingTimers());
-    expect(screen.queryByRole("button", { name: "Saved" })).toBeNull();
-    expect(hidden).toHaveBeenCalledTimes(1);
-    await act(() => root.render(<SheetSaveAction canSave pending={false} saved={false} onSave={save} />));
-    await click("Save changes");
-    expect(save).toHaveBeenCalledTimes(1);
-  } finally {
-    vi.useRealTimers();
-  }
+  await act(() => root.render(<SheetSaveAction dirty={false} canSave pending={false} onSave={save} />));
+  expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+  await act(() => root.render(<SheetSaveAction dirty canSave={false} pending={false} onSave={save} />));
+  await click("Save changes");
+  expect(save).not.toHaveBeenCalled();
+  await act(() => root.render(<SheetSaveAction dirty canSave pending onSave={save} />));
+  expect(screen.getByRole("button", { name: "Saving…" })).toHaveProperty("disabled", true);
+  await act(() => root.render(<SheetSaveAction dirty canSave pending={false} onSave={save} />));
+  await click("Save changes");
+  expect(save).toHaveBeenCalledTimes(1);
+});
+
+it("creates an agent from changed valid input and blocks duplicate submission and closing while pending", async () => {
+  const response = Promise.withResolvers<void>();
+  workspace.createAgent.mockReturnValueOnce(response.promise);
+  await act(() => root.render(<AddAgentScreen />));
+  expect(screen.queryByRole("button", { name: "Create agent" })).toBeNull();
+  await edit("Name", "Explorer");
+  expect(screen.getByRole("button", { name: "Create agent" })).toHaveProperty("disabled", true);
+  await edit("Name", "");
+  expect(screen.queryByRole("button", { name: "Create agent" })).toBeNull();
+  await edit("Name", " Explorer ");
+  await edit("What should this agent help with?", " Plan trips ");
+  await click("Create agent");
+  await click("Creating…");
+  await click("Close");
+  await act(() => mocks.leave());
+  expect(workspace.createAgent).toHaveBeenCalledExactlyOnceWith({
+    name: "Explorer",
+    description: "Plan trips",
+    initialMessage: "Your ongoing role is: Plan trips",
+    avatarSeed: "mobile:newagentseed",
+    avatarHue: null,
+  });
+  expect(mocks.dispatch).not.toHaveBeenCalled();
+  await act(() => response.resolve());
+  expect(mocks.blocked).toBe(false);
+  expect(mocks.dispatch).toHaveBeenCalledWith({ type: "GO_BACK" });
+});
+
+it("keeps a failed create draft for retry and confirms close", async () => {
+  workspace.createAgent.mockRejectedValueOnce(new Error("Create failed"));
+  await act(() => root.render(<AddAgentScreen />));
+  await edit("Name", "Explorer");
+  await edit("What should this agent help with?", "Plan trips");
+  await click("Create agent");
+  expect(screen.getByRole("textbox", { name: "Name" })).toHaveProperty("value", "Explorer");
+  expect(screen.getByRole("button", { name: "Create agent" })).toHaveProperty("disabled", false);
+  await click("Close");
+  expect(mocks.alert).toHaveBeenCalled();
+  expect(mocks.dispatch).not.toHaveBeenCalled();
+  await click("Create agent");
+  expect(workspace.createAgent).toHaveBeenCalledTimes(2);
 });
 
 it("saves the selected monthly day and wall-clock time", async () => {
@@ -945,4 +988,13 @@ it("keeps an acknowledged memory save when an older read completes on the same h
   await read;
   expect(client.getQueryData(key)).toEqual([saved]);
   expect(client.getQueryData(otherHostKey)).toEqual([memory]);
+});
+
+it("shows an incomplete routine change and hides it when the time zone is restored", async () => {
+  const initialTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  await renderSheet("routine");
+  await edit("Time zone", initialTimezone === "UTC" ? "Europe/Warsaw" : "UTC");
+  expect(screen.getByRole("button", { name: "Save changes" })).toHaveProperty("disabled", true);
+  await edit("Time zone", initialTimezone);
+  expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
 });

--- a/apps/mobile/src/features/agents/screens/edit-agent-screen.tsx
+++ b/apps/mobile/src/features/agents/screens/edit-agent-screen.tsx
@@ -3,7 +3,7 @@ import type { UpdateAgentInput } from "@openbot/contracts/ipc";
 import { userErrorMessage as errorMessage } from "@openbot/user-errors";
 import { router, useLocalSearchParams, useNavigation } from "expo-router";
 import { usePreventRemove } from "expo-router/react-navigation";
-import { Button, Typography } from "heroui-native";
+import { Typography } from "heroui-native";
 import { useRef, useState } from "react";
 import { Alert, Pressable, View } from "react-native";
 import { AgentAppearancePicker } from "@/features/agents/components/agent-appearance-picker";
@@ -52,14 +52,13 @@ function AgentForm({ agent, available, page }: { agent: MobileAgent; available: 
   const [saving, setSaving] = useState(false);
   const pending = useRef(false);
   const [error, setError] = useState<string | null>(null);
-  const [saved, setSaved] = useState(false);
   const name = edits.name ?? agent.name;
   const description = edits.description ?? agent.description;
   const avatarSeed = edits.avatarSeed ?? agent.avatarSeed;
   const avatarHue = edits.avatarHue === undefined ? agent.avatarHue : edits.avatarHue;
   const dirty =
-    name !== agent.name ||
-    description !== agent.description ||
+    name.trim() !== agent.name ||
+    description.trim() !== agent.description ||
     avatarSeed !== agent.avatarSeed ||
     avatarHue !== agent.avatarHue ||
     (edits.provider !== undefined && edits.provider !== agent.provider) ||
@@ -81,7 +80,6 @@ function AgentForm({ agent, available, page }: { agent: MobileAgent; available: 
 
   function change(value: AgentEdits) {
     setEdits((current) => ({ ...current, ...value }));
-    setSaved(false);
     setError(null);
   }
 
@@ -105,7 +103,6 @@ function AgentForm({ agent, available, page }: { agent: MobileAgent; available: 
         agent.serverId,
       );
       setEdits({});
-      setSaved(true);
     } catch (cause) {
       setError(errorMessage(cause, "OpenBot could not update this agent."));
     } finally {
@@ -205,17 +202,7 @@ function AgentForm({ agent, available, page }: { agent: MobileAgent; available: 
         </Typography.Paragraph>
       ) : null}
       {page === "info" || page === "appearance" || page === "runtime" ? (
-        <SheetSaveAction
-          canSave={valid && dirty && available}
-          pending={saving}
-          saved={saved && !dirty}
-          onSave={() => void submit()}
-        />
-      ) : null}
-      {dirty && page !== "appearance" ? (
-        <Button variant="ghost" isDisabled={saving} onPress={() => router.back()}>
-          <Button.Label>Cancel</Button.Label>
-        </Button>
+        <SheetSaveAction dirty={dirty} canSave={valid && available} pending={saving} onSave={() => void submit()} />
       ) : null}
       {page === "info" ? (
         <>

--- a/apps/mobile/src/features/settings/screens/profile-settings-screen.tsx
+++ b/apps/mobile/src/features/settings/screens/profile-settings-screen.tsx
@@ -16,6 +16,7 @@ import { mobileUserName } from "@/features/auth/api/mobile-user-name";
 import { useMobileSession } from "@/features/auth/context/mobile-session-context";
 import { SettingsContent, SettingsRow, SettingsSection } from "@/features/settings/components/settings-content";
 import { ProfileAvatar } from "@/shared/components/profile-avatar";
+import { SheetSaveAction } from "@/shared/components/sheet-save-action";
 
 export function ProfileSettingsScreen() {
   const { session, updateProfile, signOut } = useMobileSession();
@@ -42,7 +43,7 @@ export function ProfileSettingsScreen() {
   const [error, setError] = useState<string | null>(null);
   if (!session) return null;
   const validatedName = validateProfileName(name);
-  const nameChanged = name !== savedName;
+  const nameChanged = name.trim() !== savedName;
   const profileError =
     error ||
     (editingName && nameChanged && validatedName.error
@@ -98,6 +99,13 @@ export function ProfileSettingsScreen() {
 
   return (
     <SettingsContent>
+      <SheetSaveAction
+        dirty={editingName && nameChanged}
+        canSave={!busy && !validatedName.error}
+        pending={busy && editingName && nameChanged}
+        label="Save name"
+        onSave={() => void saveName()}
+      />
       <View>
         <View className="items-center gap-3 py-3">
           <ProfileAvatar neutral name={savedName} imageUrl={avatarUrl} size={72} />
@@ -203,19 +211,6 @@ export function ProfileSettingsScreen() {
               className="min-h-11 justify-center px-3"
             >
               <Typography.Paragraph className="text-grouped-secondary">Cancel</Typography.Paragraph>
-            </Pressable>
-          ) : null}
-          {editingName && nameChanged ? (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Save name"
-              accessibilityState={{ disabled: busy || Boolean(validatedName.error) }}
-              disabled={busy || Boolean(validatedName.error)}
-              onPress={() => void saveName()}
-              className="min-h-11 justify-center px-3"
-              style={{ opacity: busy || validatedName.error ? 0.45 : 1 }}
-            >
-              <Typography.Paragraph weight="semibold">{busy ? "Saving…" : "Save"}</Typography.Paragraph>
             </Pressable>
           ) : null}
         </View>

--- a/apps/mobile/src/shared/components/sheet-save-action.tsx
+++ b/apps/mobile/src/shared/components/sheet-save-action.tsx
@@ -1,42 +1,33 @@
 import { Stack } from "expo-router";
-import { useEffect, useRef, useState } from "react";
 import { isIOS } from "@/shared/lib/platform";
 
 export function SheetSaveAction({
+  dirty,
   canSave,
   pending,
-  saved,
+  label = "Save changes",
+  pendingLabel = "Saving…",
   onSave,
-  onSavedHidden,
 }: {
+  dirty: boolean;
   canSave: boolean;
   pending: boolean;
-  saved: boolean;
+  label?: string;
+  pendingLabel?: string;
   onSave: () => void;
-  onSavedHidden?: () => void;
 }) {
-  const [showSaved, setShowSaved] = useState(false);
-  const hidden = useRef(onSavedHidden);
-  hidden.current = onSavedHidden;
-  useEffect(() => {
-    setShowSaved(saved);
-    if (!saved) return;
-    const timer = setTimeout(() => {
-      setShowSaved(false);
-      hidden.current?.();
-    }, 1500);
-    return () => clearTimeout(timer);
-  }, [saved]);
   return (
     <Stack.Toolbar placement="right">
       <Stack.Toolbar.Button
-        hidden={!canSave && !pending && !showSaved}
-        disabled={!canSave || pending || showSaved}
-        icon={isIOS && !showSaved ? "checkmark" : undefined}
-        accessibilityLabel={showSaved ? "Saved" : pending ? "Saving…" : "Save changes"}
-        onPress={onSave}
+        hidden={!dirty && !pending}
+        disabled={!dirty || !canSave || pending}
+        icon={isIOS ? "checkmark" : undefined}
+        accessibilityLabel={pending ? pendingLabel : label}
+        onPress={() => {
+          if (dirty && canSave && !pending) onSave();
+        }}
       >
-        {showSaved ? "Saved" : isIOS ? "Save changes" : "✓"}
+        {isIOS ? label : "✓"}
       </Stack.Toolbar.Button>
     </Stack.Toolbar>
   );


### PR DESCRIPTION
## Summary

- Move save and create actions to native sheet headers with change-aware visibility.
- Keep invalid drafts visible with disabled actions and prevent duplicate submissions.
- Add draft guards for agent creation and preserve failed drafts for retry.
- Update routine timezone change detection and profile name saving behavior.
- Add mobile design guidance and coverage for the updated flows.

## Testing

- Added and updated unit/UI tests for save visibility, validation, pending states, retries, draft guards, agent creation, and timezone restoration.