### PR TITLE
Assign marketplace skills per agent and insert them in chat with $

### DIFF
--- a/packages/contracts/src/input-limits.ts
+++ b/packages/contracts/src/input-limits.ts
@@ -19,6 +19,7 @@ export const INPUT_LIMITS = {
   agentTitle: 120,
   agentDescription: 2_000,
   agentMemories: 64,
+  agentSkills: 32,
   // Half the agent cap. A channel packet is rebuilt every turn and the memories block is paid in
   // full each time, against `ChannelHistory.prepare`'s hard character budget.
   channelMemories: 32,

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -47,6 +47,7 @@ export const IPC_CHANNELS = {
   skillsListInstalled: "skills:list-installed",
   skillsInstall: "skills:install",
   skillsUninstall: "skills:uninstall",
+  skillsSetEnabled: "skills:set-enabled",
   customProvidersList: "custom-providers:list",
   customProvidersSave: "custom-providers:save",
   customProvidersDelete: "custom-providers:delete",

--- a/packages/contracts/src/ipc-desktop-apis.ts
+++ b/packages/contracts/src/ipc-desktop-apis.ts
@@ -143,6 +143,7 @@ import type {
   MarketplaceSkillDetail,
   MarketplaceSkillPage,
   MarketplaceSkillQuery,
+  SetEnabledSkillInput,
   SkillPackagePreview,
   SkillSubmission,
   SubmitSkillInput,
@@ -411,6 +412,7 @@ export interface SkillsDesktopApi {
   listInstalled: (agentId: string) => Promise<InstalledSkill[]>;
   install: (input: InstallSkillInput) => Promise<InstalledSkill>;
   uninstall: (input: UninstallSkillInput) => Promise<void>;
+  setEnabled: (input: SetEnabledSkillInput) => Promise<InstalledSkill>;
 }
 
 export interface HostedSitesDesktopApi {

--- a/packages/contracts/src/ipc-endpoints.ts
+++ b/packages/contracts/src/ipc-endpoints.ts
@@ -100,6 +100,7 @@ export const IPC_ENDPOINTS = {
     listInstalled: request(IPC_CHANNELS.skillsListInstalled),
     install: request(IPC_CHANNELS.skillsInstall),
     uninstall: request(IPC_CHANNELS.skillsUninstall),
+    setEnabled: request(IPC_CHANNELS.skillsSetEnabled),
   },
   // No event channel: the renderer is the only writer, and the models a saved endpoint adds arrive
   // through the ready `status` event the provider restart already emits.

--- a/packages/contracts/src/ipc-skills.ts
+++ b/packages/contracts/src/ipc-skills.ts
@@ -81,6 +81,8 @@ export interface SubmitSkillInput {
   skillId?: string;
 }
 
+export type InstalledSkillOrigin = "marketplace" | "managed";
+
 export interface InstalledSkill {
   skillId: string;
   slug: string;
@@ -88,6 +90,12 @@ export interface InstalledSkill {
   installedVersion: number;
   availableVersion: number;
   state: InstalledSkillState;
+  /** Missing on older hosts and Team GET payloads; treat as true. */
+  enabled?: boolean;
+  /** Missing on older hosts and Team GET payloads; treat as marketplace. */
+  origin?: InstalledSkillOrigin;
+  /** Missing on older hosts, Team GET payloads, and pre-description lock files. */
+  description?: string;
 }
 
 export interface InstallSkillInput {
@@ -100,6 +108,12 @@ export interface UninstallSkillInput {
   agentId: string;
   skillId: string;
   removeModified?: boolean;
+}
+
+export interface SetEnabledSkillInput {
+  agentId: string;
+  skillId: string;
+  enabled: boolean;
 }
 
 export function isSkillCategory(value: unknown): value is SkillCategory {

--- a/src/main/ipc/app-inputs.ts
+++ b/src/main/ipc/app-inputs.ts
@@ -15,6 +15,7 @@ import type {
   SaveSetupInput,
   SetAnalyticsPreferenceInput,
   SetAppLanguagePreferenceInput,
+  SetEnabledSkillInput,
   SubmitMarketplaceAgentInput,
   SubmitSkillInput,
   UninstallSkillInput,
@@ -184,6 +185,17 @@ export function parseUninstallSkill(input: unknown): UninstallSkillInput {
     agentId: requireString(input.agentId, "agentId"),
     skillId: requireString(input.skillId, "skillId"),
     ...(input.removeModified === true ? { removeModified: true } : {}),
+  };
+}
+
+export function parseSetEnabledSkill(input: unknown): SetEnabledSkillInput {
+  if (!isObject(input)) throw new Error("Invalid skill enablement.");
+  const enabled = optionalBoolean(input.enabled, "enabled");
+  if (enabled === undefined) throw new Error("Invalid skill enablement.");
+  return {
+    agentId: requireString(input.agentId, "agentId"),
+    skillId: requireString(input.skillId, "skillId"),
+    enabled,
   };
 }
 

--- a/src/main/ipc/skill-handlers.ts
+++ b/src/main/ipc/skill-handlers.ts
@@ -2,7 +2,13 @@
 
 import { type BrowserWindow, dialog, type OpenDialogOptions } from "electron";
 import type { SkillMarketplaceService } from "../skill-marketplace-service";
-import { parseInstallSkill, parseMarketplaceSkillQuery, parseSubmitSkill, parseUninstallSkill } from "./app-inputs";
+import {
+  parseInstallSkill,
+  parseMarketplaceSkillQuery,
+  parseSetEnabledSkill,
+  parseSubmitSkill,
+  parseUninstallSkill,
+} from "./app-inputs";
 import { handler, type IpcGroupHandlers, payloadHandler } from "./define-ipc-group";
 import { nullishPayload, stringPayload } from "./validation";
 
@@ -33,6 +39,7 @@ export function skillIpcHandlers({ skills, getMainWindow }: SkillIpcDependencies
       listInstalled: payloadHandler(stringPayload("agentId"), (agentId) => skills.listInstalled(agentId)),
       install: payloadHandler(parseInstallSkill, (installation) => skills.install(installation)),
       uninstall: payloadHandler(parseUninstallSkill, (removal) => skills.uninstall(removal)),
+      setEnabled: payloadHandler(parseSetEnabledSkill, (change) => skills.setEnabled(change)),
     },
   };
 }

--- a/src/main/remote-agent-decoding.ts
+++ b/src/main/remote-agent-decoding.ts
@@ -146,6 +146,7 @@ export function decodeInstalledSkillsFromHost(value: unknown): InstalledSkill[] 
     if (!isOneOf(["installed", "update-available", "modified", "needs-repair"] as const, state)) {
       throw new Error("Invalid installed skill state.");
     }
+    const description = optionalSkillDescription(skill.description);
     return {
       skillId: requiredString(skill, "skillId"),
       slug: requiredString(skill, "slug"),
@@ -153,8 +154,17 @@ export function decodeInstalledSkillsFromHost(value: unknown): InstalledSkill[] 
       installedVersion: requiredNumber(skill, "installedVersion"),
       availableVersion: requiredNumber(skill, "availableVersion"),
       state,
+      ...(skill.enabled === false ? { enabled: false } : skill.enabled === true ? { enabled: true } : {}),
+      ...(skill.origin === "managed" || skill.origin === "marketplace" ? { origin: skill.origin } : {}),
+      ...(description ? { description } : {}),
     };
   });
+}
+
+function optionalSkillDescription(value: unknown): string | undefined {
+  if (!isString(value)) return undefined;
+  const description = value.trim();
+  return description && description.length <= 500 ? description : undefined;
 }
 
 export function decodeAgentMemory(value: unknown): AgentMemory {

--- a/src/main/skill-marketplace-service.test.ts
+++ b/src/main/skill-marketplace-service.test.ts
@@ -100,6 +100,7 @@ describe("SkillMarketplaceService", () => {
 
     await expect(service.install({ agentId: agent.id, skillId: "skill-1" })).resolves.toMatchObject({
       state: "installed",
+      description: "Writes release notes.",
     });
     await expect(
       readFile(join(agent.workspacePath, ".agents", "skills", "release-notes", "SKILL.md"), "utf8"),
@@ -113,7 +114,7 @@ describe("SkillMarketplaceService", () => {
     await writeFile(join(agent.workspacePath, ".agents", "skills", "release-notes", "SKILL.md"), "locally changed");
     requests.length = 0;
     await expect(service.listInstalledForChatTags(agent.id)).resolves.toEqual([
-      expect.objectContaining({ state: "modified" }),
+      expect.objectContaining({ state: "modified", description: "Writes release notes." }),
     ]);
     expect(requests).toEqual([]);
     await expect(service.listInstalled(agent.id)).resolves.toEqual([expect.objectContaining({ state: "modified" })]);

--- a/src/main/skill-marketplace-service.ts
+++ b/src/main/skill-marketplace-service.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { lstat, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
 import type {
   AgentSummary,
   InstalledSkill,
@@ -10,6 +11,7 @@ import type {
   MarketplaceSkillPage,
   MarketplaceSkillQuery,
   MarketplaceSkillSummary,
+  SetEnabledSkillInput,
   SkillPackagePreview,
   SkillSubmission,
   SubmitSkillInput,
@@ -39,6 +41,8 @@ interface LockEntry {
   bundleSha256: string;
   receiptId: string;
   files: Record<string, string>;
+  enabled?: boolean;
+  description?: string;
 }
 interface SkillsLock {
   version: 1;
@@ -140,14 +144,9 @@ export class SkillMarketplaceService {
         /* Keep local state usable offline. */
       }
       const state = await installedState(agent.workspacePath, entry);
-      installed.push({
-        skillId: entry.skillId,
-        slug: entry.slug,
-        name: entry.name,
-        installedVersion: entry.version,
-        availableVersion,
-        state: state === "installed" && availableVersion > entry.version ? "update-available" : state,
-      });
+      installed.push(
+        toInstalledSkill(entry, availableVersion, state, await installedSkillDescription(agent.workspacePath, entry)),
+      );
     }
     return installed.sort((a, b) => a.name.localeCompare(b.name));
   }
@@ -157,14 +156,15 @@ export class SkillMarketplaceService {
     const lock = await readLock(agent.workspacePath);
     const installed: InstalledSkill[] = [];
     for (const entry of Object.values(lock.skills)) {
-      installed.push({
-        skillId: entry.skillId,
-        slug: entry.slug,
-        name: entry.name,
-        installedVersion: entry.version,
-        availableVersion: entry.version,
-        state: await installedState(agent.workspacePath, entry),
-      });
+      if (entry.enabled === false) continue;
+      installed.push(
+        toInstalledSkill(
+          entry,
+          entry.version,
+          await installedState(agent.workspacePath, entry),
+          await installedSkillDescription(agent.workspacePath, entry),
+        ),
+      );
     }
     return installed.sort((a, b) => a.name.localeCompare(b.name));
   }
@@ -234,6 +234,9 @@ export class SkillMarketplaceService {
     const files = normalizedFiles(bundle);
     const lock = await readLock(agent.workspacePath);
     const existing = lock.skills[detail.id];
+    if (!existing && Object.keys(lock.skills).length >= INPUT_LIMITS.agentSkills) {
+      throw new Error(`An agent can have up to ${INPUT_LIMITS.agentSkills} skills.`);
+    }
     if (existing) {
       const state = await installedState(agent.workspacePath, existing);
       if (state === "modified" && !replaceModified)
@@ -246,7 +249,9 @@ export class SkillMarketplaceService {
       if (!owner && (await pathExists(target))) throw new Error(`An unmanaged skill already exists at ${target}.`);
     }
     const receiptId = existing?.receiptId ?? randomUUID();
-    await replaceTargets(agent.workspacePath, detail.slug, files);
+    const stayDisabled = existing?.enabled === false;
+    if (stayDisabled) await writeFiles(disabledDirectory(agent.workspacePath, detail.slug), files);
+    else await replaceTargets(agent.workspacePath, detail.slug, files);
     const entry: LockEntry = {
       skillId: detail.id,
       versionId: detail.versionId,
@@ -256,6 +261,8 @@ export class SkillMarketplaceService {
       bundleSha256: detail.bundleSha256,
       receiptId,
       files: Object.fromEntries(Object.entries(files).map(([name, bytes]) => [name, sha256(bytes)])),
+      description: detail.description,
+      ...(stayDisabled ? { enabled: false } : {}),
     };
     lock.skills[detail.id] = entry;
     await writeLock(agent.workspacePath, lock);
@@ -265,14 +272,7 @@ export class SkillMarketplaceService {
       decodeInstalledReceipt,
     );
     await this.refreshAgentRuntime(agent.id);
-    return {
-      skillId: detail.id,
-      slug: detail.slug,
-      name: detail.name,
-      installedVersion: detail.version,
-      availableVersion: detail.version,
-      state: "installed",
-    };
+    return toInstalledSkill(entry, detail.version, "installed", entry.description);
   }
 
   async uninstall(input: UninstallSkillInput): Promise<void> {
@@ -283,11 +283,61 @@ export class SkillMarketplaceService {
     if ((await installedState(agent.workspacePath, entry)) === "modified" && !input.removeModified) {
       throw new Error("This skill has local changes. Confirm removal to delete them.");
     }
-    for (const target of targetDirectories(agent.workspacePath, entry.slug))
+    for (const target of [
+      ...targetDirectories(agent.workspacePath, entry.slug),
+      disabledDirectory(agent.workspacePath, entry.slug),
+    ]) {
       await rm(target, { recursive: true, force: true });
+    }
     delete lock.skills[input.skillId];
     await writeLock(agent.workspacePath, lock);
     await this.refreshAgentRuntime(input.agentId);
+  }
+
+  async setEnabled(input: SetEnabledSkillInput): Promise<InstalledSkill> {
+    const agent = this.requireAgent(input.agentId);
+    const lock = await readLock(agent.workspacePath);
+    const entry = lock.skills[input.skillId];
+    if (!entry) throw new Error("Skill not found.");
+    const currentlyEnabled = entry.enabled !== false;
+    if (currentlyEnabled === input.enabled) {
+      return toInstalledSkill(
+        entry,
+        entry.version,
+        await installedState(agent.workspacePath, entry),
+        await installedSkillDescription(agent.workspacePath, entry),
+      );
+    }
+    if (input.enabled) {
+      const stash = disabledDirectory(agent.workspacePath, entry.slug);
+      if (!(await pathExists(stash))) throw new Error("This skill needs repair before it can be enabled.");
+      const files = await readSkillFiles(stash);
+      await replaceTargets(agent.workspacePath, entry.slug, files);
+      await rm(stash, { recursive: true, force: true });
+      delete entry.enabled;
+    } else {
+      const live = targetDirectories(agent.workspacePath, entry.slug);
+      const source = (await pathExists(live[0])) ? live[0] : (await pathExists(live[1])) ? live[1] : null;
+      const stash = disabledDirectory(agent.workspacePath, entry.slug);
+      if (source) {
+        await mkdir(dirname(stash), { recursive: true, mode: 0o700 });
+        if (await pathExists(stash)) await rm(stash, { recursive: true, force: true });
+        await rename(source, stash);
+      } else if (!(await pathExists(stash))) {
+        throw new Error("This skill needs repair before it can be disabled.");
+      }
+      for (const target of live) await rm(target, { recursive: true, force: true });
+      entry.enabled = false;
+    }
+    lock.skills[input.skillId] = entry;
+    await writeLock(agent.workspacePath, lock);
+    await this.refreshAgentRuntime(input.agentId);
+    return toInstalledSkill(
+      entry,
+      entry.version,
+      await installedState(agent.workspacePath, entry),
+      await installedSkillDescription(agent.workspacePath, entry),
+    );
   }
 
   private requireAgent(agentId: string): AgentSummary {
@@ -404,6 +454,77 @@ function targetDirectories(workspace: string, slug: string): string[] {
   return [join(workspace, ".agents", "skills", slug), join(workspace, ".claude", "skills", slug)];
 }
 
+function disabledDirectory(workspace: string, slug: string): string {
+  return join(workspace, ".openbot", "skills-disabled", slug);
+}
+
+function toInstalledSkill(
+  entry: LockEntry,
+  availableVersion: number,
+  state: "installed" | "modified" | "needs-repair" | "update-available",
+  description?: string,
+): InstalledSkill {
+  const resolved = state === "installed" && availableVersion > entry.version ? "update-available" : state;
+  const resolvedDescription = trimmedSkillDescription(description ?? entry.description);
+  return {
+    skillId: entry.skillId,
+    slug: entry.slug,
+    name: entry.name,
+    installedVersion: entry.version,
+    availableVersion,
+    state: resolved,
+    enabled: entry.enabled !== false,
+    origin: "marketplace",
+    ...(resolvedDescription ? { description: resolvedDescription } : {}),
+  };
+}
+
+async function installedSkillDescription(workspace: string, entry: LockEntry): Promise<string | undefined> {
+  const stored = trimmedSkillDescription(entry.description);
+  if (stored) return stored;
+  const roots =
+    entry.enabled === false ? [disabledDirectory(workspace, entry.slug)] : targetDirectories(workspace, entry.slug);
+  for (const root of roots) {
+    try {
+      const parsed = parseSkillMarkdownDescription(await readFile(join(root, "SKILL.md"), "utf8"));
+      if (parsed) return parsed;
+    } catch {
+      /* Keep the lock name usable when SKILL.md is missing or malformed. */
+    }
+  }
+}
+
+function trimmedSkillDescription(value: unknown): string | undefined {
+  if (!isString(value)) return undefined;
+  const description = value.trim();
+  return description && description.length <= 500 ? description : undefined;
+}
+
+function parseSkillMarkdownDescription(text: string): string | undefined {
+  const match = text.match(/^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u);
+  if (!match) return undefined;
+  const metadata = parseYaml(match[1] ?? "");
+  if (!isDynamicRecord(metadata)) return undefined;
+  return trimmedSkillDescription(metadata.description);
+}
+
+async function readSkillFiles(root: string): Promise<Record<string, Uint8Array>> {
+  const files: Record<string, Uint8Array> = {};
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      if (entry.name === ".git" || entry.name === "node_modules" || entry.name === ".DS_Store") continue;
+      const path = join(directory, entry.name);
+      if (entry.isSymbolicLink()) throw new Error("Skill packages cannot contain symbolic links.");
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile()) {
+        files[relative(root, path).replaceAll("\\", "/")] = new Uint8Array(await readFile(path));
+      }
+    }
+  }
+  await visit(root);
+  return files;
+}
+
 async function replaceTargets(workspace: string, slug: string, files: Record<string, Uint8Array>): Promise<void> {
   const completed: Array<{ target: string; backup: string | null }> = [];
   try {
@@ -444,8 +565,10 @@ async function writeFiles(root: string, files: Record<string, Uint8Array>): Prom
 }
 
 async function installedState(workspace: string, entry: LockEntry): Promise<"installed" | "modified" | "needs-repair"> {
+  const roots =
+    entry.enabled === false ? [disabledDirectory(workspace, entry.slug)] : targetDirectories(workspace, entry.slug);
   let complete = 0;
-  for (const target of targetDirectories(workspace, entry.slug)) {
+  for (const target of roots) {
     if (!(await pathExists(target))) continue;
     complete += 1;
     for (const [name, hash] of Object.entries(entry.files)) {
@@ -456,7 +579,8 @@ async function installedState(workspace: string, entry: LockEntry): Promise<"ins
       }
     }
   }
-  return complete === 2 ? "installed" : "needs-repair";
+  const expected = entry.enabled === false ? 1 : 2;
+  return complete === expected ? "installed" : "needs-repair";
 }
 
 function lockPath(workspace: string): string {
@@ -574,7 +698,9 @@ function isLockEntry(value: unknown): value is LockEntry {
     isString(value.bundleSha256) &&
     isString(value.receiptId) &&
     isDynamicRecord(value.files) &&
-    Object.values(value.files).every(isString)
+    Object.values(value.files).every(isString) &&
+    (value.enabled === undefined || isBoolean(value.enabled)) &&
+    (value.description === undefined || isString(value.description))
   );
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -565,6 +565,7 @@ function decodeInstalledSkill(value: unknown): InstalledSkill {
   if (!isOneOf(["installed", "update-available", "modified", "needs-repair"], state)) {
     throw new Error("Invalid installed skill state.");
   }
+  const description = optionalSkillDescription(item.description);
   return {
     skillId: requiredString(item, "skillId"),
     slug: requiredString(item, "slug"),
@@ -572,7 +573,16 @@ function decodeInstalledSkill(value: unknown): InstalledSkill {
     installedVersion: requiredNumber(item, "installedVersion"),
     availableVersion: requiredNumber(item, "availableVersion"),
     state,
+    ...(item.enabled === false ? { enabled: false } : item.enabled === true ? { enabled: true } : {}),
+    ...(item.origin === "managed" || item.origin === "marketplace" ? { origin: item.origin } : {}),
+    ...(description ? { description } : {}),
   };
+}
+
+function optionalSkillDescription(value: unknown): string | undefined {
+  if (!isString(value)) return undefined;
+  const description = value.trim();
+  return description && description.length <= 500 ? description : undefined;
 }
 
 function decodeInstalledSkillsFromMain(value: unknown): InstalledSkill[] {
@@ -867,6 +877,7 @@ const openbotApi: OpenBotDesktopApi = {
       ipcRenderer.invoke(IPC_CHANNELS.skillsListInstalled, agentId).then(decodeInstalledSkillsFromMain),
     install: (input) => ipcRenderer.invoke(IPC_CHANNELS.skillsInstall, input).then(decodeInstalledSkill),
     uninstall: (input) => ipcRenderer.invoke(IPC_CHANNELS.skillsUninstall, input).then(decodeVoid),
+    setEnabled: (input) => ipcRenderer.invoke(IPC_CHANNELS.skillsSetEnabled, input).then(decodeInstalledSkill),
   },
   hostedSites: {
     list: () => ipcRenderer.invoke(IPC_CHANNELS.hostedSitesList).then(decodeHostedSites),

--- a/src/renderer/src/analytics.ts
+++ b/src/renderer/src/analytics.ts
@@ -119,7 +119,7 @@ export interface DesktopAnalyticsEvents {
   };
   marketplace_action: {
     entity: "skill" | "agent";
-    action: "view" | "install" | "update" | "uninstall" | "publish";
+    action: "view" | "install" | "update" | "uninstall" | "publish" | "enable" | "disable";
     result: AnalyticsResult;
     failure_code?: string;
   };
@@ -316,7 +316,7 @@ const EVENT_ACTIONS: Partial<Record<AnalyticsEventName, readonly string[]>> = {
   browser_action: ["open", "activate", "reload", "close"],
   remote_desktop_action: ["connect", "disconnect", "select_display"],
   update_action: ["check", "download", "install"],
-  marketplace_action: ["view", "install", "update", "uninstall", "publish"],
+  marketplace_action: ["view", "install", "update", "uninstall", "publish", "enable", "disable"],
   memory_action: ["create", "update", "delete", "clear"],
   provider_action: [
     "connect_started",

--- a/src/renderer/src/features/conversation/AgentSettingsPanel.tsx
+++ b/src/renderer/src/features/conversation/AgentSettingsPanel.tsx
@@ -42,6 +42,7 @@ import { errorMessage } from "../../error-message";
 import { AgentAvatar } from "../agents/AgentAvatar";
 import { AgentMemoriesModal } from "./AgentMemoriesModal";
 import { AgentRoutinesSettings, type RoutineSelectionRequest } from "./AgentRoutinesSettings";
+import { AgentSkillsModal, type AgentSkillsMode, userAssignedSkills } from "./AgentSkillsModal";
 import { agentMemoriesPort } from "./memories-port";
 import { agentRoutinesPort } from "./routines-port";
 
@@ -79,7 +80,12 @@ interface AgentSettingsPanelProps {
   routineSelectionRequest?: RoutineSelectionRequest | null;
   onRoutineSelectionRequestHandled?: (nonce: number) => void;
   onOpenRoutineRun?: (messageId: string) => void;
+  skillsMode?: AgentSkillsMode;
+  skillsMarketplaceOpen?: boolean;
+  onAddFromMarketplace?: (agentId: string) => void;
 }
+
+export type { AgentSkillsMode };
 
 /** The three free-text fields of the panel, each with a flag for edits made since the last save. */
 interface AgentTextFields {
@@ -109,6 +115,7 @@ interface AgentSettingsDraft {
   memories: { count: number; open: boolean };
   notifications: boolean;
   routines: { count: number; open: boolean };
+  skills: { count: number; open: boolean; reopenAfterMarketplace: boolean };
   runtime: AgentRuntimeSettings;
   saveError: string | null;
 }
@@ -129,6 +136,7 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
     memories: { count: 0, open: false },
     notifications: true,
     routines: { count: 0, open: false },
+    skills: { count: 0, open: false, reopenAfterMarketplace: false },
     runtime: { model: "gpt-5.6-luna", provider: props.agent.provider, reasoningEffort: "medium" },
     saveError: null,
   });
@@ -143,6 +151,8 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
 
   const memoriesPort = createMemo(() => agentMemoriesPort(props.agent.id, props.agent.name));
   const routinesPort = createMemo(() => agentRoutinesPort(props.agent.id));
+  const skillsMode = () => props.skillsMode ?? "mutable";
+  let lastSkillsMarketplaceOpen = props.skillsMarketplaceOpen === true;
   const selectedModel = createMemo(() =>
     props.modelOptions.find(
       (option) => option.provider === draft.runtime.provider && option.id === draft.runtime.model,
@@ -218,6 +228,8 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
           state.avatar.pickerOpen = false;
           state.memories.open = false;
           state.routines.open = false;
+          state.skills.open = false;
+          state.skills.reopenAfterMarketplace = false;
         }
       });
       if (agentChanged) {
@@ -237,7 +249,43 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
               state.routines.count = items.length;
             });
           });
+        void loadSkillsCount(agent.id);
       }
+    },
+  );
+
+  async function loadSkillsCount(agentId: string): Promise<void> {
+    if (skillsMode() === "hidden") {
+      setDraft((state) => {
+        state.skills.count = 0;
+      });
+      return;
+    }
+    try {
+      const items =
+        skillsMode() === "readonly"
+          ? await window.openbot.agent.listInstalledSkills(agentId)
+          : await window.openbot.skills.listInstalled(agentId);
+      setDraft((state) => {
+        state.skills.count = userAssignedSkills(items).length;
+      });
+    } catch {
+      setDraft((state) => {
+        state.skills.count = 0;
+      });
+    }
+  }
+
+  createEffect(
+    () => props.skillsMarketplaceOpen === true,
+    (open) => {
+      if (lastSkillsMarketplaceOpen && !open && draft.skills.reopenAfterMarketplace) {
+        setDraft((state) => {
+          state.skills.reopenAfterMarketplace = false;
+          state.skills.open = true;
+        });
+      }
+      lastSkillsMarketplaceOpen = open;
     },
   );
 
@@ -681,6 +729,17 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
                 })
               }
             />
+            <Show when={skillsMode() !== "hidden"}>
+              <SettingsLinkRow
+                label="Skills"
+                value={`${draft.skills.count} assigned`}
+                onClick={() =>
+                  setDraft((state) => {
+                    state.skills.open = true;
+                  })
+                }
+              />
+            </Show>
             <SettingsLinkRow
               label="Routines"
               value={`${draft.routines.count} configured`}
@@ -807,6 +866,35 @@ export default function AgentSettingsPanel(props: AgentSettingsPanelProps) {
           })
         }
       />
+      <Show when={skillsMode() !== "hidden"}>
+        <AgentSkillsModal
+          agentId={props.agent.id}
+          agentName={props.agent.name}
+          open={draft.skills.open}
+          skillsMode={skillsMode()}
+          onAddFromMarketplace={
+            props.onAddFromMarketplace
+              ? (agentId) => {
+                  setDraft((state) => {
+                    state.skills.reopenAfterMarketplace = true;
+                    state.skills.open = false;
+                  });
+                  props.onAddFromMarketplace?.(agentId);
+                }
+              : undefined
+          }
+          onOpenChange={(open) =>
+            setDraft((state) => {
+              state.skills.open = open;
+            })
+          }
+          onCountChange={(count) =>
+            setDraft((state) => {
+              state.skills.count = count;
+            })
+          }
+        />
+      </Show>
     </SettingsPanel>
   );
 }

--- a/src/renderer/src/features/conversation/AgentSkillsModal.tsx
+++ b/src/renderer/src/features/conversation/AgentSkillsModal.tsx
@@ -1,0 +1,575 @@
+import { INPUT_LIMITS } from "@openbot/contracts/input-limits";
+import type { InstalledSkill, MarketplaceSkillDetail } from "@openbot/contracts/ipc";
+import { createEffect, createMemo, createSignal, For, onSettled, Show } from "solid-js";
+import { desktopAnalytics } from "../../analytics";
+import { createScrollFades } from "../../components/createScrollFades";
+import {
+  Button,
+  ChevronRight,
+  Dialog,
+  DropdownMenu,
+  Ellipsis,
+  IconButton,
+  Puzzle,
+  Switch,
+  Trash2,
+  X,
+} from "../../components/ui";
+import { errorMessage } from "../../error-message";
+
+export type AgentSkillsMode = "mutable" | "readonly" | "hidden";
+
+interface AgentSkillsModalProps {
+  agentId: string;
+  agentName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCountChange: (count: number) => void;
+  skillsMode?: AgentSkillsMode;
+  onAddFromMarketplace?: (agentId: string) => void;
+}
+
+type ConfirmKind = "remove" | "replace";
+
+interface ConfirmRequest {
+  kind: ConfirmKind;
+  skill: InstalledSkill;
+}
+
+export function AgentSkillsModal(props: AgentSkillsModalProps) {
+  const [skills, setSkills] = createSignal<InstalledSkill[]>([]);
+  const [catalog, setCatalog] = createSignal<Record<string, { description: string; iconUrl: string | null }>>({});
+  const [selectedId, setSelectedId] = createSignal<string | null>(null);
+  const [detail, setDetail] = createSignal<MarketplaceSkillDetail | null>(null);
+  const [detailLoading, setDetailLoading] = createSignal(false);
+  const [loading, setLoading] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+  const [savingId, setSavingId] = createSignal<string | null>(null);
+  const [confirm, setConfirm] = createSignal<ConfirmRequest | null>(null);
+  const scrollFades = createScrollFades();
+  let modalContent: HTMLDivElement | undefined;
+  let confirmationTrigger: HTMLButtonElement | undefined;
+  const skillsMode = () => props.skillsMode ?? "mutable";
+  const mutable = () => skillsMode() === "mutable";
+  const assignmentCount = createMemo(() => skills().length);
+  const atCap = createMemo(() => assignmentCount() >= INPUT_LIMITS.agentSkills);
+  const canAdd = createMemo(() => mutable() && !atCap() && props.onAddFromMarketplace !== undefined && !loading());
+  const selectedSkill = createMemo(() => {
+    const id = selectedId();
+    return id ? (skills().find((skill) => skill.skillId === id) ?? null) : null;
+  });
+
+  onSettled(() => scrollFades.stop);
+
+  async function loadSkills(showLoading = true): Promise<void> {
+    if (showLoading) setLoading(true);
+    setError(null);
+    try {
+      const next = userAssignedSkills(
+        skillsMode() === "readonly"
+          ? await window.openbot.agent.listInstalledSkills(props.agentId)
+          : await window.openbot.skills.listInstalled(props.agentId),
+      );
+      setSkills(next);
+      props.onCountChange(next.length);
+    } catch (caught) {
+      setError(errorMessage(caught, "Could not load skills."));
+    } finally {
+      if (showLoading) setLoading(false);
+    }
+  }
+
+  createEffect(
+    () => [props.open, props.agentId, skillsMode()] as const,
+    ([open]) => {
+      if (!open) {
+        closeDetail();
+        setConfirm(null);
+        return;
+      }
+      setConfirm(null);
+      void loadSkills();
+      void loadCatalog();
+    },
+  );
+
+  async function loadCatalog(): Promise<void> {
+    try {
+      const page = await window.openbot.skills.list({ limit: 50 });
+      const hints: Record<string, { description: string; iconUrl: string | null }> = {};
+      for (const skill of page.skills) {
+        hints[skill.id] = { description: skill.description, iconUrl: skill.iconUrl };
+      }
+      setCatalog(hints);
+    } catch {
+      setCatalog({});
+    }
+  }
+
+  function closeDetail(): void {
+    setSelectedId(null);
+    setDetail(null);
+    setDetailLoading(false);
+  }
+
+  async function openDetail(skill: InstalledSkill): Promise<void> {
+    setSelectedId(skill.skillId);
+    setDetail(null);
+    setDetailLoading(true);
+    setError(null);
+    try {
+      setDetail(await window.openbot.skills.get(skill.skillId));
+    } catch (caught) {
+      setError(errorMessage(caught, "Could not load skill details."));
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  function addFromMarketplace(): void {
+    if (!canAdd() || !props.onAddFromMarketplace) return;
+    props.onAddFromMarketplace(props.agentId);
+  }
+
+  function requestRemove(skill: InstalledSkill): void {
+    setConfirm({ kind: "remove", skill });
+  }
+
+  function requestReplace(skill: InstalledSkill): void {
+    setConfirm({ kind: "replace", skill });
+  }
+
+  async function setEnabled(skill: InstalledSkill, enabled: boolean): Promise<void> {
+    const analytics = desktopAnalytics.scope();
+    const action = enabled ? "enable" : "disable";
+    let operationSucceeded = false;
+    setSavingId(skill.skillId);
+    setError(null);
+    try {
+      await window.openbot.skills.setEnabled({ agentId: props.agentId, skillId: skill.skillId, enabled });
+      analytics.track("marketplace_action", { entity: "skill", action, result: "succeeded" });
+      operationSucceeded = true;
+      await loadSkills(false);
+    } catch (caught) {
+      if (!operationSucceeded) {
+        analytics.track("marketplace_action", {
+          entity: "skill",
+          action,
+          result: "failed",
+          failure_code: `${action}_failed`,
+        });
+      }
+      setError(errorMessage(caught, enabled ? "Could not enable the skill." : "Could not disable the skill."));
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  async function uninstall(skill: InstalledSkill, removeModified: boolean): Promise<void> {
+    const analytics = desktopAnalytics.scope();
+    let operationSucceeded = false;
+    setSavingId(skill.skillId);
+    setError(null);
+    try {
+      await window.openbot.skills.uninstall({
+        agentId: props.agentId,
+        skillId: skill.skillId,
+        ...(removeModified ? { removeModified: true } : {}),
+      });
+      analytics.track("marketplace_action", { entity: "skill", action: "uninstall", result: "succeeded" });
+      operationSucceeded = true;
+      setConfirm(null);
+      if (selectedId() === skill.skillId) closeDetail();
+      await loadSkills(false);
+    } catch (caught) {
+      if (!operationSucceeded) {
+        analytics.track("marketplace_action", {
+          entity: "skill",
+          action: "uninstall",
+          result: "failed",
+          failure_code: "uninstall_failed",
+        });
+      }
+      setError(errorMessage(caught, "Could not remove the skill."));
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  async function install(skill: InstalledSkill, replaceModified: boolean): Promise<void> {
+    const analytics = desktopAnalytics.scope();
+    let operationSucceeded = false;
+    setSavingId(skill.skillId);
+    setError(null);
+    try {
+      await window.openbot.skills.install({
+        agentId: props.agentId,
+        skillId: skill.skillId,
+        ...(replaceModified ? { replaceModified: true } : {}),
+      });
+      analytics.track("marketplace_action", { entity: "skill", action: "update", result: "succeeded" });
+      operationSucceeded = true;
+      setConfirm(null);
+      await loadSkills(false);
+    } catch (caught) {
+      if (!operationSucceeded) {
+        analytics.track("marketplace_action", {
+          entity: "skill",
+          action: "update",
+          result: "failed",
+          failure_code: "update_failed",
+        });
+      }
+      setError(errorMessage(caught, "Could not update the skill."));
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  function runConfirmed(): void {
+    const request = confirm();
+    if (!request) return;
+    if (request.kind === "remove") {
+      void uninstall(request.skill, request.skill.state === "modified");
+      return;
+    }
+    void install(request.skill, request.skill.state === "modified");
+  }
+
+  function cancelConfirm(): void {
+    if (savingId()) return;
+    setConfirm(null);
+    queueMicrotask(() => confirmationTrigger?.focus());
+  }
+
+  return (
+    <>
+      <Dialog.Root open={props.open} onOpenChange={props.onOpenChange}>
+        <Dialog.Portal>
+          <Dialog.Overlay class="agent-memories-overlay" />
+          <Dialog.Content
+            ref={(element) => (modalContent = element)}
+            class="agent-memories-modal agent-skills-modal"
+            onOpenAutoFocus={(event) => {
+              event.preventDefault();
+              modalContent?.focus({ preventScroll: true });
+            }}
+          >
+            <header class="agent-memories-header">
+              <div class="agent-memories-heading agent-skills-heading">
+                <Show when={selectedSkill()} fallback={<Dialog.Title>Skills</Dialog.Title>}>
+                  {(skill) => (
+                    <>
+                      <Button type="button" variant="ghost" class="agent-skills-parent" onClick={closeDetail}>
+                        Skills
+                      </Button>
+                      <ChevronRight class="agent-skills-crumb" aria-hidden="true" />
+                      <Dialog.Title>{skill().name}</Dialog.Title>
+                    </>
+                  )}
+                </Show>
+                <Dialog.Description class="sr-only">
+                  {selectedSkill() ? `${selectedSkill()?.name} details` : `Assigned skills for ${props.agentName}`}
+                </Dialog.Description>
+              </div>
+              <div class="agent-memories-header-actions">
+                <Show when={selectedSkill()}>
+                  {(skill) => (
+                    <Show when={mutable()}>
+                      <SkillMoreMenu
+                        skill={skill()}
+                        disabled={savingId() === skill().skillId}
+                        onUpdate={() =>
+                          skill().state === "modified" ? requestReplace(skill()) : void install(skill(), false)
+                        }
+                        onRepair={() =>
+                          skill().state === "modified" ? requestReplace(skill()) : void install(skill(), false)
+                        }
+                        onUninstall={() => requestRemove(skill())}
+                      />
+                      <Switch
+                        aria-label={`Enable ${skill().name}`}
+                        checked={isEnabled(skill())}
+                        disabled={savingId() === skill().skillId}
+                        onChange={(enabled) => void setEnabled(skill(), enabled)}
+                      />
+                    </Show>
+                  )}
+                </Show>
+                <Show when={!selectedSkill() && mutable()}>
+                  <Button size="sm" variant="ghost" disabled={!canAdd()} onClick={addFromMarketplace}>
+                    Add from marketplace
+                  </Button>
+                </Show>
+                <IconButton label="Close skills" variant="ghost" onClick={() => props.onOpenChange(false)}>
+                  <X />
+                </IconButton>
+              </div>
+            </header>
+
+            <div class="agent-memories-body">
+              <Show when={mutable() && atCap()}>
+                <p class="agent-memory-limit" role="status">
+                  This agent has reached the limit of {INPUT_LIMITS.agentSkills} skills. Remove a skill before you add
+                  another one.
+                </p>
+              </Show>
+              <Show when={skillsMode() === "readonly"}>
+                <p class="agent-memory-limit" role="status">
+                  Skills for this agent are managed on the host.
+                </p>
+              </Show>
+              <Show when={!confirm() ? error() : null}>
+                {(message) => (
+                  <p class="agent-memory-error" role="alert">
+                    {message()}
+                  </p>
+                )}
+              </Show>
+
+              <Show when={!loading()} fallback={<p class="agent-memory-state">Loading skills…</p>}>
+                <Show
+                  when={selectedSkill()}
+                  fallback={
+                    <Show
+                      when={skills().length > 0}
+                      fallback={
+                        <div class="agent-skill-empty">
+                          <p class="agent-memory-state">This agent has no assigned skills yet.</p>
+                          <Show when={canAdd()}>
+                            <Button size="sm" onClick={addFromMarketplace}>
+                              Add from marketplace
+                            </Button>
+                          </Show>
+                        </div>
+                      }
+                    >
+                      <div
+                        ref={scrollFades.bind}
+                        class={["agent-memory-list", "agent-skill-rows", scrollFades.classes()]}
+                        onScroll={scrollFades.measure}
+                      >
+                        <For each={skills()}>
+                          {(skill) => (
+                            <div
+                              class={isEnabled(skill) ? "agent-skill-row" : "agent-skill-row agent-skill-row-disabled"}
+                            >
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                class="agent-skill-open"
+                                onClick={() => void openDetail(skill)}
+                              >
+                                <SkillGlyph iconUrl={catalog()[skill.skillId]?.iconUrl ?? null} />
+                                <div class="agent-skill-copy">
+                                  <div class="agent-skill-title">
+                                    <strong>{skill.name}</strong>
+                                    <Show when={stateLabel(skill.state)}>
+                                      {(label) => <span class="agent-skill-tag">{label()}</span>}
+                                    </Show>
+                                  </div>
+                                  <small>{catalog()[skill.skillId]?.description ?? skillMeta(skill)}</small>
+                                </div>
+                              </Button>
+                              <Show when={mutable()}>
+                                <SkillMoreMenu
+                                  skill={skill}
+                                  disabled={savingId() === skill.skillId}
+                                  onUpdate={() =>
+                                    skill.state === "modified" ? requestReplace(skill) : void install(skill, false)
+                                  }
+                                  onRepair={() =>
+                                    skill.state === "modified" ? requestReplace(skill) : void install(skill, false)
+                                  }
+                                  onUninstall={() => requestRemove(skill)}
+                                  triggerRef={(element) => {
+                                    confirmationTrigger = element;
+                                  }}
+                                />
+                                <Switch
+                                  aria-label={`Enable ${skill.name}`}
+                                  checked={isEnabled(skill)}
+                                  disabled={savingId() === skill.skillId}
+                                  onChange={(enabled) => void setEnabled(skill, enabled)}
+                                />
+                              </Show>
+                            </div>
+                          )}
+                        </For>
+                      </div>
+                    </Show>
+                  }
+                >
+                  {(skill) => (
+                    <div class="agent-skill-detail">
+                      <p class="agent-skill-detail-lead">
+                        {detail()?.description ?? catalog()[skill().skillId]?.description ?? skillMeta(skill())}
+                      </p>
+                      <Show when={detailLoading()} fallback={null}>
+                        <p class="agent-memory-state">Loading details…</p>
+                      </Show>
+                      <Show when={detail()}>
+                        {(current) => (
+                          <>
+                            <div class="agent-skill-detail-body">{displayInstructions(current())}</div>
+                            <p class="agent-skill-detail-meta">
+                              Version {skill().installedVersion}
+                              {current().files.length > 0 ? ` · ${current().files.length} files` : ""}
+                            </p>
+                          </>
+                        )}
+                      </Show>
+                    </div>
+                  )}
+                </Show>
+              </Show>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <Dialog.Root
+        open={confirm() !== null}
+        onOpenChange={(open) => {
+          if (!open) cancelConfirm();
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay class="agent-memory-confirm-overlay" />
+          <Dialog.Content class="agent-memory-confirm-dialog">
+            <div class="agent-memory-confirm-content">
+              <Dialog.Title>{confirmTitle(confirm())}</Dialog.Title>
+              <Dialog.Description>{confirmBody(confirm())}</Dialog.Description>
+              <Show when={error()}>
+                {(message) => (
+                  <p class="agent-memory-error" role="alert">
+                    {message()}
+                  </p>
+                )}
+              </Show>
+              <div class="agent-memory-confirm-actions">
+                <Button variant="ghost" disabled={savingId() !== null} onClick={cancelConfirm}>
+                  Cancel
+                </Button>
+                <Button
+                  variant={confirm()?.kind === "remove" ? "destructive" : "default"}
+                  loading={savingId() !== null}
+                  onClick={runConfirmed}
+                >
+                  {confirmConfirm(confirm())}
+                </Button>
+              </div>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  );
+}
+
+function SkillMoreMenu(props: {
+  skill: InstalledSkill;
+  disabled: boolean;
+  onUpdate: () => void;
+  onRepair: () => void;
+  onUninstall: () => void;
+  triggerRef?: (element: HTMLButtonElement) => void;
+}) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        class="agent-skill-more"
+        aria-label={`More for ${props.skill.name}`}
+        disabled={props.disabled}
+        ref={props.triggerRef}
+      >
+        <Ellipsis />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content class="agent-skill-menu">
+          <Show when={props.skill.state === "update-available"}>
+            <DropdownMenu.Item onSelect={props.onUpdate}>Update</DropdownMenu.Item>
+          </Show>
+          <Show when={props.skill.state === "needs-repair"}>
+            <DropdownMenu.Item onSelect={props.onRepair}>Repair</DropdownMenu.Item>
+          </Show>
+          <DropdownMenu.Item class="ui-action-menu-danger" onSelect={props.onUninstall}>
+            <Trash2 />
+            Uninstall
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
+function SkillGlyph(props: { iconUrl: string | null }) {
+  const [failedUrl, setFailedUrl] = createSignal<string | null>(null);
+  const iconUrl = () => (props.iconUrl && failedUrl() !== props.iconUrl ? props.iconUrl : null);
+
+  return (
+    <span class="agent-skill-icon" aria-hidden="true">
+      <Show when={iconUrl()} fallback={<Puzzle />} keyed>
+        {(url) => <img src={url} alt="" onError={() => setFailedUrl(url)} />}
+      </Show>
+    </span>
+  );
+}
+
+function isBuiltInSkill(skill: InstalledSkill): boolean {
+  return (
+    skill.origin === "managed" || skill.slug === "openbot-site-hosting" || skill.skillId === "openbot-site-hosting"
+  );
+}
+
+function isEnabled(skill: InstalledSkill): boolean {
+  return skill.enabled !== false;
+}
+
+export function userAssignedSkills(skills: InstalledSkill[]): InstalledSkill[] {
+  return skills
+    .filter((skill) => !isBuiltInSkill(skill))
+    .slice()
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function stateLabel(state: InstalledSkill["state"]) {
+  if (state === "update-available") return "Update available";
+  if (state === "modified") return "Local changes";
+  if (state === "needs-repair") return "Needs repair";
+  return null;
+}
+
+function skillMeta(skill: InstalledSkill): string {
+  if (skill.state === "update-available") return `v${skill.installedVersion} · v${skill.availableVersion} available`;
+  return `v${skill.installedVersion}`;
+}
+
+function displayInstructions(skill: MarketplaceSkillDetail): string {
+  const instructions = skill.instructions || skill.description;
+  const [firstLine, ...remaining] = instructions.split(/\r?\n/u);
+  if (firstLine?.replace(/^#\s+/u, "").trim() === skill.name) return remaining.join("\n").trim();
+  return instructions;
+}
+
+function confirmTitle(request: ConfirmRequest | null) {
+  if (!request) return "";
+  if (request.kind === "replace") return "Replace local changes?";
+  return "Remove this skill?";
+}
+
+function confirmBody(request: ConfirmRequest | null) {
+  if (!request) return "";
+  if (request.kind === "replace") {
+    return "Updating this skill replaces the local files with the marketplace package. Your edits in this skill folder will be lost.";
+  }
+  if (request.skill.state === "modified") {
+    return "This skill has local changes in the agent workspace. Remove deletes those files. Original chat messages stay.";
+  }
+  return "OpenBot will remove this skill from the agent. Chat history stays.";
+}
+
+function confirmConfirm(request: ConfirmRequest | null) {
+  if (request?.kind === "replace") return "Replace skill";
+  return "Remove skill";
+}

--- a/src/renderer/src/features/conversation/ComposerEditor.test.tsx
+++ b/src/renderer/src/features/conversation/ComposerEditor.test.tsx
@@ -358,7 +358,32 @@ describe("ComposerEditor", () => {
     expect(screen.queryByRole("listbox", { name: "Insert mention" })).toBeNull();
   });
 
-  it("searches installed skills in the unified picker and inserts a typed skill token", async () => {
+  it("searches installed skills with $ and inserts a typed skill token", async () => {
+    const skill: InstalledSkill = {
+      skillId: "release-notes",
+      slug: "release-notes",
+      name: "Release Notes",
+      installedVersion: 1,
+      availableVersion: 1,
+      state: "installed",
+      description: "Turns merged work into clear release notes.",
+    };
+    const { editor, onValueChange } = renderComposer([], "", [], [skill]);
+    editor.textContent = "$release";
+    placeCaretAtEnd(editor);
+    await fireEvent.input(editor);
+
+    await screen.findByRole("listbox", { name: "Insert skill" });
+    await fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onValueChange).toHaveBeenLastCalledWith("@[Release Notes](skill:release-notes) ");
+    expect(editor.querySelector('[data-skill-id="release-notes"]')).not.toBeNull();
+    expect(editor).toHaveTextContent("Release Notes");
+    expect(editor).not.toHaveTextContent("Turns merged work into clear release notes.");
+  });
+
+  it("keeps $ skill queries out of the @ mention picker", async () => {
+    const research = testAgent("research", "Research");
     const skill: InstalledSkill = {
       skillId: "release-notes",
       slug: "release-notes",
@@ -367,15 +392,20 @@ describe("ComposerEditor", () => {
       availableVersion: 1,
       state: "installed",
     };
-    const { editor, onValueChange } = renderComposer([], "", [], [skill]);
-    editor.textContent = "@release";
+    const { editor } = renderComposer([], "", [research], [skill]);
+    editor.textContent = "@";
     placeCaretAtEnd(editor);
     await fireEvent.input(editor);
 
-    await fireEvent.keyDown(editor, { key: "Enter" });
+    await screen.findByRole("option", { name: "Research Agent" });
+    expect(screen.queryByRole("option", { name: "Release Notes Skill" })).toBeNull();
 
-    expect(onValueChange).toHaveBeenLastCalledWith("@[Release Notes](skill:release-notes) ");
-    expect(editor.querySelector('[data-skill-id="release-notes"]')).not.toBeNull();
+    editor.textContent = "$";
+    placeCaretAtEnd(editor);
+    await fireEvent.input(editor);
+
+    await screen.findByRole("option", { name: "Release Notes Skill" });
+    expect(screen.queryByRole("option", { name: "Research Agent" })).toBeNull();
   });
 
   it("round-trips encoded semantic tag names and ids", async () => {
@@ -425,7 +455,7 @@ describe("ComposerEditor", () => {
     ));
     const editor = screen.getByRole("textbox", { name: "Loading skills" });
     editor.focus();
-    editor.textContent = "@release";
+    editor.textContent = "$release";
     placeCaretAtEnd(editor);
     await fireEvent.input(editor);
 

--- a/src/renderer/src/features/conversation/ComposerEditor.tsx
+++ b/src/renderer/src/features/conversation/ComposerEditor.tsx
@@ -31,6 +31,7 @@ interface MentionContext {
   query: string;
   start: number;
   end: number;
+  trigger: "@" | "$";
 }
 
 interface PickerPosition {
@@ -96,17 +97,23 @@ export function ComposerEditor(props: ComposerEditorProps) {
     const query = mention()?.query.trim().toLocaleLowerCase() ?? "";
     return (props.skills ?? []).filter(
       (skill) =>
-        skill.state !== "needs-repair" && (!query || `${skill.name} ${skill.slug}`.toLocaleLowerCase().includes(query)),
+        skill.state !== "needs-repair" &&
+        skill.enabled !== false &&
+        (!query || `${skill.name} ${skill.slug} ${skill.description ?? ""}`.toLocaleLowerCase().includes(query)),
     );
   });
-  const matchingOptions = createMemo<PickerOption[]>(() => [
-    ...matchingAgents().map((agent) => ({ type: "agent" as const, agent })),
-    ...matchingSkills().map((skill) => ({ type: "skill" as const, skill })),
-    ...matchingAttachments().map((attachment) => ({
-      type: "attachment" as const,
-      attachment,
-    })),
-  ]);
+  const matchingOptions = createMemo<PickerOption[]>(() => {
+    const trigger = mention()?.trigger;
+    if (trigger === "$") return matchingSkills().map((skill) => ({ type: "skill" as const, skill }));
+    if (trigger !== "@") return [];
+    return [
+      ...matchingAgents().map((agent) => ({ type: "agent" as const, agent })),
+      ...matchingAttachments().map((attachment) => ({
+        type: "attachment" as const,
+        attachment,
+      })),
+    ];
+  });
   const activePickerValue = createMemo(() => {
     const option = matchingOptions()[activeOption()];
     return option ? new Set([pickerOptionKey(option)]) : new Set<string>();
@@ -159,7 +166,9 @@ export function ComposerEditor(props: ComposerEditorProps) {
     ({ agentId, value, agents, skills, attachments, focusRequest }) => {
       if (!editor) return;
       const attachmentKey = attachments.map((attachment) => `${attachment.id}:${attachment.name}`).join("|");
-      const skillKey = skills.map((skill) => `${skill.skillId}:${skill.name}:${skill.state}`).join("|");
+      const skillKey = skills
+        .map((skill) => `${skill.skillId}:${skill.name}:${skill.state}:${skill.description ?? ""}`)
+        .join("|");
       const contentChanged =
         agentId !== lastAgentId || value !== lastEmittedValue || attachmentKey !== lastAttachmentKey;
       const skillsChanged = skillKey !== lastSkillKey;
@@ -243,12 +252,13 @@ export function ComposerEditor(props: ComposerEditorProps) {
     range.selectNodeContents(editor);
     range.setEnd(selection.anchorNode ?? editor, selection.anchorOffset);
     const beforeCaret = range.toString();
-    const match = beforeCaret.match(/(?:^|\s)@([^@\n]{0,60})$/u);
+    const match = beforeCaret.match(/(?:^|\s)([@$])([^@$\n]{0,60})$/u);
     if (!match) {
       setMention(null);
       return;
     }
-    const query = match[1] ?? "";
+    const trigger = match[1] === "$" ? "$" : "@";
+    const query = match[2] ?? "";
     const bounds = editor.getBoundingClientRect();
     const gutter = 12;
     const width = Math.min(720, bounds.width + 36, window.innerWidth - gutter * 2);
@@ -257,7 +267,7 @@ export function ComposerEditor(props: ComposerEditorProps) {
       left: Math.max(gutter, Math.min(bounds.left, window.innerWidth - width - gutter)),
       width,
     });
-    setMention({ query, start: beforeCaret.length - query.length - 1, end: beforeCaret.length });
+    setMention({ query, start: beforeCaret.length - query.length - 1, end: beforeCaret.length, trigger });
     setActiveOption(0);
   }
 
@@ -533,7 +543,7 @@ export function ComposerEditor(props: ComposerEditorProps) {
           <Listbox.Root<PickerOption>
             as="div"
             class="mention-picker"
-            aria-label="Insert mention"
+            aria-label={mention()?.trigger === "$" ? "Insert skill" : "Insert mention"}
             options={matchingOptions()}
             optionValue={pickerOptionKey}
             optionTextValue={pickerOptionText}
@@ -553,8 +563,9 @@ export function ComposerEditor(props: ComposerEditorProps) {
               const option = item.rawValue;
               const optionIndex = () =>
                 matchingOptions().findIndex((candidate) => pickerOptionKey(candidate) === item.key);
-              const firstSkillIndex = () => matchingAgents().length;
-              const firstAttachmentIndex = () => matchingAgents().length + matchingSkills().length;
+              const firstSkillIndex = () => matchingOptions().findIndex((candidate) => candidate.type === "skill");
+              const firstAttachmentIndex = () =>
+                matchingOptions().findIndex((candidate) => candidate.type === "attachment");
               return (
                 <>
                   <Show when={option.type === "agent" && item.index === 0}>
@@ -574,6 +585,7 @@ export function ComposerEditor(props: ComposerEditorProps) {
                       "mention-picker-option",
                       {
                         "mention-picker-file-option": option.type === "attachment",
+                        "mention-picker-skill-option": option.type === "skill",
                         "mention-picker-option-active": activeOption() === optionIndex(),
                       },
                     ]}
@@ -589,14 +601,17 @@ export function ComposerEditor(props: ComposerEditorProps) {
                     ) : (
                       <AttachmentReferenceVisual name={option.attachment.name} />
                     )}
-                    <strong>
-                      {option.type === "agent"
-                        ? option.agent.name
-                        : option.type === "skill"
-                          ? option.skill.name
-                          : option.attachment.name}
-                    </strong>
-                    <span>{option.type === "agent" ? "Agent" : option.type === "skill" ? "Skill" : "File"}</span>
+                    {option.type === "skill" ? (
+                      <span class="mention-picker-skill-copy">
+                        <strong>{option.skill.name}</strong>
+                        <span>{skillDescription(option.skill) ?? "Skill"}</span>
+                      </span>
+                    ) : (
+                      <>
+                        <strong>{option.type === "agent" ? option.agent.name : option.attachment.name}</strong>
+                        <span>{option.type === "agent" ? "Agent" : "File"}</span>
+                      </>
+                    )}
                   </Listbox.Item>
                 </>
               );
@@ -724,17 +739,26 @@ function createSkillToken(skill: InstalledSkill): HTMLSpanElement {
 }
 
 function updateSkillToken(token: HTMLSpanElement, skill: InstalledSkill): void {
-  token.className = "composer-mention-token composer-skill-token";
+  token.className = "composer-mention-token skill-chip";
   token.contentEditable = "false";
   token.dataset.skillId = skill.skillId;
   token.dataset.skillName = skill.name;
-  token.removeAttribute("aria-label");
   token.setAttribute("aria-label", `Skill ${skill.name}`);
-  const icon = Puzzle({ class: "composer-skill-icon" });
+  const iconWrap = document.createElement("span");
+  iconWrap.className = "skill-chip-icon";
+  iconWrap.setAttribute("aria-hidden", "true");
+  const icon = Puzzle({ class: "skill-chip-glyph" });
   if (!(icon instanceof Node)) throw new Error("Puzzle icon did not render to a DOM node");
+  iconWrap.append(icon);
   const name = document.createElement("span");
+  name.className = "skill-chip-name";
   name.textContent = skill.name;
-  token.replaceChildren(icon, name);
+  token.replaceChildren(iconWrap, name);
+}
+
+function skillDescription(skill: InstalledSkill): string | undefined {
+  const description = skill.description?.trim();
+  return description || undefined;
 }
 
 function createUnavailableTagToken(kind: "agent" | "skill", id: string, name: string): HTMLSpanElement {
@@ -763,7 +787,9 @@ function updateUnavailableSkillToken(token: HTMLSpanElement, id: string, name: s
 
 function syncSkillTokens(editor: HTMLDivElement, skills: InstalledSkill[]): void {
   const available = new Map(
-    skills.filter((skill) => skill.state !== "needs-repair").map((skill) => [skill.skillId, skill]),
+    skills
+      .filter((skill) => skill.state !== "needs-repair" && skill.enabled !== false)
+      .map((skill) => [skill.skillId, skill]),
   );
   for (const token of editor.querySelectorAll<HTMLSpanElement>("[data-skill-id]")) {
     const id = token.dataset.skillId;
@@ -801,7 +827,9 @@ function renderEditorValue(
     }
     if (target.startsWith("skill:")) {
       const id = target.slice("skill:".length);
-      const skill = skills.find((candidate) => candidate.skillId === id && candidate.state !== "needs-repair");
+      const skill = skills.find(
+        (candidate) => candidate.skillId === id && candidate.state !== "needs-repair" && candidate.enabled !== false,
+      );
       editor.append(skill ? createSkillToken(skill) : createUnavailableTagToken("skill", id, name));
       cursor = index + match[0].length;
       continue;

--- a/src/renderer/src/features/conversation/RichMessageText.test.tsx
+++ b/src/renderer/src/features/conversation/RichMessageText.test.tsx
@@ -23,6 +23,7 @@ describe("RichMessageText tooltips", () => {
             installedVersion: 1,
             availableVersion: 1,
             state: "installed",
+            description: "Turns merged work into clear release notes.",
           },
         ]}
         onSelectAgent={vi.fn()}
@@ -32,6 +33,7 @@ describe("RichMessageText tooltips", () => {
 
     expect(screen.getByText("Skill")).toBeInTheDocument();
     expect(screen.getByText("Release Notes")).toBeInTheDocument();
+    expect(screen.queryByText("Turns merged work into clear release notes.")).not.toBeInTheDocument();
     expect(screen.getByText("Unavailable agent")).toBeInTheDocument();
     expect(screen.getByText("Former")).toBeInTheDocument();
   });

--- a/src/renderer/src/features/conversation/RichMessageText.tsx
+++ b/src/renderer/src/features/conversation/RichMessageText.tsx
@@ -131,10 +131,12 @@ export function RichMessageText(props: RichMessageTextProps) {
           }
           if (part.skill) {
             return (
-              <span class="message-skill-tag">
-                <Puzzle aria-hidden="true" />
+              <span class="skill-chip message-skill-tag">
+                <span class="skill-chip-icon" aria-hidden="true">
+                  <Puzzle />
+                </span>
                 <span class="sr-only">Skill </span>
-                <span>{part.skill.name}</span>
+                <span class="skill-chip-name">{part.skill.name}</span>
               </span>
             );
           }

--- a/src/renderer/src/features/conversation/conversation.css
+++ b/src/renderer/src/features/conversation/conversation.css
@@ -1653,6 +1653,41 @@
   min-width: 0;
 }
 
+.agent-skills-heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--openbot-space-1);
+}
+
+.agent-skills-parent {
+  min-width: 0;
+  height: auto;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: var(--openbot-text-muted);
+  padding: 0;
+  font-size: var(--openbot-text-lg);
+  font-weight: var(--openbot-weight-semibold);
+  line-height: var(--openbot-leading-lg);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-skills-crumb {
+  flex: 0 0 auto;
+  width: var(--openbot-icon-sm);
+  height: var(--openbot-icon-sm);
+  color: var(--openbot-text-muted);
+}
+
+.agent-skills-heading h2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .agent-memories-heading h2 {
   margin: 0;
   color: var(--openbot-text-primary);
@@ -1841,6 +1876,197 @@
   min-height: 48px;
   align-items: center;
   padding: var(--openbot-space-2) var(--openbot-space-3) var(--openbot-space-3);
+}
+
+.agent-skill-empty {
+  min-height: 160px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: var(--openbot-space-3);
+}
+
+.agent-skill-empty .agent-memory-state {
+  min-height: 0;
+  padding: 0;
+}
+
+.agent-skill-rows {
+  display: grid;
+  align-content: start;
+  gap: 2px;
+}
+
+.agent-skill-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: var(--openbot-space-2);
+  min-height: 56px;
+  padding: var(--openbot-space-1) var(--openbot-space-2);
+  border-radius: var(--openbot-radius-lg);
+}
+
+.agent-skill-open {
+  min-width: 0;
+  height: auto;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  justify-content: stretch;
+  justify-items: stretch;
+  align-items: center;
+  gap: var(--openbot-space-3);
+  padding: var(--openbot-space-1);
+  color: inherit;
+  text-align: left;
+}
+
+.agent-skill-open:hover {
+  background: transparent;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .agent-skill-row:hover {
+    background: var(--openbot-bg-control-hover);
+  }
+}
+
+.agent-skill-icon {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid var(--openbot-border);
+  border-radius: var(--openbot-radius-lg);
+  background: var(--openbot-bg-control);
+  color: var(--openbot-accent-text);
+}
+
+.agent-skill-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.agent-skill-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.agent-skill-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.agent-skill-title {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: var(--openbot-space-2);
+}
+
+.agent-skill-title strong {
+  overflow: hidden;
+  color: var(--openbot-text-primary);
+  font-size: var(--openbot-text-md);
+  font-weight: var(--openbot-weight-medium);
+  line-height: var(--openbot-leading-md);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-skill-tag {
+  overflow: hidden;
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-sm);
+  font-weight: var(--openbot-weight-regular);
+  line-height: var(--openbot-leading-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-skill-copy small {
+  overflow: hidden;
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-sm);
+  line-height: var(--openbot-leading-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-skill-row-disabled .agent-skill-title strong {
+  color: var(--openbot-text-muted);
+}
+
+.agent-skill-more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: var(--openbot-radius-md);
+  background: var(--openbot-bg-control-active);
+  color: var(--openbot-text-secondary);
+  opacity: 0;
+  cursor: pointer;
+}
+
+.agent-skill-more svg {
+  width: var(--openbot-icon-sm);
+  height: var(--openbot-icon-sm);
+}
+
+.agent-skill-row:hover .agent-skill-more,
+.agent-skill-row:focus-within .agent-skill-more,
+.agent-skill-row:has([aria-expanded="true"]) .agent-skill-more {
+  opacity: 1;
+}
+
+.agent-skill-menu {
+  z-index: calc(var(--openbot-layer-dialog) + var(--openbot-layer-popover) + 1);
+}
+
+.agent-skills-modal .ui-switch[data-checked] {
+  background: var(--openbot-accent);
+}
+
+.agent-skills-modal .ui-switch-thumb[data-checked] {
+  background: var(--openbot-text-primary);
+}
+
+.agent-skill-detail {
+  min-height: 0;
+  display: grid;
+  align-content: start;
+  gap: var(--openbot-space-4);
+  overflow: auto;
+  padding: var(--openbot-space-3);
+}
+
+.agent-skill-detail-lead {
+  margin: 0;
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-md);
+  line-height: var(--openbot-leading-md);
+}
+
+.agent-skill-detail-body {
+  margin: 0;
+  color: var(--openbot-text-secondary);
+  font-size: var(--openbot-text-md);
+  line-height: var(--openbot-leading-lg);
+  white-space: pre-wrap;
+}
+
+.agent-skill-detail-meta {
+  margin: 0;
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-sm);
+  line-height: var(--openbot-leading-sm);
 }
 
 .agent-memory-confirm-dialog {
@@ -5176,36 +5402,68 @@ button.chat-action-target:active,
   background: var(--openbot-border-strong);
 }
 
-.message-skill-tag,
 .message-tag-unavailable {
   display: inline-flex;
   height: 22px;
   align-items: center;
   gap: 4px;
   margin: 0 1px;
+  border: 1px dashed var(--openbot-border-strong);
   border-radius: var(--openbot-radius-sm);
-  background: var(--openbot-accent-soft);
+  background: transparent;
   padding: 0 6px;
-  color: inherit;
+  color: var(--openbot-text-muted);
   font: inherit;
   line-height: 20px;
   vertical-align: middle;
   white-space: nowrap;
 }
 
-.message-skill-tag > svg {
-  width: 14px;
-  height: 14px;
+.skill-chip {
+  display: inline-flex;
+  max-width: 100%;
+  min-width: 0;
+  height: 24px;
+  align-items: center;
+  gap: 6px;
+  margin: 0 1px;
+  overflow: hidden;
+  border-radius: var(--openbot-radius-pill);
+  background: var(--openbot-marketplace-detail-bg);
+  padding: 0 8px 0 4px;
+  color: var(--openbot-text-primary);
+  font-size: var(--openbot-text-sm);
+  line-height: 18px;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
-.message-tag-unavailable {
-  border: 1px dashed var(--openbot-border-strong);
-  background: transparent;
-  color: var(--openbot-text-muted);
+.skill-chip-icon {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: var(--openbot-radius-xs);
+  background: var(--openbot-accent-soft);
+  color: var(--openbot-accent-text);
 }
 
-[data-slot="bubble"][data-author="user"] .message-agent-tag,
-[data-slot="bubble"][data-author="user"] .message-skill-tag {
+.skill-chip-glyph,
+.skill-chip-icon > svg {
+  width: 11px;
+  height: 11px;
+}
+
+.skill-chip-name {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  font-weight: 650;
+  text-overflow: ellipsis;
+}
+
+[data-slot="bubble"][data-author="user"] .message-agent-tag {
   background: var(--openbot-shadow-popover-ambient);
 }
 
@@ -5954,15 +6212,13 @@ button.chat-action-target:active,
   white-space: nowrap;
 }
 
-.composer-skill-token {
-  background: var(--openbot-accent-soft);
-}
-
-.composer-skill-icon {
-  width: 13px;
-  height: 13px;
-  flex: 0 0 auto;
-  color: var(--openbot-accent-hover);
+.composer-mention-token.skill-chip {
+  height: 24px;
+  gap: 6px;
+  border-radius: var(--openbot-radius-pill);
+  background: var(--openbot-marketplace-detail-bg);
+  padding: 0 8px 0 4px;
+  color: var(--openbot-text-primary);
 }
 
 .composer-tag-unavailable {
@@ -6076,6 +6332,36 @@ button.chat-action-target:active,
   height: 15px;
 }
 
+.mention-picker-skill-option {
+  height: auto;
+  min-height: 38px;
+  align-items: center;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.mention-picker-skill-copy {
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  gap: 1px;
+}
+
+.mention-picker-skill-copy strong {
+  margin: 0;
+}
+
+.mention-picker-skill-copy > span {
+  min-width: 0;
+  overflow: hidden;
+  margin: 0;
+  color: var(--openbot-text-muted);
+  font-size: var(--openbot-text-sm);
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .mention-picker-option strong {
   min-width: 0;
   overflow: hidden;
@@ -6086,7 +6372,7 @@ button.chat-action-target:active,
   white-space: nowrap;
 }
 
-.mention-picker-option > span:last-child {
+.mention-picker-option > span:last-child:not(.mention-picker-skill-copy) {
   margin-left: auto;
   color: var(--openbot-text-muted);
   font-size: var(--openbot-text-md);

--- a/src/renderer/src/features/settings/SkillsMarketplaceModal.test.tsx
+++ b/src/renderer/src/features/settings/SkillsMarketplaceModal.test.tsx
@@ -73,6 +73,7 @@ describe("SkillsMarketplaceModal", () => {
       listInstalled: vi.fn(async () => []),
       install: vi.fn(),
       uninstall: vi.fn(),
+      setEnabled: vi.fn(),
     };
     window.openbot = { ...window.openbot, skills };
     window.openbot.marketplaceAgents = {

--- a/src/renderer/src/preview/fixtures.ts
+++ b/src/renderer/src/preview/fixtures.ts
@@ -232,7 +232,7 @@ export const STORY_CONVERSATION_MESSAGES: ConversationMessage[] = [
     id: "message-user-1",
     author: "user",
     source: "user",
-    text: "Can you turn the latest notes into a short plan and tag @Research for the source check?",
+    text: "Use @[Release notes](skill:skill-release-notes) to turn the latest notes into a short plan and tag @Research for the source check.",
     createdAt: "2026-08-19T09:42:00.000Z",
     status: "completed",
   },
@@ -658,12 +658,25 @@ export const STORY_MARKETPLACE_SKILL_DETAILS: Record<string, MarketplaceSkillDet
 export const STORY_INSTALLED_SKILLS: Record<string, InstalledSkill[]> = {
   chief: [
     {
+      skillId: "openbot-site-hosting",
+      slug: "openbot-site-hosting",
+      name: "openbot-site-hosting",
+      installedVersion: 1,
+      availableVersion: 1,
+      state: "installed",
+      enabled: true,
+      origin: "managed",
+    },
+    {
       skillId: "skill-release-notes",
       slug: "release-notes",
       name: "Release notes",
       installedVersion: 4,
       availableVersion: 4,
       state: "installed",
+      enabled: true,
+      origin: "marketplace",
+      description: "Turns a range of commits into a changelog a reader outside the team can follow.",
     },
     {
       skillId: "skill-inbox-triage",
@@ -672,6 +685,20 @@ export const STORY_INSTALLED_SKILLS: Record<string, InstalledSkill[]> = {
       installedVersion: 1,
       availableVersion: 1,
       state: "modified",
+      enabled: true,
+      origin: "marketplace",
+      description: "Sorts a morning inbox into what needs a reply today and what can wait.",
+    },
+    {
+      skillId: "skill-source-check",
+      slug: "source-check",
+      name: "Source check",
+      installedVersion: 2,
+      availableVersion: 3,
+      state: "update-available",
+      enabled: false,
+      origin: "marketplace",
+      description: "Follows every citation in a draft and flags the ones that do not say what is claimed.",
     },
   ],
   research: [
@@ -682,6 +709,7 @@ export const STORY_INSTALLED_SKILLS: Record<string, InstalledSkill[]> = {
       installedVersion: 2,
       availableVersion: 3,
       state: "update-available",
+      description: "Follows every citation in a draft and flags the ones that do not say what is claimed.",
     },
   ],
 };

--- a/src/renderer/src/preview/mock-openbot.ts
+++ b/src/renderer/src/preview/mock-openbot.ts
@@ -141,6 +141,7 @@ export interface MockOpenBotOptions {
   updateStatus?: UpdateStatus;
   memories?: Record<string, AgentMemory[]>;
   routines?: Record<string, Routine[]>;
+  installedSkills?: Record<string, InstalledSkill[]>;
   customProviders?: CustomProviderSummary[];
 }
 
@@ -276,7 +277,7 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
   let agentCounter = agents.length;
   const marketplaceSkills = clone(STORY_MARKETPLACE_SKILLS);
   let skillSubmissions = clone(STORY_SKILL_SUBMISSIONS);
-  const installedSkills = new Map(Object.entries(clone(STORY_INSTALLED_SKILLS)));
+  const installedSkills = new Map(Object.entries(clone(options.installedSkills ?? STORY_INSTALLED_SKILLS)));
   let hostedSites = clone(STORY_HOSTED_SITES);
   // The same two endpoints the model-picker stories invent, so preview shows one list everywhere.
   let customProviders = clone(
@@ -786,6 +787,7 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
       install: async ({ agentId, skillId }) => {
         const skill = marketplaceSkills.find((candidate) => candidate.id === skillId);
         if (!skill) throw new Error("Skill not found");
+        const previous = readInstalledSkills(agentId).find((item) => item.skillId === skillId);
         const installed: InstalledSkill = {
           skillId: skill.id,
           slug: skill.slug,
@@ -793,6 +795,9 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
           installedVersion: skill.version,
           availableVersion: skill.version,
           state: "installed",
+          enabled: previous?.enabled !== false,
+          origin: previous?.origin ?? "marketplace",
+          description: skill.description,
         };
         installedSkills.set(agentId, [
           ...readInstalledSkills(agentId).filter((item) => item.skillId !== skillId),
@@ -801,10 +806,24 @@ export function createMockOpenBot(options: MockOpenBotOptions = {}): MockOpenBot
         return clone(installed);
       },
       uninstall: async ({ agentId, skillId }) => {
+        const skill = readInstalledSkills(agentId).find((item) => item.skillId === skillId);
+        if (skill?.origin === "managed") throw new Error("This skill is managed by OpenBot.");
         installedSkills.set(
           agentId,
           readInstalledSkills(agentId).filter((item) => item.skillId !== skillId),
         );
+      },
+      setEnabled: async ({ agentId, skillId, enabled }) => {
+        const current = readInstalledSkills(agentId);
+        const skill = current.find((item) => item.skillId === skillId);
+        if (!skill) throw new Error("Skill not found.");
+        if (skill.origin === "managed") throw new Error("This skill is managed by OpenBot.");
+        const next: InstalledSkill = { ...skill, enabled };
+        installedSkills.set(
+          agentId,
+          current.map((item) => (item.skillId === skillId ? next : item)),
+        );
+        return clone(next);
       },
     },
     hostedSites: {

--- a/src/renderer/stories/AgentSkills.stories.tsx
+++ b/src/renderer/stories/AgentSkills.stories.tsx
@@ -1,0 +1,157 @@
+import type { InstalledSkill } from "@openbot/contracts/ipc";
+import { onCleanup } from "solid-js";
+import { expect, fn, waitFor, within } from "storybook/test";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import AgentSettingsPanel from "../src/features/conversation/AgentSettingsPanel";
+import { STORY_AGENT_STATUS, STORY_AGENTS, STORY_INSTALLED_SKILLS, STORY_MODELS } from "./fixtures";
+import { createMockOpenBot } from "./mock-openbot";
+
+function AgentSkillsStory(props: {
+  skills: InstalledSkill[];
+  skillsMode?: "mutable" | "readonly" | "hidden";
+  onAddFromMarketplace?: (agentId: string) => void;
+}) {
+  const previousApi = window.openbot;
+  const mock = createMockOpenBot({ installedSkills: { chief: props.skills } });
+  window.openbot = mock.api;
+
+  onCleanup(() => {
+    mock.dispose();
+    window.openbot = previousApi;
+  });
+
+  return (
+    <main class="agent-memories-story-stage">
+      <AgentSettingsPanel
+        onOpenUsage={fn()}
+        agent={STORY_AGENTS[0]}
+        runtimeSettings={{
+          provider: STORY_AGENTS[0].provider,
+          model: STORY_AGENTS[0].model,
+          reasoningEffort: STORY_AGENTS[0].reasoningEffort,
+        }}
+        agentStatus={STORY_AGENT_STATUS}
+        modelOptions={STORY_MODELS}
+        working={false}
+        maxWidth={() => 640}
+        onClose={fn()}
+        onWidthChange={fn()}
+        skillsMode={props.skillsMode}
+        onAddFromMarketplace={props.onAddFromMarketplace}
+        onUpdateAgent={async (agentId, updates) => {
+          await mock.api.agent.updateAgent({ agentId, ...updates });
+        }}
+        onUpdateRuntimeSettings={async (agentId, _settings, updates) => {
+          await mock.api.agent.updateAgent({ agentId, ...updates });
+          return true;
+        }}
+        onSetAgentAvatar={async (agentId, image) => {
+          await mock.api.agent.setAvatar({ agentId, image });
+        }}
+      />
+    </main>
+  );
+}
+
+const meta = {
+  title: "Settings/Agent Skills",
+  component: AgentSettingsPanel,
+  args: {
+    agent: STORY_AGENTS[0],
+    runtimeSettings: {
+      provider: STORY_AGENTS[0].provider,
+      model: STORY_AGENTS[0].model,
+      reasoningEffort: STORY_AGENTS[0].reasoningEffort,
+    },
+    agentStatus: STORY_AGENT_STATUS,
+    modelOptions: STORY_MODELS,
+    working: false,
+    maxWidth: () => 640,
+    onClose: fn(),
+    onWidthChange: fn(),
+    onUpdateAgent: fn(async () => undefined),
+    onUpdateRuntimeSettings: fn(async () => true),
+    onSetAgentAvatar: fn(async () => undefined),
+  },
+  parameters: { layout: "fullscreen", a11y: { test: "error" } },
+} satisfies Meta<typeof AgentSettingsPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const addFromMarketplace = fn();
+
+export const SettingsRow: Story = {
+  render: () => (
+    <AgentSkillsStory skills={STORY_INSTALLED_SKILLS.chief ?? []} onAddFromMarketplace={addFromMarketplace} />
+  ),
+  play: async ({ canvas }) => {
+    await waitFor(() => expect(canvas.getByRole("button", { name: /Skills/ })).toHaveTextContent("3 assigned"));
+  },
+};
+
+export const OpenModal: Story = {
+  render: () => (
+    <AgentSkillsStory skills={STORY_INSTALLED_SKILLS.chief ?? []} onAddFromMarketplace={addFromMarketplace} />
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(await canvas.findByRole("button", { name: /Skills/ }));
+    const dialog = await within(document.body).findByRole("dialog", { name: "Skills" });
+    await expect(dialog).toBeVisible();
+    await expect(within(dialog).queryByText("Managed")).toBeNull();
+    await expect(within(dialog).queryByText("openbot-site-hosting")).toBeNull();
+    await expect(within(dialog).getByText("Release notes")).toBeVisible();
+    await expect(within(dialog).getByText("Local changes")).toBeVisible();
+    await expect(within(dialog).getByText("Update available")).toBeVisible();
+  },
+};
+
+export const OpenDetail: Story = {
+  render: () => (
+    <AgentSkillsStory skills={STORY_INSTALLED_SKILLS.chief ?? []} onAddFromMarketplace={addFromMarketplace} />
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(await canvas.findByRole("button", { name: /Skills/ }));
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("button", { name: /^Inbox triage/ }));
+    const dialog = await body.findByRole("dialog", { name: "Inbox triage" });
+    await expect(dialog).toBeVisible();
+    await expect(within(dialog).getByRole("button", { name: "Skills" })).toBeVisible();
+    await expect(within(dialog).getByText(/Sorts a morning inbox/)).toBeVisible();
+  },
+};
+
+export const EmptyState: Story = {
+  render: () => <AgentSkillsStory skills={[]} onAddFromMarketplace={addFromMarketplace} />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(await canvas.findByRole("button", { name: /Skills/ }));
+    const dialog = await within(document.body).findByRole("dialog", { name: "Skills" });
+    await expect(dialog).toBeVisible();
+    await expect(within(dialog).getByText("This agent has no assigned skills yet.")).toBeVisible();
+    await expect(within(dialog).getAllByRole("button", { name: "Add from marketplace" }).length).toBeGreaterThan(0);
+  },
+};
+
+export const RemoteReadOnly: Story = {
+  render: () => <AgentSkillsStory skills={STORY_INSTALLED_SKILLS.research ?? []} skillsMode="readonly" />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(await canvas.findByRole("button", { name: /Skills/ }));
+    const body = within(document.body);
+    await expect(await body.findByText("Skills for this agent are managed on the host.")).toBeVisible();
+    await expect(body.queryByRole("button", { name: "Add from marketplace" })).toBeNull();
+    await expect(body.queryByRole("switch")).toBeNull();
+  },
+};
+
+export const RemoveConfirm: Story = {
+  render: () => (
+    <AgentSkillsStory skills={STORY_INSTALLED_SKILLS.chief ?? []} onAddFromMarketplace={addFromMarketplace} />
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(await canvas.findByRole("button", { name: /Skills/ }));
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("button", { name: "More for Inbox triage" }));
+    await userEvent.click(await body.findByRole("menuitem", { name: "Uninstall" }));
+    await expect(await body.findByRole("dialog", { name: "Remove this skill?" })).toBeVisible();
+  },
+};

--- a/src/renderer/stories/ComposerEditor.stories.tsx
+++ b/src/renderer/stories/ComposerEditor.stories.tsx
@@ -59,6 +59,7 @@ const installedSkills: InstalledSkill[] = [
     installedVersion: 1,
     availableVersion: 1,
     state: "installed",
+    description: "Turns a range of commits into a changelog a reader outside the team can follow.",
   },
 ];
 
@@ -122,6 +123,37 @@ export const MentionPicker: Story = {
     await expect(sales).toHaveClass("mention-picker-option-active");
     await userEvent.keyboard("{Enter}");
     await expect(editor.querySelector('[data-mention-id="sales"]')).not.toBeNull();
+    await expect(storyArgs.onSubmit).not.toHaveBeenCalled();
+  },
+};
+
+export const SkillPicker: Story = {
+  args: {
+    skills: installedSkills,
+  },
+  render: (storyArgs) => {
+    const [value, setValue] = createSignal(storyArgs.value);
+    return <ComposerEditor {...storyArgs} value={value()} onValueChange={setValue} onSubmit={storyArgs.onSubmit} />;
+  },
+  play: async ({ args: storyArgs, canvas, userEvent }) => {
+    const editor = canvas.getByRole("textbox", { name: "Message Chief" });
+    await userEvent.click(editor);
+    editor.textContent = "$";
+    const textNode = editor.firstChild;
+    if (!textNode) throw new Error("Composer editor did not create a text node");
+    const selectionRange = document.createRange();
+    selectionRange.setStart(textNode, textNode.textContent?.length ?? 0);
+    selectionRange.collapse(true);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(selectionRange);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    const picker = await within(document.body).findByRole("listbox", { name: "Insert skill" });
+    await expect(picker).toBeInTheDocument();
+    await expect(within(document.body).getByRole("option", { name: "Release Notes Skill" })).toBeInTheDocument();
+    await userEvent.keyboard("{Enter}");
+    await expect(editor.querySelector('[data-skill-id="skill-release-notes"]')).not.toBeNull();
+    await expect(editor).toHaveTextContent("Release Notes");
     await expect(storyArgs.onSubmit).not.toHaveBeenCalled();
   },
 };

--- a/src/renderer/stories/RichMessageText.stories.tsx
+++ b/src/renderer/stories/RichMessageText.stories.tsx
@@ -1,10 +1,11 @@
 import { serializeAttachmentReference } from "@openbot/contracts/attachment-references";
+import { serializeChatTagReference } from "@openbot/contracts/chat-tag-references";
 import type { AttachmentSummary } from "@openbot/contracts/ipc";
 import { expect, fn, waitFor, within } from "storybook/test";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import type { MessageCitation } from "../src/data";
 import { RichMessageText } from "../src/features/conversation/RichMessageText";
-import { STORY_AGENTS, STORY_ATTACHMENTS } from "./fixtures";
+import { STORY_AGENTS, STORY_ATTACHMENTS, STORY_INSTALLED_SKILLS } from "./fixtures";
 
 const args: Parameters<typeof RichMessageText>[0] = {
   body: "Ask @Research to review https://openbot.run/docs before the launch.",
@@ -83,6 +84,13 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const LinksAndMentions: Story = {};
+
+export const SkillChip: Story = {
+  args: {
+    body: `Use ${serializeChatTagReference("skill", "Release notes", "skill-release-notes")} to turn the latest notes into a short plan.`,
+    skills: STORY_INSTALLED_SKILLS.chief,
+  },
+};
 
 export const InlineCitations: Story = {
   args: {


### PR DESCRIPTION
## What changed

Users can now assign marketplace skills to one agent, and insert those skills in chat.

**Agent settings.** A Skills row opens a modal (same pattern as Memories). The list shows icon, name, description, and a switch. A `...` menu has Uninstall, Update, and Repair. A row click opens skill details in the same modal. Built-in managed skills stay hidden. Disable moves the skill files aside; enable moves them back. The marketplace overlay still installs. Cap is 32 skills per agent (`INPUT_LIMITS.agentSkills`).

**Composer and chat.** `$` opens a skills-only picker. `@` stays agents and files. A selected skill becomes a dark title-only chip (icon + name). Stored tags stay `@[name](skill:id)`, so existing messages and Team API text do not change.

## Surfaces

- Desktop renderer (`AgentSkillsModal`, settings panel, composer, chat)
- IPC contracts (`skills:set-enabled`, optional `enabled` / `origin` / `description` on `InstalledSkill`)
- Main process skill marketplace (lock + file move for enable/disable)
- Preload and remote host decoders
- Preview mock (`mock-openbot.ts`) and Storybook
- Not mobile. No SQLite migration. No Team API meaning change (optional fields only)

## Verification

- [x] Narrow checks for what changed: `biome check` on the touched files, `bun run typecheck`, `bun run check:ui`, and `bun run test:desktop --` on `ComposerEditor.test.tsx`, `RichMessageText.test.tsx`, `MessageRendering.test.tsx`, and `skill-marketplace-service.test.ts` — CI owns the full suite
- [x] Surfaces touched are named under "What changed"
- [x] Manual smoke in Storybook: `Conversation/AgentSkills`, `Conversation/ComposerEditor/Skill Picker`, `Conversation/RichMessageText/Skill Chip`
- [x] No credentials, private data, generated output, or real user files are included

## Risk and security impact

New IPC request `skills:set-enabled` (trusted renderer, parsed payload). Enable/disable moves skill directories under the agent workspace (`.agents/skills`, `.claude/skills`, `.openbot/skills-disabled`). Optional `description` on installed-skill payloads is additive; older hosts omit it.

## Screenshots

**Before.** Agent settings had no Skills row. Composer mixed skills into the `@` mention picker as a small accent tag.

**After.** Skills modal in agent settings (list, switch, details). Composer `$` picker. Chat and composer chips show icon + title only.

Storybook: `Conversation/AgentSkills`, `Conversation/ComposerEditor/Skill Picker`, `Conversation/RichMessageText/Skill Chip`.

Model: Grok 4.6. Harness: T3 Code.