### PR TITLE
feat(ui): add liquid switch motion

### DIFF
--- a/packages/brand/src/tokens.css
+++ b/packages/brand/src/tokens.css
@@ -274,6 +274,17 @@
   --openbot-control-md: 32px;
   --openbot-control-lg: 36px;
   --openbot-control-xl: 40px;
+  /* The switch follows the same compact pill proportions across desktop and web.
+   * Keep its geometry named so the motion code can measure the same inset and travel
+   * that CSS paints. */
+  --openbot-switch-width: 36px;
+  --openbot-switch-height: 20px;
+  --openbot-switch-thumb: 16px;
+  --openbot-switch-inset: 2px;
+  --openbot-switch-sm-width: 24px;
+  --openbot-switch-sm-height: 14px;
+  --openbot-switch-sm-thumb: 12px;
+  --openbot-switch-sm-inset: 1px;
   /* Unitless on purpose. Lucide icons carry viewBox="0 0 24 24", so CSS stroke-width
    * resolves in user units, not px: a literal 1px paints 1 * (16/24) = 0.67 device px at
    * the 16px default size and reads blurry. 1.5 user units is the 1px the design asks for.

--- a/src/renderer/src/components/ui/switch.tsx
+++ b/src/renderer/src/components/ui/switch.tsx
@@ -1,7 +1,7 @@
 import type { PolymorphicProps } from "@kobalte/core/polymorphic";
 import * as SwitchPrimitive from "@kobalte/core/switch";
 import type { ComponentProps, JSX, ValidComponent } from "@solidjs/web";
-import { createSignal, createUniqueId, omit, Show } from "solid-js";
+import { createEffect, createSignal, createUniqueId, omit, onCleanup, Show, untrack } from "solid-js";
 import { cx } from "./utils";
 
 export type SwitchSize = "sm" | "default";
@@ -21,9 +21,216 @@ export type SwitchProps<T extends ValidComponent = "div"> = PolymorphicProps<T, 
   OpenBotSwitchProps &
   Partial<Pick<ComponentProps<T>, "class">>;
 
+type SwitchMotionControlProps = {
+  setPointerFocus: (pointerFocus: boolean) => void;
+};
+
+type SwitchMotionThumbProps = {
+  checked: () => boolean;
+  dragProgress: () => number | undefined;
+};
+
+function SwitchMotionThumb(props: SwitchMotionThumbProps): JSX.Element {
+  let thumb: HTMLDivElement | undefined;
+  let position = untrack(props.checked) ? 1 : 0;
+  let target = position;
+  let velocity = 0;
+  let frame: number | undefined;
+  let lastTimestamp: number | undefined;
+  const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+  function paint(): void {
+    if (!thumb) return;
+    const stretch = Math.min(0.24, Math.abs(velocity) * 0.035);
+    thumb.style.setProperty("--ui-switch-position", String(position));
+    thumb.style.setProperty("--ui-switch-scale-x", String(1 + stretch));
+    thumb.style.setProperty("--ui-switch-scale-y", String(1 - stretch * 0.55));
+  }
+
+  function stopAnimation(): void {
+    if (frame === undefined) return;
+    window.cancelAnimationFrame(frame);
+    frame = undefined;
+    lastTimestamp = undefined;
+  }
+
+  function step(timestamp: number): void {
+    frame = undefined;
+    const previousTimestamp = lastTimestamp ?? timestamp;
+    lastTimestamp = timestamp;
+    const delta = Math.min((timestamp - previousTimestamp) / 1_000, 0.032);
+    velocity += (target - position) * 520 * delta;
+    velocity *= Math.exp(-32 * delta);
+    position += velocity * delta;
+
+    const settled = Math.abs(target - position) < 0.001 && Math.abs(velocity) < 0.001;
+    if (settled) {
+      position = target;
+      velocity = 0;
+    }
+    paint();
+    if (!settled) frame = window.requestAnimationFrame(step);
+    else lastTimestamp = undefined;
+  }
+
+  function scheduleAnimation(): void {
+    if (frame !== undefined || !thumb) return;
+    if (reducedMotion || typeof window.requestAnimationFrame !== "function") {
+      position = target;
+      velocity = 0;
+      paint();
+      return;
+    }
+    frame = window.requestAnimationFrame(step);
+  }
+
+  createEffect(
+    () => ({ dragPosition: props.dragProgress(), checked: props.checked() }),
+    ({ dragPosition, checked }) => {
+      if (dragPosition !== undefined) {
+        stopAnimation();
+        position = dragPosition;
+        target = dragPosition;
+        velocity = 0;
+        paint();
+        return;
+      }
+
+      target = checked ? 1 : 0;
+      scheduleAnimation();
+    },
+  );
+
+  onCleanup(stopAnimation);
+
+  return (
+    <SwitchPrimitive.Thumb
+      ref={(element) => {
+        thumb = element;
+        paint();
+      }}
+      data-slot="switch-thumb"
+      class="ui-switch-thumb"
+    />
+  );
+}
+
+function SwitchMotionControl(props: SwitchMotionControlProps): JSX.Element {
+  const context = SwitchPrimitive.useSwitchContext();
+  const [dragProgress, setDragProgress] = createSignal<number | undefined>();
+  const [dragging, setDragging] = createSignal(false);
+  const [controlElement, setControlElement] = createSignal<HTMLDivElement>();
+  let control: HTMLDivElement | undefined;
+  let drag:
+    | {
+        pointerId: number;
+        grab: number;
+        startProgress: number;
+        startChecked: boolean;
+        moved: boolean;
+      }
+    | undefined;
+  let suppressClick = false;
+
+  function metrics(): { left: number; inset: number; travel: number } | undefined {
+    if (!control) return undefined;
+    const rect = control.getBoundingClientRect();
+    const styles = window.getComputedStyle(control);
+    const inset = Number.parseFloat(styles.getPropertyValue("--ui-switch-inset")) || 0;
+    const travel =
+      Number.parseFloat(styles.getPropertyValue("--ui-switch-travel")) ||
+      Math.max(1, rect.width - rect.height - inset * 2);
+    return { left: rect.left, inset, travel };
+  }
+
+  function finishPointer(event: PointerEvent, cancelled = false): void {
+    const activeDrag = drag;
+    if (!activeDrag || activeDrag.pointerId !== event.pointerId) return;
+
+    drag = undefined;
+    setDragging(false);
+    if (cancelled) context.setIsChecked(activeDrag.startChecked);
+    if (activeDrag.moved) suppressClick = true;
+    setDragProgress(undefined);
+
+    if (control?.hasPointerCapture?.(event.pointerId)) control.releasePointerCapture?.(event.pointerId);
+  }
+
+  function suppressDraggedClick(event: MouseEvent): void {
+    if (!suppressClick) return;
+    suppressClick = false;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+
+  createEffect(
+    () => controlElement(),
+    (element) => {
+      if (!element) return;
+      element.addEventListener("click", suppressDraggedClick, true);
+      onCleanup(() => element.removeEventListener("click", suppressDraggedClick, true));
+    },
+  );
+
+  return (
+    <SwitchPrimitive.Control
+      ref={(element) => {
+        control = element;
+        setControlElement(element);
+      }}
+      data-slot="switch-control"
+      data-dragging={dragging() ? "" : undefined}
+      class="ui-switch-control"
+      onPointerDown={(event) => {
+        props.setPointerFocus(true);
+        event.preventDefault();
+        if (context.inputRef()?.disabled || context.inputRef()?.readOnly) return;
+
+        const switchMetrics = metrics();
+        if (!switchMetrics) return;
+        const startProgress = context.checked() ? 1 : 0;
+        const thumbStart = switchMetrics.left + switchMetrics.inset + startProgress * switchMetrics.travel;
+        drag = {
+          pointerId: event.pointerId,
+          grab: event.clientX - thumbStart,
+          startProgress,
+          startChecked: context.checked(),
+          moved: false,
+        };
+        setDragging(true);
+        setDragProgress(startProgress);
+        control?.setPointerCapture?.(event.pointerId);
+      }}
+      onPointerMove={(event) => {
+        const activeDrag = drag;
+        if (!activeDrag || activeDrag.pointerId !== event.pointerId) return;
+        const switchMetrics = metrics();
+        if (!switchMetrics) return;
+        const nextProgress = Math.min(
+          1,
+          Math.max(
+            0,
+            (event.clientX - switchMetrics.left - switchMetrics.inset - activeDrag.grab) / switchMetrics.travel,
+          ),
+        );
+        if (Math.abs(nextProgress - activeDrag.startProgress) > 0.01) activeDrag.moved = true;
+        setDragProgress(nextProgress);
+        const nextChecked = nextProgress >= 0.5;
+        if (nextChecked !== context.checked()) context.setIsChecked(nextChecked);
+      }}
+      onPointerUp={(event) => finishPointer(event)}
+      onPointerCancel={(event) => finishPointer(event, true)}
+      onLostPointerCapture={(event) => finishPointer(event, true)}
+      onClick={(event) => event.preventDefault()}
+    >
+      <SwitchMotionThumb checked={context.checked} dragProgress={dragProgress} />
+    </SwitchPrimitive.Control>
+  );
+}
+
 export function Switch<T extends ValidComponent = "div">(props: SwitchProps<T>): JSX.Element {
   const [pointerFocus, setPointerFocus] = createSignal(false);
-  const others = omit(props, "class", "size", "id", "aria-label", "aria-labelledby", "aria-describedby");
+  const others = omit(props, "class", "size", "id", "aria-label", "aria-labelledby", "aria-describedby", "children");
   // biome-ignore lint/nursery/noUnsafeTypeAssertion: Solid 2's omit cannot preserve Kobalte's generic polymorphic props.
   const rootProps = others as PolymorphicProps<T, SwitchPrimitive.SwitchRootProps<T>>;
 
@@ -45,17 +252,7 @@ export function Switch<T extends ValidComponent = "div">(props: SwitchProps<T>):
         onKeyDown={() => setPointerFocus(false)}
         onBlur={() => setPointerFocus(false)}
       />
-      <SwitchPrimitive.Control
-        data-slot="switch-control"
-        class="ui-switch-control"
-        onPointerDown={(event) => {
-          setPointerFocus(true);
-          event.preventDefault();
-        }}
-        onClick={(event) => event.preventDefault()}
-      >
-        <SwitchPrimitive.Thumb data-slot="switch-thumb" class="ui-switch-thumb" />
-      </SwitchPrimitive.Control>
+      <SwitchMotionControl setPointerFocus={setPointerFocus} />
     </SwitchPrimitive.Root>
   );
 }

--- a/src/renderer/src/components/ui/switch.tsx
+++ b/src/renderer/src/components/ui/switch.tsx
@@ -156,7 +156,7 @@ function SwitchMotionControl(props: SwitchMotionControlProps): JSX.Element {
     if (!cancelled && activeDrag.moved) context.setIsChecked(activeDrag.progress >= 0.5);
     drag = undefined;
     setDragging(false);
-    if (activeDrag.moved) suppressClick = true;
+    suppressClick = !cancelled && activeDrag.moved;
     setDragProgress(undefined);
 
     if (control?.hasPointerCapture?.(event.pointerId)) control.releasePointerCapture?.(event.pointerId);
@@ -202,6 +202,8 @@ function SwitchMotionControl(props: SwitchMotionControlProps): JSX.Element {
       data-dragging={dragging() ? "" : undefined}
       class="ui-switch-control"
       onPointerDown={(event) => {
+        suppressClick = false;
+        if (event.button !== 0) return;
         props.setPointerFocus(true);
         event.preventDefault();
         if (context.inputRef()?.disabled || context.inputRef()?.readOnly) return;

--- a/src/renderer/src/components/ui/switch.tsx
+++ b/src/renderer/src/components/ui/switch.tsx
@@ -21,6 +21,8 @@ export type SwitchProps<T extends ValidComponent = "div"> = PolymorphicProps<T, 
   OpenBotSwitchProps &
   Partial<Pick<ComponentProps<T>, "class">>;
 
+const SWITCH_DRAG_THRESHOLD_PX = 3;
+
 type SwitchMotionControlProps = {
   setPointerFocus: (pointerFocus: boolean) => void;
 };
@@ -126,7 +128,8 @@ function SwitchMotionControl(props: SwitchMotionControlProps): JSX.Element {
         pointerId: number;
         grab: number;
         startProgress: number;
-        startChecked: boolean;
+        startClientX: number;
+        progress: number;
         moved: boolean;
       }
     | undefined;
@@ -137,9 +140,11 @@ function SwitchMotionControl(props: SwitchMotionControlProps): JSX.Element {
     const rect = control.getBoundingClientRect();
     const styles = window.getComputedStyle(control);
     const inset = Number.parseFloat(styles.getPropertyValue("--ui-switch-inset")) || 0;
-    const travel =
-      Number.parseFloat(styles.getPropertyValue("--ui-switch-travel")) ||
-      Math.max(1, rect.width - rect.height - inset * 2);
+    const thumb = control.querySelector<HTMLElement>('[data-slot="switch-thumb"]');
+    const thumbWidth = thumb
+      ? thumb.offsetWidth || Number.parseFloat(window.getComputedStyle(thumb).width)
+      : rect.height;
+    const travel = Math.max(1, rect.width - (thumbWidth || rect.height) - inset * 2);
     return { left: rect.left, inset, travel };
   }
 
@@ -147,13 +152,28 @@ function SwitchMotionControl(props: SwitchMotionControlProps): JSX.Element {
     const activeDrag = drag;
     if (!activeDrag || activeDrag.pointerId !== event.pointerId) return;
 
+    if (!cancelled) updateDrag(event);
+    if (!cancelled && activeDrag.moved) context.setIsChecked(activeDrag.progress >= 0.5);
     drag = undefined;
     setDragging(false);
-    if (cancelled) context.setIsChecked(activeDrag.startChecked);
     if (activeDrag.moved) suppressClick = true;
     setDragProgress(undefined);
 
     if (control?.hasPointerCapture?.(event.pointerId)) control.releasePointerCapture?.(event.pointerId);
+  }
+
+  function updateDrag(event: PointerEvent): void {
+    const activeDrag = drag;
+    if (!activeDrag || activeDrag.pointerId !== event.pointerId) return;
+    const switchMetrics = metrics();
+    if (!switchMetrics) return;
+    const nextProgress = Math.min(
+      1,
+      Math.max(0, (event.clientX - switchMetrics.left - switchMetrics.inset - activeDrag.grab) / switchMetrics.travel),
+    );
+    if (Math.abs(event.clientX - activeDrag.startClientX) >= SWITCH_DRAG_THRESHOLD_PX) activeDrag.moved = true;
+    activeDrag.progress = nextProgress;
+    setDragProgress(nextProgress);
   }
 
   function suppressDraggedClick(event: MouseEvent): void {
@@ -194,7 +214,8 @@ function SwitchMotionControl(props: SwitchMotionControlProps): JSX.Element {
           pointerId: event.pointerId,
           grab: event.clientX - thumbStart,
           startProgress,
-          startChecked: context.checked(),
+          startClientX: event.clientX,
+          progress: startProgress,
           moved: false,
         };
         setDragging(true);
@@ -202,21 +223,7 @@ function SwitchMotionControl(props: SwitchMotionControlProps): JSX.Element {
         control?.setPointerCapture?.(event.pointerId);
       }}
       onPointerMove={(event) => {
-        const activeDrag = drag;
-        if (!activeDrag || activeDrag.pointerId !== event.pointerId) return;
-        const switchMetrics = metrics();
-        if (!switchMetrics) return;
-        const nextProgress = Math.min(
-          1,
-          Math.max(
-            0,
-            (event.clientX - switchMetrics.left - switchMetrics.inset - activeDrag.grab) / switchMetrics.travel,
-          ),
-        );
-        if (Math.abs(nextProgress - activeDrag.startProgress) > 0.01) activeDrag.moved = true;
-        setDragProgress(nextProgress);
-        const nextChecked = nextProgress >= 0.5;
-        if (nextChecked !== context.checked()) context.setIsChecked(nextChecked);
+        updateDrag(event);
       }}
       onPointerUp={(event) => finishPointer(event)}
       onPointerCancel={(event) => finishPointer(event, true)}

--- a/src/renderer/src/components/ui/ui.test.tsx
+++ b/src/renderer/src/components/ui/ui.test.tsx
@@ -20,6 +20,28 @@ import {
 
 const originalClipboard = navigator.clipboard;
 
+function mockSwitchLayout(): HTMLDivElement {
+  const control = document.querySelector<HTMLDivElement>('[data-slot="switch-control"]');
+  const thumb = document.querySelector<HTMLElement>('[data-slot="switch-thumb"]');
+  if (!control || !thumb) throw new Error("Expected the switch control and thumb to be rendered.");
+
+  vi.spyOn(control, "getBoundingClientRect").mockReturnValue({
+    bottom: 20,
+    height: 20,
+    left: 100,
+    right: 136,
+    top: 0,
+    width: 36,
+    x: 100,
+    y: 0,
+    toJSON: () => ({}),
+  });
+  control.style.setProperty("--ui-switch-inset", "2px");
+  thumb.style.width = "16px";
+  thumb.style.height = "16px";
+  return control;
+}
+
 afterEach(() => {
   toast.dismiss();
   vi.useRealTimers();
@@ -150,6 +172,39 @@ describe("UI primitives", () => {
     expect(control).toBeChecked();
     expect(control).toHaveAttribute("name", "notifications");
     expect(control).toHaveAttribute("value", "enabled");
+  });
+
+  it("commits pointer drags only when the pointer is released", async () => {
+    const onChange = vi.fn();
+    render(() => <SwitchField label="Notifications" onChange={onChange} />);
+
+    const input = screen.getByRole("switch", { name: "Notifications" });
+    const control = mockSwitchLayout();
+    await fireEvent.pointerDown(control, { clientX: 102, pointerId: 1 });
+    await fireEvent.pointerMove(control, { clientX: 112, pointerId: 1 });
+
+    expect(input).not.toBeChecked();
+    expect(onChange).not.toHaveBeenCalled();
+
+    await fireEvent.pointerUp(control, { clientX: 112, pointerId: 1 });
+
+    expect(input).toBeChecked();
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps normal clicks when pointer movement stays below the drag threshold", async () => {
+    const onChange = vi.fn();
+    render(() => <SwitchField label="Notifications" onChange={onChange} />);
+
+    const input = screen.getByRole("switch", { name: "Notifications" });
+    const control = mockSwitchLayout();
+    await fireEvent.pointerDown(control, { clientX: 102, pointerId: 1 });
+    await fireEvent.pointerMove(control, { clientX: 103, pointerId: 1 });
+    await fireEvent.pointerUp(control, { clientX: 103, pointerId: 1 });
+    await fireEvent.click(control);
+
+    expect(input).toBeChecked();
+    expect(onChange).toHaveBeenCalledWith(true);
   });
 
   it("exposes invalid switch state and field description", async () => {

--- a/src/renderer/src/components/ui/ui.test.tsx
+++ b/src/renderer/src/components/ui/ui.test.tsx
@@ -207,6 +207,44 @@ describe("UI primitives", () => {
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
+  it("clears drag click suppression after pointer cancellation", async () => {
+    const onChange = vi.fn();
+    render(() => <SwitchField label="Notifications" onChange={onChange} />);
+
+    const input = screen.getByRole("switch", { name: "Notifications" });
+    const control = mockSwitchLayout();
+    await fireEvent.pointerDown(control, { clientX: 102, pointerId: 1 });
+    await fireEvent.pointerMove(control, { clientX: 112, pointerId: 1 });
+    await fireEvent.pointerCancel(control, { clientX: 112, pointerId: 1 });
+
+    expect(input).not.toBeChecked();
+    expect(onChange).not.toHaveBeenCalled();
+
+    await fireEvent.click(control);
+
+    expect(input).toBeChecked();
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("ignores non-primary pointer buttons", async () => {
+    const onChange = vi.fn();
+    render(() => <SwitchField label="Notifications" onChange={onChange} />);
+
+    const input = screen.getByRole("switch", { name: "Notifications" });
+    const control = mockSwitchLayout();
+    await fireEvent.pointerDown(control, { button: 1, clientX: 102, pointerId: 1 });
+    await fireEvent.pointerMove(control, { button: 1, clientX: 112, pointerId: 1 });
+    await fireEvent.pointerUp(control, { button: 1, clientX: 112, pointerId: 1 });
+
+    expect(input).not.toBeChecked();
+    expect(onChange).not.toHaveBeenCalled();
+
+    await fireEvent.click(control);
+
+    expect(input).toBeChecked();
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
   it("exposes invalid switch state and field description", async () => {
     render(() => (
       <SwitchField

--- a/src/renderer/src/styles/primitives.css
+++ b/src/renderer/src/styles/primitives.css
@@ -839,28 +839,35 @@
 }
 
 .ui-switch {
+  --ui-switch-thumb-size: var(--openbot-switch-thumb);
+  --ui-switch-inset: var(--openbot-switch-inset);
+  --ui-switch-travel: calc(var(--openbot-switch-width) - var(--ui-switch-thumb-size) - (var(--ui-switch-inset) * 2));
   position: relative;
   z-index: 0;
-  width: 32px;
-  height: 18.4px;
+  width: var(--openbot-switch-width);
+  height: var(--openbot-switch-height);
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  border: 1px solid transparent;
+  border: 0;
   border-radius: var(--openbot-radius-pill);
   outline: none;
-  background: var(--openbot-border-strong);
-  box-shadow: 0 1px 2px var(--openbot-shadow-ring);
+  background: var(--openbot-bg-control);
+  box-shadow:
+    inset 0 0 0 1px var(--openbot-border-strong),
+    0 1px 2px var(--openbot-shadow-ring);
   transition:
     background-color var(--openbot-duration-hover) ease,
-    border-color var(--openbot-duration-hover) ease,
     box-shadow var(--openbot-duration-hover) ease,
     opacity var(--openbot-duration-hover) ease;
 }
 
 .ui-switch[data-size="sm"] {
-  width: 24px;
-  height: 14px;
+  --ui-switch-thumb-size: var(--openbot-switch-sm-thumb);
+  --ui-switch-inset: var(--openbot-switch-sm-inset);
+  --ui-switch-travel: calc(var(--openbot-switch-sm-width) - var(--ui-switch-thumb-size) - (var(--ui-switch-inset) * 2));
+  width: var(--openbot-switch-sm-width);
+  height: var(--openbot-switch-sm-height);
 }
 
 .ui-switch[data-checked] {
@@ -868,17 +875,14 @@
 }
 
 .ui-switch[data-invalid] {
-  border-color: var(--openbot-danger-border);
   box-shadow: 0 0 0 3px var(--openbot-danger-focus);
 }
 
 .ui-switch:not([data-pointer-focus]):has(.ui-switch-input:focus-visible) {
-  border-color: var(--openbot-border-focus);
   box-shadow: var(--openbot-focus-ring);
 }
 
 .ui-switch[data-invalid]:not([data-pointer-focus]):has(.ui-switch-input:focus-visible) {
-  border-color: var(--openbot-danger-border);
   box-shadow: 0 0 0 3px var(--openbot-danger-focus);
 }
 
@@ -925,34 +929,38 @@
   inset: 0;
   display: flex;
   align-items: center;
+  overflow: hidden;
   border-radius: inherit;
   cursor: pointer;
 }
 
+.ui-switch-control[data-dragging] {
+  cursor: grabbing;
+}
+
 .ui-switch-thumb {
-  width: 16px;
-  height: 16px;
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: var(--ui-switch-thumb-size);
+  height: var(--ui-switch-thumb-size);
   display: block;
   border-radius: var(--openbot-radius-pill);
   background: var(--openbot-text-primary);
   box-shadow: 0 1px 2px var(--openbot-shadow-ring);
-  transition:
-    background-color var(--openbot-duration-hover) ease,
-    transform var(--openbot-duration-normal) var(--openbot-ease-out);
-}
-
-.ui-switch[data-size="sm"] .ui-switch-thumb {
-  width: 12px;
-  height: 12px;
+  transform: translate3d(
+      calc(var(--ui-switch-inset) + (var(--ui-switch-position, 0) * var(--ui-switch-travel))),
+      -50%,
+      0
+    )
+    scale(var(--ui-switch-scale-x, 1), var(--ui-switch-scale-y, 1));
+  transform-origin: center;
+  will-change: transform;
+  transition: background-color var(--openbot-duration-fast) var(--openbot-ease-out);
 }
 
 .ui-switch-thumb[data-checked] {
-  transform: translateX(14px);
   background: var(--openbot-text-on-light);
-}
-
-.ui-switch[data-size="sm"] .ui-switch-thumb[data-checked] {
-  transform: translateX(10px);
 }
 
 .ui-switch[data-disabled] {


### PR DESCRIPTION
## Summary

- Add liquid spring motion to the default switch thumb.
- Support direct pointer dragging with a release threshold.
- Add shared switch geometry tokens and keep existing keyboard, form, disabled, and invalid behavior.

## Verification

- `bun run test:desktop -- src/renderer/src/components/ui/ui.test.tsx`
- `bun run check:ui`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`