### PR TITLE
Add accessible full-swipe pinning for mobile agents

### DIFF
--- a/apps/mobile/src/features/agents/components/agent-list-row.tsx
+++ b/apps/mobile/src/features/agents/components/agent-list-row.tsx
@@ -4,10 +4,8 @@ import { BlurView } from "expo-blur";
 import { Link, router } from "expo-router";
 import { Typography } from "heroui-native";
 import { useThemeColor } from "heroui-native/hooks";
-import { Pin } from "lucide-react-native";
 import { type PropsWithChildren, useEffect, useId, useRef } from "react";
-import { Platform, Pressable, StyleSheet, View } from "react-native";
-import ReanimatedSwipeable, { type SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
+import { Platform, StyleSheet, View } from "react-native";
 import Animated, {
   Easing,
   interpolate,
@@ -22,10 +20,10 @@ import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 import { useUniwind } from "uniwind";
 import { useAgentContextMenu } from "@/features/agents/components/agent-context-menu";
 import { AgentPinAvatar } from "@/features/agents/components/agent-pin-avatar";
+import { AgentPinSwipeRow } from "@/features/agents/components/agent-pin-swipe-row";
 import { type AgentAvatarLocation, useAgentPinTransition } from "@/features/agents/components/agent-pin-transition";
 import { BloubAvatar } from "@/features/agents/components/bloub-avatar";
 import { ChatLinkPressable } from "@/features/agents/components/chat-link-pressable";
-import { useAppDrawer } from "@/features/servers/components/app-drawer-shell";
 import { type MobileAgent, useMobileWorkspace } from "@/features/workspace/context/mobile-workspace-context";
 
 const AnimatedRect = Animated.createAnimatedComponent(Rect);
@@ -102,11 +100,9 @@ export function AgentListRow({
   rightInset = 20,
 }: AgentListRowProps) {
   const { theme } = useUniwind();
-  const [background, accent, accentForeground] = useThemeColor(["background", "accent", "accent-foreground"]);
+  const [background] = useThemeColor(["background"]);
   const { unreadAgentIds } = useMobileWorkspace();
-  const { openingGesture } = useAppDrawer();
   const { startAgentNavigationAnimated, toggleAgentPinAnimated, transition } = useAgentPinTransition();
-  const pendingPinRef = useRef(false);
   const editMenu = useRef<MenuComponentRef>(null);
   const agentContextMenu = useAgentContextMenu(agent);
   const isUnread = unreadAgentIds.includes(agent.id);
@@ -126,6 +122,14 @@ export function AgentListRow({
       <ChatLinkPressable
         accessibilityLabel={`Open chat with ${agent.name}`}
         accessibilityRole="button"
+        accessibilityActions={enableActions ? [{ name: "pin", label: `Pin ${agent.name}` }] : undefined}
+        onAccessibilityAction={
+          enableActions
+            ? (event) => {
+                if (event.nativeEvent.actionName === "pin") toggleAgentPinAnimated(agent.id);
+              }
+            : undefined
+        }
         className="w-full"
         onLongPress={enableActions && Platform.OS === "android" ? () => editMenu.current?.show() : undefined}
       >
@@ -179,44 +183,10 @@ export function AgentListRow({
 
   if (!enableActions) return agentLink;
 
-  const handlePin = (swipeable: SwipeableMethods) => {
-    pendingPinRef.current = true;
-    swipeable.close();
-  };
-
-  const handleSwipeableClose = () => {
-    if (!pendingPinRef.current) return;
-    pendingPinRef.current = false;
-    toggleAgentPinAnimated(agent.id);
-  };
-
   return (
-    <ReanimatedSwipeable
-      childrenContainerStyle={{ backgroundColor: background }}
-      containerStyle={{ backgroundColor: background, overflow: "hidden" }}
-      enableTrackpadTwoFingerGesture
-      onSwipeableClose={handleSwipeableClose}
-      overshootFriction={8}
-      overshootRight={false}
-      // Rightward drags belong to the drawer; it yields to row actions on leftward drags.
-      requireExternalGestureToFail={openingGesture}
-      renderRightActions={(_progress, _translation, swipeable) => (
-        <View className="w-[88px] overflow-hidden" style={{ backgroundColor: accent }}>
-          <Pressable
-            accessibilityLabel={`Pin ${agent.name}`}
-            accessibilityRole="button"
-            className="flex-1 items-center justify-center gap-1.5"
-            style={({ pressed }) => ({ backgroundColor: accent, opacity: pressed ? 0.72 : 1 })}
-            onPress={() => handlePin(swipeable)}
-          >
-            <Pin color={String(accentForeground)} fill={String(accentForeground)} size={22} strokeWidth={1.8} />
-            <Typography.Paragraph type="body-xs" weight="semibold" style={{ color: accentForeground }}>
-              Pin
-            </Typography.Paragraph>
-          </Pressable>
-        </View>
-      )}
-      rightThreshold={42}
+    <AgentPinSwipeRow
+      agentName={agent.name}
+      onPin={(withHaptic) => toggleAgentPinAnimated(agent.id, { haptic: withHaptic })}
     >
       {Platform.OS === "android" ? (
         <MenuView
@@ -237,6 +207,6 @@ export function AgentListRow({
       ) : (
         agentLink
       )}
-    </ReanimatedSwipeable>
+    </AgentPinSwipeRow>
   );
 }

--- a/apps/mobile/src/features/agents/components/agent-pin-swipe-row.test.tsx
+++ b/apps/mobile/src/features/agents/components/agent-pin-swipe-row.test.tsx
@@ -1,0 +1,281 @@
+import { fireEvent, screen } from "@testing-library/dom";
+import { act, type PropsWithChildren, useImperativeHandle } from "react";
+import { createRoot } from "react-dom/client";
+import type { PanGesture } from "react-native-gesture-handler";
+import { type SwipeableProps, SwipeDirection } from "react-native-gesture-handler/ReanimatedSwipeable";
+import { useSharedValue } from "react-native-reanimated";
+import { afterEach, expect, it, vi } from "vitest";
+import { AgentPinSwipeRow } from "./agent-pin-swipe-row";
+
+type Motion = { translationX: number; velocityX: number };
+type Touch = { allTouches: { absoluteX: number; absoluteY: number }[]; numberOfTouches: number };
+type Manager = { activate: () => void; fail: () => void };
+const native = vi.hoisted(() => {
+  const handlers = {
+    down: (_e: Touch, _m: Manager) => {},
+    move: (_e: Touch, _m: Manager) => {},
+    start: () => {},
+    update: (_e: Motion) => {},
+    end: (_e: Motion, _success: boolean) => {},
+    finalize: (_e: Motion, _success: boolean) => {},
+  };
+  const springs: ((finished: boolean) => void)[] = [];
+  const props: SwipeableProps = {};
+  return { handlers, springs, props, impact: vi.fn(), blocked: vi.fn() };
+});
+
+// Replace only native event delivery and animation completion. The real gesture
+// callbacks decide ownership, thresholds, cancellation, haptics and pinning.
+vi.mock("react-native-gesture-handler", () => ({
+  GestureDetector: ({ children }: PropsWithChildren) => children,
+  Gesture: {
+    Pan: () => {
+      const gesture = {
+        manualActivation: () => gesture,
+        enableTrackpadTwoFingerGesture: () => gesture,
+        blocksExternalGesture: (other: PanGesture) => {
+          native.blocked(other);
+          return gesture;
+        },
+        onTouchesDown: (cb: typeof native.handlers.down) => {
+          native.handlers.down = cb;
+          return gesture;
+        },
+        onTouchesMove: (cb: typeof native.handlers.move) => {
+          native.handlers.move = cb;
+          return gesture;
+        },
+        onStart: (cb: typeof native.handlers.start) => {
+          native.handlers.start = cb;
+          return gesture;
+        },
+        onUpdate: (cb: typeof native.handlers.update) => {
+          native.handlers.update = cb;
+          return gesture;
+        },
+        onEnd: (cb: typeof native.handlers.end) => {
+          native.handlers.end = cb;
+          return gesture;
+        },
+        onFinalize: (cb: typeof native.handlers.finalize) => {
+          native.handlers.finalize = cb;
+          return gesture;
+        },
+      };
+      return gesture;
+    },
+  },
+}));
+vi.mock("react-native-gesture-handler/ReanimatedSwipeable", () => ({
+  SwipeDirection: { LEFT: "left", RIGHT: "right" },
+  default: (props: SwipeableProps) => {
+    native.props = props;
+    const methods = {
+      close: () => {
+        native.props.onSwipeableWillClose?.(SwipeDirection.RIGHT);
+        native.springs.push(() => native.props.onSwipeableClose?.(SwipeDirection.RIGHT));
+      },
+      openRight: () => native.props.onSwipeableWillOpen?.(SwipeDirection.LEFT),
+      openLeft: () => {},
+      reset: () => {},
+    };
+    useImperativeHandle(props.ref, () => methods);
+    const progress = useSharedValue(1);
+    const translation = useSharedValue(-88);
+    return (
+      <>
+        {props.renderRightActions?.(progress, translation, methods)}
+        {props.children}
+      </>
+    );
+  },
+}));
+vi.mock("@/features/servers/components/app-drawer-shell", () => ({ useAppDrawer: () => ({ openingGesture: {} }) }));
+vi.mock("@/shared/lib/haptics", () => ({ haptics: { impact: native.impact } }));
+vi.mock("react-native-worklets", () => ({
+  scheduleOnRN: (fn: (value?: boolean) => void, value?: boolean) => fn(value),
+}));
+vi.mock("react-native", () => ({
+  View: ({ children, accessibilityElementsHidden }: PropsWithChildren<{ accessibilityElementsHidden?: boolean }>) => (
+    <div aria-hidden={accessibilityElementsHidden}>{children}</div>
+  ),
+  Pressable: ({
+    children,
+    accessibilityLabel,
+    onPress,
+  }: PropsWithChildren<{ accessibilityLabel: string; onPress: () => void }>) => (
+    <button type="button" aria-label={accessibilityLabel} onClick={onPress}>
+      {children}
+    </button>
+  ),
+}));
+vi.mock("react-native-reanimated", async () => {
+  const { useRef } = await import("react");
+  return {
+    default: {
+      View: ({
+        children,
+        accessibilityElementsHidden,
+      }: PropsWithChildren<{ accessibilityElementsHidden?: boolean }>) => (
+        <div aria-hidden={accessibilityElementsHidden}>{children}</div>
+      ),
+    },
+    useAnimatedStyle: () => ({}),
+    useReducedMotion: () => false,
+    ReduceMotion: { System: "system" },
+    useSharedValue: <T,>(value: T) =>
+      useRef({
+        value,
+        get() {
+          return this.value;
+        },
+        set(next: T) {
+          this.value = next;
+        },
+      }).current,
+  };
+});
+vi.mock("heroui-native/hooks", () => ({ useThemeColor: () => ["background", "foreground"] }));
+vi.mock("heroui-native", () => ({
+  Typography: { Paragraph: ({ children }: PropsWithChildren) => <span>{children}</span> },
+}));
+vi.mock("lucide-react-native", () => ({ Pin: () => null }));
+const container = document.createElement("div");
+document.body.append(container);
+let root = createRoot(container);
+afterEach(async () => {
+  await act(() => root.unmount());
+  root = createRoot(container);
+  native.springs = [];
+  native.impact.mockClear();
+  native.blocked.mockClear();
+});
+async function renderRow() {
+  const onPin = vi.fn();
+  await act(() =>
+    root.render(
+      <AgentPinSwipeRow agentName="Ada" onPin={onPin}>
+        <button type="button">Open chat with Ada</button>
+      </AgentPinSwipeRow>,
+    ),
+  );
+  return onPin;
+}
+const motion = (translationX: number): Motion => ({ translationX, velocityX: 0 });
+const touch = (x: number, y = 0): Touch => ({ allTouches: [{ absoluteX: x, absoluteY: y }], numberOfTouches: 1 });
+function begin() {
+  native.handlers.start();
+}
+function move(x: number) {
+  native.handlers.update(motion(x));
+}
+async function release(x: number, success = true, opens = true) {
+  await act(() => {
+    // Deliver the library's settle event separately from the observer's release.
+    if (success) {
+      if (opens) native.props.onSwipeableWillOpen?.(SwipeDirection.LEFT);
+      else native.props.onSwipeableWillClose?.(SwipeDirection.RIGHT);
+    }
+    native.handlers.end(motion(x), success);
+    native.handlers.finalize(motion(x), success);
+  });
+}
+async function finish() {
+  await act(() =>
+    native.springs.splice(0).forEach((done) => {
+      done(true);
+    }),
+  );
+}
+
+it("reveals without pinning, then arms on a further drag and pins only after release", async () => {
+  const onPin = await renderRow();
+  begin();
+  move(-88);
+  await release(-88);
+  expect(screen.getByRole("button", { name: "Close pin action for Ada" })).toBeTruthy();
+  expect(onPin).not.toHaveBeenCalled();
+  expect(native.impact).not.toHaveBeenCalled();
+  begin();
+  move(-55);
+  expect(native.impact).not.toHaveBeenCalled();
+  move(-56);
+  expect(native.impact).toHaveBeenCalledExactlyOnceWith("light");
+  expect(onPin).not.toHaveBeenCalled();
+  move(-70);
+  expect(native.impact).toHaveBeenCalledOnce();
+  await release(-70);
+  await finish();
+  expect(onPin).toHaveBeenCalledExactlyOnceWith(false);
+});
+it("disarms when reversed below the threshold and permits a rightward close", async () => {
+  const onPin = await renderRow();
+  begin();
+  move(-150);
+  move(-120);
+  await release(-120);
+  await finish();
+  expect(onPin).not.toHaveBeenCalled();
+  begin();
+  move(88);
+  await release(88, true, false);
+  expect(screen.queryByRole("button", { name: "Close pin action for Ada" })).toBeNull();
+  expect(screen.getByRole("button", { name: "Open chat with Ada" })).toBeTruthy();
+});
+it("does not pin on cancellation or a short fast flick", async () => {
+  const onPin = await renderRow();
+  begin();
+  move(-150);
+  await release(-150, false);
+  await finish();
+  expect(onPin).not.toHaveBeenCalled();
+  begin();
+  move(-30);
+  await act(() => native.handlers.end({ translationX: -30, velocityX: -2000 }, true));
+  await finish();
+  expect(onPin).not.toHaveBeenCalled();
+});
+it("lets the drawer and vertical scroll win on closed rows, but closes exposed rows itself", async () => {
+  await renderRow();
+  const manager = { activate: vi.fn(), fail: vi.fn() };
+  native.handlers.down(touch(0), manager);
+  native.handlers.move(touch(20), manager);
+  expect(manager.fail).toHaveBeenCalledOnce();
+  native.handlers.down(touch(0), manager);
+  native.handlers.move(touch(-5, 20), manager);
+  expect(manager.fail).toHaveBeenCalledTimes(2);
+  native.handlers.down(touch(0), manager);
+  native.handlers.move(touch(-20), manager);
+  expect(manager.activate).toHaveBeenCalledOnce();
+  begin();
+  move(-88);
+  await release(-88);
+  native.handlers.down(touch(0), manager);
+  native.handlers.move(touch(20), manager);
+  expect(manager.activate).toHaveBeenCalledTimes(2);
+  expect(native.blocked).toHaveBeenCalled();
+});
+it("supports tapping Pin and rejects repeat activation during the return animation", async () => {
+  const onPin = await renderRow();
+  begin();
+  move(-88);
+  await release(-88);
+  await act(() => {
+    fireEvent.click(screen.getByRole("button", { name: "Pin Ada" }));
+    fireEvent.click(screen.getByRole("button", { name: "Pin Ada" }));
+  });
+  await finish();
+  expect(onPin).toHaveBeenCalledExactlyOnceWith(true);
+});
+
+it("closes the exposed action on tap and hides the action from accessibility when closed", async () => {
+  const onPin = await renderRow();
+  expect(screen.queryByRole("button", { name: "Pin Ada" })).toBeNull();
+  begin();
+  move(-88);
+  await release(-88);
+  await act(() => fireEvent.click(screen.getByRole("button", { name: "Close pin action for Ada" })));
+  expect(screen.queryByRole("button", { name: "Pin Ada" })).toBeNull();
+  expect(screen.getByRole("button", { name: "Open chat with Ada" })).toBeTruthy();
+  expect(onPin).not.toHaveBeenCalled();
+});

--- a/apps/mobile/src/features/agents/components/agent-pin-swipe-row.test.tsx
+++ b/apps/mobile/src/features/agents/components/agent-pin-swipe-row.test.tsx
@@ -180,6 +180,15 @@ async function release(x: number, success = true, opens = true) {
     native.handlers.finalize(motion(x), success);
   });
 }
+// An enabled native pan can cancel the close spring before its completion.
+// The observer failing does not stop Swipeable's separate movement gesture.
+async function interruptWithSwipe() {
+  await act(() => {
+    if (native.props.enabled === false) return;
+    native.springs = [];
+    native.props.onSwipeableWillOpen?.(SwipeDirection.LEFT);
+  });
+}
 async function finish() {
   await act(() =>
     native.springs.splice(0).forEach((done) => {
@@ -205,6 +214,7 @@ it("reveals without pinning, then arms on a further drag and pins only after rel
   move(-70);
   expect(native.impact).toHaveBeenCalledOnce();
   await release(-70);
+  await interruptWithSwipe();
   await finish();
   expect(onPin).toHaveBeenCalledExactlyOnceWith(false);
 });
@@ -255,7 +265,7 @@ it("lets the drawer and vertical scroll win on closed rows, but closes exposed r
   expect(manager.activate).toHaveBeenCalledTimes(2);
   expect(native.blocked).toHaveBeenCalled();
 });
-it("supports tapping Pin and rejects repeat activation during the return animation", async () => {
+it("keeps a pending pin closing through repeat taps and swipes, then accepts swipes again", async () => {
   const onPin = await renderRow();
   begin();
   move(-88);
@@ -264,8 +274,11 @@ it("supports tapping Pin and rejects repeat activation during the return animati
     fireEvent.click(screen.getByRole("button", { name: "Pin Ada" }));
     fireEvent.click(screen.getByRole("button", { name: "Pin Ada" }));
   });
+  await interruptWithSwipe();
   await finish();
   expect(onPin).toHaveBeenCalledExactlyOnceWith(true);
+  await interruptWithSwipe();
+  expect(screen.getByRole("button", { name: "Close pin action for Ada" })).toBeTruthy();
 });
 
 it("closes the exposed action on tap and hides the action from accessibility when closed", async () => {

--- a/apps/mobile/src/features/agents/components/agent-pin-swipe-row.tsx
+++ b/apps/mobile/src/features/agents/components/agent-pin-swipe-row.tsx
@@ -1,0 +1,116 @@
+import { Typography } from "heroui-native";
+import { useThemeColor } from "heroui-native/hooks";
+import { Pin } from "lucide-react-native";
+import type { PropsWithChildren } from "react";
+import { Pressable, View } from "react-native";
+import { GestureDetector } from "react-native-gesture-handler";
+import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
+import Animated, { type SharedValue, useAnimatedStyle, useReducedMotion } from "react-native-reanimated";
+import { useAppDrawer } from "@/features/servers/components/app-drawer-shell";
+
+import { PIN_COMMIT_DISTANCE, PIN_REVEAL_DISTANCE, useAgentPinSwipe } from "./use-agent-pin-swipe";
+
+function PinAction({
+  agentName,
+  revealed,
+  translation,
+  onPress,
+}: {
+  agentName: string;
+  revealed: boolean;
+  translation: SharedValue<number>;
+  onPress: () => void;
+}) {
+  const [accent, foreground] = useThemeColor(["accent", "accent-foreground"]);
+  const reducedMotion = useReducedMotion();
+  const circleStyle = useAnimatedStyle(() => ({
+    transform: [
+      { scale: reducedMotion ? 1 : 0.65 + Math.min(1, Math.max(0, -translation.get() / PIN_COMMIT_DISTANCE)) * 0.55 },
+    ],
+  }));
+
+  const actionStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: Math.min(0, (translation.get() + PIN_REVEAL_DISTANCE) / 2) }],
+  }));
+
+  return (
+    <Animated.View
+      className="w-[88px] items-center justify-center"
+      style={actionStyle}
+      accessibilityElementsHidden={!revealed}
+      importantForAccessibility={revealed ? "auto" : "no-hide-descendants"}
+    >
+      <Pressable
+        accessibilityLabel={`Pin ${agentName}`}
+        accessibilityRole="button"
+        className="size-16 items-center justify-center"
+        onPress={onPress}
+        style={({ pressed }) => ({ opacity: pressed ? 0.72 : 1 })}
+      >
+        <Animated.View
+          pointerEvents="none"
+          className="absolute size-16 rounded-full"
+          style={[{ backgroundColor: accent }, circleStyle]}
+        />
+        <Pin color={String(foreground)} fill={String(foreground)} size={22} strokeWidth={1.8} />
+        <Typography.Paragraph type="body-xs" weight="semibold" style={{ color: foreground }}>
+          Pin
+        </Typography.Paragraph>
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+export function AgentPinSwipeRow({
+  agentName,
+  onPin,
+  children,
+}: PropsWithChildren<{ agentName: string; onPin: (withHaptic: boolean) => void }>) {
+  const [background] = useThemeColor(["background"]);
+  const { openingGesture } = useAppDrawer();
+  const swipe = useAgentPinSwipe(openingGesture, onPin);
+
+  return (
+    <GestureDetector gesture={swipe.gesture}>
+      <ReanimatedSwipeable
+        ref={swipe.swipeable}
+        containerStyle={{ backgroundColor: background, overflow: "hidden" }}
+        childrenContainerStyle={{ backgroundColor: background }}
+        friction={1}
+        overshootRight
+        overshootFriction={1}
+        rightThreshold={PIN_REVEAL_DISTANCE / 2}
+        enableTrackpadTwoFingerGesture
+        simultaneousWithExternalGesture={swipe.gesture}
+        requireExternalGestureToFail={openingGesture}
+        onSwipeableWillOpen={swipe.onWillOpen}
+        onSwipeableWillClose={swipe.onWillClose}
+        onSwipeableClose={swipe.onClose}
+        renderRightActions={(_progress, translation) => (
+          <PinAction
+            revealed={swipe.revealed}
+            agentName={agentName}
+            translation={translation}
+            onPress={() => swipe.pin()}
+          />
+        )}
+      >
+        <View
+          pointerEvents={swipe.revealed ? "none" : "auto"}
+          accessibilityElementsHidden={swipe.revealed}
+          importantForAccessibility={swipe.revealed ? "no-hide-descendants" : "auto"}
+        >
+          {children}
+        </View>
+        {swipe.revealed ? (
+          <Pressable
+            className="absolute inset-0"
+            accessibilityRole="button"
+            accessibilityLabel={`Close pin action for ${agentName}`}
+            onPress={swipe.close}
+          />
+        ) : null}
+      </ReanimatedSwipeable>
+    </GestureDetector>
+  );
+}

--- a/apps/mobile/src/features/agents/components/agent-pin-swipe-row.tsx
+++ b/apps/mobile/src/features/agents/components/agent-pin-swipe-row.tsx
@@ -74,6 +74,7 @@ export function AgentPinSwipeRow({
     <GestureDetector gesture={swipe.gesture}>
       <ReanimatedSwipeable
         ref={swipe.swipeable}
+        enabled={!swipe.pinPending}
         containerStyle={{ backgroundColor: background, overflow: "hidden" }}
         childrenContainerStyle={{ backgroundColor: background }}
         friction={1}

--- a/apps/mobile/src/features/agents/components/agent-pin-transition.tsx
+++ b/apps/mobile/src/features/agents/components/agent-pin-transition.tsx
@@ -41,7 +41,7 @@ interface AgentPinTransitionContextValue {
   registerAvatar: (agentId: string, location: AgentAvatarLocation, node: View | null) => void;
   notifyAvatarLayout: (agentId: string, location: AgentAvatarLocation) => void;
   startAgentNavigationAnimated: (agentId: string, source: AgentAvatarLocation) => void;
-  toggleAgentPinAnimated: (agentId: string) => void;
+  toggleAgentPinAnimated: (agentId: string, options?: { haptic: boolean }) => void;
   transition: AgentPinTransitionState | null;
 }
 
@@ -204,7 +204,7 @@ export function AgentPinTransitionProvider({ children }: PropsWithChildren) {
   );
 
   const toggleAgentPinAnimated = useCallback(
-    (agentId: string) => {
+    (agentId: string, options?: { haptic: boolean }) => {
       const agent = agents.find((item) => item.id === agentId);
       if (!agent || transitionRef.current) return;
 
@@ -216,7 +216,7 @@ export function AgentPinTransitionProvider({ children }: PropsWithChildren) {
 
       const commitWithoutMovement = () => {
         toggleAgentPin(agentId);
-        void haptics.selection();
+        if (options?.haptic !== false) void haptics.selection();
       };
 
       if (!sourceNode || !container) {
@@ -240,7 +240,7 @@ export function AgentPinTransitionProvider({ children }: PropsWithChildren) {
 
           requestAnimationFrame(() => {
             toggleAgentPin(agentId);
-            void haptics.selection();
+            if (options?.haptic !== false) void haptics.selection();
             fallbackTimerRef.current = setTimeout(finishTransition, 700);
           });
         });

--- a/apps/mobile/src/features/agents/components/use-agent-pin-swipe.ts
+++ b/apps/mobile/src/features/agents/components/use-agent-pin-swipe.ts
@@ -1,0 +1,120 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Gesture, type PanGesture } from "react-native-gesture-handler";
+import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
+import { useSharedValue } from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+import { haptics } from "@/shared/lib/haptics";
+
+export const PIN_REVEAL_DISTANCE = 88;
+export const PIN_COMMIT_DISTANCE = 144;
+const PIN_DISARM_DISTANCE = 128;
+
+function thresholdFeedback() {
+  void haptics.impact("light");
+}
+
+export function useAgentPinSwipe(openingGesture: PanGesture, onPin: (withHaptic: boolean) => void) {
+  const swipeable = useRef<SwipeableMethods>(null);
+  const restOffset = useSharedValue(0);
+  const pendingPin = useRef<boolean | null>(null);
+  const origin = useSharedValue({ x: 0, y: 0 });
+  const start = useSharedValue(0);
+  const active = useSharedValue(false);
+  const armed = useSharedValue(false);
+  const feedbackPlayed = useSharedValue(false);
+  const committing = useSharedValue(false);
+  const [revealed, setRevealed] = useState(false);
+
+  const close = useCallback(() => swipeable.current?.close(), []);
+  const restore = useCallback(() => {
+    if (restOffset.get() < 0) swipeable.current?.openRight();
+    else swipeable.current?.close();
+  }, [restOffset]);
+
+  const pin = useCallback(
+    (withHaptic = true) => {
+      if (pendingPin.current !== null) return;
+      pendingPin.current = withHaptic;
+      committing.set(true);
+      swipeable.current?.close();
+    },
+    [committing],
+  );
+
+  const onWillOpen = () => {
+    restOffset.set(-PIN_REVEAL_DISTANCE);
+    setRevealed(true);
+  };
+  const onWillClose = () => {
+    restOffset.set(0);
+    setRevealed(false);
+  };
+  const onClose = () => {
+    const withHaptic = pendingPin.current;
+    pendingPin.current = null;
+    committing.set(false);
+    if (withHaptic !== null) onPin(withHaptic);
+  };
+
+  // Swipeable owns movement and settling. This simultaneous observer adds only
+  // the full-swipe threshold and resolves conflicts with the server drawer.
+  const gesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .manualActivation(true)
+        .enableTrackpadTwoFingerGesture(true)
+        // A closed row yields rightward movement to the drawer. An exposed row owns
+        // the same movement so it can close without opening the drawer.
+        .blocksExternalGesture(openingGesture)
+        .onTouchesDown((event, manager) => {
+          if (active.get()) return;
+          const touch = event.allTouches[0];
+          if (!touch || event.numberOfTouches > 2 || committing.get()) {
+            manager.fail();
+            return;
+          }
+          origin.set({ x: touch.absoluteX, y: touch.absoluteY });
+        })
+        .onTouchesMove((event, manager) => {
+          if (active.get()) return;
+          const touch = event.allTouches[0];
+          if (!touch || event.numberOfTouches > 2) {
+            manager.fail();
+            return;
+          }
+          const dx = touch.absoluteX - origin.get().x;
+          const dy = touch.absoluteY - origin.get().y;
+          if (Math.abs(dy) > 10) manager.fail();
+          else if (dx < -10 || (restOffset.get() < 0 && dx > 10)) manager.activate();
+          else if (dx > 10) manager.fail();
+        })
+        .onStart(() => {
+          active.set(true);
+          start.set(restOffset.get());
+          armed.set(false);
+          feedbackPlayed.set(false);
+        })
+        .onUpdate((event) => {
+          const distance = Math.max(0, -(start.get() + event.translationX));
+          if (distance >= PIN_COMMIT_DISTANCE && !armed.get()) {
+            armed.set(true);
+            if (!feedbackPlayed.get()) {
+              feedbackPlayed.set(true);
+              scheduleOnRN(thresholdFeedback);
+            }
+          } else if (distance < PIN_DISARM_DISTANCE) armed.set(false);
+        })
+        .onEnd((_event, success) => {
+          if (success && armed.get()) scheduleOnRN(pin, false);
+        })
+        .onFinalize((_event, success) => {
+          if (!active.get()) return;
+          active.set(false);
+          armed.set(false);
+          if (!success && !committing.get()) scheduleOnRN(restore);
+        }),
+    [active, armed, committing, feedbackPlayed, openingGesture, origin, pin, restOffset, restore, start],
+  );
+
+  return { close, gesture, onClose, onWillClose, onWillOpen, pin, revealed, swipeable };
+}

--- a/apps/mobile/src/features/agents/components/use-agent-pin-swipe.ts
+++ b/apps/mobile/src/features/agents/components/use-agent-pin-swipe.ts
@@ -24,6 +24,7 @@ export function useAgentPinSwipe(openingGesture: PanGesture, onPin: (withHaptic:
   const feedbackPlayed = useSharedValue(false);
   const committing = useSharedValue(false);
   const [revealed, setRevealed] = useState(false);
+  const [pinPending, setPinPending] = useState(false);
 
   const close = useCallback(() => swipeable.current?.close(), []);
   const restore = useCallback(() => {
@@ -36,6 +37,7 @@ export function useAgentPinSwipe(openingGesture: PanGesture, onPin: (withHaptic:
       if (pendingPin.current !== null) return;
       pendingPin.current = withHaptic;
       committing.set(true);
+      setPinPending(true);
       swipeable.current?.close();
     },
     [committing],
@@ -53,6 +55,7 @@ export function useAgentPinSwipe(openingGesture: PanGesture, onPin: (withHaptic:
     const withHaptic = pendingPin.current;
     pendingPin.current = null;
     committing.set(false);
+    setPinPending(false);
     if (withHaptic !== null) onPin(withHaptic);
   };
 
@@ -116,5 +119,5 @@ export function useAgentPinSwipe(openingGesture: PanGesture, onPin: (withHaptic:
     [active, armed, committing, feedbackPlayed, openingGesture, origin, pin, restOffset, restore, start],
   );
 
-  return { close, gesture, onClose, onWillClose, onWillOpen, pin, revealed, swipeable };
+  return { close, gesture, onClose, onWillClose, onWillOpen, pin, pinPending, revealed, swipeable };
 }


### PR DESCRIPTION
## Summary

- Extract agent pin swipe behavior into a reusable gesture row.
- Support reveal, threshold arming, cancellation, drawer/scroll gesture coordination, and accessible close and pin actions.
- Preserve transition animations while allowing swipe-triggered pinning to control haptic feedback.
- Add focused unit tests for gesture thresholds, cancellation, accessibility, and repeat activation.

## Testing

- Added Vitest and Testing Library coverage for agent pin swipe behavior.