### PR TITLE
feat: ship a Linux x64 AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,6 +441,26 @@ jobs:
       - name: Build AppImage
         run: bun run dist:linux
 
+      # Ubuntu 24.04 restricts unprivileged user namespaces through AppArmor, which is the same
+      # restriction the shipped profile answers for an installed AppImage. The verifier starts the
+      # unpacked build from the workspace, so that path needs its own profile, and the SUID helper
+      # needs the ownership a package manager would give it. The sandbox stays on either way:
+      # `--no-sandbox` would make the launch check prove nothing about a real install.
+      - name: Permit the Electron sandbox for the verification build
+        run: |
+          set -euo pipefail
+          sudo chown root:root dist/linux-unpacked/chrome-sandbox
+          sudo chmod 4755 dist/linux-unpacked/chrome-sandbox
+          sudo tee /etc/apparmor.d/openbot-verify >/dev/null <<PROFILE
+          abi <abi/4.0>,
+          include <tunables/global>
+
+          profile openbot-verify "$GITHUB_WORKSPACE/dist/linux-unpacked/openbot" flags=(unconfined) {
+            userns,
+          }
+          PROFILE
+          sudo apparmor_parser -r /etc/apparmor.d/openbot-verify
+
       - name: Verify packaged application metadata and launch
         run: xvfb-run -a bun run verify:package:linux --require-update-metadata
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,9 +403,103 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  linux:
+    name: Build unsigned Linux x64 release
+    needs: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    environment: release
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    env:
+      RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Install a virtual display for the launch check
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes xvfb
+
+      - name: Run Linux checks
+        run: bun run lint && bun run typecheck && bunx vitest run src/backend/cli.test.ts
+
+      - name: Install and verify provider control artifacts
+        run: |
+          bun scripts/install-codex-runtime.ts linux x64
+          bun scripts/install-claude-runtime.ts linux x64
+          bun scripts/install-grok-runtime.ts linux x64
+
+      - name: Build AppImage
+        run: bun run dist:linux
+
+      - name: Verify packaged application metadata and launch
+        run: xvfb-run -a bun run verify:package:linux --require-update-metadata
+
+      - name: Verify AppImage and updater metadata
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          appImages=(dist/*.AppImage)
+          if [ "${#appImages[@]}" -ne 1 ] || [ ! -f dist/latest-linux.yml ]; then
+            echo "Expected one AppImage and latest-linux.yml." >&2
+            exit 1
+          fi
+          # The AppImage has to stay executable, or the download is unusable without a chmod.
+          if [ ! -x "${appImages[0]}" ]; then
+            echo "The AppImage is not executable." >&2
+            exit 1
+          fi
+          grep -Fq "version: $RELEASE_VERSION" dist/latest-linux.yml
+          grep -Fq ".AppImage" dist/latest-linux.yml
+          bun run verify:update-artifacts linux
+
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          cd dist
+          shasum -a 256 ./*.AppImage | sed 's| \./| |' > SHA256SUMS-linux.txt
+          cat SHA256SUMS-linux.txt
+
+      - name: Generate Linux release SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: dist/linux-unpacked
+          format: spdx-json
+          output-file: dist/OpenBot-${{ env.RELEASE_VERSION }}-linux.spdx.json
+          artifact-name: OpenBot-${{ env.RELEASE_VERSION }}-Linux-SBOM
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest Linux release provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-checksums: dist/SHA256SUMS-linux.txt
+
+      - name: Upload Linux release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-linux
+          # An AppImage embeds its block map, so there is no sidecar file to upload beside it.
+          path: |
+            dist/*.AppImage
+            dist/latest-linux.yml
+            dist/*.spdx.json
+            dist/SHA256SUMS-linux.txt
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
     name: Publish GitHub Release
-    needs: [validate, macos, windows]
+    needs: [validate, macos, windows, linux]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -426,18 +520,25 @@ jobs:
           name: release-windows
           path: release-assets/windows
 
+      - name: Download Linux release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-linux
+          path: release-assets/linux
+
       - name: Generate combined checksums
         shell: bash
         run: |
           cat release-assets/macos/SHA256SUMS-macos.txt \
             release-assets/windows/SHA256SUMS-windows.txt \
+            release-assets/linux/SHA256SUMS-linux.txt \
             > release-assets/SHA256SUMS.txt
 
       - name: Publish GitHub Release
         shell: bash
         run: |
           shopt -s nullglob
-          artifacts=(release-assets/macos/* release-assets/windows/* release-assets/SHA256SUMS.txt)
+          artifacts=(release-assets/macos/* release-assets/windows/* release-assets/linux/* release-assets/SHA256SUMS.txt)
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release upload "$RELEASE_TAG" "${artifacts[@]}" --clobber --repo "$GITHUB_REPOSITORY"
             gh release edit "$RELEASE_TAG" --draft=false --latest --repo "$GITHUB_REPOSITORY"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The same file ships inside the AppImage at `resources/linux/openbot.apparmor`. E
 path in the profile if you keep the AppImage outside the usual locations. Do not start OpenBot with
 `--no-sandbox`: that removes the boundary between a renderer and the rest of the computer.
 
+On the first start from an AppImage, OpenBot writes `~/.local/share/applications/openbot.desktop`,
+which is what lets an `openbot://` invitation link open the app. Delete that file to undo it.
+
 Voice prompts and remote desktop are not available on Linux.
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ visited pages use the network, and installed plugins may connect to their own se
 
 ## Install
 
-OpenBot supports macOS 13 or newer on Apple Silicon and Windows 10 or newer on x64 systems.
+OpenBot supports macOS 13 or newer on Apple Silicon, Windows 10 or newer on x64 systems, and x64
+Linux as an AppImage.
 
 ### macOS
 
@@ -47,6 +48,25 @@ OpenBot supports macOS 13 or newer on Apple Silicon and Windows 10 or newer on x
 
 1. Download the latest `OpenBot-*-x64.exe` from [GitHub Releases](https://github.com/NorbertBodziony/openbot/releases).
 2. Run the installer and open OpenBot.
+
+### Linux
+
+1. Download the latest `OpenBot-*-x86_64.AppImage` from [GitHub Releases](https://github.com/NorbertBodziony/openbot/releases).
+2. Make it executable with `chmod +x OpenBot-*-x86_64.AppImage`, then run it.
+
+On Ubuntu 23.10 or newer and on Debian 13, unprivileged user namespaces are restricted by AppArmor
+and OpenBot exits during launch until you install an AppArmor profile:
+
+```bash
+sudo install -m 0644 build/linux/openbot.apparmor /etc/apparmor.d/openbot
+sudo systemctl reload apparmor
+```
+
+The same file ships inside the AppImage at `resources/linux/openbot.apparmor`. Edit the attachment
+path in the profile if you keep the AppImage outside the usual locations. Do not start OpenBot with
+`--no-sandbox`: that removes the boundary between a renderer and the rest of the computer.
+
+Voice prompts and remote desktop are not available on Linux.
 
 > [!IMPORTANT]
 > The Windows preview is not code-signed. Windows can show an `Unknown publisher` or SmartScreen
@@ -195,9 +215,12 @@ Seed the approved OpenBot team catalog locally with `bun run marketplace:seed:lo
 | `bun run package:verify` | Build and verify the real ARM64 app bundle, icon, metadata, ASAR, and fuses. |
 | `bun run package:win` | Build an unpacked local Windows x64 application on Windows. |
 | `bun run package:win:verify` | Build and verify the Windows x64 application on Windows. |
+| `bun run package:linux` | Build an unpacked local Linux x64 application on Linux. |
+| `bun run package:linux:verify` | Build and verify the Linux x64 application on Linux. Run it under `xvfb-run -a` without a display. |
 | `bun run release:preflight` | Verify version, Git state, and GitHub release secrets before tagging. |
 | `bun run dist:mac` | Build unsigned local ARM64 DMG and ZIP update artifacts. |
 | `bun run dist:win` | Build an unsigned Windows x64 NSIS installer on Windows. |
+| `bun run dist:linux` | Build an unsigned Linux x64 AppImage on Linux. |
 | `bun run release:patch` | Create the next patch version commit and tag. |
 | `bun run test:filesystem` | **Online/manual:** run real full-access Codex and Claude filesystem turns across private and shared workspaces. |
 | `bun run test:imagegen` | **Online/manual:** run a real full-access image-generation turn. |
@@ -335,7 +358,8 @@ described above.
 
 Releases are tag-driven. `bun run release:patch`, `release:minor`, or `release:major` prepares the
 version and changelog. After review, commit, preflight, and tag the release; pushing the tag builds a
-signed and notarized macOS ARM64 release and an unsigned Windows x64 release in GitHub Actions.
+signed and notarized macOS ARM64 release, an unsigned Windows x64 release, and an unsigned Linux x64
+AppImage in GitHub Actions.
 Installed builds check GitHub Releases for updates and expose download/restart controls in the account
 popover. Release signing secrets and the complete procedure are documented in
 [docs/RELEASING.md](docs/RELEASING.md).

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ The same file ships inside the AppImage at `resources/linux/openbot.apparmor`. E
 path in the profile if you keep the AppImage outside the usual locations. Do not start OpenBot with
 `--no-sandbox`: that removes the boundary between a renderer and the rest of the computer.
 
-On the first start from an AppImage, OpenBot writes `~/.local/share/applications/openbot.desktop`,
-which is what lets an `openbot://` invitation link open the app. Delete that file to undo it.
+On the first start from an AppImage, OpenBot writes `~/.local/share/applications/openbot.desktop`
+and `~/.local/share/icons/openbot.png`, which is what lets an `openbot://` invitation link open the
+app and gives the launcher an icon that stays after the app exits. Delete the two files to undo it.
 
 Voice prompts and remote desktop are not available on Linux.
 

--- a/apps/auth-api/src/lib/analytics.ts
+++ b/apps/auth-api/src/lib/analytics.ts
@@ -10,7 +10,7 @@ export type LandingAcquisitionSource = "direct" | "search" | "social" | "github"
 
 interface LandingAnalyticsEvents {
   landing_viewed: Record<string, never>;
-  landing_download_clicked: { platform: "macos" | "windows"; placement: LandingPlacement };
+  landing_download_clicked: { platform: LandingDownloadPlatform; placement: LandingPlacement };
   landing_link_clicked: { destination: LandingDestination; placement: LandingPlacement };
   join_page_action:
     | { action: "view"; valid_invite: boolean }
@@ -20,6 +20,8 @@ interface LandingAnalyticsEvents {
 
 type LandingEventName = keyof LandingAnalyticsEvents;
 type LandingPlacement = "header" | "hero" | "download_section" | "footer" | "other";
+/** The platforms the landing page can send a visitor to a download for. */
+type LandingDownloadPlatform = "linux" | "macos" | "windows";
 type LandingDestination =
   | "download_section"
   | "contact"
@@ -50,6 +52,13 @@ function createOpenPanelClient(options: OpenPanelOptions): OpenPanelClient {
     trackScreenView: (path) => OpenPanelBase.prototype.track.call(client, "screen_view", { __path: path }),
   };
 }
