### PR TITLE
Allow agents to be created without instructions

### DIFF
--- a/apps/mobile/src/features/agents/screens/add-agent-screen.tsx
+++ b/apps/mobile/src/features/agents/screens/add-agent-screen.tsx
@@ -27,7 +27,7 @@ export function AddAgentScreen() {
   const [finished, setFinished] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const valid = name.trim().length > 0 && description.trim().length > 0;
+  const valid = name.trim().length > 0;
 
   const dirty = Boolean(
     name.trim() || description.trim() || avatarSeed !== initialAvatarSeed.current || avatarHue !== null,
@@ -52,7 +52,7 @@ export function AddAgentScreen() {
       await createAgent({
         name: name.trim(),
         description: description.trim(),
-        initialMessage: `Your ongoing role is: ${description.trim()}`,
+        initialMessage: description.trim() ? `Your ongoing role is: ${description.trim()}` : "Greet me briefly.",
         avatarSeed,
         avatarHue,
       });
@@ -126,7 +126,7 @@ export function AddAgentScreen() {
 
       {dirty && !valid ? (
         <Typography.Paragraph accessibilityRole="alert" className="text-danger-text">
-          Enter a name and instructions for this agent.
+          Enter a name for this agent.
         </Typography.Paragraph>
       ) : null}
       {error ? (

--- a/apps/mobile/src/features/agents/screens/edit-agent-screen.test.tsx
+++ b/apps/mobile/src/features/agents/screens/edit-agent-screen.test.tsx
@@ -904,7 +904,7 @@ it("creates an agent from changed valid input and blocks duplicate submission an
   await act(() => root.render(<AddAgentScreen />));
   expect(screen.queryByRole("button", { name: "Create agent" })).toBeNull();
   await edit("Name", "Explorer");
-  expect(screen.getByRole("button", { name: "Create agent" })).toHaveProperty("disabled", true);
+  expect(screen.getByRole("button", { name: "Create agent" })).toHaveProperty("disabled", false);
   await edit("Name", "");
   expect(screen.queryByRole("button", { name: "Create agent" })).toBeNull();
   await edit("Name", " Explorer ");
@@ -924,6 +924,20 @@ it("creates an agent from changed valid input and blocks duplicate submission an
   await act(() => response.resolve());
   expect(mocks.blocked).toBe(false);
   expect(mocks.dispatch).toHaveBeenCalledWith({ type: "GO_BACK" });
+});
+
+it.each(["", "   "])("creates an agent with a greeting when instructions are %j", async (instructions) => {
+  await act(() => root.render(<AddAgentScreen />));
+  await edit("What should this agent help with?", instructions);
+  await edit("Name", " Explorer ");
+  await click("Create agent");
+  expect(workspace.createAgent).toHaveBeenCalledExactlyOnceWith({
+    name: "Explorer",
+    description: "",
+    initialMessage: "Greet me briefly.",
+    avatarSeed: "mobile:newagentseed",
+    avatarHue: null,
+  });
 });
 
 it("keeps a failed create draft for retry and confirms close", async () => {

--- a/src/backend/agent-store.test.ts
+++ b/src/backend/agent-store.test.ts
@@ -561,41 +561,50 @@ describe("AgentStore", () => {
     });
   });
 
-  it("creates unique new agents at the top of the persistent list", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openbot-store-"));
-    temporaryRoots.push(root);
-    const userData = join(root, "user-data");
-    const store = new AgentStore(userData, join(root, "home"));
-    await store.initialize();
+  it.each(["", "   ", AGENT_PROFILE_INPUT.description])(
+    "creates unique agents with description %j at the top of the persistent list",
+    async (description) => {
+      const root = await mkdtemp(join(tmpdir(), "openbot-store-"));
+      temporaryRoots.push(root);
+      const userData = join(root, "user-data");
+      const store = new AgentStore(userData, join(root, "home"));
+      await store.initialize();
 
-    const first = await store.createAgent({ ...AGENT_PROFILE_INPUT, name: "First Agent", avatarSeed: "setup:first" });
-    const second = await store.createAgent({
-      ...AGENT_PROFILE_INPUT,
-      name: "Second Agent",
-      avatarSeed: "setup:second",
-    });
+      const first = await store.createAgent({
+        ...AGENT_PROFILE_INPUT,
+        name: "First Agent",
+        avatarSeed: "setup:first",
+        description,
+      });
+      const second = await store.createAgent({
+        ...AGENT_PROFILE_INPUT,
+        name: "Second Agent",
+        avatarSeed: "setup:second",
+      });
 
-    expect(first.id).not.toBe(second.id);
-    expect(first.name).toBe("First Agent");
-    expect(second.name).toBe("Second Agent");
-    expect(first.title).toBe("");
-    expect(second.title).toBe("");
-    expect(
-      store
-        .list()
-        .slice(0, 2)
-        .map((agent) => agent.id),
-    ).toEqual([second.id, first.id]);
+      expect(first.id).not.toBe(second.id);
+      expect(first.name).toBe("First Agent");
+      expect(second.name).toBe("Second Agent");
+      expect(first.title).toBe("");
+      expect(second.title).toBe("");
+      expect(
+        store
+          .list()
+          .slice(0, 2)
+          .map((agent) => agent.id),
+      ).toEqual([second.id, first.id]);
 
-    const reloaded = new AgentStore(userData, join(root, "home"));
-    await reloaded.initialize();
-    expect(
-      reloaded
-        .list()
-        .slice(0, 2)
-        .map((agent) => agent.id),
-    ).toEqual([second.id, first.id]);
-  });
+      const reloaded = new AgentStore(userData, join(root, "home"));
+      await reloaded.initialize();
+      expect(reloaded.list().find((agent) => agent.id === first.id)?.description).toBe(description.trim());
+      expect(
+        reloaded
+          .list()
+          .slice(0, 2)
+          .map((agent) => agent.id),
+      ).toEqual([second.id, first.id]);
+    },
+  );
 
   it("duplicates the profile, avatar, workspace, and symbolic links into an independent agent", async () => {
     const root = await mkdtemp(join(tmpdir(), "openbot-store-duplicate-"));
@@ -883,9 +892,9 @@ describe("AgentStore", () => {
     await store.initialize();
 
     await expect(store.createAgent({ ...AGENT_PROFILE_INPUT, name: " " })).rejects.toThrow("Agent name is required.");
-    await expect(store.createAgent({ ...AGENT_PROFILE_INPUT, description: " " })).rejects.toThrow(
-      "Agent description is required.",
-    );
+    await expect(
+      store.createAgent({ ...AGENT_PROFILE_INPUT, description: "x".repeat(INPUT_LIMITS.agentDescription + 1) }),
+    ).rejects.toThrow("Agent description is too long.");
     await expect(store.createAgent({ ...AGENT_PROFILE_INPUT, avatarSeed: "" })).rejects.toThrow("Invalid avatar seed.");
     expect(store.list()).toEqual([]);
   });

--- a/src/backend/agent-store.ts
+++ b/src/backend/agent-store.ts
@@ -243,7 +243,7 @@ export class AgentStore {
       throw new Error(`A host can have up to ${INPUT_LIMITS.agents} agents.`);
     }
     const name = requiredText(input.name, "Agent name", INPUT_LIMITS.agentName);
-    const description = requiredText(input.description, "Agent description", INPUT_LIMITS.agentDescription);
+    const description = limitedText(input.description, "Agent description", INPUT_LIMITS.agentDescription);
     if (!isAvatarSeed(input.avatarSeed)) throw new Error("Invalid avatar seed.");
     if (input.avatarHue !== null && !isAvatarHue(input.avatarHue)) throw new Error("Invalid avatar hue.");
     const record = this.#createRecord(`agent-${randomUUID()}`, name, "", description);

--- a/src/main/team-api-server.agents.test.ts
+++ b/src/main/team-api-server.agents.test.ts
@@ -19,6 +19,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentStore } from "../backend/agent-store";
 import { SidebarLayoutStore } from "../backend/sidebar-layout-store";
 import { addRemotePreviewUrls } from "./remote-server-urls";
+import { agentCreate } from "./team-api/request-helpers";
 import {
   createAgents,
   createTeamApiFixture,
@@ -31,6 +32,44 @@ import {
 afterEach(stopTeamApiFixtures);
 
 describe("TeamApiServer agents", () => {
+  it.each(["", "   ", "Plan trips"])("creates an agent through the API with description %j", async (description) => {
+    const { root, start, signIn } = await createTeamApiFixture("agent-create", { configure: true });
+    const store = new AgentStore(join(root, "agents"), join(root, "home"));
+    await store.initialize();
+    const { base } = await start({
+      agents: createAgents({ createAgent: (input) => store.createAgent(input) }),
+    });
+    const token = await signIn();
+    const input = {
+      name: "Explorer",
+      description,
+      initialMessage: "Greet me briefly.",
+      avatarSeed: "mobile:newagentseed",
+      avatarHue: null,
+    };
+    const created = await jsonRequest<AgentSummary>(base, "/v1/agents", { token, body: input });
+    expect(store.list()).toEqual([
+      expect.objectContaining({ id: created.id, name: input.name, description: description.trim() }),
+    ]);
+  });
+
+  it.each([
+    { label: "missing", description: undefined },
+    { label: "null", description: null },
+    { label: "number", description: 42 },
+    { label: "too long", description: "x".repeat(INPUT_LIMITS.agentDescription + 1) },
+  ])("rejects a $label description during agent creation", ({ description }) => {
+    expect(() =>
+      agentCreate({
+        name: "Explorer",
+        description,
+        initialMessage: "Greet me briefly.",
+        avatarSeed: "mobile:newagentseed",
+        avatarHue: null,
+      }),
+    ).toThrow("description is invalid.");
+  });
+
   it("downloads uploaded and replaced avatars through a WebRTC request and removes them", async () => {
     const { root, start, signIn } = await createTeamApiFixture("agent-avatar", { configure: true });
     const store = new AgentStore(join(root, "agents"), join(root, "home"));

--- a/src/main/team-api/request-helpers.ts
+++ b/src/main/team-api/request-helpers.ts
@@ -363,9 +363,12 @@ export function agentCreate(value: DynamicRecord): CreateAgentInput {
   const avatarHue = value.avatarHue;
   if (!isAvatarSeed(value.avatarSeed)) throw new HttpError(400, "avatarSeed is invalid.");
   if (avatarHue !== null && !isAvatarHue(avatarHue)) throw new HttpError(400, "avatarHue is invalid.");
+  if (!isString(value.description) || value.description.length > INPUT_LIMITS.agentDescription) {
+    throw new HttpError(400, "description is invalid.");
+  }
   return {
     name: requiredCreateText(value.name, "name", INPUT_LIMITS.agentName),
-    description: requiredCreateText(value.description, "description", INPUT_LIMITS.agentDescription),
+    description: value.description,
     avatarSeed: value.avatarSeed,
     avatarHue,
     initialMessage: requiredCreateText(value.initialMessage, "initialMessage", INPUT_LIMITS.messageText),


### PR DESCRIPTION
## Summary

- Make agent instructions optional in the mobile create flow.
- Use a default greeting when instructions are empty.
- Accept empty descriptions in the backend and Team API while enforcing type and length checks.
- Add mobile, backend, and Team API coverage for empty and invalid descriptions.

## Testing

Not run (not requested).