### PR TITLE
Remove break-and-restore test rule from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,8 +141,6 @@ risks since the last release.
 - Tests are mandatory for changes to the renderer-to-main boundary, IPC contracts, database schema
   and migrations, persisted state, secrets, provider processes, Team API wire protocols, and the
   updater. Test once at the lowest stable boundary.
-- For each added assertion, break the behavior and confirm the test fails for the intended reason.
-  Restore the code and report this check in the PR.
 - Wait for state, an event, or a promise, not elapsed time. A spy can provide the wait condition,
   such as `await waitFor(() => expect(send).toHaveBeenCalled())`; assert the user consequence after
   that wait. Do not remove synchronization because it uses a spy.


### PR DESCRIPTION
## What changed

Removes the Tests rule in `AGENTS.md` that told agents to break the behavior for each added assertion, confirm the test fails for the intended reason, restore the code, and report the check in the PR.

Why:
- The per-assertion scope made the check costly, even for low-risk tests.
- Reviewers could not verify the PR report, so it added text but not confidence.

`.github/review/tests.md:12` stays unchanged. There, the reviewer judges whether an added test would fail for an actionable reason. That is review judgment, not a manual break step.

Surfaces touched: agent instructions (`AGENTS.md`) only. No renderer, mobile, `apps/auth-api`, IPC contract, migration, or product documentation changes.

## Verification

- [x] Narrow checks for what changed: the pre-commit hook ran `biome check` on staged files and the typecheck projects; all passed. There are no affected tests (Markdown-only change).
- [x] Surfaces touched are named under "What changed"
- [x] Relevant manual smoke test completed, or not applicable (not applicable)
- [x] No credentials, private data, generated output, or real user files are included

## Risk and security impact

None. This changes only agent guidance. The mandatory-test areas in `AGENTS.md` stay unchanged.

Model and harness: Claude Opus 5 (`claude-opus-5`), Claude Code in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)