+
+/** The download route each platform uses, reversed so a click can name the platform it asked for. */
+const DOWNLOAD_PLATFORMS_BY_HREF = new Map<string, LandingDownloadPlatform>([
+  [OPENBOT_DOWNLOAD_LINKS.macos, "macos"],
+  [OPENBOT_DOWNLOAD_LINKS.windows, "windows"],
+  [OPENBOT_DOWNLOAD_LINKS.linux, "linux"],
+]);
 
 const LINK_DESTINATIONS = new Map<string, LandingDestination>([
   [OPENBOT_LINKS.download, "download_section"],
@@ -181,12 +190,9 @@ export class LandingAnalytics {
     if (!link) return;
     const placement = landingPlacement(link);
     const href = link.getAttribute("href") ?? "";
-    if (href === OPENBOT_DOWNLOAD_LINKS.macos) {
-      this.#track("landing_download_clicked", { platform: "macos", placement });
-      return;
-    }
-    if (href === OPENBOT_DOWNLOAD_LINKS.windows) {
-      this.#track("landing_download_clicked", { platform: "windows", placement });
+    const downloadPlatform = DOWNLOAD_PLATFORMS_BY_HREF.get(href);
+    if (downloadPlatform) {
+      this.#track("landing_download_clicked", { platform: downloadPlatform, placement });
       return;
     }
     const destination = LINK_DESTINATIONS.get(href);

--- a/apps/auth-api/src/lib/download-platforms.ts
+++ b/apps/auth-api/src/lib/download-platforms.ts
@@ -43,10 +43,11 @@ export const DOWNLOAD_PLATFORMS: Record<DownloadPlatform, DownloadPlatformDetail
   linux: {
     id: "linux",
     label: "Linux",
-    status: "Coming soon",
-    description: "Native Linux build in progress",
-    action: "Linux coming soon",
-    available: false,
+    status: "Available",
+    description: "x64 · AppImage",
+    action: "Download for Linux",
+    available: true,
+    href: OPENBOT_DOWNLOAD_LINKS.linux,
   },
 };
 

--- a/apps/auth-api/src/lib/landing-links.ts
+++ b/apps/auth-api/src/lib/landing-links.ts
@@ -3,6 +3,7 @@ export const EXTERNAL_LINK_REL = "noopener noreferrer";
 export const OPENBOT_DOWNLOAD_LINKS = {
   macos: "/download/macos",
   windows: "/download/windows",
+  linux: "/download/linux",
 } as const;
 
 export const OPENBOT_LINKS = {

--- a/apps/auth-api/src/routeTree.gen.ts
+++ b/apps/auth-api/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as JoinRouteImport } from './routes/join'
 import { Route as ReportSiteRouteImport } from './routes/report-site'
 import { Route as DotwellKnownAppleAppSiteAssociationRouteImport } from './routes/[.]well-known/apple-app-site-association'
 import { Route as DotwellKnownJwksDotjsonRouteImport } from './routes/[.]well-known/jwks[.]json'
+import { Route as DownloadLinuxRouteImport } from './routes/download/linux'
 import { Route as DownloadMacosRouteImport } from './routes/download/macos'
 import { Route as DownloadWindowsRouteImport } from './routes/download/windows'
 import { Route as HealthLiveRouteImport } from './routes/health/live'
@@ -105,6 +106,11 @@ const DotwellKnownAppleAppSiteAssociationRoute =
 const DotwellKnownJwksDotjsonRoute = DotwellKnownJwksDotjsonRouteImport.update({
   id: '/.well-known/jwks.json',
   path: '/.well-known/jwks.json',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DownloadLinuxRoute = DownloadLinuxRouteImport.update({
+  id: '/download/linux',
+  path: '/download/linux',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DownloadMacosRoute = DownloadMacosRouteImport.update({
@@ -436,6 +442,7 @@ export interface FileRoutesByFullPath {
   '/report-site': typeof ReportSiteRoute
   '/.well-known/apple-app-site-association': typeof DotwellKnownAppleAppSiteAssociationRoute
   '/.well-known/jwks.json': typeof DotwellKnownJwksDotjsonRoute
+  '/download/linux': typeof DownloadLinuxRoute
   '/download/macos': typeof DownloadMacosRoute
   '/download/windows': typeof DownloadWindowsRoute
   '/health/live': typeof HealthLiveRoute
@@ -504,6 +511,7 @@ export interface FileRoutesByTo {
   '/report-site': typeof ReportSiteRoute
   '/.well-known/apple-app-site-association': typeof DotwellKnownAppleAppSiteAssociationRoute
   '/.well-known/jwks.json': typeof DotwellKnownJwksDotjsonRoute
+  '/download/linux': typeof DownloadLinuxRoute
   '/download/macos': typeof DownloadMacosRoute
   '/download/windows': typeof DownloadWindowsRoute
   '/health/live': typeof HealthLiveRoute
@@ -573,6 +581,7 @@ export interface FileRoutesById {
   '/report-site': typeof ReportSiteRoute
   '/.well-known/apple-app-site-association': typeof DotwellKnownAppleAppSiteAssociationRoute
   '/.well-known/jwks.json': typeof DotwellKnownJwksDotjsonRoute
+  '/download/linux': typeof DownloadLinuxRoute
   '/download/macos': typeof DownloadMacosRoute
   '/download/windows': typeof DownloadWindowsRoute
   '/health/live': typeof HealthLiveRoute
@@ -643,6 +652,7 @@ export interface FileRouteTypes {
     | '/report-site'
     | '/.well-known/apple-app-site-association'
     | '/.well-known/jwks.json'
+    | '/download/linux'
     | '/download/macos'
     | '/download/windows'
     | '/health/live'
@@ -711,6 +721,7 @@ export interface FileRouteTypes {
     | '/report-site'
     | '/.well-known/apple-app-site-association'
     | '/.well-known/jwks.json'
+    | '/download/linux'
     | '/download/macos'
     | '/download/windows'
     | '/health/live'
@@ -779,6 +790,7 @@ export interface FileRouteTypes {
     | '/report-site'
     | '/.well-known/apple-app-site-association'
     | '/.well-known/jwks.json'
+    | '/download/linux'
     | '/download/macos'
     | '/download/windows'
     | '/health/live'
@@ -848,6 +860,7 @@ export interface RootRouteChildren {
   ReportSiteRoute: typeof ReportSiteRoute
   DotwellKnownAppleAppSiteAssociationRoute: typeof DotwellKnownAppleAppSiteAssociationRoute
   DotwellKnownJwksDotjsonRoute: typeof DotwellKnownJwksDotjsonRoute
+  DownloadLinuxRoute: typeof DownloadLinuxRoute
   DownloadMacosRoute: typeof DownloadMacosRoute
   DownloadWindowsRoute: typeof DownloadWindowsRoute
   HealthLiveRoute: typeof HealthLiveRoute
@@ -940,6 +953,13 @@ declare module '@tanstack/solid-router' {
       path: '/.well-known/jwks.json'
       fullPath: '/.well-known/jwks.json'
       preLoaderRoute: typeof DotwellKnownJwksDotjsonRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/download/linux': {
+      id: '/download/linux'
+      path: '/download/linux'
+      fullPath: '/download/linux'
+      preLoaderRoute: typeof DownloadLinuxRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/download/macos': {
@@ -1478,6 +1498,7 @@ const rootRouteChildren: RootRouteChildren = {
   DotwellKnownAppleAppSiteAssociationRoute:
     DotwellKnownAppleAppSiteAssociationRoute,
   DotwellKnownJwksDotjsonRoute: DotwellKnownJwksDotjsonRoute,
+  DownloadLinuxRoute: DownloadLinuxRoute,
   DownloadMacosRoute: DownloadMacosRoute,
   DownloadWindowsRoute: DownloadWindowsRoute,
   HealthLiveRoute: HealthLiveRoute,
@@ -1533,12 +1554,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/solid-start'
-declare module '@tanstack/solid-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/apps/auth-api/src/routes/download/linux.ts
+++ b/apps/auth-api/src/routes/download/linux.ts
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/solid-router";
+import { latestDownloadResponse } from "../../server/latest-download";
+
+export const Route = createFileRoute("/download/linux")({
+  server: {
+    handlers: {
+      GET: async () => latestDownloadResponse("linux"),
+    },
+  },
+});

--- a/apps/auth-api/src/server/latest-download.ts
+++ b/apps/auth-api/src/server/latest-download.ts
@@ -1,15 +1,20 @@
 import { OPENBOT_LINKS } from "../lib/landing-links";
 
-export type AvailableDownloadPlatform = "macos" | "windows";
+export type AvailableDownloadPlatform = "linux" | "macos" | "windows";
 
 interface DownloadManifestConfig {
-  extension: ".dmg" | ".exe";
-  manifest: "latest-mac.yml" | "latest.yml";
+  /**
+   * Compared against a lowercased asset name, so it must be lowercase itself. The Linux asset is
+   * published as `.AppImage`.
+   */
+  extension: ".appimage" | ".dmg" | ".exe";
+  manifest: "latest-linux.yml" | "latest-mac.yml" | "latest.yml";
 }
 
 const RELEASES_BASE_URL = "https://github.com/NorbertBodziony/openbot/releases";
 
 const DOWNLOAD_MANIFESTS: Record<AvailableDownloadPlatform, DownloadManifestConfig> = {
+  linux: { extension: ".appimage", manifest: "latest-linux.yml" },
   macos: { extension: ".dmg", manifest: "latest-mac.yml" },
   windows: { extension: ".exe", manifest: "latest.yml" },
 };

--- a/apps/auth-api/test/download-platforms.test.ts
+++ b/apps/auth-api/test/download-platforms.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { detectDownloadPlatform } from "../src/lib/download-platforms";
+import { DOWNLOAD_PLATFORM_ORDER, DOWNLOAD_PLATFORMS, detectDownloadPlatform } from "../src/lib/download-platforms";
+import { OPENBOT_DOWNLOAD_LINKS } from "../src/lib/landing-links";
 
 describe("download platforms", () => {
   it.each([
@@ -14,5 +15,17 @@ describe("download platforms", () => {
 
   it("returns no platform for an unknown client", () => {
     expect(detectDownloadPlatform({ platform: "Unknown" })).toBeUndefined();
+  });
+
+  it("offers a download for every platform it can detect", () => {
+    for (const platform of DOWNLOAD_PLATFORM_ORDER) {
+      const details = DOWNLOAD_PLATFORMS[platform];
+      expect(details).toMatchObject({ available: true, status: "Available", href: OPENBOT_DOWNLOAD_LINKS[platform] });
+    }
+  });
+
+  it("describes the Linux download as an x64 AppImage", () => {
+    expect(DOWNLOAD_PLATFORMS.linux.description).toBe("x64 · AppImage");
+    expect(DOWNLOAD_PLATFORMS.linux.action).toBe("Download for Linux");
   });
 });

--- a/apps/auth-api/test/hero-download-selector.test.tsx
+++ b/apps/auth-api/test/hero-download-selector.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, waitFor } from "@solidjs/testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HeroDownloadSelector } from "../src/components/landing/HeroDownloadSelector";
+import { DOWNLOAD_PLATFORMS } from "../src/lib/download-platforms";
 import { OPENBOT_DOWNLOAD_LINKS } from "../src/lib/landing-links";
 
 function setPlatform(platform: string): void {
@@ -12,6 +13,7 @@ const AVAILABLE_PLATFORM_CASES: ReadonlyArray<
 > = [
   ["MacIntel", "macos", "Download for macOS"],
   ["Win32", "windows", "Download for Windows"],
+  ["Linux x86_64", "linux", "Download for Linux"],
 ];
 
 describe("HeroDownloadSelector", () => {
@@ -48,11 +50,16 @@ describe("HeroDownloadSelector", () => {
     expect(view.queryByRole("menu")).not.toBeInTheDocument();
   });
 
-  it("shows the Linux state immediately after Linux detection", async () => {
-    setPlatform("Linux x86_64");
+  it("offers every platform in the menu", async () => {
+    setPlatform("MacIntel");
     const view = render(() => <HeroDownloadSelector />);
+    const trigger = view.getByRole("button", { name: "Choose download platform" });
 
-    await waitFor(() => expect(view.getByText("Linux coming soon")).toBeInTheDocument());
-    expect(view.queryByRole("link", { name: "Linux coming soon" })).not.toBeInTheDocument();
+    await fireEvent.click(trigger);
+    await waitFor(() => view.getByRole("menu", { name: "Download platforms" }));
+    for (const [, platform] of AVAILABLE_PLATFORM_CASES) {
+      const item = view.getByRole("menuitem", { name: `${DOWNLOAD_PLATFORMS[platform].label}Available` });
+      expect(item).toHaveAttribute("href", OPENBOT_DOWNLOAD_LINKS[platform]);
+    }
   });
 });

--- a/apps/auth-api/test/latest-download.test.ts
+++ b/apps/auth-api/test/latest-download.test.ts
@@ -6,6 +6,8 @@ describe("latest download", () => {
   it.each([
     ["macos", "latest-mac.yml", "OpenBot-0.1.11-arm64.dmg"],
     ["windows", "latest.yml", "OpenBot-0.1.11-x64.exe"],
+    // The AppImage extension is mixed case in the published manifest, and the match is lowercase.
+    ["linux", "latest-linux.yml", "OpenBot-0.1.11-x64.AppImage"],
   ] as const)("redirects %s to its installer from the latest manifest", async (platform, manifest, installer) => {
     const fetcher = vi
       .fn<typeof fetch>()

--- a/build/linux/openbot.apparmor
+++ b/build/linux/openbot.apparmor
@@ -1,0 +1,23 @@
+# AppArmor profile that lets the OpenBot AppImage create the unprivileged user namespace that its
+# Electron sandbox is built on.
+#
+# Ubuntu 23.10 and later, and Debian 13, restrict unprivileged user namespaces by default. Without
+# a profile the sandbox cannot start and OpenBot exits during launch. This profile is the answer,
+# never `--no-sandbox`: switching the sandbox off would remove the boundary between a renderer and
+# the rest of the computer, which is the reason the boundary exists.
+#
+# Install it as root, then reload AppArmor:
+#
+#   sudo install -m 0644 openbot.apparmor /etc/apparmor.d/openbot
+#   sudo systemctl reload apparmor
+#
+# The attachment path below covers the usual places to keep an AppImage. If you keep yours
+# somewhere else, edit the path to match before you install the profile.
+
+abi <abi/4.0>,
+include <tunables/global>
+
+profile openbot "/{home/*/{Applications,Desktop,Downloads,.local/bin},opt/OpenBot}/OpenBot*.AppImage" flags=(unconfined) {
+  userns,
+  include if exists <local/openbot>
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -500,7 +500,7 @@ The OpenPanel Growth dashboard uses a session funnel from `landing_viewed` to
 Break down the funnel by `acquisition_source`, then `source_platform` once schema version 7
 events reach OpenPanel. Historical events do not contain the new platform property.
 
-For download-click reports, `platform` means the requested macOS or Windows download;
+For download-click reports, `platform` means the requested macOS, Windows, or Linux download;
 `placement` means the button location. These properties exist only on the download step.
 Use them to compare click counts, not as a shared visit-to-click funnel breakdown.
 The invitation-page funnel is separate: `join_page_action` with `action=view` followed by
@@ -508,9 +508,10 @@ The invitation-page funnel is separate: `join_page_action` with `action=view` fo
 
 ### Managed provider updates
 
-The main process offers provider versions pinned in `native-runtime.lock.json`. An older managed
-installation is display metadata until the pinned runtime passes the existing download and install
-checks. Runtime snapshots carry the previous version and an optional `availableVersion` through the
+The main process offers provider versions pinned in `native-runtime.lock.json`. Each provider is
+pinned for `darwin-arm64`, `linux-x64`, and `win32-x64`; a platform with no pinned artifact reports
+that it is not supported instead of offering a download. An older managed installation is display
+metadata until the pinned runtime passes the existing download and install checks. Runtime snapshots carry the previous version and an optional `availableVersion` through the
 preload decoder. Cancellation and failure preserve the previous installation and its update offer.
 
 Settings starts the shared renderer runtime store. The store announces each provider that gains an

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,15 +7,18 @@ The mobile workflow is separate from the desktop tag release described below.
 OpenBot updates are published through GitHub Releases and installed with `electron-updater`.
 macOS requires every auto-updatable build to be signed with a Developer ID Application certificate.
 The release workflow also notarizes and staples the macOS application before publishing it. Windows
-x64 releases are currently unsigned, so Windows can show an Unknown publisher or SmartScreen warning.
-Both platforms must pass before one release is published. A release also requires the pinned Sunshine
-and Moonlight Web runtime artifacts. GitHub Actions downloads those artifacts, checks SHA-256, and
+x64 and Linux x64 releases are currently unsigned, so Windows can show an Unknown publisher or
+SmartScreen warning and the Linux AppImage carries no signature.
+All three platforms must pass before one release is published. A release also requires the pinned
+Sunshine and Moonlight Web runtime artifacts. GitHub Actions downloads those artifacts, checks SHA-256, and
 verifies their native executables as part of the final OpenBot package. Release packages are not built
 on a developer machine.
 
 Codex, Claude, and Grok runtimes are optional downloads. They are not part of the application package.
-Release CI downloads the pinned macOS and Windows provider artifacts as control artifacts. It checks
-their SHA-256 values, versions, licenses, and vendor signatures without copying them into OpenBot.
+Release CI downloads the pinned macOS, Windows, and Linux provider artifacts as control artifacts. It
+checks their SHA-256 values, versions, licenses, and vendor signatures without copying them into
+OpenBot. Linux has no code-signature contract to check, so its provider artifacts are verified by
+SHA-256 and version only.
 
 ## One-time GitHub setup
 
@@ -159,10 +162,13 @@ The workflow:
 3. runs the complete offline repository check;
 4. builds signed and notarized ARM64 DMG and ZIP artifacts on a GitHub macOS runner;
 5. builds an unsigned Windows x64 NSIS installer on a GitHub Windows runner;
-6. verifies both unpacked applications, update metadata, included runtimes, provider control artifacts,
-   licenses, checksums, platform signing contracts, launch behavior, and update artifact size limits;
-7. generates SPDX SBOMs and GitHub build-provenance attestations for both platforms;
-8. publishes one non-draft GitHub Release only after both platform jobs pass.
+6. builds an unsigned Linux x64 AppImage on a GitHub Ubuntu 24.04 runner, with the launch check under
+   `xvfb-run`;
+7. verifies all three unpacked applications, update metadata, included runtimes, provider control
+   artifacts, licenses, checksums, platform signing contracts, launch behavior, and update artifact
+   size limits;
+8. generates SPDX SBOMs and GitHub build-provenance attestations for all three platforms;
+9. publishes one non-draft GitHub Release only after all three platform jobs pass.
 
 Users can verify a downloaded artifact with
 `gh attestation verify <file> --repo NorbertBodziony/openbot`.
@@ -172,17 +178,18 @@ download automatically while **Automatically download updates** is on, which is 
 persisted per user in `openbot-update-preference-v1.json`; with the setting off, a download starts
 only on a user action. The account popover shows the current state and lets the user download an
 available version, then restart into it. The restart action appears as
-soon as the download completes on both platforms, and neither platform installs without that
+soon as the download completes, and no platform installs without that
 explicit action, because `autoInstallOnAppQuit` stays off so shutdown preparation always runs. Every
 stage the user waits on is bounded by a timeout and recorded in `logs/update/update.log`, so a failed
 check, download, or restart reports an actionable error and can be retried in place.
 
-The Whisper executable is part of the application. The `ggml-medium-q5_0.bin` model is not part of an
-application or update artifact. OpenBot downloads the pinned model on first voice use, checks its size
+The Whisper executable is part of the macOS and Windows applications. Linux ships no Whisper binary
+and no remote desktop runtime, so voice prompts and remote desktop report themselves as unavailable
+there. The `ggml-medium-q5_0.bin` model is not part of an application or update artifact. OpenBot downloads the pinned model on first voice use, checks its size
 and SHA-256, and keeps the verified file in the user data directory for later offline use.
 
-The release workflow stops if the macOS update ZIP or Windows NSIS installer is larger than 700 MiB,
-or if the DMG is larger than 750 MiB. It also stops if update metadata has a wrong size or SHA-512, if
+The release workflow stops if the macOS update ZIP, the Windows NSIS installer, or the Linux AppImage
+is larger than 700 MiB, or if the DMG is larger than 750 MiB. It also stops if update metadata has a wrong size or SHA-512, if
 the Whisper model is present, or if the application contains a second native Claude runtime.
 
 If a release is bad, publish a newer patch version. Do not replace an already published version with
@@ -200,17 +207,20 @@ Before creating the first tag or any later release:
 0. run the Team API compatibility matrix for every protocol that remains in the adapter registry. The matrix must cover an older client with the new host, the new client with an older host, matching versions, no shared protocol, capability omission, unknown optional events, and malformed known events. Do not reduce this matrix because a protocol is old or because many application versions separate the peers. Confirm that each supported protocol still has unchanged client and host fixtures;
 
 1. run `bun run release:preflight` and resolve every reported release-secret or repository gate;
-2. confirm the `release` environment contains all six macOS secrets above; Windows remains unsigned;
+2. confirm the `release` environment contains all six macOS secrets above; Windows and Linux remain
+   unsigned;
 3. confirm the production `/join` page and Apple association file pass the deployment checks in CI;
 4. run `bun install --frozen-lockfile` and `bun run check` from a clean clone;
-5. run `bun run package:verify` on macOS; Windows packaging and launch verification run on the release
-   runner;
+5. run `bun run package:verify` on macOS; Windows and Linux packaging and launch verification run on
+   the release runners;
 6. confirm that the lock file contains all six provider artifacts, their download and install sizes,
    and that their install checks pass;
 7. smoke-test sign-in/setup, chat streaming, queues, attachments, agent messaging, browser control,
    context compaction, and the update popover;
-8. on macOS ARM64 and Windows x64, update from the last public version and confirm check, download,
-   preparation, explicit restart, new version, local agents, conversations, and queues;
+8. on macOS ARM64, Windows x64, and Linux x64, update from the last public version and confirm check,
+   download, preparation, explicit restart, new version, local agents, conversations, and queues. A
+   Linux build only auto-updates when it runs from the AppImage, which the runtime reports through
+   `APPIMAGE`;
 9. test first voice use, download progress, retry after a stopped download, transcription, and cached
    offline use;
 10. build a signed and notarized canary and test an update from the official `0.1.21` application on
@@ -219,8 +229,12 @@ Before creating the first tag or any later release:
     the new version, and can run three provider downloads with restricted memory;
 12. on Windows 10 and 11 x64, confirm that normal exit, restart, and sign-out do not start NSIS, while
     `Restart and install` does start it;
-13. confirm `CHANGELOG.md` describes the version and the working tree is clean;
-14. create and push the version commit and tag only after CI passes on `main`.
+13. on Ubuntu 24.04 x64 with the AppArmor profile from `build/linux/openbot.apparmor` installed,
+    confirm the AppImage starts with the sandbox on, that `xdg-open 'openbot://join?...'` focuses the
+    running application, that a provider downloads in-app, that the server rail is drawn, and that the
+    microphone control is absent;
+14. confirm `CHANGELOG.md` describes the version and the working tree is clean;
+15. create and push the version commit and tag only after CI passes on `main`.
 
 The macOS ZIP must be smaller than 800,000,000 bytes and smaller than the official `0.1.21` ZIP.
 Do not publish when either size gate fails, the `0.1.21` canary update crashes, or Windows starts NSIS

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -29,6 +29,34 @@ absolute Codex executable path.
 
 For a non-standard Claude location, set `OPENBOT_CLAUDE_PATH` to the absolute Claude executable path.
 
+## The Linux AppImage exits immediately
+
+On Ubuntu 23.10 or newer and on Debian 13, unprivileged user namespaces are restricted by AppArmor.
+The Electron sandbox is built on one, so OpenBot exits during launch and writes a message about the
+SUID sandbox or a user namespace to the terminal.
+
+Install the AppArmor profile that ships with OpenBot, then reload AppArmor:
+
+```bash
+sudo install -m 0644 build/linux/openbot.apparmor /etc/apparmor.d/openbot
+sudo systemctl reload apparmor
+```
+
+The same file is inside the AppImage at `resources/linux/openbot.apparmor`. The profile attaches to
+the usual places to keep an AppImage; if yours is somewhere else, edit the path in the profile before
+you install it.
+
+Do not start OpenBot with `--no-sandbox`. It is not a supported workaround. The sandbox is the
+boundary between a web renderer and the rest of your computer, and OpenBot gives its agents full
+local access on the other side of it.
+
+## Voice prompts or remote desktop are missing on Linux
+
+Neither is available in the Linux build. The Whisper transcription binary and the Sunshine remote
+desktop runtime are built for macOS and Windows only, so the microphone control is not drawn and
+remote desktop reports itself as unavailable. Everything else works as it does on the other
+platforms.
+
 ## Computer Use is unavailable
 
 Computer Use requires a compatible local Codex plugin plus macOS Screen Recording and Accessibility
@@ -99,13 +127,15 @@ remove `~/.codex` or `~/.claude` unless you intentionally want to manage CLI log
 
 ## Uninstall
 
-Quit OpenBot and remove `OpenBot.app` from Applications. If you also want to remove local OpenBot
+Quit OpenBot. On macOS remove `OpenBot.app` from Applications; on Windows use the installer's
+uninstaller; on Linux delete the AppImage, and `/etc/apparmor.d/openbot` if you installed the
+profile. If you also want to remove local OpenBot
 data, follow the reset steps above. Agent CLIs and their data are independent and are not removed
 with OpenBot.
 
 ## Report a problem
 
 Use [GitHub Issues](https://github.com/NorbertBodziony/openbot/issues) for reproducible bugs. Include
-the OpenBot version, macOS version, Apple Silicon model, provider and CLI version, and minimal
-reproduction steps. Never publish tokens, `~/.codex`, `~/.claude`, conversations, private files,
+the OpenBot version, the operating system and its version, the hardware, the provider and CLI
+version, and minimal reproduction steps. Never publish tokens, `~/.codex`, `~/.claude`, conversations, private files,
 Electron user data, or full unreviewed diagnostics.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -128,8 +128,8 @@ remove `~/.codex` or `~/.claude` unless you intentionally want to manage CLI log
 ## Uninstall
 
 Quit OpenBot. On macOS remove `OpenBot.app` from Applications; on Windows use the installer's
-uninstaller; on Linux delete the AppImage, and `/etc/apparmor.d/openbot` if you installed the
-profile. If you also want to remove local OpenBot
+uninstaller; on Linux delete the AppImage, `~/.local/share/applications/openbot.desktop`, and
+`/etc/apparmor.d/openbot` if you installed the profile. If you also want to remove local OpenBot
 data, follow the reset steps above. Agent CLIs and their data are independent and are not removed
 with OpenBot.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -128,10 +128,10 @@ remove `~/.codex` or `~/.claude` unless you intentionally want to manage CLI log
 ## Uninstall
 
 Quit OpenBot. On macOS remove `OpenBot.app` from Applications; on Windows use the installer's
-uninstaller; on Linux delete the AppImage, `~/.local/share/applications/openbot.desktop`, and
-`/etc/apparmor.d/openbot` if you installed the profile. If you also want to remove local OpenBot
-data, follow the reset steps above. Agent CLIs and their data are independent and are not removed
-with OpenBot.
+uninstaller; on Linux delete the AppImage, `~/.local/share/applications/openbot.desktop`,
+`~/.local/share/icons/openbot.png`, and `/etc/apparmor.d/openbot` if you installed the profile. If
+you also want to remove local OpenBot data, follow the reset steps above. Agent CLIs and their data
+are independent and are not removed with OpenBot.
 
 ## Report a problem
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,6 +27,7 @@ files:
   - LICENSE
   - NOTICE
   - "!node_modules/@anthropic-ai/claude-agent-sdk-darwin-*/**/*"
+  - "!node_modules/@anthropic-ai/claude-agent-sdk-linux-*/**/*"
   - "!node_modules/@anthropic-ai/claude-agent-sdk-win32-*/**/*"
 extraResources:
   - from: resources/managed-skills
@@ -45,10 +46,9 @@ extraResources:
     to: licenses/OpenAI-Whisper-LICENSE
   - from: build/licenses/whisper.cpp-LICENSE
     to: licenses/whisper.cpp-LICENSE
-  - from: .openbot-build/whisper/bin
-    to: whisper/bin
-  - from: build/remote-desktop-runtime
-    to: remote-desktop-runtime
+# Voice and remote desktop are prepared for macOS and Windows only, so their resources are listed
+# under each of those platforms instead of here. electron-builder merges the root and platform
+# lists, so both still get them, while the Linux build has no missing `from` to fail on.
 directories:
   output: dist
 mac:
@@ -64,6 +64,10 @@ mac:
       to: icons/icon-dev-macos-safe-area.png
     - from: build/icon-preview-macos-safe-area.png
       to: icons/icon-preview-macos-safe-area.png
+    - from: .openbot-build/whisper/bin
+      to: whisper/bin
+    - from: build/remote-desktop-runtime
+      to: remote-desktop-runtime
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.inherit.plist
   darkModeSupport: true
@@ -81,8 +85,28 @@ mac:
         - arm64
 win:
   icon: build/icon-production.ico
+  extraResources:
+    - from: .openbot-build/whisper/bin
+      to: whisper/bin
+    - from: build/remote-desktop-runtime
+      to: remote-desktop-runtime
   target:
     - target: nsis
+      arch:
+        - x64
+linux:
+  category: Development
+  icon: build/icon-production.png
+  synopsis: A local-first multi-agent desktop workspace.
+  extraResources:
+    - from: build/linux/openbot.apparmor
+      to: linux/openbot.apparmor
+  # Electron takes its Linux app id from `desktopName` in package.json, and the window manager
+  # matches a running window to the launcher through `StartupWMClass`. Syncing the two from one
+  # value is what makes the taskbar icon group with the window it belongs to.
+  syncDesktopName: true
+  target:
+    - target: AppImage
       arch:
         - x64
 dmg:

--- a/native-runtime.lock.json
+++ b/native-runtime.lock.json
@@ -14,6 +14,13 @@
         "installedBytes": 310000000,
         "executable": "bin/codex"
       },
+      "linux-x64": {
+        "asset": "codex-package-x86_64-unknown-linux-musl.tar.gz",
+        "assetSha256": "a822187e1a2420c61c5926721bfbd878701ed95547c9bb0d4de4498a16ba1821",
+        "downloadBytes": 126196303,
+        "installedBytes": 360000000,
+        "executable": "bin/codex"
+      },
       "win32-x64": {
         "asset": "codex-package-x86_64-pc-windows-msvc.tar.gz",
         "assetSha256": "a6ef3442cb12766a88b39311d79244289e4f9763e2c53ff4fbebc2cb653cc5f3",
@@ -39,6 +46,16 @@
         "installedBytes": 250000000,
         "executable": "claude",
         "platformDirectory": "mac"
+      },
+      "linux-x64": {
+        "package": "@anthropic-ai/claude-agent-sdk-linux-x64",
+        "asset": "claude-agent-sdk-linux-x64-0.3.263.tgz",
+        "assetSha256": "f07fcb22da213dae5c03bdc01c37f4cc0588441e1128220102fdeb8f25f4dd63",
+        "binarySha256": "26d020351e8112f4006790f3cfce43b4c9df0c1bb1d0e542364d64151b81d5ba",
+        "downloadBytes": 96941292,
+        "installedBytes": 250000000,
+        "executable": "claude",
+        "platformDirectory": "linux"
       },
       "win32-x64": {
         "package": "@anthropic-ai/claude-agent-sdk-win32-x64",
@@ -69,6 +86,16 @@
         "executable": "opencode",
         "platformDirectory": "mac"
       },
+      "linux-x64": {
+        "package": "opencode-linux-x64",
+        "asset": "opencode-linux-x64-1.18.30.tgz",
+        "assetSha256": "aa31a7e68ce5c73cba302c6a4f31c2e308398db125e49d3dbea32f61862fe6de",
+        "binarySha256": "87bd160e053af86b5b409daabf71f8dc05bbc3a2a3a5f563f36011cdf706a999",
+        "downloadBytes": 60202013,
+        "installedBytes": 200000000,
+        "executable": "opencode",
+        "platformDirectory": "linux"
+      },
       "win32-x64": {
         "package": "opencode-windows-x64",
         "asset": "opencode-windows-x64-1.18.30.tgz",
@@ -97,6 +124,14 @@
         "installedBytes": 150000000,
         "executable": "grok",
         "platformDirectory": "mac"
+      },
+      "linux-x64": {
+        "asset": "grok-1.0.22-linux-x86_64",
+        "assetSha256": "ad2510e8d7edcfe04fbdd25fa0f19dd1fb5babc8b238532b06e4bf3548d210ad",
+        "downloadBytes": 156995968,
+        "installedBytes": 170000000,
+        "executable": "grok",
+        "platformDirectory": "linux"
       },
       "win32-x64": {
         "asset": "grok-1.0.22-windows-x86_64.exe",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "openbot",
   "productName": "OpenBot",
+  "desktopName": "openbot.desktop",
   "version": "0.8.0",
   "description": "A local-first multi-agent desktop workspace for Codex, Claude, and Grok.",
   "author": {
@@ -181,10 +182,14 @@
     "package:verify": "bun run package && bun run verify:package",
     "package:win": "bun run voice:prepare-runtime && bun scripts/prepare-remote-desktop-runtime.ts win32 x64 && bun run verify:remote-desktop-runtime --windows && bun run build && electron-builder --dir --win --x64 --publish never",
     "verify:package:win": "bun scripts/verify-windows-package.ts",
+    "package:linux": "bun run build && electron-builder --dir --linux --x64 --publish never",
+    "verify:package:linux": "bun scripts/verify-linux-package.ts",
+    "package:linux:verify": "bun run package:linux && bun run verify:package:linux",
     "verify:update-artifacts": "bun scripts/verify-update-artifacts.ts",
     "package:win:verify": "bun run package:win && bun run verify:package:win",
     "dist:mac": "bun run voice:prepare-runtime && bun run prepare:remote-desktop-runtime && bun run verify:remote-desktop-runtime && bun run build && electron-builder --mac --arm64 --config.mac.identity=null --config.mac.notarize=false",
     "dist:win": "bun run voice:prepare-runtime && bun scripts/prepare-remote-desktop-runtime.ts win32 x64 && bun run verify:remote-desktop-runtime --windows && bun run build && electron-builder --win nsis --x64 --publish never",
+    "dist:linux": "bun run build && electron-builder --linux AppImage --x64 --publish never",
     "dist:release": "bun run voice:prepare-runtime && bun run prepare:remote-desktop-runtime && bun run verify:remote-desktop-runtime && bun run build && electron-builder --mac --arm64 --publish never"
   },
   "dependencies": {

--- a/scripts/agent-runtime-lock.test.ts
+++ b/scripts/agent-runtime-lock.test.ts
@@ -17,6 +17,20 @@ describe("agent runtime lock", () => {
     expect(lock.grok.artifacts["win32-x64"].assetSha256).toHaveLength(64);
   });
 
+  // The schema strips a key it does not name, so this is what proves the Linux artifacts survive.
+  it("keeps the Linux artifact of every provider", async () => {
+    const lock = await loadAgentRuntimeLock();
+
+    expect(lock.codex.artifacts["linux-x64"].assetSha256).toHaveLength(64);
+    expect(lock.claude.artifacts["linux-x64"].binarySha256).toHaveLength(64);
+    expect(lock.opencode.artifacts["linux-x64"].binarySha256).toHaveLength(64);
+    expect(lock.grok.artifacts["linux-x64"].assetSha256).toHaveLength(64);
+    expect(lock.codex.artifacts["linux-x64"].asset).toContain("unknown-linux-musl");
+    expect(lock.claude.artifacts["linux-x64"].platformDirectory).toBe("linux");
+    expect(lock.opencode.artifacts["linux-x64"].platformDirectory).toBe("linux");
+    expect(lock.grok.artifacts["linux-x64"].platformDirectory).toBe("linux");
+  });
+
   it("rejects incomplete provider checksums", async () => {
     const lock = structuredClone(await loadAgentRuntimeLock());
     lock.codex.artifacts["darwin-arm64"].assetSha256 = "bad";

--- a/scripts/agent-runtime-lock.ts
+++ b/scripts/agent-runtime-lock.ts
@@ -11,32 +11,32 @@ const codexArtifactSchema = z.object({
   executable: z.string().regex(/^bin\/codex(?:\.exe)?$/u),
 });
 const claudeArtifactSchema = z.object({
-  package: z.string().regex(/^@anthropic-ai\/claude-agent-sdk-(?:darwin-arm64|win32-x64)$/u),
-  asset: z.string().regex(/^claude-agent-sdk-(?:darwin-arm64|win32-x64)-\d+\.\d+\.\d+\.tgz$/u),
+  package: z.string().regex(/^@anthropic-ai\/claude-agent-sdk-(?:darwin-arm64|linux-x64|win32-x64)$/u),
+  asset: z.string().regex(/^claude-agent-sdk-(?:darwin-arm64|linux-x64|win32-x64)-\d+\.\d+\.\d+\.tgz$/u),
   assetSha256: sha256Schema,
   binarySha256: sha256Schema,
   downloadBytes: z.number().int().positive(),
   installedBytes: z.number().int().positive(),
   executable: z.enum(["claude", "claude.exe"]),
-  platformDirectory: z.enum(["mac", "win"]),
+  platformDirectory: z.enum(["linux", "mac", "win"]),
 });
 const opencodeArtifactSchema = z.object({
-  package: z.string().regex(/^opencode-(?:darwin-arm64|windows-x64)$/u),
-  asset: z.string().regex(/^opencode-(?:darwin-arm64|windows-x64)-\d+\.\d+\.\d+\.tgz$/u),
+  package: z.string().regex(/^opencode-(?:darwin-arm64|linux-x64|windows-x64)$/u),
+  asset: z.string().regex(/^opencode-(?:darwin-arm64|linux-x64|windows-x64)-\d+\.\d+\.\d+\.tgz$/u),
   assetSha256: sha256Schema,
   binarySha256: sha256Schema,
   downloadBytes: z.number().int().positive(),
   installedBytes: z.number().int().positive(),
   executable: z.enum(["opencode", "opencode.exe"]),
-  platformDirectory: z.enum(["mac", "win"]),
+  platformDirectory: z.enum(["linux", "mac", "win"]),
 });
 const grokArtifactSchema = z.object({
-  asset: z.string().regex(/^grok-\d+\.\d+\.\d+-(?:macos-aarch64|windows-x86_64(?:\.exe)?)$/u),
+  asset: z.string().regex(/^grok-\d+\.\d+\.\d+-(?:linux-x86_64|macos-aarch64|windows-x86_64(?:\.exe)?)$/u),
   assetSha256: sha256Schema,
   downloadBytes: z.number().int().positive(),
   installedBytes: z.number().int().positive(),
   executable: z.enum(["grok", "grok.exe"]),
-  platformDirectory: z.enum(["mac", "win"]),
+  platformDirectory: z.enum(["linux", "mac", "win"]),
 });
 
 const agentRuntimeLockSchema = z.object({
@@ -49,6 +49,7 @@ const agentRuntimeLockSchema = z.object({
     licenseSha256: sha256Schema,
     artifacts: z.object({
       "darwin-arm64": codexArtifactSchema,
+      "linux-x64": codexArtifactSchema,
       "win32-x64": codexArtifactSchema,
     }),
   }),
@@ -60,6 +61,7 @@ const agentRuntimeLockSchema = z.object({
     licenseSha256: sha256Schema,
     artifacts: z.object({
       "darwin-arm64": claudeArtifactSchema,
+      "linux-x64": claudeArtifactSchema,
       "win32-x64": claudeArtifactSchema,
     }),
   }),
@@ -78,6 +80,7 @@ const agentRuntimeLockSchema = z.object({
     licenseSha256: sha256Schema,
     artifacts: z.object({
       "darwin-arm64": opencodeArtifactSchema,
+      "linux-x64": opencodeArtifactSchema,
       "win32-x64": opencodeArtifactSchema,
     }),
   }),
@@ -91,6 +94,7 @@ const agentRuntimeLockSchema = z.object({
     noticesSha256: sha256Schema,
     artifacts: z.object({
       "darwin-arm64": grokArtifactSchema,
+      "linux-x64": grokArtifactSchema,
       "win32-x64": grokArtifactSchema,
     }),
   }),

--- a/scripts/install-claude-runtime.test.ts
+++ b/scripts/install-claude-runtime.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { execFileSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -16,32 +16,34 @@ afterEach(async () => {
 });
 
 describe.runIf(process.platform !== "win32")("bundled Claude installer", () => {
-  it("installs a verified SDK binary and reuses the current runtime", async () => {
+  // The fixture binary is a shell script, so a Linux target installs and verifies on macOS too.
+  it.each([
+    ["darwin-arm64", "mac/arm64"],
+    ["linux-x64", "linux/x64"],
+  ] as const)("installs a verified %s SDK binary into %s and reuses the current runtime", async (target, directory) => {
     const root = await temporaryRoot();
     const fixture = join(root, "fixture");
     const archive = join(root, "claude.tgz");
     const output = join(root, "output");
-    await createPackage(fixture);
+    const lock = structuredClone(await loadAgentRuntimeLock());
+    await createPackage(fixture, lock.claude.artifacts[target].package);
     createArchive(fixture, archive);
     const archiveBytes = await readFile(archive);
     const binary = await readFile(join(fixture, "package/claude"));
     const license = await readFile(join(fixture, "package/LICENSE.md"));
-    const lock = structuredClone(await loadAgentRuntimeLock());
-    lock.claude.artifacts["darwin-arm64"].assetSha256 = sha256(archiveBytes);
-    lock.claude.artifacts["darwin-arm64"].binarySha256 = sha256(binary);
+    lock.claude.artifacts[target].assetSha256 = sha256(archiveBytes);
+    lock.claude.artifacts[target].binarySha256 = sha256(binary);
     lock.claude.licenseSha256 = sha256(license);
     const fetchImpl = async () => new Response(archiveBytes, { status: 200 });
 
-    await expect(installClaudeRuntime({ outputRoot: output, target: "darwin-arm64", fetchImpl, lock })).resolves.toBe(
-      "installed",
-    );
-    await expect(installClaudeRuntime({ outputRoot: output, target: "darwin-arm64", fetchImpl, lock })).resolves.toBe(
-      "current",
-    );
-    await expect(readFile(join(output, "mac/arm64/claude-package.json"), "utf8")).resolves.toContain('"2.1.263"');
+    await expect(installClaudeRuntime({ outputRoot: output, target, fetchImpl, lock })).resolves.toBe("installed");
+    await expect(installClaudeRuntime({ outputRoot: output, target, fetchImpl, lock })).resolves.toBe("current");
+    await expect(readFile(join(output, directory, "claude-package.json"), "utf8")).resolves.toContain('"2.1.263"');
     await expect(readFile(join(output, "licenses/Claude-Code-LICENSE.md"), "utf8")).resolves.toBe(
       license.toString("utf8"),
     );
+    const mode = (await stat(join(output, directory, "bin/claude"))).mode & 0o777;
+    expect(mode).toBe(0o755);
   });
 
   it("rejects links in an archive before extraction", async () => {
@@ -62,16 +64,13 @@ async function temporaryRoot(): Promise<string> {
   return root;
 }
 
-async function createPackage(root: string): Promise<void> {
+async function createPackage(root: string, packageName = "@anthropic-ai/claude-agent-sdk-darwin-arm64"): Promise<void> {
   const packageRoot = join(root, "package");
   await mkdir(packageRoot, { recursive: true });
   await Promise.all([
     writeFile(join(packageRoot, "claude"), "#!/bin/sh\nprintf '2.1.263 (Claude Code)\\n'\n"),
     writeFile(join(packageRoot, "LICENSE.md"), "Anthropic license fixture\n"),
-    writeFile(
-      join(packageRoot, "package.json"),
-      `${JSON.stringify({ name: "@anthropic-ai/claude-agent-sdk-darwin-arm64", version: "0.3.263" })}\n`,
-    ),
+    writeFile(join(packageRoot, "package.json"), `${JSON.stringify({ name: packageName, version: "0.3.263" })}\n`),
   ]);
   await chmod(join(packageRoot, "claude"), 0o755);
 }

--- a/scripts/install-claude-runtime.ts
+++ b/scripts/install-claude-runtime.ts
@@ -9,7 +9,7 @@ import { rejectNonRegularFiles, sha256 } from "./remote-desktop-runtime-release"
 
 const logger = createOpenBotLogger("install-claude-runtime");
 
-export type ClaudeRuntimeTarget = "darwin-arm64" | "win32-x64";
+export type ClaudeRuntimeTarget = "darwin-arm64" | "linux-x64" | "win32-x64";
 
 const packageManifestSchema = z.object({
   name: z.string(),
@@ -20,7 +20,7 @@ const installedManifestSchema = z.object({
   layoutVersion: z.literal(1),
   version: z.string(),
   sdkVersion: z.string(),
-  target: z.enum(["darwin-arm64", "win32-x64"]),
+  target: z.enum(["darwin-arm64", "linux-x64", "win32-x64"]),
   executable: z.string(),
 });
 
@@ -86,12 +86,14 @@ export function claudeRuntimeTarget(
   architecture: string = process.arch,
 ): ClaudeRuntimeTarget {
   const target = `${platform}-${architecture}`;
-  if (target === "darwin-arm64" || target === "win32-x64") return target;
+  if (target === "darwin-arm64" || target === "linux-x64" || target === "win32-x64") return target;
   throw new Error(`Unsupported bundled Claude target: ${target}`);
 }
 
 export function claudeRuntimePath(root: string, target: ClaudeRuntimeTarget): string {
-  return target === "darwin-arm64" ? join(root, "mac", "arm64") : join(root, "win", "x64");
+  if (target === "darwin-arm64") return join(root, "mac", "arm64");
+  if (target === "linux-x64") return join(root, "linux", "x64");
+  return join(root, "win", "x64");
 }
 
 export async function verifyClaudeRuntime(
@@ -170,7 +172,7 @@ async function stageClaudeRuntime(
       )}\n`,
     ),
   ]);
-  if (target === "darwin-arm64") await chmod(join(destination, "bin", artifact.executable), 0o755);
+  if (target !== "win32-x64") await chmod(join(destination, "bin", artifact.executable), 0o755);
 }
 
 function validateArchivePath(name: string): void {

--- a/scripts/install-codex-runtime.test.ts
+++ b/scripts/install-codex-runtime.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { execFileSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -16,32 +16,37 @@ afterEach(async () => {
 });
 
 describe.runIf(process.platform !== "win32")("bundled Codex installer", () => {
-  it("installs a verified full package and reuses the current runtime", async () => {
-    const root = await temporaryRoot();
-    const fixture = join(root, "fixture");
-    const archive = join(root, "codex.tar.gz");
-    const output = join(root, "output");
-    await createPackage(fixture);
-    createArchive(fixture, archive);
-    const archiveBytes = await readFile(archive);
-    const license = Buffer.from("Apache License fixture\n");
-    const lock = structuredClone(await loadAgentRuntimeLock());
-    lock.codex.artifacts["darwin-arm64"].assetSha256 = sha256(archiveBytes);
-    lock.codex.licenseSha256 = sha256(license);
-    const fetchImpl = async (input: string | URL | Request) =>
-      new Response(String(input).endsWith("/LICENSE") ? license : archiveBytes, { status: 200 });
+  // The fixture entrypoint is a shell script, so a Linux target installs and verifies on macOS too.
+  it.each([
+    ["darwin-arm64", "aarch64-apple-darwin", "mac/arm64"],
+    ["linux-x64", "x86_64-unknown-linux-musl", "linux/x64"],
+  ] as const)(
+    "installs a verified %s package into %s and reuses the current runtime",
+    async (target, manifestTarget, directory) => {
+      const root = await temporaryRoot();
+      const fixture = join(root, "fixture");
+      const archive = join(root, "codex.tar.gz");
+      const output = join(root, "output");
+      await createPackage(fixture, manifestTarget);
+      createArchive(fixture, archive);
+      const archiveBytes = await readFile(archive);
+      const license = Buffer.from("Apache License fixture\n");
+      const lock = structuredClone(await loadAgentRuntimeLock());
+      lock.codex.artifacts[target].assetSha256 = sha256(archiveBytes);
+      lock.codex.licenseSha256 = sha256(license);
+      const fetchImpl = async (input: string | URL | Request) =>
+        new Response(String(input).endsWith("/LICENSE") ? license : archiveBytes, { status: 200 });
 
-    await expect(installCodexRuntime({ outputRoot: output, target: "darwin-arm64", fetchImpl, lock })).resolves.toBe(
-      "installed",
-    );
-    await expect(installCodexRuntime({ outputRoot: output, target: "darwin-arm64", fetchImpl, lock })).resolves.toBe(
-      "current",
-    );
-    await expect(readFile(join(output, "mac/arm64/codex-package.json"), "utf8")).resolves.toContain('"0.153.4"');
-    await expect(readFile(join(output, "licenses/Codex-Apache-2.0.txt"), "utf8")).resolves.toBe(
-      license.toString("utf8"),
-    );
-  });
+      await expect(installCodexRuntime({ outputRoot: output, target, fetchImpl, lock })).resolves.toBe("installed");
+      await expect(installCodexRuntime({ outputRoot: output, target, fetchImpl, lock })).resolves.toBe("current");
+      await expect(readFile(join(output, directory, "codex-package.json"), "utf8")).resolves.toContain('"0.153.4"');
+      await expect(readFile(join(output, "licenses/Codex-Apache-2.0.txt"), "utf8")).resolves.toBe(
+        license.toString("utf8"),
+      );
+      const mode = (await stat(join(output, directory, "bin/codex"))).mode & 0o777;
+      expect(mode).toBe(0o755);
+    },
+  );
 
   it("rejects links in an archive before extraction", async () => {
     const root = await temporaryRoot();
@@ -61,7 +66,7 @@ async function temporaryRoot(): Promise<string> {
   return root;
 }
 
-async function createPackage(root: string): Promise<void> {
+async function createPackage(root: string, manifestTarget = "aarch64-apple-darwin"): Promise<void> {
   await Promise.all([
     mkdir(join(root, "bin"), { recursive: true }),
     mkdir(join(root, "codex-path"), { recursive: true }),
@@ -77,7 +82,7 @@ async function createPackage(root: string): Promise<void> {
       `${JSON.stringify({
         layoutVersion: 1,
         version: "0.153.4",
-        target: "aarch64-apple-darwin",
+        target: manifestTarget,
         variant: "codex",
         entrypoint: "bin/codex",
         resourcesDir: "codex-resources",

--- a/scripts/install-codex-runtime.ts
+++ b/scripts/install-codex-runtime.ts
@@ -9,12 +9,12 @@ import { rejectNonRegularFiles, sha256 } from "./remote-desktop-runtime-release"
 
 const logger = createOpenBotLogger("install-codex-runtime");
 
-export type CodexRuntimeTarget = "darwin-arm64" | "win32-x64";
+export type CodexRuntimeTarget = "darwin-arm64" | "linux-x64" | "win32-x64";
 
 const packageManifestSchema = z.object({
   layoutVersion: z.literal(1),
   version: z.string(),
-  target: z.enum(["aarch64-apple-darwin", "x86_64-pc-windows-msvc"]),
+  target: z.enum(["aarch64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-linux-musl"]),
   variant: z.literal("codex"),
   entrypoint: z.string(),
   resourcesDir: z.literal("codex-resources"),
@@ -75,17 +75,26 @@ export async function installCodexRuntime(
   return "installed";
 }
 
+/** The `target` the Codex package manifest carries for each runtime target OpenBot ships. */
+const CODEX_MANIFEST_TARGETS = {
+  "darwin-arm64": "aarch64-apple-darwin",
+  "linux-x64": "x86_64-unknown-linux-musl",
+  "win32-x64": "x86_64-pc-windows-msvc",
+} as const satisfies Record<CodexRuntimeTarget, string>;
+
 export function codexRuntimeTarget(
   platform: string = process.platform,
   architecture: string = process.arch,
 ): CodexRuntimeTarget {
   const target = `${platform}-${architecture}`;
-  if (target === "darwin-arm64" || target === "win32-x64") return target;
+  if (target === "darwin-arm64" || target === "linux-x64" || target === "win32-x64") return target;
   throw new Error(`Unsupported bundled Codex target: ${target}`);
 }
 
 export function codexRuntimePath(root: string, target: CodexRuntimeTarget): string {
-  return target === "darwin-arm64" ? join(root, "mac", "arm64") : join(root, "win", "x64");
+  if (target === "darwin-arm64") return join(root, "mac", "arm64");
+  if (target === "linux-x64") return join(root, "linux", "x64");
+  return join(root, "win", "x64");
 }
 
 export async function verifyCodexRuntime(
@@ -95,7 +104,7 @@ export async function verifyCodexRuntime(
 ): Promise<void> {
   const artifact = lock.codex.artifacts[target];
   const manifest = packageManifestSchema.parse(JSON.parse(await readFile(join(root, "codex-package.json"), "utf8")));
-  const expectedTarget = target === "darwin-arm64" ? "aarch64-apple-darwin" : "x86_64-pc-windows-msvc";
+  const expectedTarget = CODEX_MANIFEST_TARGETS[target];
   if (
     manifest.version !== lock.codex.version ||
     manifest.target !== expectedTarget ||

--- a/scripts/install-grok-runtime.test.ts
+++ b/scripts/install-grok-runtime.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { chmod, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -15,7 +15,11 @@ afterEach(async () => {
 });
 
 describe.runIf(process.platform !== "win32")("bundled Grok installer", () => {
-  it("installs a verified binary and reuses the current runtime", async () => {
+  // The fixture binary is a shell script, so a Linux target installs and verifies on macOS too.
+  it.each([
+    ["darwin-arm64", "mac/arm64"],
+    ["linux-x64", "linux/x64"],
+  ] as const)("installs a verified %s binary into %s and reuses the current runtime", async (target, directory) => {
     const root = await mkdtemp(join(tmpdir(), "openbot-grok-runtime-test-"));
     temporaryPaths.push(root);
     const output = join(root, "output");
@@ -23,11 +27,11 @@ describe.runIf(process.platform !== "win32")("bundled Grok installer", () => {
     const license = Buffer.from("Apache license fixture\n");
     const notices = Buffer.from("Third-party notices fixture\n");
     const lock = structuredClone(await loadAgentRuntimeLock());
-    lock.grok.artifacts["darwin-arm64"].assetSha256 = sha256(executable);
+    lock.grok.artifacts[target].assetSha256 = sha256(executable);
     lock.grok.licenseSha256 = sha256(license);
     lock.grok.noticesSha256 = sha256(notices);
     const values = new Map([
-      [lock.grok.artifacts["darwin-arm64"].asset, executable],
+      [lock.grok.artifacts[target].asset, executable],
       ["LICENSE", license],
       ["THIRD-PARTY-NOTICES", notices],
     ]);
@@ -36,15 +40,12 @@ describe.runIf(process.platform !== "win32")("bundled Grok installer", () => {
       return new Response(values.get(key), { status: values.has(key) ? 200 : 404 });
     };
 
-    await expect(installGrokRuntime({ outputRoot: output, target: "darwin-arm64", fetchImpl, lock })).resolves.toBe(
-      "installed",
-    );
-    await expect(installGrokRuntime({ outputRoot: output, target: "darwin-arm64", fetchImpl, lock })).resolves.toBe(
-      "current",
-    );
-    await expect(readFile(join(output, "mac/arm64/grok-package.json"), "utf8")).resolves.toContain('"1.0.22"');
+    await expect(installGrokRuntime({ outputRoot: output, target, fetchImpl, lock })).resolves.toBe("installed");
+    await expect(installGrokRuntime({ outputRoot: output, target, fetchImpl, lock })).resolves.toBe("current");
+    await expect(readFile(join(output, directory, "grok-package.json"), "utf8")).resolves.toContain('"1.0.22"');
     await expect(readFile(join(output, "licenses/Grok-CLI-LICENSE"), "utf8")).resolves.toBe(license.toString());
-    await chmod(join(output, "mac/arm64/bin/grok"), 0o755);
+    const mode = (await stat(join(output, directory, "bin/grok"))).mode & 0o777;
+    expect(mode).toBe(0o755);
   });
 
   it("rejects a binary with the wrong checksum", async () => {

--- a/scripts/install-grok-runtime.ts
+++ b/scripts/install-grok-runtime.ts
@@ -9,12 +9,12 @@ import { sha256 } from "./remote-desktop-runtime-release";
 
 const logger = createOpenBotLogger("install-grok-runtime");
 
-export type GrokRuntimeTarget = "darwin-arm64" | "win32-x64";
+export type GrokRuntimeTarget = "darwin-arm64" | "linux-x64" | "win32-x64";
 
 const installedManifestSchema = z.object({
   layoutVersion: z.literal(1),
   version: z.string(),
-  target: z.enum(["darwin-arm64", "win32-x64"]),
+  target: z.enum(["darwin-arm64", "linux-x64", "win32-x64"]),
   executable: z.string(),
 });
 
@@ -63,7 +63,7 @@ export async function installGrokRuntime(
     const staged = join(temporaryRoot, "runtime");
     await mkdir(join(staged, "bin"), { recursive: true });
     await Promise.all([
-      writeFile(join(staged, "bin", artifact.executable), binary, { mode: target === "darwin-arm64" ? 0o755 : 0o644 }),
+      writeFile(join(staged, "bin", artifact.executable), binary, { mode: target === "win32-x64" ? 0o644 : 0o755 }),
       writeFile(join(staged, "LICENSE"), license),
       writeFile(join(staged, "THIRD-PARTY-NOTICES"), notices),
       writeFile(
@@ -92,12 +92,14 @@ export function grokRuntimeTarget(
   architecture: string = process.arch,
 ): GrokRuntimeTarget {
   const target = `${platform}-${architecture}`;
-  if (target === "darwin-arm64" || target === "win32-x64") return target;
+  if (target === "darwin-arm64" || target === "linux-x64" || target === "win32-x64") return target;
   throw new Error(`Unsupported bundled Grok target: ${target}`);
 }
 
 export function grokRuntimePath(root: string, target: GrokRuntimeTarget): string {
-  return target === "darwin-arm64" ? join(root, "mac", "arm64") : join(root, "win", "x64");
+  if (target === "darwin-arm64") return join(root, "mac", "arm64");
+  if (target === "linux-x64") return join(root, "linux", "x64");
+  return join(root, "win", "x64");
 }
 
 export async function verifyGrokRuntime(
@@ -124,7 +126,7 @@ export async function verifyGrokRuntime(
   if (sha256(await readFile(join(root, "THIRD-PARTY-NOTICES"))) !== lock.grok.noticesSha256) {
     throw new Error("The bundled Grok third-party notices checksum is invalid.");
   }
-  if (target === "darwin-arm64") await chmod(executable, 0o755);
+  if (target !== "win32-x64") await chmod(executable, 0o755);
   const output = execFileSync(executable, ["--version"], { encoding: "utf8", windowsHide: true }).trim();
   if (!new RegExp(`(?:^|\\s)${escapeRegExp(lock.grok.version)}(?:\\s|$)`, "u").test(output)) {
     throw new Error(`Unexpected bundled Grok version: ${output}`);

--- a/scripts/pin-opencode-runtime.ts
+++ b/scripts/pin-opencode-runtime.ts
@@ -6,16 +6,17 @@ import { z } from "zod";
 import { type AgentRuntimeLock, loadAgentRuntimeLock } from "./agent-runtime-lock";
 import { sha256, sha256File } from "./remote-desktop-runtime-release";
 
-export type OpencodeRuntimeTarget = "darwin-arm64" | "win32-x64";
+export type OpencodeRuntimeTarget = "darwin-arm64" | "linux-x64" | "win32-x64";
 
 /** The npm platform package and the executable inside it, per target OpenBot supports. */
 const TARGETS = {
   "darwin-arm64": { package: "opencode-darwin-arm64", executable: "opencode", platformDirectory: "mac" },
+  "linux-x64": { package: "opencode-linux-x64", executable: "opencode", platformDirectory: "linux" },
   "win32-x64": { package: "opencode-windows-x64", executable: "opencode.exe", platformDirectory: "win" },
 } as const satisfies Record<OpencodeRuntimeTarget, { package: string; executable: string; platformDirectory: string }>;
 
 /** The same keys as `TARGETS`, in the order the lock file lists them. */
-const TARGET_IDS: readonly OpencodeRuntimeTarget[] = ["darwin-arm64", "win32-x64"];
+const TARGET_IDS: readonly OpencodeRuntimeTarget[] = ["darwin-arm64", "linux-x64", "win32-x64"];
 
 const REGISTRY = "https://registry.npmjs.org";
 const REPOSITORY = "https://github.com/anomalyco/opencode";
@@ -80,9 +81,10 @@ export async function pinOpencodeRuntime(
   const pinTarget = (target: OpencodeRuntimeTarget) =>
     pinArtifact(fetchImpl, target, version, umbrella.optionalDependencies, input.runBinary);
   // One target at a time, in the lock file's order: two 50 MB downloads at once only make the
-  // registry slower, and a literal is what proves both keys are present without an assertion.
+  // registry slower, and a literal is what proves every key is present without an assertion.
   const artifacts: Record<OpencodeRuntimeTarget, OpencodeArtifactPin> = {
     "darwin-arm64": await pinTarget("darwin-arm64"),
+    "linux-x64": await pinTarget("linux-x64"),
     "win32-x64": await pinTarget("win32-x64"),
   };
 

--- a/scripts/verify-linux-package.ts
+++ b/scripts/verify-linux-package.ts
@@ -1,0 +1,243 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { access, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { FuseV1Options, getCurrentFuseWire } from "@electron/fuses";
+import { isDynamicRecord, isNumber, isString } from "@openbot/contracts/runtime-values";
+import { createOpenBotLogger, toLogValue } from "@openbot/logging";
+
+const logger = createOpenBotLogger("verify-linux-package");
+
+const FUSE_DISABLED = 48;
+const FUSE_ENABLED = 49;
+
+if (process.platform !== "linux") {
+  throw new Error("The Linux package verifier must run on Linux.");
+}
+
+const requireUpdateMetadata = process.argv.includes("--require-update-metadata");
+const appPathArgument = process.argv.slice(2).find((argument) => !argument.startsWith("--"));
+const appPath = resolve(appPathArgument ?? "dist/linux-unpacked");
+// electron-builder names the Linux binary after `name` in package.json, not `productName`.
+const executablePath = resolve(appPath, "openbot");
+const resourcesPath = resolve(appPath, "resources");
+const asarPath = resolve(resourcesPath, "app.asar");
+
+await Promise.all([
+  access(executablePath),
+  access(asarPath),
+  access(resolve(resourcesPath, "managed-skills")),
+  access(resolve(resourcesPath, "licenses/Electron-LICENSE")),
+  access(resolve(resourcesPath, "licenses/LICENSES.chromium.html")),
+]);
+
+// Voice and remote desktop are not built for Linux. These two assertions are the regression guard
+// for the platform split of `extraResources`: if either ever returns to the shared list, the Linux
+// build either fails outright on a missing source or ships a runtime it cannot use.
+await assertAbsent(resolve(resourcesPath, "whisper"), "Voice transcription is not available on Linux");
+await assertAbsent(resolve(resourcesPath, "remote-desktop-runtime"), "Remote desktop is not available on Linux");
+
+// Providers and the tunnel are downloaded on demand, exactly as on macOS and Windows.
+await Promise.all(
+  ["codex", "claude", "grok", "cloudflared"].map((name) =>
+    assertAbsent(resolve(resourcesPath, name), "Runtimes must not be packaged"),
+  ),
+);
+await assertAbsent(
+  resolve(resourcesPath, "app.asar.unpacked/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64"),
+  "The native Claude runtime must not be duplicated",
+);
+
+const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+if (!isDynamicRecord(packageJson)) throw new Error("package.json is not a JSON object.");
+if (!isString(packageJson.version)) throw new Error("package.json version is missing.");
+
+// The Linux build has no version resource to read, so the packaged manifest is the record of what
+// was built. It is the same file the running app reports through `app.getVersion()`.
+const packagedManifest = JSON.parse(await readAsarFile(asarPath, "package.json"));
+if (!isDynamicRecord(packagedManifest)) throw new Error("The packaged package.json is not a JSON object.");
+expectEqual(packagedManifest.name, "openbot", "packaged name");
+expectEqual(packagedManifest.productName, "OpenBot", "packaged product name");
+expectEqual(packagedManifest.version, packageJson.version, "packaged version");
+
+const executable = await readFile(executablePath);
+if (executable.toString("binary", 0, 4) !== "\x7fELF") throw new Error("The executable has no ELF header.");
+if (executable[4] !== 2) throw new Error("Expected a 64-bit ELF executable.");
+const machine = executable.readUInt16LE(18);
+if (machine !== 0x3e) {
+  throw new Error(`Expected a Linux x86-64 executable, but its ELF machine type is 0x${machine.toString(16)}.`);
+}
+
+const appImages = existsSync("dist") ? await findAppImages() : [];
+for (const appImage of appImages) {
+  if (!appImage.startsWith(`OpenBot-${packageJson.version}-`)) {
+    throw new Error(`Unexpected AppImage name: ${appImage} (expected OpenBot-${packageJson.version}-<arch>.AppImage)`);
+  }
+}
+
+const updateMetadataPath = resolve(resourcesPath, "app-update.yml");
+let updateMetadata: string | null = null;
+try {
+  updateMetadata = await readFile(updateMetadataPath, "utf8");
+} catch (error) {
+  if (requireUpdateMetadata) throw error;
+}
+if (updateMetadata !== null && !updateMetadata.includes("provider: github")) {
+  throw new Error("The packaged update provider is not GitHub.");
+}
+
+const fuses = await getCurrentFuseWire(executablePath);
+const expectedFuses: Array<[FuseV1Options, number]> = [
+  [FuseV1Options.RunAsNode, FUSE_DISABLED],
+  [FuseV1Options.EnableCookieEncryption, FUSE_ENABLED],
+  [FuseV1Options.EnableNodeOptionsEnvironmentVariable, FUSE_DISABLED],
+  [FuseV1Options.EnableNodeCliInspectArguments, FUSE_DISABLED],
+  [FuseV1Options.EnableEmbeddedAsarIntegrityValidation, FUSE_ENABLED],
+  [FuseV1Options.OnlyLoadAppFromAsar, FUSE_ENABLED],
+  [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot, FUSE_DISABLED],
+  [FuseV1Options.GrantFileProtocolExtraPrivileges, FUSE_DISABLED],
+];
+for (const [fuse, expected] of expectedFuses) {
+  if (fuses[fuse] !== expected) {
+    throw new Error(`Unexpected Electron fuse ${FuseV1Options[fuse]}: ${String(fuses[fuse])}`);
+  }
+}
+
+await verifyLaunch(executablePath);
+
+logger.info(`Verified ${appPath}`);
+logger.info(
+  `OpenBot ${packageJson.version} · Linux x64 · manifest · no voice or remote desktop · ASAR integrity · hardened fuses · launch`,
+);
+
+function expectEqual(actual: unknown, expected: unknown, label: string): void {
+  if (actual !== expected) {
+    throw new Error(`Unexpected ${label}: ${String(actual)} (expected ${String(expected)})`);
+  }
+}
+
+async function assertAbsent(path: string, reason: string): Promise<void> {
+  try {
+    await access(path);
+  } catch {
+    return;
+  }
+  throw new Error(`${reason}: ${path}`);
+}
+
+async function findAppImages(): Promise<string[]> {
+  return (await readdir("dist")).filter((name) => name.endsWith(".AppImage"));
+}
+
+/**
+ * Reads one top-level file out of an asar archive.
+ *
+ * The archive opens with four little-endian 32-bit words - a constant `4`, the size of the header
+ * block, the size of the JSON inside it, and the length of the JSON string itself - and then the
+ * JSON file table, which gives every entry an offset into the data that follows the header block.
+ * Doing this here keeps the verifier on the declared dependencies: `@electron/asar` is only a
+ * transitive dependency of electron-builder, and reading four words of a stable on-disk format is a
+ * smaller commitment than depending on it.
+ */
+async function readAsarFile(archive: string, name: string): Promise<string> {
+  const buffer = await readFile(archive);
+  const headerSize = buffer.readUInt32LE(4);
+  const headerJsonLength = buffer.readUInt32LE(12);
+  const header = JSON.parse(buffer.toString("utf8", 16, 16 + headerJsonLength));
+  if (!isDynamicRecord(header) || !isDynamicRecord(header.files)) {
+    throw new Error(`${archive} has no asar file table.`);
+  }
+  const entry = header.files[name];
+  if (!isDynamicRecord(entry) || !isString(entry.offset) || !isNumber(entry.size)) {
+    throw new Error(`${archive} does not contain ${name}.`);
+  }
+  const start = 8 + headerSize + Number(entry.offset);
+  return buffer.toString("utf8", start, start + entry.size);
+}
+
+/**
+ * Starts the packaged application once and makes sure it stays up.
+ *
+ * This needs a display, so in CI it runs under `xvfb-run -a`. It cannot be verified on a macOS
+ * worktree at all: the verifier refuses to run there, and a headless Electron does not reach
+ * `ready` in an agent shell.
+ *
+ * No `--no-sandbox` here or anywhere else. If the launch fails with a user-namespace error, the
+ * host is missing the AppArmor profile, which is a real defect in the install instructions rather
+ * than something to switch the sandbox off for.
+ */
+async function verifyLaunch(executable: string): Promise<void> {
+  if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    throw new Error("The launch check needs a display. Run it under `xvfb-run -a`.");
+  }
+  const userDataPath = await mkdtemp(join(tmpdir(), "openbot-package-smoke-"));
+  const child = spawn(executable, [`--user-data-dir=${userDataPath}`], {
+    env: launchEnvironment(userDataPath),
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr = `${stderr}${chunk}`.slice(-4_000);
+  });
+
+  try {
+    await Promise.race([
+      new Promise<never>((_, reject) => {
+        child.once("exit", (code, signal) => {
+          reject(
+            new Error(`Packaged OpenBot exited during launch (${signal ?? `code ${String(code)}`}): ${stderr.trim()}`),
+          );
+        });
+      }),
+      new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 3_000)),
+    ]);
+    await verifySecondInstanceExits(executable, userDataPath);
+  } finally {
+    child.kill("SIGTERM");
+    await Promise.race([
+      new Promise<void>((resolveExit) => child.once("exit", () => resolveExit())),
+      new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 5_000)),
+    ]);
+    child.kill("SIGKILL");
+    try {
+      await rm(userDataPath, { recursive: true, force: true, maxRetries: 5, retryDelay: 300 });
+    } catch (error) {
+      logger.warn("Could not remove the temporary Linux profile:", toLogValue(error));
+    }
+  }
+}
+
+function launchEnvironment(userDataPath: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    CODEX_HOME: join(userDataPath, "codex-home"),
+    CLAUDE_CONFIG_DIR: join(userDataPath, "claude-home"),
+    OPENBOT_CODEX_PATH: join(userDataPath, "missing-codex"),
+    OPENBOT_CLAUDE_PATH: join(userDataPath, "missing-claude"),
+    OPENBOT_GROK_PATH: join(userDataPath, "missing-grok"),
+  };
+}
+
+async function verifySecondInstanceExits(executable: string, userDataPath: string): Promise<void> {
+  const second = spawn(executable, [`--user-data-dir=${userDataPath}`], {
+    env: launchEnvironment(userDataPath),
+    stdio: "ignore",
+  });
+  const result = await Promise.race([
+    new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit) => {
+      second.once("exit", (code, signal) => resolveExit({ code, signal }));
+    }),
+    new Promise<null>((resolveDelay) => setTimeout(() => resolveDelay(null), 3_000)),
+  ]);
+  if (!result) {
+    second.kill();
+    throw new Error("A second OpenBot instance did not exit.");
+  }
+  if (result.code !== 0 || result.signal) {
+    throw new Error(
+      `A second OpenBot instance exited unexpectedly (${result.signal ?? `code ${String(result.code)}`}).`,
+    );
+  }
+}

--- a/scripts/verify-update-artifacts.ts
+++ b/scripts/verify-update-artifacts.ts
@@ -10,13 +10,20 @@ const logger = createOpenBotLogger("verify-update-artifacts");
 
 const MIB = 1024 * 1024;
 const platform = process.argv[2];
-if (platform !== "macos" && platform !== "windows") {
-  throw new Error("Usage: bun scripts/verify-update-artifacts.ts <macos|windows>");
+if (platform !== "linux" && platform !== "macos" && platform !== "windows") {
+  throw new Error("Usage: bun scripts/verify-update-artifacts.ts <linux|macos|windows>");
 }
 
+/** The artifact electron-updater downloads, and the manifest that names it, for each platform. */
+const UPDATE_ARTIFACTS = {
+  linux: { extension: ".AppImage", manifest: "latest-linux.yml" },
+  macos: { extension: ".zip", manifest: "latest-mac.yml" },
+  windows: { extension: ".exe", manifest: "latest.yml" },
+} as const;
+
 const distRoot = resolve("dist");
-const artifactExtension = platform === "macos" ? ".zip" : ".exe";
-const manifestPath = join(distRoot, platform === "macos" ? "latest-mac.yml" : "latest.yml");
+const artifactExtension = UPDATE_ARTIFACTS[platform].extension;
+const manifestPath = join(distRoot, UPDATE_ARTIFACTS[platform].manifest);
 const artifacts = (await readdir(distRoot)).filter((name) => name.endsWith(artifactExtension));
 if (artifacts.length !== 1) throw new Error(`Expected one ${artifactExtension} update artifact.`);
 
@@ -27,20 +34,28 @@ if (platform === "macos") {
   if (dmgs.length !== 1) throw new Error("Expected one DMG artifact.");
   await verifyMaximumSize(join(distRoot, dmgs[0]), 750 * MIB);
 }
-await verifyManifest(manifestPath, artifactPath);
-if (!existsSync(`${artifactPath}.blockmap`)) throw new Error(`Missing blockmap for ${basename(artifactPath)}.`);
+const embeddedBlockMapBytes = await verifyManifest(manifestPath, artifactPath);
+// An AppImage carries its block map inside the file, so the size the manifest records is what proves
+// a differential update is possible. The other targets write the block map beside the artifact.
+if (platform === "linux") {
+  if (embeddedBlockMapBytes === null) {
+    throw new Error(`The manifest records no embedded block map for ${basename(artifactPath)}.`);
+  }
+} else if (!existsSync(`${artifactPath}.blockmap`)) {
+  throw new Error(`Missing blockmap for ${basename(artifactPath)}.`);
+}
 
 const resourcesRoot =
   platform === "macos"
     ? join(distRoot, "mac-arm64", "OpenBot.app", "Contents", "Resources")
-    : join(distRoot, "win-unpacked", "resources");
+    : join(distRoot, platform === "linux" ? "linux-unpacked" : "win-unpacked", "resources");
 if (existsSync(join(resourcesRoot, "whisper", "model"))) {
   throw new Error("The packaged application contains the on-demand Whisper model.");
 }
 const unpackedRoot = join(resourcesRoot, "app.asar.unpacked", "node_modules", "@anthropic-ai");
 if (existsSync(unpackedRoot)) {
   const entries = await walk(unpackedRoot);
-  if (entries.some((path) => /claude-agent-sdk-(?:darwin|win32)-/u.test(path))) {
+  if (entries.some((path) => /claude-agent-sdk-(?:darwin|linux|win32)-/u.test(path))) {
     throw new Error("The packaged application contains a duplicate native Claude runtime.");
   }
 }
@@ -53,7 +68,11 @@ async function verifyMaximumSize(path: string, maximumBytes: number): Promise<vo
   }
 }
 
-async function verifyManifest(path: string, artifact: string): Promise<void> {
+/**
+ * Checks the manifest describes the artifact on disk, and reports the size of the block map the
+ * manifest records inside it, or `null` when it records none.
+ */
+async function verifyManifest(path: string, artifact: string): Promise<number | null> {
   const manifest = parse(await readFile(path, "utf8"));
   if (!isDynamicRecord(manifest) || !Array.isArray(manifest.files)) {
     throw new Error("The update manifest has no file list.");
@@ -73,6 +92,7 @@ async function verifyManifest(path: string, artifact: string): Promise<void> {
   if (!isString(entry.sha512) || entry.sha512 !== hash.digest("base64")) {
     throw new Error(`The manifest SHA-512 does not match ${artifactName}.`);
   }
+  return isNumber(entry.blockMapSize) && entry.blockMapSize > 0 ? entry.blockMapSize : null;
 }
 
 async function walk(root: string): Promise<string[]> {

--- a/src/backend/cli.test.ts
+++ b/src/backend/cli.test.ts
@@ -11,6 +11,7 @@ import {
   bundledOpencodeExecutable,
   CodexCliError,
   cliSpawnTarget,
+  loginShellCommand,
   parseClaudeVersion,
   parseCodexVersion,
   parseGrokVersion,
@@ -57,7 +58,9 @@ describe("bundled Codex resolution", () => {
     expect(bundledCodexExecutable("win32", "x64", "C:\\Program Files\\OpenBot\\resources")).toBe(
       "C:\\Program Files\\OpenBot\\resources\\codex\\win\\x64\\bin\\codex.exe",
     );
-    expect(bundledCodexExecutable("linux", "x64", "/resources")).toBeNull();
+    expect(bundledCodexExecutable("linux", "x64", "/resources")).toBe("/resources/codex/linux/x64/bin/codex");
+    expect(bundledCodexExecutable("linux", "arm64", "/resources")).toBeNull();
+    expect(bundledCodexExecutable("freebsd", "x64", "/resources")).toBeNull();
   });
 
   it("resolves the build runtime path during development", () => {
@@ -113,7 +116,7 @@ describe("bundled Claude resolution", () => {
     expect(bundledClaudeExecutable("win32", "x64", "C:\\Program Files\\OpenBot\\resources")).toBe(
       "C:\\Program Files\\OpenBot\\resources\\claude\\win\\x64\\bin\\claude.exe",
     );
-    expect(bundledClaudeExecutable("linux", "x64", "/resources")).toBeNull();
+    expect(bundledClaudeExecutable("linux", "x64", "/resources")).toBe("/resources/claude/linux/x64/bin/claude");
   });
 
   it.runIf(process.platform !== "win32")("prefers the managed CLI over a compatible system CLI", async () => {
@@ -142,10 +145,30 @@ describe("bundled Claude resolution", () => {
   });
 });
 
+describe("login shell discovery", () => {
+  it("uses zsh on macOS and the user's own shell on Linux", () => {
+    expect(loginShellCommand("darwin", {})).toEqual({ command: "/bin/zsh", args: ["-lic"] });
+    expect(loginShellCommand("win32", {})).toEqual({ command: "/bin/zsh", args: ["-lic"] });
+    expect(loginShellCommand("linux", { SHELL: "/usr/bin/fish" })).toEqual({
+      command: "/usr/bin/fish",
+      args: ["-lic"],
+    });
+  });
+
+  it("falls back to a non-interactive /bin/sh when Linux has no usable login shell", () => {
+    // dash exits rather than running the command when it is given -i without a tty.
+    expect(loginShellCommand("linux", {})).toEqual({ command: "/bin/sh", args: ["-lc"] });
+    expect(loginShellCommand("linux", { SHELL: "  " })).toEqual({ command: "/bin/sh", args: ["-lc"] });
+    expect(loginShellCommand("linux", { SHELL: "/bin/sh" })).toEqual({ command: "/bin/sh", args: ["-lc"] });
+  });
+});
+
 describe("bundled Grok CLI resolution", () => {
   it("reads Grok versions and includes documented macOS and Windows locations", () => {
     expect(parseGrokVersion("grok 1.0.5\n")).toBe("1.0.5");
-    expect(posixFallbackPaths("grok", "/Users/jane")).toContain("/Users/jane/.grok/bin/grok");
+    expect(posixFallbackPaths("grok", "/Users/jane")).toEqual(
+      expect.arrayContaining(["/Users/jane/.grok/bin/grok", "/opt/homebrew/bin/grok", "/usr/bin/grok"]),
+    );
     expect(
       windowsFallbackPaths("grok", "C:\\Users\\Jane", {
         LOCALAPPDATA: "C:\\Users\\Jane\\AppData\\Local",
@@ -165,7 +188,7 @@ describe("bundled Grok CLI resolution", () => {
     expect(bundledGrokExecutable("win32", "x64", "C:\\Program Files\\OpenBot\\resources")).toBe(
       "C:\\Program Files\\OpenBot\\resources\\grok\\win\\x64\\bin\\grok.exe",
     );
-    expect(bundledGrokExecutable("linux", "x64", "/resources")).toBeNull();
+    expect(bundledGrokExecutable("linux", "x64", "/resources")).toBe("/resources/grok/linux/x64/bin/grok");
   });
 
   it.runIf(process.platform !== "win32")("honors OPENBOT_GROK_PATH and probes --version", async () => {
@@ -345,7 +368,7 @@ describe("OpenCode CLI resolution", () => {
     expect(bundledOpencodeExecutable("darwin", "arm64", "/Applications/OpenBot.app/Contents/Resources")).toBe(
       "/Applications/OpenBot.app/Contents/Resources/opencode/mac/arm64/bin/opencode",
     );
-    expect(bundledOpencodeExecutable("linux", "x64", "/resources")).toBeNull();
+    expect(bundledOpencodeExecutable("linux", "x64", "/resources")).toBe("/resources/opencode/linux/x64/bin/opencode");
   });
 
   it.runIf(process.platform !== "win32")("uses the installed CLI and reports a missing override", async () => {

--- a/src/backend/cli.ts
+++ b/src/backend/cli.ts
@@ -242,9 +242,11 @@ function bundledProviderExecutable(
   const targetPlatform =
     platform === "darwin" && architecture === "arm64"
       ? "mac"
-      : platform === "win32" && architecture === "x64"
-        ? "win"
-        : null;
+      : platform === "linux" && architecture === "x64"
+        ? "linux"
+        : platform === "win32" && architecture === "x64"
+          ? "win"
+          : null;
   if (!targetPlatform) return null;
 
   const executable = platform === "win32" ? `${provider}.exe` : provider;
@@ -333,14 +335,15 @@ async function collectCandidates(command: AgentProviderId, configuredPath: strin
     }
     candidates.push(...windowsFallbackPaths(command));
   } else {
+    const loginShell = loginShellCommand();
     try {
-      const { stdout } = await execFileAsync("/bin/zsh", ["-lic", `command -v ${command}`], {
+      const { stdout } = await execFileAsync(loginShell.command, [...loginShell.args, `command -v ${command}`], {
         timeout: 5_000,
         maxBuffer: 64 * 1024,
       });
       if (stdout.trim()) candidates.push(stdout.trim());
     } catch {
-      // Packaged macOS apps often have a restricted PATH; known locations are checked next.
+      // Packaged apps often start with a restricted PATH; known locations are checked next.
     }
     candidates.push(...posixFallbackPaths(command));
   }
@@ -380,12 +383,31 @@ export function windowsFallbackPaths(
   return paths;
 }
 
+/**
+ * The shell that answers `command -v`. It has to be a login shell, because that is what reads the
+ * profile a version manager appends its `PATH` to, and a packaged app inherits none of it.
+ *
+ * macOS keeps `/bin/zsh`: it is the default login shell and is always present. Linux cannot assume
+ * zsh is installed at all, so it prefers the user's own `$SHELL` and falls back to `/bin/sh`. The
+ * `-i` flag goes with it, because `sh` is not required to accept an interactive non-tty invocation
+ * and dash exits rather than running the command.
+ */
+export function loginShellCommand(
+  platform: NodeJS.Platform = process.platform,
+  environment: NodeJS.ProcessEnv = process.env,
+): { command: string; args: string[] } {
+  if (platform !== "linux") return { command: "/bin/zsh", args: ["-lic"] };
+  const preferred = environment.SHELL?.trim();
+  if (!preferred) return { command: "/bin/sh", args: ["-lc"] };
+  return { command: preferred, args: preferred.endsWith("/sh") ? ["-lc"] : ["-lic"] };
+}
+
 export function posixFallbackPaths(command: AgentProviderId, userHome = homedir()): string[] {
   const paths = [posix.join(userHome, ".local", "bin", command)];
   if (command === "claude") paths.push(posix.join(userHome, ".claude", "local", "claude"));
   if (command === "opencode") paths.push(posix.join(userHome, ".opencode", "bin", "opencode"));
   if (command === "grok") paths.push(posix.join(userHome, ".grok", "bin", "grok"));
-  paths.push(`/opt/homebrew/bin/${command}`, `/usr/local/bin/${command}`);
+  paths.push(`/opt/homebrew/bin/${command}`, `/usr/local/bin/${command}`, `/usr/bin/${command}`);
   return paths;
 }
 

--- a/src/main/application-services.ts
+++ b/src/main/application-services.ts
@@ -648,7 +648,9 @@ export async function createApplicationServices({
     beforeInstall: prepareForUpdateInstall,
     platform: process.platform,
     logDirectory: join(app.getPath("userData"), "logs", "update"),
-    shipItDirectory: join(homedir(), "Library", "Caches", "app.openbot.desktop.ShipIt"),
+    // Squirrel.Mac only. The path is meaningless under a Linux or Windows home directory.
+    shipItDirectory:
+      process.platform === "darwin" ? join(homedir(), "Library", "Caches", "app.openbot.desktop.ShipIt") : undefined,
   });
   teardown.push(TEARDOWN_ORDER.updater, "the update service", () => updater.stop());
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -480,7 +480,12 @@ if (!hasSingleInstanceLock) {
         (policy) => app.setActivationPolicy(policy),
         () => app.dock?.show() ?? Promise.resolve(),
       );
-      if (process.platform === "darwin") app.setAsDefaultProtocolClient("openbot");
+      // Linux registers the scheme through xdg-settings, which matters when the AppImage runs
+      // without a package manager having installed its desktop entry. Windows gets the scheme from
+      // the NSIS installer instead.
+      if (process.platform === "darwin" || process.platform === "linux") {
+        app.setAsDefaultProtocolClient("openbot");
+      }
       if (process.platform === "darwin") app.dock?.setIcon(appIconPath);
       configureContentSecurityPolicy();
       configureRendererPermissions();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ import { skillIpcHandlers } from "./ipc/skill-handlers";
 import { teamIpcHandlers } from "./ipc/team-handlers";
 import { updateIpcHandlers } from "./ipc/update-handlers";
 import { voiceIpcHandlers } from "./ipc/voice-handlers";
+import { installLinuxDesktopEntry } from "./linux-desktop-entry";
 import { MacHapticFeedback } from "./mac-haptic-feedback";
 import {
   configureApplicationMenu,
@@ -480,11 +481,14 @@ if (!hasSingleInstanceLock) {
         (policy) => app.setActivationPolicy(policy),
         () => app.dock?.show() ?? Promise.resolve(),
       );
-      // Linux registers the scheme through xdg-settings, which matters when the AppImage runs
-      // without a package manager having installed its desktop entry. Windows gets the scheme from
-      // the NSIS installer instead.
+      // Linux registers the scheme through xdg-settings, which can only name a desktop entry that
+      // exists, so an AppImage writes its own first. Windows gets the scheme from the NSIS installer
+      // instead.
+      await installLinuxDesktopEntry({ platform: process.platform, environment: process.env, iconPath: appIconPath });
       if (process.platform === "darwin" || process.platform === "linux") {
-        app.setAsDefaultProtocolClient("openbot");
+        if (!app.setAsDefaultProtocolClient("openbot")) {
+          logger.warn("Unable to register the openbot:// scheme. Invitation links will not open OpenBot.");
+        }
       }
       if (process.platform === "darwin") app.dock?.setIcon(appIconPath);
       configureContentSecurityPolicy();

--- a/src/main/linux-desktop-entry.test.ts
+++ b/src/main/linux-desktop-entry.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { installLinuxDesktopEntry, linuxDesktopEntry } from "./linux-desktop-entry";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("linux desktop entry", () => {
+  it("points the invitation scheme at the AppImage that is running", async () => {
+    const home = await temporaryHome();
+    const path = await installLinuxDesktopEntry({
+      platform: "linux",
+      environment: { APPIMAGE: "/home/jane/Applications/OpenBot-0.8.0-x86_64.AppImage" },
+      iconPath: "/opt/openbot/resources/icons/icon-production.png",
+      homeDirectory: home,
+    });
+
+    expect(path).toBe(join(home, ".local/share/applications/openbot.desktop"));
+    const entry = await readFile(String(path), "utf8");
+    expect(entry).toContain('Exec="/home/jane/Applications/OpenBot-0.8.0-x86_64.AppImage" %U');
+    expect(entry).toContain("MimeType=x-scheme-handler/openbot;");
+    expect(entry).toContain("Icon=/opt/openbot/resources/icons/icon-production.png");
+    expect((await stat(String(path))).mode & 0o777).toBe(0o644);
+  });
+
+  it("writes into XDG_DATA_HOME when the user moved it", async () => {
+    const home = await temporaryHome();
+    const path = await installLinuxDesktopEntry({
+      platform: "linux",
+      environment: { APPIMAGE: "/opt/OpenBot.AppImage", XDG_DATA_HOME: join(home, "data") },
+      iconPath: "/opt/openbot/icon.png",
+      homeDirectory: home,
+    });
+
+    expect(path).toBe(join(home, "data/applications/openbot.desktop"));
+  });
+
+  it("leaves an entry a package manager owns alone", async () => {
+    const home = await temporaryHome();
+
+    await expect(
+      installLinuxDesktopEntry({ platform: "linux", environment: {}, iconPath: "/icon.png", homeDirectory: home }),
+    ).resolves.toBeNull();
+    await expect(
+      installLinuxDesktopEntry({
+        platform: "darwin",
+        environment: { APPIMAGE: "/opt/OpenBot.AppImage" },
+        iconPath: "/icon.png",
+        homeDirectory: home,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  // A path with a space is ordinary on a desktop, and an unquoted one would make the entry launch
+  // the wrong program with the rest of the path as arguments.
+  it("quotes a path the desktop entry specification reserves characters in", () => {
+    const entry = linuxDesktopEntry('/home/jane/My Apps/Open"Bot.AppImage', "/icon.png");
+
+    expect(entry).toContain('Exec="/home/jane/My Apps/Open\\"Bot.AppImage" %U');
+  });
+});
+
+async function temporaryHome(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "openbot-desktop-entry-test-"));
+  roots.push(root);
+  return root;
+}

--- a/src/main/linux-desktop-entry.test.ts
+++ b/src/main/linux-desktop-entry.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -18,7 +18,7 @@ describe("linux desktop entry", () => {
     const path = await installLinuxDesktopEntry({
       platform: "linux",
       environment: { APPIMAGE: "/home/jane/Applications/OpenBot-0.8.0-x86_64.AppImage" },
-      iconPath: "/opt/openbot/resources/icons/icon-production.png",
+      iconPath: await temporaryIcon(home),
       homeDirectory: home,
     });
 
@@ -26,8 +26,37 @@ describe("linux desktop entry", () => {
     const entry = await readFile(String(path), "utf8");
     expect(entry).toContain('Exec="/home/jane/Applications/OpenBot-0.8.0-x86_64.AppImage" %U');
     expect(entry).toContain("MimeType=x-scheme-handler/openbot;");
-    expect(entry).toContain("Icon=/opt/openbot/resources/icons/icon-production.png");
     expect((await stat(String(path))).mode & 0o777).toBe(0o644);
+  });
+
+  // An AppImage unmounts its resources when it exits, so an entry that names the packaged icon
+  // leaves the application menu without one for as long as OpenBot is not running.
+  it("copies the icon out of the package and names the copy", async () => {
+    const home = await temporaryHome();
+    const iconPath = join(home, ".local/share/icons/openbot.png");
+    const path = await installLinuxDesktopEntry({
+      platform: "linux",
+      environment: { APPIMAGE: "/tmp/.mount_OpenBoAbc123/OpenBot.AppImage" },
+      iconPath: await temporaryIcon(home),
+      homeDirectory: home,
+    });
+
+    expect(await readFile(String(path), "utf8")).toContain(`Icon=${iconPath}`);
+    await expect(readFile(iconPath)).resolves.toEqual(Buffer.from("icon bytes"));
+    expect((await stat(iconPath)).mode & 0o777).toBe(0o644);
+  });
+
+  // The entry is what registers the invitation scheme, so a missing icon must not stop it.
+  it("names the packaged icon when it cannot copy one", async () => {
+    const home = await temporaryHome();
+    const path = await installLinuxDesktopEntry({
+      platform: "linux",
+      environment: { APPIMAGE: "/opt/OpenBot.AppImage" },
+      iconPath: join(home, "absent.png"),
+      homeDirectory: home,
+    });
+
+    expect(await readFile(String(path), "utf8")).toContain(`Icon=${join(home, "absent.png")}`);
   });
 
   it("writes into XDG_DATA_HOME when the user moved it", async () => {
@@ -35,11 +64,12 @@ describe("linux desktop entry", () => {
     const path = await installLinuxDesktopEntry({
       platform: "linux",
       environment: { APPIMAGE: "/opt/OpenBot.AppImage", XDG_DATA_HOME: join(home, "data") },
-      iconPath: "/opt/openbot/icon.png",
+      iconPath: await temporaryIcon(home),
       homeDirectory: home,
     });
 
     expect(path).toBe(join(home, "data/applications/openbot.desktop"));
+    expect(await readFile(String(path), "utf8")).toContain(`Icon=${join(home, "data/icons/openbot.png")}`);
   });
 
   it("leaves an entry a package manager owns alone", async () => {
@@ -71,4 +101,11 @@ async function temporaryHome(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "openbot-desktop-entry-test-"));
   roots.push(root);
   return root;
+}
+
+/** Stands in for the icon the package carries, which is a PNG this test does not have to read. */
+async function temporaryIcon(home: string): Promise<string> {
+  const path = join(home, "packaged-icon.png");
+  await writeFile(path, "icon bytes");
+  return path;
 }

--- a/src/main/linux-desktop-entry.ts
+++ b/src/main/linux-desktop-entry.ts
@@ -11,6 +11,7 @@ const logger = createOpenBotLogger("linux-desktop-entry");
  * into `StartupWMClass` so a window groups with this entry.
  */
 const DESKTOP_FILE_NAME = "openbot.desktop";
+const ICON_FILE_NAME = "openbot.png";
 const WM_CLASS = "openbot";
 
 /**
@@ -53,9 +54,10 @@ export async function installLinuxDesktopEntry(options: {
   const appImagePath = options.environment.APPIMAGE?.trim();
   if (!appImagePath) return null;
   const dataHome = options.environment.XDG_DATA_HOME?.trim();
-  const directory = join(dataHome || join(options.homeDirectory ?? homedir(), ".local", "share"), "applications");
+  const dataDirectory = dataHome || join(options.homeDirectory ?? homedir(), ".local", "share");
+  const directory = join(dataDirectory, "applications");
   const path = join(directory, DESKTOP_FILE_NAME);
-  const entry = linuxDesktopEntry(appImagePath, options.iconPath);
+  const entry = linuxDesktopEntry(appImagePath, await installIcon(dataDirectory, options.iconPath));
   try {
     if ((await readEntry(path)) === entry) return path;
     await mkdir(directory, { recursive: true });
@@ -65,6 +67,40 @@ export async function installLinuxDesktopEntry(options: {
   } catch (error) {
     logger.warn("Unable to install the desktop entry, so openbot:// links stay unregistered.", toLogValue(error));
     return null;
+  }
+}
+
+/**
+ * Copies the launcher icon to a path that outlives the process, and reports the path the entry has
+ * to name. Reports the packaged path instead when the copy fails, because an entry with an icon
+ * that can disappear is still better than no invitation links at all.
+ *
+ * An AppImage mounts its resources in a temporary directory that the runtime removes when the app
+ * exits, so an entry that points there loses its icon as soon as OpenBot is not running. The entry
+ * names the copy by absolute path, which the desktop entry specification allows, rather than by
+ * icon theme name: one loose file under the data home is not a theme.
+ */
+async function installIcon(dataDirectory: string, iconPath: string): Promise<string> {
+  const directory = join(dataDirectory, "icons");
+  const path = join(directory, ICON_FILE_NAME);
+  try {
+    const icon = await readFile(iconPath);
+    if (icon.equals(await readIcon(path))) return path;
+    await mkdir(directory, { recursive: true });
+    await writeFile(path, icon, { mode: 0o644 });
+    logger.info(`Installed the launcher icon at ${path}.`);
+    return path;
+  } catch (error) {
+    logger.warn("Unable to install the launcher icon, so the entry names the packaged one.", toLogValue(error));
+    return iconPath;
+  }
+}
+
+async function readIcon(path: string): Promise<Buffer> {
+  try {
+    return await readFile(path);
+  } catch {
+    return Buffer.alloc(0);
   }
 }
 

--- a/src/main/linux-desktop-entry.ts
+++ b/src/main/linux-desktop-entry.ts
@@ -1,0 +1,85 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createOpenBotLogger, toLogValue } from "@openbot/logging";
+
+const logger = createOpenBotLogger("linux-desktop-entry");
+
+/**
+ * The file name has to stay `openbot.desktop`: it is `desktopName` in package.json, which is what
+ * Electron uses as the application id it hands to `xdg-settings`, and what electron-builder writes
+ * into `StartupWMClass` so a window groups with this entry.
+ */
+const DESKTOP_FILE_NAME = "openbot.desktop";
+const WM_CLASS = "openbot";
+
+/**
+ * The desktop entry that makes an `openbot://` link reach the app.
+ *
+ * `Exec` names the AppImage itself, because that is the only path that survives a restart, and `%U`
+ * is what passes the invitation URL to it.
+ */
+export function linuxDesktopEntry(appImagePath: string, iconPath: string): string {
+  return `${[
+    "[Desktop Entry]",
+    "Type=Application",
+    "Name=OpenBot",
+    "Comment=A local-first multi-agent desktop workspace.",
+    `Exec=${quoteExecutable(appImagePath)} %U`,
+    `Icon=${iconPath}`,
+    "Terminal=false",
+    "Categories=Development;",
+    `StartupWMClass=${WM_CLASS}`,
+    "MimeType=x-scheme-handler/openbot;",
+  ].join("\n")}\n`;
+}
+
+/**
+ * Writes the desktop entry for an AppImage, and reports the path it wrote, or `null` when there was
+ * nothing to write.
+ *
+ * `app.setAsDefaultProtocolClient` calls `xdg-settings` on Linux, and `xdg-settings` can only name a
+ * desktop entry that already exists. A downloaded AppImage has none, so without this the scheme
+ * registration silently does nothing and every invitation link fails. Any other Linux build was
+ * installed by a package manager, which owns the entry; this leaves that one alone.
+ */
+export async function installLinuxDesktopEntry(options: {
+  platform: NodeJS.Platform;
+  environment: NodeJS.ProcessEnv;
+  iconPath: string;
+  homeDirectory?: string;
+}): Promise<string | null> {
+  if (options.platform !== "linux") return null;
+  const appImagePath = options.environment.APPIMAGE?.trim();
+  if (!appImagePath) return null;
+  const dataHome = options.environment.XDG_DATA_HOME?.trim();
+  const directory = join(dataHome || join(options.homeDirectory ?? homedir(), ".local", "share"), "applications");
+  const path = join(directory, DESKTOP_FILE_NAME);
+  const entry = linuxDesktopEntry(appImagePath, options.iconPath);
+  try {
+    if ((await readEntry(path)) === entry) return path;
+    await mkdir(directory, { recursive: true });
+    await writeFile(path, entry, { mode: 0o644 });
+    logger.info(`Installed the desktop entry at ${path}.`);
+    return path;
+  } catch (error) {
+    logger.warn("Unable to install the desktop entry, so openbot:// links stay unregistered.", toLogValue(error));
+    return null;
+  }
+}
+
+async function readEntry(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Quotes a path for the `Exec` key. The desktop entry specification reserves a set of characters
+ * inside a quoted argument, and a backslash is what escapes them.
+ */
+function quoteExecutable(path: string): string {
+  return `"${path.replace(/(["`$\\])/gu, "\\$1")}"`;
+}

--- a/src/main/provider-runtime-descriptors.ts
+++ b/src/main/provider-runtime-descriptors.ts
@@ -6,7 +6,7 @@ import type { AgentRuntimeLock } from "../../scripts/agent-runtime-lock";
 import { parseClaudeVersion, parseCodexVersion, parseGrokVersion, parseOpencodeVersion } from "../backend/cli";
 import { assertSafeArchive, extractArchive, rejectNonRegularFiles, sha256File } from "./provider-runtime-archive";
 
-export type RuntimeTarget = "darwin-arm64" | "win32-x64";
+export type RuntimeTarget = "darwin-arm64" | "linux-x64" | "win32-x64";
 
 export interface RuntimeSpec {
   provider: ManagedProviderId;
@@ -138,7 +138,7 @@ export const PROVIDER_RUNTIME_DESCRIPTORS: Record<ManagedProviderId, ProviderRun
             })}\n`,
           ),
         ]);
-        if (spec.target === "darwin-arm64") await chmod(join(staging, "bin", artifact.executable), 0o755);
+        if (spec.target !== "win32-x64") await chmod(join(staging, "bin", artifact.executable), 0o755);
       } finally {
         await rm(extracted, { recursive: true, force: true });
       }
@@ -206,7 +206,7 @@ export const PROVIDER_RUNTIME_DESCRIPTORS: Record<ManagedProviderId, ProviderRun
             })}\n`,
           ),
         ]);
-        if (spec.target === "darwin-arm64") await chmod(join(staging, "bin", artifact.executable), 0o755);
+        if (spec.target !== "win32-x64") await chmod(join(staging, "bin", artifact.executable), 0o755);
       } finally {
         await rm(extracted, { recursive: true, force: true });
       }
@@ -259,7 +259,7 @@ export const PROVIDER_RUNTIME_DESCRIPTORS: Record<ManagedProviderId, ProviderRun
           })}\n`,
         ),
       ]);
-      if (spec.target === "darwin-arm64") await chmod(join(staging, "bin", spec.executableName), 0o755);
+      if (spec.target !== "win32-x64") await chmod(join(staging, "bin", spec.executableName), 0o755);
     },
     verify: async (root, spec, lock) => {
       const executable = join(root, "bin", spec.executableName);

--- a/src/main/provider-runtime-manager.test.ts
+++ b/src/main/provider-runtime-manager.test.ts
@@ -548,6 +548,30 @@ describe("ProviderRuntimeManager", () => {
     expect(entries).not.toContain("darwin-arm64");
     expect(entries.some((entry) => entry.startsWith(".installing-"))).toBe(false);
   });
+
+  it.each([
+    ["darwin", "arm64"],
+    ["linux", "x64"],
+    ["win32", "x64"],
+  ] as const)("offers managed downloads on %s %s", async (platform, architecture) => {
+    const root = await temporaryRoot();
+    const manager = new ProviderRuntimeManager({ root, platform, architecture });
+
+    const snapshot = await manager.initialize();
+
+    for (const provider of MANAGED_RUNTIME_PROVIDERS) {
+      expect(snapshot.providers[provider]).toMatchObject({ phase: "not-downloaded", message: null });
+    }
+  });
+
+  it("reports an unsupported platform rather than a download that cannot work", async () => {
+    const root = await temporaryRoot();
+    const manager = new ProviderRuntimeManager({ root, platform: "linux", architecture: "arm64" });
+
+    const snapshot = await manager.initialize();
+
+    expect(snapshot.providers.codex.message).toBe("This platform is not supported.");
+  });
 });
 
 interface OpencodeFixture {

--- a/src/main/provider-runtime-manager.ts
+++ b/src/main/provider-runtime-manager.ts
@@ -445,6 +445,7 @@ export class ProviderRuntimeManager extends EventEmitter<ProviderRuntimeManagerE
 
 function runtimeTarget(platform: NodeJS.Platform, architecture: string): RuntimeTarget | null {
   if (platform === "darwin" && architecture === "arm64") return "darwin-arm64";
+  if (platform === "linux" && architecture === "x64") return "linux-x64";
   if (platform === "win32" && architecture === "x64") return "win32-x64";
   return null;
 }

--- a/src/main/update-service.test.ts
+++ b/src/main/update-service.test.ts
@@ -713,6 +713,12 @@ describe("supportsInstalledUpdates", () => {
     ["win32", true],
     ["linux", false],
   ] as const)("returns %s support as %s", (platform, expected) => {
-    expect(supportsInstalledUpdates(platform)).toBe(expected);
+    expect(supportsInstalledUpdates(platform, {})).toBe(expected);
+  });
+
+  // Only the AppImage runtime can replace itself, and `APPIMAGE` is how it says it is the one running.
+  it("supports a Linux build only when it runs from an AppImage", () => {
+    expect(supportsInstalledUpdates("linux", { APPIMAGE: "/tmp/OpenBot-0.8.0-x64.AppImage" })).toBe(true);
+    expect(supportsInstalledUpdates("linux", { APPIMAGE: "  " })).toBe(false);
   });
 });

--- a/src/main/update-service.ts
+++ b/src/main/update-service.ts
@@ -111,7 +111,18 @@ const DEFAULT_PHASE_TIMEOUTS: Record<UpdateBusyPhase, number> = {
   installing: 300_000,
 };
 
-export function supportsInstalledUpdates(platform: NodeJS.Platform): boolean {
+/**
+ * Whether the installed app can replace itself in place.
+ *
+ * Linux is conditional: electron-updater can only self-update an AppImage, and the AppImage runtime
+ * is the thing that says so, through `APPIMAGE`. An unpacked or repackaged Linux build has nothing
+ * to write back to, so it reports no updates rather than failing at install time.
+ */
+export function supportsInstalledUpdates(
+  platform: NodeJS.Platform,
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (platform === "linux") return Boolean(environment.APPIMAGE?.trim());
   return platform === "darwin" || platform === "win32";
 }
 

--- a/src/main/voice-transcription-service.ts
+++ b/src/main/voice-transcription-service.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, execFile } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -17,6 +18,13 @@ interface VoiceTranscriptionEvents {
   modelStatus: [status: VoiceModelStatus];
 }
 
+/**
+ * What the renderer is told when the build carries no whisper binary at all. Linux packages ship
+ * without one, so this is the whole of voice on that platform: a stated limit, not a download that
+ * spends half a gigabyte on a model nothing can read.
+ */
+const RUNTIME_UNAVAILABLE_MESSAGE = "Local voice transcription is not available on this platform.";
+
 interface VoiceTranscriptionServiceOptions {
   resourcesRoot: string;
   modelPath: string;
@@ -27,12 +35,16 @@ interface VoiceTranscriptionServiceOptions {
 export class VoiceTranscriptionService extends EventEmitter<VoiceTranscriptionEvents> {
   private activeChild: ChildProcess | null = null;
   private busy = false;
-  private readonly resourcesRoot: string;
+  private readonly executable: string;
   private readonly model: VoiceModelService;
 
   constructor(options: VoiceTranscriptionServiceOptions) {
     super();
-    this.resourcesRoot = options.resourcesRoot;
+    this.executable = join(
+      options.resourcesRoot,
+      "bin",
+      process.platform === "win32" ? "whisper-cli.exe" : "whisper-cli",
+    );
     this.model = new VoiceModelService({
       modelPath: options.modelPath,
       downloadUrl: options.modelDownloadUrl,
@@ -42,24 +54,22 @@ export class VoiceTranscriptionService extends EventEmitter<VoiceTranscriptionEv
   }
 
   getModelStatus(): Promise<VoiceModelStatus> {
-    return this.model.getStatus();
+    return this.runtimeMissing() ?? this.model.getStatus();
   }
 
   prepareModel(): Promise<VoiceModelStatus> {
-    return this.model.prepare();
+    return this.runtimeMissing() ?? this.model.prepare();
   }
 
   async transcribe(audio: Uint8Array): Promise<VoiceTranscriptionResult> {
     if (this.busy) throw new Error("A voice transcription is already in progress.");
     this.busy = true;
     let temporaryRoot: string | undefined;
-    const executable = join(
-      this.resourcesRoot,
-      "bin",
-      process.platform === "win32" ? "whisper-cli.exe" : "whisper-cli",
-    );
-    const modelStatus = await this.model.prepare();
-    if (modelStatus.phase !== "ready") throw new Error(modelStatus.message ?? "The voice model is unavailable.");
+    const modelStatus = await this.prepareModel();
+    if (modelStatus.phase !== "ready") {
+      this.busy = false;
+      throw new Error(modelStatus.message ?? "The voice model is unavailable.");
+    }
     const model = this.model.modelPath;
     const startedAt = Date.now();
 
@@ -68,7 +78,7 @@ export class VoiceTranscriptionService extends EventEmitter<VoiceTranscriptionEv
       const inputPath = join(temporaryRoot, "recording.wav");
       const outputPath = join(temporaryRoot, "transcript");
       await writeFile(inputPath, audio);
-      await this.run(executable, [
+      await this.run(this.executable, [
         "--model",
         model,
         "--file",
@@ -101,6 +111,17 @@ export class VoiceTranscriptionService extends EventEmitter<VoiceTranscriptionEv
     this.model.shutdown();
     this.activeChild?.kill();
     this.activeChild = null;
+  }
+
+  /**
+   * The error status for a build with no whisper binary, or `null` when one is present. Returned as
+   * a resolved promise so the callers stay one-liners over the model service they otherwise wrap.
+   */
+  private runtimeMissing(): Promise<VoiceModelStatus> | null {
+    if (existsSync(this.executable)) return null;
+    const status: VoiceModelStatus = { phase: "error", progress: null, message: RUNTIME_UNAVAILABLE_MESSAGE };
+    this.emit("modelStatus", status);
+    return Promise.resolve(status);
   }
 
   private run(executable: string, arguments_: string[]): Promise<void> {

--- a/src/renderer/src/App.voice.test.tsx
+++ b/src/renderer/src/App.voice.test.tsx
@@ -427,4 +427,22 @@ describe("OpenBot connected desktop shell", () => {
     expect(screen.getByRole("textbox", { name: "Message Chief" })).toHaveTextContent("Personal draft");
     expect(window.openbot.agent.updateQueuedMessage).not.toHaveBeenCalled();
   });
+
+  // The Linux package carries no whisper binary, so the composer must not offer a control that
+  // always fails. Everything else about the window, the server rail included, stays the same.
+  it("offers no microphone on Linux and still draws the server rail", async () => {
+    vi.mocked(window.openbot.getAppInfo).mockResolvedValue({
+      name: "OpenBot",
+      version: "0.1.0",
+      platform: "linux",
+      variant: "production",
+    });
+    render(() => <App />);
+
+    await screen.findByRole("heading", { name: "Chief" });
+
+    expect(await screen.findByRole("complementary", { name: "Servers" })).toBeInTheDocument();
+    expect(await screen.findByRole("textbox", { name: "Message Chief" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create prompt with voice" })).not.toBeInTheDocument();
+  });
 });

--- a/src/renderer/src/features/conversation/ConversationComposer.tsx
+++ b/src/renderer/src/features/conversation/ConversationComposer.tsx
@@ -17,13 +17,14 @@ import {
   Plus,
   Puzzle,
 } from "../../components/ui";
+import { usePlatform } from "../../platform";
 import { fileBadge, formatFileSize } from "./AttachmentCards";
 import { attachmentReferenceTone } from "./AttachmentReference";
 import { ComposerEditor } from "./ComposerEditor";
 import { CloseIcon, MoreIcon, StopIcon } from "./ConversationIcons";
 import { useConversationViewScope } from "./conversation-scope";
 import { RichMessageText } from "./RichMessageText";
-import { formatVoiceDuration, voiceButtonLabel } from "./voice-status";
+import { formatVoiceDuration, voiceButtonLabel, voiceSupported } from "./voice-status";
 
 /** @internal Stable HMR boundary for conversation composer. */
 export function ConversationComposer() {
@@ -66,6 +67,8 @@ export function ConversationComposer() {
     voicePhase,
     voiceModelProgress,
   } = useConversationViewScope();
+  const platform = usePlatform();
+  const voiceAvailable = () => voiceSupported(platform.appInfo()?.platform);
   const attachmentAccept = () => {
     const server = props.server;
     const local = server?.kind !== "remote";
@@ -278,53 +281,57 @@ export function ConversationComposer() {
               </DropdownMenu.Portal>
             </DropdownMenu.Root>
             <div class="composer-primary-actions">
-              <Show when={voicePhase() === "preparing"}>
-                <span class="voice-model-progress" role="status">
-                  Downloading voice model {voiceModelProgress() ?? 0}%
-                </span>
-              </Show>
-              <Show
-                when={voicePhase() === "recording"}
-                fallback={
-                  <Button
-                    variant="ghost"
-                    type="button"
-                    class="dictation-button"
-                    aria-label={voiceButtonLabel(voicePhase())}
-                    disabled={
-                      voicePhase() === "requesting" ||
-                      voicePhase() === "preparing" ||
-                      voicePhase() === "transcribing" ||
-                      (voicePhase() === "idle" && (!props.agent || !agentReady()))
-                    }
-                    onClick={() => void startVoiceRecording()}
-                  >
-                    <Show
-                      when={
-                        voicePhase() === "preparing" || voicePhase() === "requesting" || voicePhase() === "transcribing"
+              <Show when={voiceAvailable()}>
+                <Show when={voicePhase() === "preparing"}>
+                  <span class="voice-model-progress" role="status">
+                    Downloading voice model {voiceModelProgress() ?? 0}%
+                  </span>
+                </Show>
+                <Show
+                  when={voicePhase() === "recording"}
+                  fallback={
+                    <Button
+                      variant="ghost"
+                      type="button"
+                      class="dictation-button"
+                      aria-label={voiceButtonLabel(voicePhase())}
+                      disabled={
+                        voicePhase() === "requesting" ||
+                        voicePhase() === "preparing" ||
+                        voicePhase() === "transcribing" ||
+                        (voicePhase() === "idle" && (!props.agent || !agentReady()))
                       }
-                      fallback={<Mic aria-hidden="true" />}
+                      onClick={() => void startVoiceRecording()}
                     >
-                      <LoaderCircle class="composer-spinner" aria-hidden="true" />
-                    </Show>
-                  </Button>
-                }
-              >
-                <fieldset class="voice-recording-status" aria-label="Voice recording">
-                  <Button
-                    variant="ghost"
-                    type="button"
-                    class="voice-recording-stop"
-                    aria-label="Stop voice recording"
-                    onClick={stopVoiceRecording}
-                  >
-                    <StopIcon />
-                  </Button>
-                  <time class="voice-recording-duration" datetime={`PT${voiceElapsedSeconds()}S`}>
-                    {formatVoiceDuration(voiceElapsedSeconds())}
-                  </time>
-                  <MoreIcon />
-                </fieldset>
+                      <Show
+                        when={
+                          voicePhase() === "preparing" ||
+                          voicePhase() === "requesting" ||
+                          voicePhase() === "transcribing"
+                        }
+                        fallback={<Mic aria-hidden="true" />}
+                      >
+                        <LoaderCircle class="composer-spinner" aria-hidden="true" />
+                      </Show>
+                    </Button>
+                  }
+                >
+                  <fieldset class="voice-recording-status" aria-label="Voice recording">
+                    <Button
+                      variant="ghost"
+                      type="button"
+                      class="voice-recording-stop"
+                      aria-label="Stop voice recording"
+                      onClick={stopVoiceRecording}
+                    >
+                      <StopIcon />
+                    </Button>
+                    <time class="voice-recording-duration" datetime={`PT${voiceElapsedSeconds()}S`}>
+                      {formatVoiceDuration(voiceElapsedSeconds())}
+                    </time>
+                    <MoreIcon />
+                  </fieldset>
+                </Show>
               </Show>
               <Show
                 when={

--- a/src/renderer/src/features/conversation/voice-status.ts
+++ b/src/renderer/src/features/conversation/voice-status.ts
@@ -1,3 +1,4 @@
+import type { AppInfo } from "@openbot/contracts/ipc";
 import { errorMessage } from "../../error-message";
 export type VoicePhase = "idle" | "preparing" | "requesting" | "recording" | "transcribing";
 
@@ -7,6 +8,15 @@ export function voiceButtonLabel(phase: VoicePhase) {
   if (phase === "requesting") return "Requesting microphone access";
   if (phase === "transcribing") return "Transcribing voice prompt";
   return "Create prompt with voice";
+}
+
+/**
+ * Whether this build can transcribe at all. The whisper binary is prepared for macOS and Windows
+ * only, so the Linux package ships without one and the composer offers no microphone rather than a
+ * control that always fails.
+ */
+export function voiceSupported(platform: AppInfo["platform"] | undefined): boolean {
+  return platform !== "linux";
 }
 
 export function formatVoiceDuration(totalSeconds: number): string {

--- a/src/renderer/src/features/servers/WorkspaceServerRail.tsx
+++ b/src/renderer/src/features/servers/WorkspaceServerRail.tsx
@@ -9,10 +9,9 @@ import { useServerSettings } from "./server-settings";
 import { useServers } from "./servers-context";
 
 /**
- * The rail of team servers down the left edge, and the platform test for
- * whether there is one at all. The test lives here rather than in the shell
- * because the rail is the thing it decides about; the shell only needs to know
- * that the frame has to leave room, which it asks `serverRailVisible` itself.
+ * The rail of team servers down the left edge. It is drawn once main has
+ * reported the build, which `serverRailVisible` answers; the shell asks the
+ * same question to decide whether the frame has to leave room for it.
  */
 export function WorkspaceServerRail() {
   const platform = usePlatform();

--- a/src/renderer/src/layout.tsx
+++ b/src/renderer/src/layout.tsx
@@ -17,18 +17,21 @@ import { createSimpleContext } from "./simple-context";
 
 /**
  * Whether the conversation still has room beside a sidebar of this width. The
- * server rail only exists on macOS and Windows, and narrows on a small Windows
- * window, so the platform is part of the arithmetic rather than a style detail.
+ * server rail is part of the arithmetic rather than a style detail, and its
+ * width depends on the platform: macOS reserves space for the traffic lights,
+ * while the two platforms that draw a standard OS frame narrow the rail on a
+ * small window. A width of `0` means the rail is not drawn yet, which is only
+ * true before main reports the platform.
  */
 function shouldAutoCompactSidebar(platform: AppInfo["platform"] | undefined, panelWidth: number): boolean {
   const serverRailWidth =
-    platform === "darwin"
-      ? MAC_SERVER_RAIL_WIDTH
-      : platform === "win32"
-        ? window.innerWidth <= 800
+    platform === undefined
+      ? 0
+      : platform === "darwin"
+        ? MAC_SERVER_RAIL_WIDTH
+        : window.innerWidth <= 800
           ? NARROW_SERVER_RAIL_WIDTH
-          : SERVER_RAIL_WIDTH
-        : 0;
+          : SERVER_RAIL_WIDTH;
   return window.innerWidth - serverRailWidth - panelWidth < CONVERSATION_MIN_WIDTH;
 }
 

--- a/src/renderer/src/platform.tsx
+++ b/src/renderer/src/platform.tsx
@@ -59,13 +59,13 @@ const Platform = createSimpleContext({
       appInfo,
       appFocused,
       /**
-       * Whether the window draws the vertical server rail. Only the two
-       * platforms whose own chrome leaves room for it do. Three components need
-       * the answer once the view is split along context boundaries - the frame
-       * class, the rail itself and the account dock - so it is derived here
-       * rather than spelled out as a two-branch comparison in each of them.
+       * Whether the window draws the vertical server rail. Every desktop
+       * platform does; the memo exists because three components need the answer
+       * once the view is split along context boundaries - the frame class, the
+       * rail itself and the account dock - and because `appInfo` is null until
+       * main answers, which is the state that actually has to be handled.
        */
-      serverRailVisible: createMemo(() => appInfo()?.platform === "darwin" || appInfo()?.platform === "win32"),
+      serverRailVisible: createMemo(() => appInfo() !== null),
       appInfoLoadedFromHost: () => infoFromHost,
       landingPreview: props.landingPreview === true,
       peopleEnabled: props.peopleEnabled === true,


### PR DESCRIPTION
## What

OpenBot shipped macOS ARM64 and Windows x64 only. This adds Linux x64 as an AppImage — the one Linux format `electron-updater` can update in place — with the release job, the website download, and the documentation.

Scope decided before implementation: AppImage x64 only, providers downloaded in-app as on macOS, voice disabled, remote desktop still unavailable, AppImage unsigned as the Windows installer is.

## Changes

**Provider runtimes.** `native-runtime.lock.json` pins a real `linux-x64` artifact for codex, claude, opencode, and grok at the versions already shipped. The lock schema names the key, because `z.object` strips one it does not name. The three installers and the runtime manager resolve `linux/x64` and set the executable bit.

**Main process.**
- `loginShellCommand` prefers `$SHELL` on Linux and falls back to `/bin/sh`. Discovery ran `/bin/zsh -lic` on every non-Windows platform, so a CLI on `$PATH` was missed on any machine without zsh. `/usr/bin` joins the fallback paths.
- `openbot://` is registered on Linux as well as macOS.
- `supportsInstalledUpdates` takes the environment: Linux updates in place only when `APPIMAGE` is set, because only an AppImage can replace itself. `shipItDirectory` is now macOS-only.
- `VoiceTranscriptionService` reports `phase: "error"` when the build carries no whisper binary, instead of failing at transcribe time. This also fixes a pre-existing `busy` leak on the not-ready path.

**Packaging.** The whisper and remote-desktop `extraResources` moved out of the shared list into `mac` and `win`, because neither is built for Linux and electron-builder fails on a missing `from`. `desktopName` plus `syncDesktopName` make the desktop entry's `StartupWMClass` match the app id Electron derives, so a window groups with its launcher icon.

**Sandbox.** Ubuntu 23.10+ and Debian 13 restrict unprivileged user namespaces, which breaks the Electron SUID sandbox in an AppImage. The build ships `build/linux/openbot.apparmor` and documents installing it. `--no-sandbox` is not offered anywhere, in the product or the documentation.

**Renderer.** The server rail draws on Linux, the sidebar arithmetic uses the matching rail width, and the composer offers no microphone.

**Website.** Linux is `Available` with a `/download/linux` route resolving through `latest-linux.yml`.

## Verified locally

| Check | Result |
| --- | --- |
| `bun run lint`, `bun run typecheck`, `bun run check:ui` | pass; 109 warnings, none in a changed file |
| Installer, lock, runtime-manager, updater, CLI, renderer, auth-api tests | pass |
| `electron-builder --linux --x64` (cross-built on macOS) | `dist/linux-unpacked`, 414 MB, no whisper or remote-desktop resource |
| `scripts/verify-linux-package.ts` static checks | pass: ELF x86-64, eight fuses, asar manifest, providers absent |
| `electron-builder --linux AppImage --x64` | `OpenBot-0.8.0-x86_64.AppImage`, 137 MB, `latest-linux.yml` written |
| `bun run verify:update-artifacts linux` | pass |
| `bun run package:verify` (macOS) | pass — the `extraResources` split did not regress the macOS package |

Two defects the build itself found, both fixed here: the asar header reader used the wrong word offsets, and the block-map check assumed a sidecar file, which an AppImage does not have because it embeds its block map.

## Not verified here

The AppImage cannot be launched on a macOS worktree. These need a Linux host or a tagged CI run: the sandboxed start under Ubuntu 24.04 with the AppArmor profile, `xdg-open 'openbot://join?...'`, an in-app provider download, and the packaged launch check under `xvfb-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)